### PR TITLE
[lexical-code-prism][lexical-code-shiki] Bug Fix: Remove usage of skipTransforms in CodeHighlighterPrism and CodeHighlighterShiki

### DIFF
--- a/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
@@ -171,7 +171,6 @@ function $codeNodeTransform(
   }
 
   nodesCurrentlyHighlighting.add(nodeKey);
-
   if (!transformState.didTransform) {
     transformState.didTransform = true;
     $onUpdate(() => {
@@ -179,6 +178,7 @@ function $codeNodeTransform(
       nodesCurrentlyHighlighting.clear();
     });
   }
+
   $updateAndRetainSelection(nodeKey, () => {
     const currentNode = $getNodeByKey(nodeKey);
 
@@ -799,6 +799,10 @@ export function registerCodeHighlighting(
     ),
     editor.registerNodeTransform(
       TextNode,
+      $textNodeTransform.bind(null, editor, tokenizer, transformState),
+    ),
+    editor.registerNodeTransform(
+      CodeHighlightNode,
       $textNodeTransform.bind(null, editor, tokenizer, transformState),
     ),
     editor.registerCommand(

--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -817,6 +817,10 @@ export function registerCodeHighlighting(
       TextNode,
       $textNodeTransform.bind(null, editor, tokenizer, transformState),
     ),
+    editor.registerNodeTransform(
+      CodeHighlightNode,
+      $textNodeTransform.bind(null, editor, tokenizer, transformState),
+    ),
     editor.registerCommand(
       KEY_TAB_COMMAND,
       (event) => {


### PR DESCRIPTION
## Description

Using a nested update with skipTransforms is dangerous because it will affect subsequent updates, this refactor removes that and moves highlighter state to a local closure rather than module global.

Closes #7324

## Test plan

Shouldn't really be observable by any of the existing tests