### PR TITLE
[lexical-react] Feat: add draggable block support to individual list items

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
@@ -187,4 +187,211 @@ test.describe('DraggableBlock', () => {
     `,
     );
   });
+
+  test('List item one can be successfully dragged below list item two', async ({
+    page,
+    isPlainText,
+    browserName,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    test.skip(isPlainText);
+    test.skip(browserName === 'firefox');
+
+    await focusEditor(page);
+
+    // Create a bulleted list using markdown shortcuts
+    await page.keyboard.type('- Item 1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Item 2');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Item 3');
+
+    // Hover over the first list item
+    await mouseMoveToSelector(page, 'li:has-text("Item 1")');
+
+    await page.waitForTimeout(200);
+    // Drag the handle from Item 1 and drop it at the end of Item 2
+    await dragDraggableMenuTo(page, 'li:has-text("Item 2")', 'middle', 'end');
+    await page.pause();
+
+    // Assert the new order: Item 2 -> Item 1 -> Item 3
+    // Note: The classes might slightly differ based on the exact playground theme version,
+    // but the failure will output the actual HTML if it differs!
+    await assertHTML(
+      page,
+      `
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">Item 2</span>
+          </li>
+          <li class="PlaygroundEditorTheme__listItem" style="" value="2">
+            <span data-lexical-text="true">Item 1</span>
+          </li>
+          <li class="PlaygroundEditorTheme__listItem" value="3">
+            <span data-lexical-text="true">Item 3</span>
+          </li>
+        </ul>
+      `,
+    );
+  });
+
+  test('List item can be dragged out of a list and dropped below a paragraph', async ({
+    page,
+    isPlainText,
+    browserName,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    test.skip(isPlainText);
+    test.skip(browserName === 'firefox');
+
+    await focusEditor(page);
+
+    // 1. Create the list
+    await page.keyboard.type('- Item 1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Item 2');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Item 3');
+    await page.keyboard.press('Enter');
+
+    // 2. Break out of the list and make a paragraph
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('hello world');
+
+    // 3. Hover and drag Item 1 below "hello world"
+    await mouseMoveToSelector(page, 'li:has-text("Item 1")');
+    await page.waitForTimeout(200);
+
+    await dragDraggableMenuTo(
+      page,
+      'p:has-text("hello world")',
+      'middle',
+      'end',
+    );
+
+    // 4. The Expected Notion-like State
+    await assertHTML(
+      page,
+      `
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">Item 2</span>
+          </li>
+          <li class="PlaygroundEditorTheme__listItem" value="2">
+            <span data-lexical-text="true">Item 3</span>
+          </li>
+        </ul>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">hello world</span>
+        </p>
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">Item 1</span>
+          </li>
+        </ul>
+      `,
+    );
+  });
+
+  test('Paragraph dragged over a list targets the entire list, not individual items', async ({
+    page,
+    isPlainText,
+    browserName,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    test.skip(isPlainText);
+    test.skip(browserName === 'firefox');
+
+    await focusEditor(page);
+
+    // Setup: Paragraph -> List
+    await page.keyboard.type('Move Me');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('- Item 1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Item 2');
+
+    // Hover over the paragraph
+    await mouseMoveToSelector(page, 'p:has-text("Move Me")');
+    await page.waitForTimeout(200);
+
+    // Drag the paragraph and drop it on the bottom half of Item 2.
+    await dragDraggableMenuTo(page, 'li:has-text("Item 2")', 'middle', 'end');
+
+    // Expectation: The List is now ABOVE the Paragraph.
+    await assertHTML(
+      page,
+      `
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">Item 1</span>
+          </li>
+          <li class="PlaygroundEditorTheme__listItem" value="2">
+            <span data-lexical-text="true">Item 2</span>
+          </li>
+        </ul>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+          <span data-lexical-text="true">Move Me</span>
+        </p>
+      `,
+    );
+  });
+
+  test('Nested list items can be successfully dragged and reordered', async ({
+    page,
+    isPlainText,
+    browserName,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    test.skip(isPlainText);
+    test.skip(browserName === 'firefox');
+
+    await focusEditor(page);
+
+    // Setup: Top Level -> Nested 1 -> Nested 2
+    await page.keyboard.type('- Top Level');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Tab'); // Indent to nest
+    await page.keyboard.type('Nested 1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Nested 2');
+
+    // Hover over Nested 1
+    await mouseMoveToSelector(page, ':nth-match(li:has-text("Nested 1"), 2)');
+    await page.waitForTimeout(200);
+
+    //  Grab the 2nd match for the drop target
+    await dragDraggableMenuTo(
+      page,
+      ':nth-match(li:has-text("Nested 2"), 2)',
+      'middle',
+      'end',
+    );
+
+    // Expectation: Nested 2 is now above Nested 1
+    await assertHTML(
+      page,
+      `
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">Top Level</span>
+          </li>
+          <li class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem" value="2">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li class="PlaygroundEditorTheme__listItem" value="1">
+                <span data-lexical-text="true">Nested 2</span>
+              </li>
+              <li class="PlaygroundEditorTheme__listItem" style="" value="2">
+                <span data-lexical-text="true">Nested 1</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `,
+    );
+  });
 });

--- a/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
@@ -168,7 +168,7 @@ test.describe('DraggableBlock', () => {
 
     await mouseMoveToSelector(page, 'p:has-text("Paragraph 1")');
     await page.pause();
-    await dragDraggableMenuTo(page, '.ContentEditable__root');
+    await dragDraggableMenuTo(page, '.ContentEditable__root', 'middle');
 
     await assertHTML(
       page,
@@ -391,6 +391,53 @@ test.describe('DraggableBlock', () => {
             </ul>
           </li>
         </ul>
+      `,
+    );
+  });
+
+  test('Elements can be reordered around generic containers like Quote blocks', async ({
+    page,
+    isPlainText,
+    browserName,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    test.skip(isPlainText);
+    test.skip(browserName === 'firefox');
+
+    await focusEditor(page);
+
+    // 1. Setup: Create a Quote block
+    await page.keyboard.type('> Quote text');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter'); // Exit the quote
+
+    // 2. Setup: Create a Paragraph below it
+    await page.keyboard.type('Paragraph text');
+
+    // 3. Hover over the Paragraph
+    await mouseMoveToSelector(page, 'p:has-text("Paragraph text")');
+    await page.waitForTimeout(200);
+
+    // 4. Drag the Paragraph ABOVE the Quote block
+    await dragDraggableMenuTo(
+      page,
+      'blockquote', // Target the generic container!
+      'middle',
+      'start', // Drop at the top
+    );
+
+    // 5. Expectation: Paragraph is now above the Quote
+    await assertHTML(
+      page,
+      `
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+          <span data-lexical-text="true">Paragraph text</span>
+        </p>
+        <blockquote class="PlaygroundEditorTheme__quote" dir="auto">
+          <span data-lexical-text="true">Quote text</span>
+        </blockquote>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br></p>
       `,
     );
   });

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -22,7 +22,9 @@ import {
   COMMAND_PRIORITY_LOW,
   DRAGOVER_COMMAND,
   DROP_COMMAND,
+  INDENT_CONTENT_COMMAND,
   LexicalEditor,
+  OUTDENT_CONTENT_COMMAND,
 } from 'lexical';
 import {
   DragEvent as ReactDragEvent,
@@ -41,7 +43,8 @@ import {Rectangle} from './shared/rect';
 const SPACE = 4;
 const TARGET_LINE_HALF_HEIGHT = 2;
 const DRAG_DATA_FORMAT = 'application/x-lexical-drag-block';
-const TEXT_BOX_HORIZONTAL_PADDING = 28;
+//const TEXT_BOX_HORIZONTAL_PADDING = 28;
+const INDENT_STEP = 20;
 
 const Downward = 1;
 const Upward = -1;
@@ -95,51 +98,35 @@ function getCollapsedMargins(elem: HTMLElement): {
   return {marginBottom: collapsedBottomMargin, marginTop: collapsedTopMargin};
 }
 
-function getNestedDraggableBlock(
+function getDeepestBlockElement(
   elem: HTMLElement,
   point: Point,
   anchorElementRect: DOMRect,
-): HTMLElement | null {
-  if (elem.tagName === 'UL' || elem.tagName === 'OL') {
-    const children = Array.from(elem.children);
-    for (let i = 0; i < children.length; i++) {
-      const child = children[i];
-      if (child instanceof HTMLElement) {
-        const domRect = Rectangle.fromDOM(child);
-        const {marginTop, marginBottom} = getCollapsedMargins(child);
+): HTMLElement {
+  const children = Array.from(elem.children);
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
 
-        // Expand the child's hit area horizontally to match the editor's full width.
-        // This ensures the drag handle doesn't vanish when the mouse moves left to grab it!
-        const childRect = domRect.generateNewRect({
-          bottom: domRect.bottom + marginBottom,
-          left: anchorElementRect.left,
-          right: anchorElementRect.right,
-          top: domRect.top - marginTop,
-        });
-        if (childRect.contains(point).result) {
-          const nestedChildren = Array.from(child.children);
-          for (let j = 0; j < nestedChildren.length; j++) {
-            const nestedChild = nestedChildren[j];
-            if (
-              nestedChild instanceof HTMLElement &&
-              (nestedChild.tagName === 'UL' || nestedChild.tagName === 'OL')
-            ) {
-              const deeplyNestedBlock = getNestedDraggableBlock(
-                nestedChild,
-                point,
-                anchorElementRect,
-              );
-              if (deeplyNestedBlock !== null) {
-                return deeplyNestedBlock;
-              }
-            }
-          }
-          return child;
-        }
+    if (
+      child instanceof HTMLElement &&
+      !child.hasAttribute('data-lexical-text') &&
+      window.getComputedStyle(child).display !== 'inline'
+    ) {
+      const domRect = Rectangle.fromDOM(child);
+      const {marginTop, marginBottom} = getCollapsedMargins(child);
+      const childRect = domRect.generateNewRect({
+        bottom: domRect.bottom + marginBottom,
+        left: anchorElementRect.left,
+        right: anchorElementRect.right,
+        top: domRect.top - marginTop,
+      });
+
+      if (childRect.contains(point).result) {
+        return getDeepestBlockElement(child, point, anchorElementRect);
       }
     }
   }
-  return null;
+  return elem;
 }
 
 function getBlockElement(
@@ -207,22 +194,7 @@ function getBlockElement(
       } = rect.contains(point);
 
       if (result) {
-        let isDraggingListItem = false;
-        if (draggedNodeKey !== null) {
-          const draggedNode = $getNodeByKey(draggedNodeKey);
-          isDraggingListItem = $isListItemNode(draggedNode);
-        }
-
-        if (draggedNodeKey == null || isDraggingListItem) {
-          const nestedBlock = getNestedDraggableBlock(
-            elem,
-            point,
-            anchorElementRect,
-          );
-          blockElem = nestedBlock || elem;
-        } else {
-          blockElem = elem;
-        }
+        blockElem = getDeepestBlockElement(elem, point, anchorElementRect);
         prevIndex = index;
         break;
       }
@@ -302,13 +274,19 @@ function setTargetLine(
   targetLineElem: HTMLElement,
   targetBlockElem: HTMLElement,
   mouseY: number,
+  mouseX: number,
   anchorElem: HTMLElement,
-) {
+): number {
   const {top: targetBlockElemTop, height: targetBlockElemHeight} =
     targetBlockElem.getBoundingClientRect();
-  const {top: anchorTop, width: anchorWidth} =
-    anchorElem.getBoundingClientRect();
+  const {
+    top: anchorTop,
+    left: anchorLeft,
+    width: anchorWidth,
+  } = anchorElem.getBoundingClientRect();
   const {marginTop, marginBottom} = getCollapsedMargins(targetBlockElem);
+
+  // Calculate Y-axis
   let lineTop = targetBlockElemTop;
   if (mouseY >= targetBlockElemTop) {
     lineTop += targetBlockElemHeight + marginBottom / 2;
@@ -318,13 +296,29 @@ function setTargetLine(
 
   const top =
     lineTop - anchorTop - TARGET_LINE_HALF_HEIGHT + anchorElem.scrollTop;
-  const left = TEXT_BOX_HORIZONTAL_PADDING - SPACE;
+
+  // Calculate X-axis
+  const targetRect = targetBlockElem.getBoundingClientRect();
+  let left = targetRect.left - anchorLeft;
+
+  // Calculate how far the mouse is from the left edge of the text block
+  const mouseXOffset = mouseX - targetRect.left;
+  let indentLevel = 0;
+
+  // Require a deliberate drag to the left/right to trigger nesting
+  if (mouseXOffset > INDENT_STEP && mouseXOffset < 150) {
+    indentLevel = 1;
+  } else if (mouseXOffset < -INDENT_STEP && mouseXOffset > -150) {
+    indentLevel = -1;
+  }
+
+  left += indentLevel * INDENT_STEP;
 
   targetLineElem.style.transform = `translate(${left}px, ${top}px)`;
-  targetLineElem.style.width = `${
-    anchorWidth - (TEXT_BOX_HORIZONTAL_PADDING - SPACE) * 2
-  }px`;
+  targetLineElem.style.width = `${anchorWidth - left}px`;
   targetLineElem.style.opacity = '.4';
+
+  return indentLevel;
 }
 
 function hideTargetLine(targetLineElem: HTMLElement | null) {
@@ -351,6 +345,7 @@ function useDraggableBlockMenu(
   const [draggableBlockElem, setDraggableBlockElemState] =
     useState<HTMLElement | null>(null);
   const draggedNodeKeyRef = useRef<string | null>(null);
+  const indentLevelRef = useRef<number>(0);
 
   const setDraggableBlockElem = useCallback(
     (elem: HTMLElement | null) => {
@@ -420,7 +415,7 @@ function useDraggableBlockMenu(
       if (isFileTransfer) {
         return false;
       }
-      const {pageY, target} = event;
+      const {pageY, pageX, target} = event;
       if (!isHTMLElement(target)) {
         return false;
       }
@@ -435,12 +430,15 @@ function useDraggableBlockMenu(
       if (targetBlockElem === null || targetLineElem === null) {
         return false;
       }
-      setTargetLine(
+      const level = setTargetLine(
         targetLineElem,
         targetBlockElem,
         pageY / calculateZoomLevel(target),
+        pageX / calculateZoomLevel(target),
         anchorElem,
       );
+      indentLevelRef.current = level;
+
       // Prevent default event to be able to trigger onDrop events
       event.preventDefault();
       return true;
@@ -517,7 +515,28 @@ function useDraggableBlockMenu(
       } else {
         insertTarget.insertBefore(nodeToInsert);
       }
+
+      const level = indentLevelRef.current;
+      if (level !== 0) {
+        const nodeKey = nodeToInsert.getKey();
+        // Run this in a fresh update cycle immediately after the drop finishes
+        setTimeout(() => {
+          editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            if (node) {
+              node.selectEnd(); // Focus the dropped node
+
+              if (level > 0) {
+                editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+              } else if (level < 0) {
+                editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+              }
+            }
+          });
+        }, 0);
+      }
       setDraggableBlockElem(null);
+      indentLevelRef.current = 0;
 
       // Firefox-specific fix: Use editor.focus() after drop to properly restore
       // both focus and selection. This ensures cursor visibility immediately.


### PR DESCRIPTION
## Description

This PR addresses #7630 by enhancing the `DraggableBlockPlugin` to support dragging individual `ListItemNode`s independently of their parent `ListNode`. 

Previously, hovering over a list would only target the top-level `<ul>` or `<ol>`, making it impossible to restructure individual items via drag-and-drop. 

**Key Changes:**
* **Recursive Drill-Down:** Updated `getBlockElement` to check if a top-level block is a List. If so, it searches its children to attach the drag handle to the specific `<li>` being hovered.
* **Gap & Zoom Safety:** Expanded the horizontal bounding box for nested items so the drag handle doesn't vanish when the mouse moves left to grab it, while strictly respecting the existing CSS `calculateZoomLevel` logic.
* **Smart Insertion Logic:** Updated `$onDrop` to handle cross-node drops. If an `<li>` is dragged out of a list and dropped onto a `<p>`, it automatically wraps the item in a new `ListNode` matching the original list type (bullet, number, etc.) to prevent orphaned nodes and aggressive normalization errors.

## Impact

Brings the Lexical Playground's restructuring UX to parity with editors like Notion and PlateJS, allowing users to easily reorder list items or break them out into new lists.

## Testing

* Added E2E test: `List item one can be successfully dragged below list item two`
* Added E2E test: `List item can be dragged out of a list and dropped below a paragraph`
* Verified existing E2E tests for paragraph dragging and edge cases continue to pass.
* Manually verified in headed mode and verified CSS zoom still functions correctly.

Closes #7630