### PR TITLE
[lexical-headless] Bug Fix: Use window.happyDOM.close() to ensure proper cleanup

### DIFF
--- a/packages/lexical-headless/src/dom.ts
+++ b/packages/lexical-headless/src/dom.ts
@@ -8,9 +8,13 @@
 
 import {Window as HappyDOMWindow} from 'happy-dom';
 
-function createWindow(): typeof globalThis.window {
+function createWindow(): typeof globalThis.window & HappyDOMWindow {
   // @ts-expect-error -- DOMWindow is not exactly Window
   return new HappyDOMWindow();
+}
+
+function destroyWindow(window: HappyDOMWindow): void {
+  void window.happyDOM.close();
 }
 
 /**
@@ -49,6 +53,6 @@ export function withDOM<T>(f: (window: typeof globalThis.window) => T): T {
     globalThis.MutationObserver = prevMutationObserver;
     globalThis.document = prevDocument;
     globalThis.window = prevWindow;
-    newWindow.close();
+    destroyWindow(newWindow);
   }
 }


### PR DESCRIPTION
## Description

HappyDOM's Window API uses a strange convention for proper cleanup that the original withDOM implementation missed. Had Claude do the research to track this one down.

Closes #8272 

### Claude's research

That's the leak. Line 16:

```typescript
private static [PropertySymbol.browserFrames]: Map<number, IBrowserFrame> = new Map();
```

This is a **static `Map`** on the `WindowBrowserContext` class — a GC root. Every window created gets added to it at line 105:

```typescript
browserFrames.set(window[PropertySymbol.internalId], browserFrame);
```

The only place it gets removed is line 115, inside `removeWindowBrowserFrameRelation`, which is only called from `BrowserWindow[PropertySymbol.destroy]()`. And `destroy()` is only called from `BrowserFrameFactory.destroyFrame()`, which is only reached via `happyDOM.close()`.

So the reference chain that prevents GC is:

```
WindowBrowserContext (static class, GC root)
  └─ browserFrames Map
       └─ IBrowserFrame (the frame)
            └─ .window → BrowserWindow (the window)
            └─ .page → DetachedBrowserPage
                 └─ .context → DetachedBrowserContext
                      └─ .browser → DetachedBrowser
```

Every Window ever created stays in this static Map forever unless `happyDOM.close()` is called. `window.close()` is a no-op for directly-constructed windows (it only works for `window.open()` popups), so it never triggers the cleanup.

## Test plan

I think it'd be fragile to write tests for this happy-dom implementation detail 🤷 I've also submitted a PR to fix the upstream root cause https://github.com/capricorn86/happy-dom/pull/2121 - if that lands upstream this fix would be unobservable since GC would work as-is even with calling the no-op close