### PR TITLE
[lexical-markdown][lexical-playground] Bug Fix: Convert tabs in TabNode at import

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -303,13 +303,14 @@ function $importBlocks(
 
 // Look in node for '\t' and create a TabNode for each occurrence.
 function $normalizeMarkdownTextNode(textNode: TextNode): void {
-  const tabOffsets = [];
+  const tabOffsets: Set<number> = new Set();
   const text = textNode.getTextContent();
   let index = text.indexOf('\t');
 
   // Find all tab occurrences
   while (index !== -1) {
-    tabOffsets.push(index, index + 1);
+    tabOffsets.add(index);
+    tabOffsets.add(index + 1);
     index = text.indexOf('\t', index + 1);
   }
 

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -791,6 +791,11 @@ describe('Markdown', () => {
       md: 'foo\t \tbar\n\tbaz',
       skipExport: true,
     },
+    {
+      html: '<p><span style="white-space: pre-wrap;">Hello</span><span style="white-space: pre-wrap;">\t</span><span style="white-space: pre-wrap;">\t</span><span style="white-space: pre-wrap;">World</span></p>',
+      md: 'Hello\t\tWorld',
+      skipExport: true,
+    },
   ];
 
   for (const {


### PR DESCRIPTION
This is a follow up of #7845. I made a new PR to make it clean.

Reported issue: https://github.com/facebook/lexical/issues/7820
To summarize, if you use indent button and then switch to markdown, indent will be lost.

In this fix, once all transformers have been applied, loop on nodes to convert all '\t' in TabNodes.
I decided to do it here and not in `$importBlocks` as it was gonna create several nodes and break the function flow which only use one TextNode.

Closes https://github.com/facebook/lexical/issues/7820