### PR TITLE
[lexical-code][lexical-markdown] Use lightweight code-node import in …

### DIFF
--- a/packages/lexical-code/flow/LexicalCodeNode.js.flow
+++ b/packages/lexical-code/flow/LexicalCodeNode.js.flow
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+export type {SerializedCodeNode} from './LexicalCode';
+export {
+  $createCodeNode,
+  $isCodeNode,
+  CodeNode,
+  DEFAULT_CODE_LANGUAGE,
+  getDefaultCodeLanguage,
+} from './LexicalCode';

--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -9,7 +9,6 @@
   ],
   "license": "MIT",
   "version": "0.41.0",
-  "main": "LexicalCode.js",
   "types": "index.d.ts",
   "dependencies": {
     "@lexical/utils": "workspace:*",
@@ -27,6 +26,21 @@
   "module": "LexicalCode.mjs",
   "sideEffects": true,
   "exports": {
+    "./node": {
+      "import": {
+        "types": "./node.d.ts",
+        "development": "./LexicalCodeNode.dev.mjs",
+        "production": "./LexicalCodeNode.prod.mjs",
+        "node": "./LexicalCodeNode.node.mjs",
+        "default": "./LexicalCodeNode.mjs"
+      },
+      "require": {
+        "types": "./node.d.ts",
+        "development": "./LexicalCodeNode.dev.js",
+        "production": "./LexicalCodeNode.prod.js",
+        "default": "./LexicalCodeNode.js"
+      }
+    },
     ".": {
       "import": {
         "types": "./index.d.ts",

--- a/packages/lexical-code/src/node.ts
+++ b/packages/lexical-code/src/node.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export type {SerializedCodeNode} from './CodeNode';
+export {
+  $createCodeNode,
+  $isCodeNode,
+  CodeNode,
+  DEFAULT_CODE_LANGUAGE,
+  getDefaultCodeLanguage,
+} from './CodeNode';

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -15,7 +15,7 @@ import type {
 } from './MarkdownTransformers';
 import type {ElementNode, LexicalEditor, TextNode} from 'lexical';
 
-import {$isCodeNode} from '@lexical/code';
+import {$isCodeNode} from '@lexical/code/node';
 import {
   $createRangeSelection,
   $getSelection,

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -9,7 +9,7 @@
 import type {ListType} from '@lexical/list';
 import type {HeadingTagType} from '@lexical/rich-text';
 
-import {$createCodeNode, $isCodeNode, CodeNode} from '@lexical/code';
+import {$createCodeNode, $isCodeNode, CodeNode} from '@lexical/code/node';
 import {
   $createLinkNode,
   $isAutoLinkNode,

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -8,7 +8,7 @@
 
 import type {ListNode} from '@lexical/list';
 
-import {$isCodeNode} from '@lexical/code';
+import {$isCodeNode} from '@lexical/code/node';
 import {$isListItemNode, $isListNode} from '@lexical/list';
 import {$isHeadingNode, $isQuoteNode} from '@lexical/rich-text';
 import {

--- a/scripts/__tests__/unit/markdown-deps.test.ts
+++ b/scripts/__tests__/unit/markdown-deps.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as fs from 'fs-extra';
+import * as glob from 'glob';
+import * as ts from 'typescript';
+import {describe, expect, test} from 'vitest';
+
+const markdownSourceFiles = glob.sync(
+  'packages/lexical-markdown/src/**/*.{ts,tsx}',
+  {
+    ignore: ['**/__tests__/**'],
+  },
+);
+
+const FORBIDDEN_MODULE = '@lexical/code';
+
+describe('@lexical/markdown dependency audits', () => {
+  test.each(markdownSourceFiles)(
+    '%s does not import @lexical/code root module',
+    (filePath) => {
+      const source = fs.readFileSync(filePath, 'utf8');
+      const importedModules = ts
+        .preProcessFile(source, true, true)
+        .importedFiles.map(({fileName}) => fileName);
+      expect(
+        importedModules,
+        `${filePath} should import @lexical/code/node, not @lexical/code`,
+      ).not.toContain(FORBIDDEN_MODULE);
+    },
+  );
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,6 +9,7 @@
       "lexical": ["./packages/lexical/src/index.ts"],
       "@lexical/clipboard": ["./packages/lexical-clipboard/src/index.ts"],
       "@lexical/code": ["./packages/lexical-code/src/index.ts"],
+      "@lexical/code/node": ["./packages/lexical-code/src/node.ts"],
       "@lexical/code-shiki": ["./packages/lexical-code-shiki/src/index.ts"],
       "@lexical/devtools-core": [
         "./packages/lexical-devtools-core/src/index.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
       "lexical": ["./packages/lexical/src/index.ts"],
       "@lexical/clipboard": ["./packages/lexical-clipboard/src/index.ts"],
       "@lexical/code": ["./packages/lexical-code/src/index.ts"],
+      "@lexical/code/node": ["./packages/lexical-code/src/node.ts"],
       "@lexical/code-shiki": ["./packages/lexical-code-shiki/src/index.ts"],
       "@lexical/devtools-core": [
         "./packages/lexical-devtools-core/src/index.ts"


### PR DESCRIPTION
## Summary

Decouple `@lexical/markdown` code-block internals from the Prism-heavy `@lexical/code` root export by introducing and consuming a lightweight `@lexical/code/node` subpath.

## Problem

`@lexical/markdown` imported code-node APIs from `@lexical/code` root, which pulls Prism-related modules into markdown-only dependency graphs.

## Changes

- Added new public subpath export: `@lexical/code/node`
  - Exposes only node-focused APIs:
    - `$createCodeNode`
    - `$isCodeNode`
    - `CodeNode`
    - `DEFAULT_CODE_LANGUAGE`
    - `getDefaultCodeLanguage`
    - `SerializedCodeNode` (type)
- Switched markdown internals to import from `@lexical/code/node`:
  - `MarkdownTransformers.ts`
  - `MarkdownShortcuts.ts`
  - `utils.ts`
- Added TS path mappings for `@lexical/code/node`.
- Added regression guardrail test to ensure markdown source does not import `@lexical/code` root.

## Compatibility

No markdown API behavior changes (`TRANSFORMERS`, `CODE`, import/export/shortcuts behavior remain unchanged). 
Apps that need syntax highlighting should continue to set it up explicitly via `@lexical/code` (highlight node/plugin); this PR only removes implicit Prism inclusion from markdown-only paths.

## Validation

- `pnpm exec vitest run packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts`
- `pnpm exec vitest run packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts`
- `pnpm exec vitest run scripts/__tests__/unit/build.test.ts scripts/__tests__/unit/markdown-deps.test.ts`

Bundle proof (markdown-only entry via esbuild metafile):
- `packages/lexical-code/src/FacadePrism.ts`: **not present**
- `prismjs/components/prism-*`: **not present**

Fixes #5381
Related to #4550 #5424 #6575