### PR TITLE
[lexical-playground][lexical-react] Bug Fix: Fix accessor implementations to use getLatest/getWritable consistently

### DIFF
--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -152,7 +152,7 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
   setEquation(equation: string): this {
     const writable = this.getWritable();
     writable.__equation = equation;
-    return this;
+    return writable;
   }
 
   decorate(): JSX.Element {

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -154,27 +154,30 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
     return {element};
   }
 
-  setData(data: string): void {
+  setData(data: string): this {
     const self = this.getWritable();
     self.__data = data;
+    return self;
   }
 
   getWidth(): Dimension {
     return this.getLatest().__width;
   }
 
-  setWidth(width: Dimension): void {
+  setWidth(width: Dimension): this {
     const self = this.getWritable();
     self.__width = width;
+    return self;
   }
 
   getHeight(): Dimension {
     return this.getLatest().__height;
   }
 
-  setHeight(height: Dimension): void {
+  setHeight(height: Dimension): this {
     const self = this.getWritable();
     self.__height = height;
+    return self;
   }
 
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {

--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -96,7 +96,7 @@ export class FigmaNode extends DecoratorBlockNode {
   }
 
   getId(): string {
-    return this.__id;
+    return this.getLatest().__id;
   }
 
   getTextContent(

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -321,15 +321,17 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
   setWidthAndHeight(
     width: 'inherit' | number,
     height: 'inherit' | number,
-  ): void {
+  ): this {
     const writable = this.getWritable();
     writable.__width = width;
     writable.__height = height;
+    return writable;
   }
 
-  setShowCaption(showCaption: boolean): void {
+  setShowCaption(showCaption: boolean): this {
     const writable = this.getWritable();
     writable.__showCaption = showCaption;
+    return writable;
   }
 
   // View
@@ -349,11 +351,11 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
   }
 
   getSrc(): string {
-    return this.__src;
+    return this.getLatest().__src;
   }
 
   getAltText(): string {
-    return this.__altText;
+    return this.getLatest().__altText;
   }
 
   decorate(): JSX.Element {

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -149,16 +149,18 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     return false;
   }
 
-  setPosition(x: number, y: number): void {
+  setPosition(x: number, y: number): this {
     const writable = this.getWritable();
     writable.__x = x;
     writable.__y = y;
     $setSelection(null);
+    return writable;
   }
 
-  toggleColor(): void {
+  toggleColor(): this {
     const writable = this.getWritable();
     writable.__color = writable.__color === 'pink' ? 'yellow' : 'pink';
+    return writable;
   }
 
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -181,7 +181,7 @@ export class TweetNode extends DecoratorBlockNode {
   }
 
   getId(): string {
-    return this.__id;
+    return this.getLatest().__id;
   }
 
   getTextContent(

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -145,7 +145,7 @@ export class YouTubeNode extends DecoratorBlockNode {
   }
 
   getId(): string {
-    return this.__id;
+    return this.getLatest().__id;
   }
 
   getTextContent(

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -163,17 +163,18 @@ export class CollapsibleContainerNode extends ElementNode {
     };
   }
 
-  setOpen(open: boolean): void {
+  setOpen(open: boolean): this {
     const writable = this.getWritable();
     writable.__open = open;
+    return writable;
   }
 
   getOpen(): boolean {
     return this.getLatest().__open;
   }
 
-  toggleOpen(): void {
-    this.setOpen(!this.getOpen());
+  toggleOpen(): this {
+    return this.setOpen(!this.getOpen());
   }
 }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -52,7 +52,7 @@ export class CollapsibleContentNode extends ElementNode {
             'Expected parent node to be a CollapsibleContainerNode',
           );
         }
-        if (!containerNode.__open) {
+        if (!containerNode.getOpen()) {
           setDomHiddenUntilFound(dom);
         }
       });
@@ -64,7 +64,7 @@ export class CollapsibleContentNode extends ElementNode {
               'Expected parent node to be a CollapsibleContainerNode',
             );
           }
-          if (!containerNode.__open) {
+          if (!containerNode.getOpen()) {
             containerNode.toggleOpen();
           }
         });

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
@@ -71,6 +71,10 @@ export class DecoratorBlockNode extends DecoratorNode<JSX.Element> {
     return self;
   }
 
+  getFormat(): ElementFormatType {
+    return this.getLatest().__format;
+  }
+
   isInline(): false {
     return false;
   }


### PR DESCRIPTION
## Description

Fixes accessors of playground node classes and DecoratorBlockNode to consistently use getLatest/getWritable and return the instance from setters.

Used Claude to do most of this but reviewed the output

## Test plan

All existing tests pass