### PR TITLE
[lexical-playground] Fix: add fallback for dimensionless images to prevent collapse

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -819,4 +819,37 @@ test.describe('Images', () => {
       `,
     );
   });
+
+  test('Dimensionless SVG renders with a visible bounding box instead of collapsing', async ({
+    page,
+    isRichText,
+    isCollab,
+  }) => {
+    test.skip(!isRichText || isCollab);
+    await initialize({page});
+    await focusEditor(page);
+
+    await focusEditor(page);
+
+    // 1. Create a raw SVG without width/height attributes
+    const svgContent = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red"/></svg>`;
+    const base64Svg = `data:image/svg+xml;base64,${Buffer.from(svgContent).toString('base64')}`;
+
+    // 2. Use the repository's native helper instead of hacking the clipboard!
+    await insertUrlImage(page, base64Svg, 'dimensionless-svg');
+
+    // 3. Locator for the image (using the same selector pattern as the other tests)
+    const imageLocator = page.locator(
+      '.editor-image img[alt="dimensionless-svg"]',
+    );
+    await imageLocator.waitFor({state: 'attached', timeout: 5000});
+
+    // 4. Verification: The bounding box should NOT be 0x0
+    const boundingBox = await imageLocator.boundingBox();
+    expect(boundingBox).not.toBeNull();
+
+    // This verifies your fix in ImageComponent.tsx
+    expect(boundingBox.width).toBeGreaterThan(0);
+    expect(boundingBox.height).toBeGreaterThan(0);
+  });
 });

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -118,7 +118,11 @@ function useSuspenseImage(src: string): ImageStatus {
 }
 
 function isSVG(src: string): boolean {
-  return src.toLowerCase().endsWith('.svg');
+  const lowerCaseSrc = src.toLowerCase();
+  return (
+    lowerCaseSrc.endsWith('.svg') ||
+    lowerCaseSrc.startsWith('data:image/svg+xml')
+  );
 }
 
 function LazyImage({
@@ -140,7 +144,6 @@ function LazyImage({
   width: 'inherit' | number;
   onError: () => void;
 }): JSX.Element {
-  const isSVGImage = isSVG(src);
   const status = useSuspenseImage(src);
 
   useEffect(() => {
@@ -155,7 +158,18 @@ function LazyImage({
 
   // Calculate final dimensions with proper scaling
   const calculateDimensions = () => {
-    if (!isSVGImage) {
+    if (width !== 'inherit' && height !== 'inherit') {
+      return {
+        height,
+        maxWidth,
+        width,
+      };
+    }
+
+    const isActuallySVG = isSVG(src);
+
+    // For standard images, Lexical expects 'inherit'
+    if (!isActuallySVG) {
       return {
         height,
         maxWidth,
@@ -167,8 +181,9 @@ function LazyImage({
     const naturalWidth = status.width;
     const naturalHeight = status.height;
 
-    let finalWidth = naturalWidth;
-    let finalHeight = naturalHeight;
+    //  If SVG has no intrinsic dimensions (0), fallback to a sensible default (maxWidth)
+    let finalWidth = naturalWidth || maxWidth;
+    let finalHeight = naturalHeight || finalWidth;
 
     // Scale down if width exceeds maxWidth while maintaining aspect ratio
     if (finalWidth > maxWidth) {


### PR DESCRIPTION
## Description

This PR fixes an issue where SVGs inserted without explicit `width` and `height` attributes (such as dimensionless SVGs or base64 data URIs) would visually collapse to `0x0` in the editor.

### The Problem
When a dimensionless SVG or a base64 SVG string is parsed:
1. The browser reports `naturalWidth` and `naturalHeight` as `0`.
2. The `ImageNode` constructor defaults missing dimensions to `'inherit'`.
3. In the React layer (`ImageComponent`), the previous fallback logic relied on a fragile `isSVG` check that failed for base64 data URIs.
4. Because the intrinsic dimensions were `0`, the component rendered with `0px` inline styles, making the node invisible and unselectable.

### The Fix
I pivoted from a global fallback to a **Surgical SVG Fallback** to maintain compatibility with Lexical's existing E2E test suite:
-  Updated the logic to identify SVGs using both file extensions and `data:image/svg+xml` prefixes.
- **Preserved CSS Inheritance:** Standard images (JPG/PNG) continue to return `'inherit'` for dimensions. This ensures that existing E2E tests (which rely on specific HTML snapshots for standard images) remain green and global CSS remains in control of responsive sizing.
- **SVG Math Safety Net:** For SVGs specifically, if no intrinsic dimensions are found, the logic now falls back to the node's `maxWidth`. This ensures a visible bounding box is rendered, allowing the user to see, select, and resize the image.

Fixes #7511

## Test Plan

- **New Test:** Added `Images.spec.ts` -> "Dimensionless SVG renders with a visible bounding box instead of collapsing". This verifies that a base64 encoded SVG without attributes renders with a width/height > 0.
- **Regressions:** Verified that standard image snapshots (e.g., the "Yellow Flower" JPG in `Toolbar.spec.mjs`) still receive `style="width: inherit; height: inherit"` to satisfy existing Playwright assertions.
- **Local Verification:** Ran `npx playwright test packages/lexical-playground/__tests__/e2e/` and confirmed all 600+ tests pass.