### PR TITLE
[lexical] Chore: Change alias from type to interface for `EditorThemeClasses`

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -74,7 +74,7 @@ export type Klass<T extends LexicalNode> =
 
 export type EditorThemeClassName = string;
 
-export type TextNodeThemeClasses = {
+export interface TextNodeThemeClasses {
   base?: EditorThemeClassName;
   bold?: EditorThemeClassName;
   code?: EditorThemeClassName;
@@ -89,7 +89,7 @@ export type TextNodeThemeClasses = {
   underline?: EditorThemeClassName;
   underlineStrikethrough?: EditorThemeClassName;
   [key: string]: EditorThemeClassName | undefined;
-};
+}
 
 export type EditorUpdateOptions = {
   /**
@@ -128,7 +128,7 @@ export interface EditorFocusOptions {
   defaultSelection?: 'rootStart' | 'rootEnd';
 }
 
-export type EditorThemeClasses = {
+export interface EditorThemeClasses {
   blockCursor?: EditorThemeClassName;
   characterLimit?: EditorThemeClassName;
   code?: EditorThemeClassName;
@@ -190,7 +190,7 @@ export type EditorThemeClasses = {
   indent?: EditorThemeClassName;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
-};
+}
 
 export type EditorConfig = {
   disableEvents?: boolean;


### PR DESCRIPTION
## Description

This change allows you to extend the theme object type with indexable specific properties and take advantage of IDE and TypeScript hints

## Test plan

### Before

The `EditorThemeClasses` type is based on an indexed signature: 

```ts
type EditorThemeClasses = {
  [key: string]: any;
}
```
This means that if you are using TypeScript, you can declare a theme with any properties that differ from the standard ones, but TypeScript will not know about this and will cast others properties to the `any` type

```ts
// Method in a custom node
createDOM(config: EditorConfig): HTMLElement {
  const element = document.createElement('span');
  // (index) EditorThemeClasses[string]: any
  addClassNamesToElement(element, config.theme.tooltip);
  return element;
}
```

### After

You can still assign any properties to the `EditorThemeClasses` object, but using TypeScript, you can extend it with specific properties to target IDE hints

```ts
// Define this in the global type file in your project.
declare module 'lexical' {
  interface EditorThemeClasses {
    tooltip?: 'MyEditorTheme__tooltip';
  }
}

// Method in a custom node
createDOM(config: EditorConfig): HTMLElement {
  const element = document.createElement('span');
  // (property) EditorThemeClasses.tooltip?: "MyEditorTheme__tooltip" | undefined
  addClassNamesToElement(element, config.theme.tooltip);
  return element;
}
```

⚠️ This is not the best approach, but it is one of the available ones.
The best practice is to define custom themes for nodes through the Extension API. See the example in the documentation: https://lexical.dev/docs/extensions/migration#react-plug-in-without-ui