### PR TITLE
fix: preserve block equations ($$) in MarkdownShortcutPlugin

### DIFF
--- a/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
@@ -111,10 +111,30 @@ export const EMOJI: TextMatchTransformer = {
   type: 'text-match',
 };
 
+export const BLOCK_EQUATION: TextMatchTransformer = {
+  dependencies: [EquationNode],
+  export: (node) => {
+    if (!$isEquationNode(node) || node.__inline) {
+      return null;
+    }
+
+    return `$$${node.getEquation()}$$`;
+  },
+  importRegExp: /\$\$([^$]+?)\$\$/,
+  regExp: /\$\$([^$]+?)\$\$$/,
+  replace: (textNode, match) => {
+    const [, equation] = match;
+    const equationNode = $createEquationNode(equation, false);
+    textNode.replace(equationNode);
+  },
+  trigger: '$',
+  type: 'text-match',
+};
+
 export const EQUATION: TextMatchTransformer = {
   dependencies: [EquationNode],
   export: (node) => {
-    if (!$isEquationNode(node)) {
+    if (!$isEquationNode(node) || !node.__inline) {
       return null;
     }
 
@@ -312,6 +332,7 @@ export const PLAYGROUND_TRANSFORMERS: Array<Transformer> = [
   HR,
   IMAGE,
   EMOJI,
+  BLOCK_EQUATION,
   EQUATION,
   TWEET,
   CHECK_LIST,


### PR DESCRIPTION
## Summary

Fixes #6936

Block math equations (`$$...$$`) created via the toolbar were incorrectly converted to inline equations (`$...$`) when toggling markdown mode via the `MarkdownShortcutPlugin`.

**Root cause:** The `EQUATION` transformer's `export` function always returned `$${equation}$` (inline syntax) regardless of whether the node was a block or inline equation. There was also no transformer to import/match `$$...$$` patterns.

## Changes

- Added `BLOCK_EQUATION` transformer that handles `$$...$$` syntax (export and import)
- Updated `EQUATION` transformer to only export when the node is inline (`node.__inline === true`)
- Placed `BLOCK_EQUATION` before `EQUATION` in `PLAYGROUND_TRANSFORMERS` so the `$$` pattern is matched before the single `$` pattern

## Before / After

**Before:** inserting a block equation and clicking the Markdown button converted `$$x^2 + y^2 = z^2$$` → `$x^2 + y^2 = z^2$` (inline)

**After:** block equations are preserved as `$$x^2 + y^2 = z^2$$` when toggling markdown mode