### PR TITLE
[*] Chore: Update unit tests with extensions to use explicit resource management (using)

### DIFF
--- a/packages/lexical-extension/src/__tests__/unit/LexicalBuilder.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/LexicalBuilder.test.ts
@@ -121,7 +121,7 @@ describe('LexicalBuilder', () => {
       nodes: [NodeB],
     });
     it('can mix deferred and direct node config', () => {
-      const editor = buildEditorFromExtensions(ExtDefer, ExtDirect, {
+      using editor = buildEditorFromExtensions(ExtDefer, ExtDirect, {
         $initialEditorState() {
           $getRoot().append(
             $createParagraphNode().append(

--- a/packages/lexical-extension/src/__tests__/unit/NestedEditorExtension.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/NestedEditorExtension.test.ts
@@ -15,7 +15,7 @@ import {describe, expect, test} from 'vitest';
 
 describe('NestedEditorExtension', () => {
   test('it sets _parentEditor implicitly', () => {
-    const editor = buildEditorFromExtensions({name: 'parent'});
+    using editor = buildEditorFromExtensions({name: 'parent'});
     const childEditor = editor.read(() =>
       buildEditorFromExtensions({
         dependencies: [NestedEditorExtension],
@@ -25,7 +25,7 @@ describe('NestedEditorExtension', () => {
     expect(childEditor._parentEditor).toBe(editor);
   });
   test('$getParentEditor can be overridden', () => {
-    const editor = buildEditorFromExtensions({name: 'parent'});
+    using editor = buildEditorFromExtensions({name: 'parent'});
     const childEditor = buildEditorFromExtensions({
       dependencies: [
         configExtension(NestedEditorExtension, {
@@ -50,7 +50,7 @@ describe('NestedEditorExtension', () => {
     expect(childEditor._config.theme.text?.bold).toBe('bold');
   });
   test('If the child has a theme it is not inherited', () => {
-    const editor = buildEditorFromExtensions({
+    using editor = buildEditorFromExtensions({
       name: 'parent',
       theme: {text: {bold: 'bold', italic: 'italic'}},
     });
@@ -65,7 +65,7 @@ describe('NestedEditorExtension', () => {
     expect(childEditor._config.theme.text?.italic).toBe('child-italic');
   });
   test('inheritEditableFromParent defaults false but can be enabled later', () => {
-    const editor = buildEditorFromExtensions({
+    using editor = buildEditorFromExtensions({
       name: 'parent',
     });
     const childEditor = editor.read(() =>
@@ -87,7 +87,7 @@ describe('NestedEditorExtension', () => {
     expect(childEditor.isEditable()).toBe(false);
   });
   test('inheritEditableFromParent works when configured true', () => {
-    const editor = buildEditorFromExtensions({
+    using editor = buildEditorFromExtensions({
       editable: false,
       name: 'parent',
     });

--- a/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkExtension.test.ts
@@ -65,7 +65,7 @@ describe('LexicalAutoLinkExtension tests', () => {
     // Register AutoLink with a hashtag matcher that matches # followed by digits
     const hashtagMatcher = createLinkMatcherWithRegExp(/#\d+/);
 
-    const editor = buildEditorFromExtensions({
+    using editor = buildEditorFromExtensions({
       $initialEditorState() {
         // Initialize content with #1234.Another - this should not cause an infinite loop
         $getRoot().append(
@@ -109,7 +109,7 @@ describe('LexicalAutoLinkExtension tests', () => {
   });
 
   test('excludeParents prevents auto-linking inside excluded parent nodes', async () => {
-    const editor = buildEditorFromExtensions({
+    using editor = buildEditorFromExtensions({
       $initialEditorState() {
         $getRoot().append(
           $create(ExcludedParentNode).append(
@@ -141,7 +141,7 @@ describe('LexicalAutoLinkExtension tests', () => {
   });
 
   test('excludeParents does not prevent auto-linking in non-excluded parents', async () => {
-    const editor = buildEditorFromExtensions({
+    using editor = buildEditorFromExtensions({
       $initialEditorState() {
         $getRoot().append(
           $createParagraphNode().append($createTextNode('https://example.com')),

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -899,7 +899,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('extracts block child (HeadingNode) from link', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let textKey: string;
     editor.update(
       () => {
@@ -939,7 +939,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('extracts block child (ParagraphNode) from link', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let textKey: string;
     editor.update(
       () => {
@@ -982,7 +982,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('handles siblings after block child', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let afterTextKey: string;
     editor.update(
       () => {
@@ -1036,7 +1036,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('fixes element selection in paragraph split to the right of LinkNode', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let afterTextKey: string;
     editor.update(
       () => {
@@ -1073,7 +1073,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('fixes element selection in LinkNode to the right of non-inline node', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let afterTextKey: string;
     editor.update(
       () => {
@@ -1118,7 +1118,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('fixes element selection with multiple non-inline siblings', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let heading2TextKey: string;
     editor.update(
       () => {
@@ -1161,7 +1161,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('fixes element selection when no siblings to the right of LinkNode', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     editor.update(
       () => {
         const root = $getRoot();
@@ -1195,7 +1195,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('selection in paragraph right of link with trailing text in link', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let afterTextKey: string;
     editor.update(
       () => {
@@ -1232,7 +1232,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('selection at end of link with heading only child', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let headingTextKey: string;
     editor.update(
       () => {
@@ -1268,7 +1268,7 @@ describe('LinkNode transform (Regression #8083)', () => {
   });
 
   test('an empty link is not deleted if the transformation did not occur', () => {
-    const editor = buildEditorFromExtensions(transformExtension);
+    using editor = buildEditorFromExtensions(transformExtension);
     let linkKey: string;
     editor.update(
       () => {

--- a/packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts
@@ -38,7 +38,7 @@ describe('Link', () => {
     name: '[root]',
   });
   it('can convert a text node to a link with $toggleLink', () => {
-    const editor = buildEditorFromExtensions(extension);
+    using editor = buildEditorFromExtensions(extension);
     editor.update(
       () => {
         const textNode: TextNode = $getRoot().getLastDescendant()!;
@@ -67,12 +67,11 @@ describe('Link', () => {
       },
       {discrete: true},
     );
-    editor.dispose();
   });
 
   describe('merge adjacent LinkNodes', () => {
     it('merges adjacent LinkNodes with identical attributes', () => {
-      const editor = buildEditorFromExtensions(extension);
+      using editor = buildEditorFromExtensions(extension);
       editor.update(
         () => {
           const p = $getRoot().getFirstChild();
@@ -107,11 +106,10 @@ describe('Link', () => {
         expect(link.getTitle()).toBe('Lexical');
         expect(link.getTextContent()).toBe('Hello World');
       });
-      editor.dispose();
     });
 
     it('does not merge LinkNodes with different URLs', () => {
-      const editor = buildEditorFromExtensions(extension);
+      using editor = buildEditorFromExtensions(extension);
       editor.update(
         () => {
           const p = $getRoot().getFirstChild();
@@ -130,7 +128,6 @@ describe('Link', () => {
         assert($isParagraphNode(p), 'Expecting a ParagraphNode in the root');
         expect(p.getChildren().length).toBe(2);
       });
-      editor.dispose();
     });
 
     it('does not merge LinkNode with AutoLinkNode', () => {
@@ -144,7 +141,7 @@ describe('Link', () => {
         name: '[root-autolink]',
         nodes: () => [AutoLinkNode],
       });
-      const editor = buildEditorFromExtensions(autoLinkExtension);
+      using editor = buildEditorFromExtensions(autoLinkExtension);
       editor.update(
         () => {
           const p = $getRoot().getFirstChild();
@@ -163,11 +160,10 @@ describe('Link', () => {
         assert($isParagraphNode(p), 'Expecting a ParagraphNode in the root');
         expect(p.getChildren().length).toBe(2);
       });
-      editor.dispose();
     });
 
     it('does not merge LinkNodes with different rel', () => {
-      const editor = buildEditorFromExtensions(extension);
+      using editor = buildEditorFromExtensions(extension);
       editor.update(
         () => {
           const p = $getRoot().getFirstChild();
@@ -190,11 +186,10 @@ describe('Link', () => {
         assert($isParagraphNode(p), 'Expecting a ParagraphNode in the root');
         expect(p.getChildren().length).toBe(2);
       });
-      editor.dispose();
     });
 
     it('merges three adjacent identical links into one', () => {
-      const editor = buildEditorFromExtensions(extension);
+      using editor = buildEditorFromExtensions(extension);
       editor.update(
         () => {
           const p = $getRoot().getFirstChild();
@@ -218,11 +213,10 @@ describe('Link', () => {
         expect($isLinkNode(children[0])).toBe(true);
         expect(children[0].getTextContent()).toBe('ABC');
       });
-      editor.dispose();
     });
 
     it('preserves selection when cursor is in the second link during merge', () => {
-      const editor = buildEditorFromExtensions(extension);
+      using editor = buildEditorFromExtensions(extension);
       editor.update(
         () => {
           const p = $getRoot().getFirstChild();
@@ -256,11 +250,10 @@ describe('Link', () => {
           );
         }
       });
-      editor.dispose();
     });
 
     it('merges when only the second link is changed to match the first', () => {
-      const editor = buildEditorFromExtensions(extension);
+      using editor = buildEditorFromExtensions(extension);
       editor.update(
         () => {
           const p = $getRoot().getFirstChild();
@@ -297,11 +290,10 @@ describe('Link', () => {
         expect($isLinkNode(children[0])).toBe(true);
         expect(children[0].getTextContent()).toBe('Hello World');
       });
-      editor.dispose();
     });
 
     it('preserves selection when cursor is in a link that merges into its left neighbor', () => {
-      const editor = buildEditorFromExtensions(extension);
+      using editor = buildEditorFromExtensions(extension);
       editor.update(
         () => {
           const p = $getRoot().getFirstChild();
@@ -345,7 +337,6 @@ describe('Link', () => {
           );
         }
       });
-      editor.dispose();
     });
   });
 });

--- a/packages/lexical-list/src/__tests__/unit/ListExtension.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListExtension.test.ts
@@ -34,7 +34,7 @@ describe('ListExtension', () => {
     name: '[root]',
   });
   it('Creates the list', () => {
-    const editor = buildEditorFromExtensions(extension);
+    using editor = buildEditorFromExtensions(extension);
     editor.update(
       () => {
         const ol = $getRoot().getFirstChildOrThrow();
@@ -42,7 +42,6 @@ describe('ListExtension', () => {
       },
       {discrete: true},
     );
-    editor.dispose();
   });
 });
 describe('CheckListExtension', () => {
@@ -81,7 +80,7 @@ describe('CheckListExtension', () => {
       name: '[root-configured]',
     });
 
-    const editor = buildEditorFromExtensions(configuredExtension);
+    using editor = buildEditorFromExtensions(configuredExtension);
 
     editor.update(() => {
       const root = $getRoot();
@@ -119,7 +118,7 @@ describe('CheckListExtension', () => {
   });
 
   it('Creates the list', () => {
-    const editor = buildEditorFromExtensions(extension);
+    using editor = buildEditorFromExtensions(extension);
     editor.update(
       () => {
         const ul = $getRoot().getFirstChildOrThrow();
@@ -127,6 +126,5 @@ describe('CheckListExtension', () => {
       },
       {discrete: true},
     );
-    editor.dispose();
   });
 });

--- a/packages/lexical-list/src/__tests__/unit/ListExtension.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListExtension.test.ts
@@ -113,8 +113,6 @@ describe('CheckListExtension', () => {
       // Item 1 stays in List 1. Item 2 moves to List 2.
       expect(secondList.getStart()).toBe(2);
     });
-
-    editor.dispose();
   });
 
   it('Creates the list', () => {

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
@@ -51,7 +51,7 @@ function typeMarkdown(editor: LexicalEditor, text: string) {
 
 describe('LINK', () => {
   test('text before a markdown link is preserved', () => {
-    const editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
     typeMarkdown(editor, 'Start [test](url)');
     editor.read(() => {
       const paragraph = $getRoot().getFirstChildOrThrow();
@@ -66,7 +66,7 @@ describe('LINK', () => {
   });
 
   test('formatted text before a markdown link is preserved', () => {
-    const editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
     typeMarkdown(editor, '**Bold** [Link](url)');
 
     editor.read(() => {
@@ -89,7 +89,7 @@ describe('LINK', () => {
 
   test('LINK is not too greedy if there is a preceding match that was not processed', () => {
     // https://github.com/facebook/lexical/issues/8129
-    const editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
     // Set up initial condition, since we are not typing a character at a time
     // it's not handled by markdown shortcuts in this update
     editor.update(
@@ -121,7 +121,7 @@ describe('LINK', () => {
   });
 
   test('markdown link should not be created inside another link.', async () => {
-    const editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
     editor.update(
       () => {
         $getRoot()

--- a/packages/lexical-playground/__tests__/unit/ImageHTML.test.ts
+++ b/packages/lexical-playground/__tests__/unit/ImageHTML.test.ts
@@ -26,7 +26,7 @@ const ImageTestExtension = defineExtension({
 describe('ImageNode HTML serialization', () => {
   describe('ImageNode export', () => {
     it('with no caption', async () => {
-      const editor = buildEditorFromExtensions(ImageTestExtension);
+      using editor = buildEditorFromExtensions(ImageTestExtension);
       editor.update(
         () => {
           const imageNode = $createImageNode({
@@ -52,7 +52,7 @@ describe('ImageNode HTML serialization', () => {
       );
     });
     it('with plain text caption', async () => {
-      const editor = buildEditorFromExtensions(ImageTestExtension);
+      using editor = buildEditorFromExtensions(ImageTestExtension);
       editor.update(
         () => {
           const imageNode = $createImageNode({

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -38,7 +38,15 @@ import {
   NodeKey,
   SELECT_ALL_COMMAND,
 } from 'lexical';
-import {assert, beforeEach, describe, expect, it, test} from 'vitest';
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  test,
+} from 'vitest';
 
 describe('TableExtension', () => {
   let editor: LexicalEditorWithDispose;

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -34,14 +34,14 @@ import {
   $isParagraphNode,
   $isRangeSelection,
   defineExtension,
-  LexicalEditor,
+  LexicalEditorWithDispose,
   NodeKey,
   SELECT_ALL_COMMAND,
 } from 'lexical';
 import {assert, beforeEach, describe, expect, it, test} from 'vitest';
 
 describe('TableExtension', () => {
-  let editor: LexicalEditor;
+  let editor: LexicalEditorWithDispose;
 
   beforeEach(() => {
     editor = buildEditorFromExtensions(
@@ -51,6 +51,9 @@ describe('TableExtension', () => {
         theme: {tableScrollableWrapper: 'table-scrollable-wrapper'},
       }),
     );
+  });
+  afterEach(() => {
+    editor.dispose();
   });
 
   it('Creates a table with INSERT_TABLE_COMMAND', () => {

--- a/packages/lexical-tailwind/src/__tests__/unit/LexicalTailwind.test.ts
+++ b/packages/lexical-tailwind/src/__tests__/unit/LexicalTailwind.test.ts
@@ -16,7 +16,7 @@ import {describe, it} from 'vitest';
 describe('TailwindExtension', () => {
   it('applies the expected classes', () => {
     const container = document.createElement('div');
-    const editor = buildEditorFromExtensions({
+    using _editor = buildEditorFromExtensions({
       $initialEditorState() {
         $getRoot().append(
           $createParagraphNode().append(
@@ -39,6 +39,5 @@ describe('TailwindExtension', () => {
         </p>
       `,
     );
-    editor.dispose();
   });
 });

--- a/packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts
@@ -11,7 +11,7 @@ import {describe, expect, test, vi} from 'vitest';
 describe('LexicalEditor listeners', () => {
   describe('registerRootListener', () => {
     test('can return a function that is called when unregistered', () => {
-      const editor = buildEditorFromExtensions({name: '@test'});
+      using editor = buildEditorFromExtensions({name: '@test'});
       const rootListenerCallback = vi.fn();
       const rootListener = vi
         .fn()
@@ -29,7 +29,7 @@ describe('LexicalEditor listeners', () => {
       expect(editor._listeners.root.has(rootListener)).toBe(false);
     });
     test('updates the function on each call', () => {
-      const editor = buildEditorFromExtensions({name: '@test'});
+      using editor = buildEditorFromExtensions({name: '@test'});
       const rootListenerCallback = vi.fn();
       const rootListener = vi
         .fn()
@@ -45,7 +45,7 @@ describe('LexicalEditor listeners', () => {
       expect(rootListenerCallback).toHaveBeenCalledTimes(1);
     });
     test('works when the root element changes too', () => {
-      const editor = buildEditorFromExtensions({name: '@test'});
+      using editor = buildEditorFromExtensions({name: '@test'});
       const rootListenerCallback = vi.fn();
       const rootListener = vi
         .fn()
@@ -79,7 +79,7 @@ describe('LexicalEditor listeners', () => {
 
   describe('registerEditableListener', () => {
     test('can return a function that is called when unregistered', () => {
-      const editor = buildEditorFromExtensions({name: '@test'});
+      using editor = buildEditorFromExtensions({name: '@test'});
       const editableListenerCallback = vi.fn();
       const editableListener = vi
         .fn()
@@ -100,7 +100,7 @@ describe('LexicalEditor listeners', () => {
       expect(editor._listeners.editable.has(editableListener)).toBe(false);
     });
     test('updates the function on each call', () => {
-      const editor = buildEditorFromExtensions({name: '@test'});
+      using editor = buildEditorFromExtensions({name: '@test'});
       const editableListenerCallback = vi.fn();
       const editableListener = vi
         .fn()
@@ -123,7 +123,7 @@ describe('LexicalEditor listeners', () => {
       expect(editableListenerCallback).toHaveBeenCalledTimes(1);
     });
     test('works when editable state changes', () => {
-      const editor = buildEditorFromExtensions({name: '@test'});
+      using editor = buildEditorFromExtensions({name: '@test'});
       const editableListenerCallback = vi.fn();
       const editableListener = vi
         .fn()


### PR DESCRIPTION
## Description

Refactors unit tests using `buildEditorFromExtensions` to use an explicit `using` (if the editor is block scoped) or `dispose` call (if the editor is not block scoped). `using` will call dispose (Symbol.dispose) on the editor when it goes out of scope.

## Test plan

Unit tests still pass