### PR TITLE
[lexical-link]: Refactor: add `afterCloneFrom` method to LinkNode/AutoLinkNode

### DIFF
--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -339,7 +339,7 @@ export function $linkNodeTransform(link: LinkNode): void {
         const innerLink = $copyNode(link);
         innerLink.append(...blockChildren);
         node.append(innerLink);
-        transformed ||= true;
+        transformed = true;
       }
       $insertNodeToNearestRootAtCaret(node, $rewindSiblingCaret(caret), {
         $shouldSplit: () => false,
@@ -349,7 +349,7 @@ export function $linkNodeTransform(link: LinkNode): void {
   if (!transformed) {
     return;
   }
-  if (link.isEmpty()) {
+  if (!link.canBeEmpty() && link.isEmpty()) {
     const parent = link.getParent();
     link.remove();
     if (parent && parent.isEmpty()) {

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -1267,7 +1267,7 @@ describe('LinkNode transform (Regression #8083)', () => {
     });
   });
 
-  test('an empty link is not deleted if the transformation did not occurred', () => {
+  test('an empty link is not deleted if the transformation did not occur', () => {
     const editor = buildEditorFromExtensions(transformExtension);
     let linkKey: string;
     editor.update(


### PR DESCRIPTION
## Description

These changes fix some rare bugs that occur when using subclasses extended from LinkNode and relax the typing constraints of the `canBeEmpty` method

This PR adds the classic `afterCloneFrom` method to `LinkNode` to avoid copying issues, and adds an additional check to the transformation function to prevent unnecessary operations when no mutations occur. 

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*