### PR TITLE
[lexical-playground] Chore: Remove unused code from playground TablePlugin

### DIFF
--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -61,7 +61,6 @@ import {ImagesExtension} from './plugins/ImagesExtension';
 import {PlaygroundMarkdownShortcutsExtension} from './plugins/MarkdownShortcutsExtension';
 import {MaxLengthExtension} from './plugins/MaxLengthPlugin';
 import PasteLogPlugin from './plugins/PasteLogPlugin';
-import {TableContext} from './plugins/TablePlugin';
 import TestRecorderPlugin from './plugins/TestRecorderPlugin';
 import TypingPerfPlugin from './plugins/TypingPerfPlugin';
 import Settings from './Settings';
@@ -227,24 +226,22 @@ function App(): JSX.Element {
   return (
     <LexicalCollaboration>
       <LexicalExtensionComposer extension={app} contentEditable={null}>
-        <TableContext>
-          <ToolbarContext>
-            <header>
-              <a href="https://lexical.dev" target="_blank" rel="noreferrer">
-                <img src={logo} alt="Lexical Logo" />
-              </a>
-            </header>
-            <div className="editor-shell">
-              <Editor />
-            </div>
-            <Settings />
-            {isDevPlayground ? <DocsPlugin /> : null}
-            {isDevPlayground ? <PasteLogPlugin /> : null}
-            {isDevPlayground ? <TestRecorderPlugin /> : null}
+        <ToolbarContext>
+          <header>
+            <a href="https://lexical.dev" target="_blank" rel="noreferrer">
+              <img src={logo} alt="Lexical Logo" />
+            </a>
+          </header>
+          <div className="editor-shell">
+            <Editor />
+          </div>
+          <Settings />
+          {isDevPlayground ? <DocsPlugin /> : null}
+          {isDevPlayground ? <PasteLogPlugin /> : null}
+          {isDevPlayground ? <TestRecorderPlugin /> : null}
 
-            {measureTypingPerf ? <TypingPerfPlugin /> : null}
-          </ToolbarContext>
-        </TableContext>
+          {measureTypingPerf ? <TypingPerfPlugin /> : null}
+        </ToolbarContext>
       </LexicalExtensionComposer>
     </LexicalCollaboration>
   );

--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -8,75 +8,13 @@
 
 import type {JSX} from 'react';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {
-  INSERT_TABLE_COMMAND,
-  TableCellNode,
-  TableNode,
-  TableRowNode,
-} from '@lexical/table';
-import {EditorThemeClasses, Klass, LexicalEditor, LexicalNode} from 'lexical';
-import {createContext, useContext, useEffect, useMemo, useState} from 'react';
+import {INSERT_TABLE_COMMAND} from '@lexical/table';
+import {LexicalEditor} from 'lexical';
+import {useEffect, useState} from 'react';
 
 import Button from '../ui/Button';
 import {DialogActions} from '../ui/Dialog';
 import TextInput from '../ui/TextInput';
-
-export type InsertTableCommandPayload = Readonly<{
-  columns: string;
-  rows: string;
-  includeHeaders?: boolean;
-}>;
-
-export type CellContextShape = {
-  cellEditorConfig: null | CellEditorConfig;
-  cellEditorPlugins: null | JSX.Element | Array<JSX.Element>;
-  set: (
-    cellEditorConfig: null | CellEditorConfig,
-    cellEditorPlugins: null | JSX.Element | Array<JSX.Element>,
-  ) => void;
-};
-
-export type CellEditorConfig = Readonly<{
-  namespace: string;
-  nodes?: ReadonlyArray<Klass<LexicalNode>>;
-  onError: (error: Error, editor: LexicalEditor) => void;
-  readOnly?: boolean;
-  theme?: EditorThemeClasses;
-}>;
-
-export const CellContext = createContext<CellContextShape>({
-  cellEditorConfig: null,
-  cellEditorPlugins: null,
-  set: () => {
-    // Empty
-  },
-});
-
-export function TableContext({children}: {children: JSX.Element}) {
-  const [contextValue, setContextValue] = useState<{
-    cellEditorConfig: null | CellEditorConfig;
-    cellEditorPlugins: null | JSX.Element | Array<JSX.Element>;
-  }>({
-    cellEditorConfig: null,
-    cellEditorPlugins: null,
-  });
-  return (
-    <CellContext.Provider
-      value={useMemo(
-        () => ({
-          cellEditorConfig: contextValue.cellEditorConfig,
-          cellEditorPlugins: contextValue.cellEditorPlugins,
-          set: (cellEditorConfig, cellEditorPlugins) => {
-            setContextValue({cellEditorConfig, cellEditorPlugins});
-          },
-        }),
-        [contextValue.cellEditorConfig, contextValue.cellEditorPlugins],
-      )}>
-      {children}
-    </CellContext.Provider>
-  );
-}
 
 export function InsertTableDialog({
   activeEditor,
@@ -133,26 +71,4 @@ export function InsertTableDialog({
       </DialogActions>
     </>
   );
-}
-
-export function TablePlugin({
-  cellEditorConfig,
-  children,
-}: {
-  cellEditorConfig: CellEditorConfig;
-  children: JSX.Element | Array<JSX.Element>;
-}): JSX.Element | null {
-  const [editor] = useLexicalComposerContext();
-  const cellContext = useContext(CellContext);
-  useEffect(() => {
-    if (!editor.hasNodes([TableNode, TableRowNode, TableCellNode])) {
-      throw new Error(
-        'TablePlugin: TableNode, TableRowNode, or TableCellNode is not registered on editor',
-      );
-    }
-  }, [editor]);
-  useEffect(() => {
-    cellContext.set(cellEditorConfig, children);
-  }, [cellContext, cellEditorConfig, children]);
-  return null;
 }


### PR DESCRIPTION
## Description

Most of the code from the playground's TablePlugin, except for the `InsertTableDialog` component, wasn't doing anything.

## Test plan

Tests should all still pass without this unused context and code