### PR TITLE
[lexical-website] Fix: Correct the mistake in the argument in the example on the Updates page

### DIFF
--- a/packages/lexical-website/docs/concepts/updates.md
+++ b/packages/lexical-website/docs/concepts/updates.md
@@ -56,9 +56,9 @@ editor.registerUpdateListener(({tags}) => {
   }
 });
 
-editor.registerMutationListener(MyNode, (mutations) => {
+editor.registerMutationListener(MyNode, (mutatedNodes, { updateTags }) => {
   // updateTags contains tags from the current update
-  if (mutations.updateTags.has(HISTORIC_TAG)) {
+  if (updateTags.has(HISTORIC_TAG)) {
     // Handle mutations with historic tag
   }
 });


### PR DESCRIPTION
## Description

Fixes a mistake using `updateTags` argument in the example of `registerMutationListener` listener. I also changed the name of the first argument to match the example on the [Listeners](https://lexical.dev/docs/concepts/listeners#registermutationlistener) page