### PR TITLE
[lexical-react] Feature: Add @lexical/react/useExtensionSignalValue module for reading signals

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -88,6 +88,7 @@ module.name_mapper='^@lexical/react/ReactPluginHostExtension$' -> '<PROJECT_ROOT
 module.name_mapper='^@lexical/react/ReactProviderExtension$' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalReactProviderExtension.js.flow'
 module.name_mapper='^@lexical/react/TreeViewExtension$' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalTreeViewExtension.js.flow'
 module.name_mapper='^@lexical/react/useExtensionComponent$' -> '<PROJECT_ROOT>/packages/lexical-react/flow/useLexicalExtensionComponent.js.flow'
+module.name_mapper='^@lexical/react/useExtensionSignalValue$' -> '<PROJECT_ROOT>/packages/lexical-react/flow/useLexicalExtensionSignalValue.js.flow'
 module.name_mapper='^@lexical/react/useLexicalEditable$' -> '<PROJECT_ROOT>/packages/lexical-react/flow/useLexicalEditable.js.flow'
 module.name_mapper='^@lexical/react/useLexicalIsTextContentEmpty$' -> '<PROJECT_ROOT>/packages/lexical-react/flow/useLexicalIsTextContentEmpty.js.flow'
 module.name_mapper='^@lexical/react/useLexicalNodeSelection$' -> '<PROJECT_ROOT>/packages/lexical-react/flow/useLexicalNodeSelection.js.flow'

--- a/examples/agent-example/package.json
+++ b/examples/agent-example/package.json
@@ -30,9 +30,9 @@
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",
     "cross-env": "^7.0.3",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.2.1",
     "typescript": "^5.9.2",
-    "jsdom": "^26.1.0",
     "vite": "^7.3.1",
     "vitest": "^3.2.4"
   },

--- a/examples/website-chat/package.json
+++ b/examples/website-chat/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@lexical/extension": "0.42.0",
     "@lexical/history": "0.42.0",
-    "@lexical/rich-text": "0.42.0",
     "@lexical/react": "0.42.0",
+    "@lexical/rich-text": "0.42.0",
     "lexical": "0.42.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/packages/lexical-devtools/tsconfig.json
+++ b/packages/lexical-devtools/tsconfig.json
@@ -167,6 +167,9 @@
       "@lexical/react/useExtensionComponent": [
         "../lexical-react/src/useExtensionComponent.tsx"
       ],
+      "@lexical/react/useExtensionSignalValue": [
+        "../lexical-react/src/useExtensionSignalValue.ts"
+      ],
       "@lexical/react/useLexicalEditable": [
         "../lexical-react/src/useLexicalEditable.ts"
       ],

--- a/packages/lexical-react/flow/useLexicalExtensionSignalValue.js.flow
+++ b/packages/lexical-react/flow/useLexicalExtensionSignalValue.js.flow
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {ReadonlySignal} from '@lexical/extension';
+import type {AnyLexicalExtension} from 'lexical';
+
+declare export function useSignalValue<V>(s: ReadonlySignal<V>): V;
+
+declare export function useExtensionSignalValue<V>(
+  extension: AnyLexicalExtension,
+  prop: string,
+): V;

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -1390,6 +1390,36 @@
         "default": "./useLexicalExtensionComponent.js"
       }
     },
+    "./useExtensionSignalValue": {
+      "import": {
+        "types": "./useExtensionSignalValue.d.ts",
+        "development": "./useLexicalExtensionSignalValue.dev.mjs",
+        "production": "./useLexicalExtensionSignalValue.prod.mjs",
+        "node": "./useLexicalExtensionSignalValue.node.mjs",
+        "default": "./useLexicalExtensionSignalValue.mjs"
+      },
+      "require": {
+        "types": "./useExtensionSignalValue.d.ts",
+        "development": "./useLexicalExtensionSignalValue.dev.js",
+        "production": "./useLexicalExtensionSignalValue.prod.js",
+        "default": "./useLexicalExtensionSignalValue.js"
+      }
+    },
+    "./useExtensionSignalValue.js": {
+      "import": {
+        "types": "./useExtensionSignalValue.d.ts",
+        "development": "./useLexicalExtensionSignalValue.dev.mjs",
+        "production": "./useLexicalExtensionSignalValue.prod.mjs",
+        "node": "./useLexicalExtensionSignalValue.node.mjs",
+        "default": "./useLexicalExtensionSignalValue.mjs"
+      },
+      "require": {
+        "types": "./useExtensionSignalValue.d.ts",
+        "development": "./useLexicalExtensionSignalValue.dev.js",
+        "production": "./useLexicalExtensionSignalValue.prod.js",
+        "default": "./useLexicalExtensionSignalValue.js"
+      }
+    },
     "./useLexicalEditable": {
       "import": {
         "types": "./useLexicalEditable.d.ts",

--- a/packages/lexical-react/src/__tests__/unit/useExtensionSignalValue.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useExtensionSignalValue.test.tsx
@@ -118,7 +118,7 @@ describe('useSignalValue', () => {
 
     // Override subscribe to count calls
     const originalSubscribe = testSignal.subscribe.bind(testSignal);
-    testSignal.subscribe = (callback: () => void) => {
+    testSignal.subscribe = (callback: (value: number) => void) => {
       subscriptionCount++;
       return originalSubscribe(callback);
     };

--- a/packages/lexical-react/src/__tests__/unit/useExtensionSignalValue.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useExtensionSignalValue.test.tsx
@@ -1,0 +1,414 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  buildEditorFromExtensions,
+  defineExtension,
+  getExtensionDependencyFromEditor,
+  signal,
+} from '@lexical/extension';
+import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
+import {LexicalExtensionEditorComposer} from '@lexical/react/LexicalExtensionEditorComposer';
+import {ReactPluginHostExtension} from '@lexical/react/ReactPluginHostExtension';
+import {
+  useExtensionSignalValue,
+  useSignalValue,
+} from '@lexical/react/useExtensionSignalValue';
+import * as React from 'react';
+import {createRoot, Root} from 'react-dom/client';
+import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+
+describe('useSignalValue', () => {
+  let container: HTMLDivElement | null = null;
+  let reactRoot: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    reactRoot = createRoot(container);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container!);
+    container = null;
+  });
+
+  test('subscribes to signal and returns current value', async () => {
+    const testSignal = signal(42);
+    let renderedValue: number | null = null;
+
+    function TestComponent() {
+      const value = useSignalValue(testSignal);
+      renderedValue = value;
+      return <div>{value}</div>;
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<TestComponent />);
+    });
+
+    expect(renderedValue).toBe(42);
+    expect(container?.textContent).toBe('42');
+  });
+
+  test('re-renders when signal value changes', async () => {
+    const testSignal = signal(0);
+    const renderCounts: number[] = [];
+
+    function TestComponent() {
+      const value = useSignalValue(testSignal);
+      renderCounts.push(value);
+      return <div>{value}</div>;
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<TestComponent />);
+    });
+
+    expect(renderCounts).toEqual([0]);
+    expect(container?.textContent).toBe('0');
+
+    await ReactTestUtils.act(async () => {
+      testSignal.value = 1;
+    });
+
+    expect(renderCounts).toEqual([0, 1]);
+    expect(container?.textContent).toBe('1');
+
+    await ReactTestUtils.act(async () => {
+      testSignal.value = 2;
+    });
+
+    expect(renderCounts).toEqual([0, 1, 2]);
+    expect(container?.textContent).toBe('2');
+  });
+
+  test('works with different value types', async () => {
+    const stringSignal = signal('hello');
+    const booleanSignal = signal(true);
+    const objectSignal = signal({count: 5});
+
+    function TestComponent() {
+      const str = useSignalValue(stringSignal);
+      const bool = useSignalValue(booleanSignal);
+      const obj = useSignalValue(objectSignal);
+      return (
+        <div>
+          {str}-{bool.toString()}-{obj.count}
+        </div>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<TestComponent />);
+    });
+
+    expect(container?.textContent).toBe('hello-true-5');
+  });
+
+  test('maintains stable subscription across re-renders', async () => {
+    const testSignal = signal(1);
+    let subscriptionCount = 0;
+
+    // Override subscribe to count calls
+    const originalSubscribe = testSignal.subscribe.bind(testSignal);
+    testSignal.subscribe = (callback: () => void) => {
+      subscriptionCount++;
+      return originalSubscribe(callback);
+    };
+
+    function TestComponent({dummy}: {dummy: number}) {
+      const value = useSignalValue(testSignal);
+      return (
+        <div>
+          {value}-{dummy}
+        </div>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<TestComponent dummy={1} />);
+    });
+
+    const initialSubscriptionCount = subscriptionCount;
+    expect(initialSubscriptionCount).toBeGreaterThan(0);
+
+    // Re-render with different prop (but same signal)
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<TestComponent dummy={2} />);
+    });
+
+    // Should not create new subscription
+    expect(subscriptionCount).toBe(initialSubscriptionCount);
+  });
+});
+
+describe('useExtensionSignalValue', () => {
+  let container: HTMLDivElement | null = null;
+  let reactRoot: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    reactRoot = createRoot(container);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container!);
+    container = null;
+  });
+
+  test('subscribes to extension signal property', async () => {
+    const TestExtension = defineExtension({
+      build: () => ({count: signal(10)}),
+      name: 'test',
+    });
+
+    function TestComponent() {
+      const count = useExtensionSignalValue(TestExtension, 'count');
+      return <div>Count: {count}</div>;
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(
+        <LexicalExtensionComposer extension={TestExtension}>
+          <TestComponent />
+        </LexicalExtensionComposer>,
+      );
+    });
+
+    expect(container?.textContent).toBe('Count: 10');
+  });
+
+  test('re-renders when extension signal changes', async () => {
+    const TestExtension = defineExtension({
+      build: () => ({value: signal('initial')}),
+      name: 'test',
+    });
+
+    const editor = buildEditorFromExtensions({
+      dependencies: [ReactPluginHostExtension, TestExtension],
+      name: '[root]',
+    });
+
+    const dep = getExtensionDependencyFromEditor(editor, TestExtension);
+
+    function TestComponent() {
+      const value = useExtensionSignalValue(TestExtension, 'value');
+      return <div>{value}</div>;
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(
+        <LexicalExtensionEditorComposer initialEditor={editor}>
+          <TestComponent />
+        </LexicalExtensionEditorComposer>,
+      );
+    });
+
+    expect(container?.textContent).toBe('initial');
+
+    await ReactTestUtils.act(async () => {
+      dep.output.value.value = 'updated';
+    });
+
+    expect(container?.textContent).toBe('updated');
+  });
+
+  test('works with multiple signal properties', async () => {
+    const TestExtension = defineExtension({
+      build: () => ({
+        count: signal(0),
+        enabled: signal(true),
+        name: signal('test'),
+      }),
+      name: 'test',
+    });
+
+    function TestComponent() {
+      const count = useExtensionSignalValue(TestExtension, 'count');
+      const name = useExtensionSignalValue(TestExtension, 'name');
+      const enabled = useExtensionSignalValue(TestExtension, 'enabled');
+      return (
+        <div>
+          {name}: {count} ({enabled ? 'enabled' : 'disabled'})
+        </div>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(
+        <LexicalExtensionComposer extension={TestExtension}>
+          <TestComponent />
+        </LexicalExtensionComposer>,
+      );
+    });
+
+    expect(container?.textContent).toBe('test: 0 (enabled)');
+  });
+
+  test('works with mixed signal and non-signal outputs', async () => {
+    const TestExtension = defineExtension({
+      build: () => ({
+        count: signal(5),
+        staticValue: 'static',
+      }),
+      name: 'test',
+    });
+
+    function TestComponent() {
+      const count = useExtensionSignalValue(TestExtension, 'count');
+      return <div>Count: {count}</div>;
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(
+        <LexicalExtensionComposer extension={TestExtension}>
+          <TestComponent />
+        </LexicalExtensionComposer>,
+      );
+    });
+
+    expect(container?.textContent).toBe('Count: 5');
+  });
+
+  test('each component independently subscribes to signals', async () => {
+    const TestExtension = defineExtension({
+      build: () => ({count: signal(1)}),
+      name: 'test',
+    });
+
+    const editor = buildEditorFromExtensions({
+      dependencies: [ReactPluginHostExtension, TestExtension],
+      name: '[root]',
+    });
+
+    const dep = getExtensionDependencyFromEditor(editor, TestExtension);
+
+    function ComponentA() {
+      const count = useExtensionSignalValue(TestExtension, 'count');
+      return <div>A: {count}</div>;
+    }
+
+    function ComponentB() {
+      const count = useExtensionSignalValue(TestExtension, 'count');
+      return <div>B: {count}</div>;
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(
+        <LexicalExtensionEditorComposer initialEditor={editor}>
+          <ComponentA />
+          <ComponentB />
+        </LexicalExtensionEditorComposer>,
+      );
+    });
+
+    expect(container?.textContent).toBe('A: 1B: 1');
+
+    await ReactTestUtils.act(async () => {
+      dep.output.count.value = 5;
+    });
+
+    expect(container?.textContent).toBe('A: 5B: 5');
+  });
+
+  test('works with complex object signals', async () => {
+    interface User {
+      email: string;
+      id: number;
+      name: string;
+    }
+
+    const TestExtension = defineExtension({
+      build: () => ({
+        user: signal<User>({
+          email: 'john@example.com',
+          id: 1,
+          name: 'John Doe',
+        }),
+      }),
+      name: 'test',
+    });
+
+    const editor = buildEditorFromExtensions({
+      dependencies: [ReactPluginHostExtension, TestExtension],
+      name: '[root]',
+    });
+
+    const dep = getExtensionDependencyFromEditor(editor, TestExtension);
+
+    function TestComponent() {
+      const user = useExtensionSignalValue(TestExtension, 'user');
+      return (
+        <div>
+          {user.name} ({user.email})
+        </div>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(
+        <LexicalExtensionEditorComposer initialEditor={editor}>
+          <TestComponent />
+        </LexicalExtensionEditorComposer>,
+      );
+    });
+
+    expect(container?.textContent).toBe('John Doe (john@example.com)');
+
+    await ReactTestUtils.act(async () => {
+      dep.output.user.value = {
+        email: 'jane@example.com',
+        id: 2,
+        name: 'Jane Smith',
+      };
+    });
+
+    expect(container?.textContent).toBe('Jane Smith (jane@example.com)');
+  });
+
+  test('updates correctly with rapid signal changes', async () => {
+    const TestExtension = defineExtension({
+      build: () => ({count: signal(0)}),
+      name: 'test',
+    });
+
+    const editor = buildEditorFromExtensions({
+      dependencies: [ReactPluginHostExtension, TestExtension],
+      name: '[root]',
+    });
+
+    const dep = getExtensionDependencyFromEditor(editor, TestExtension);
+
+    function TestComponent() {
+      const count = useExtensionSignalValue(TestExtension, 'count');
+      return <div>{count}</div>;
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(
+        <LexicalExtensionEditorComposer initialEditor={editor}>
+          <TestComponent />
+        </LexicalExtensionEditorComposer>,
+      );
+    });
+
+    expect(container?.textContent).toBe('0');
+
+    // Make rapid updates
+    await ReactTestUtils.act(async () => {
+      for (let i = 1; i <= 10; i++) {
+        dep.output.count.value = i;
+      }
+    });
+
+    expect(container?.textContent).toBe('10');
+  });
+});

--- a/packages/lexical-react/src/useExtensionSignalValue.ts
+++ b/packages/lexical-react/src/useExtensionSignalValue.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {ReadonlySignal} from '@lexical/extension';
+import type {AnyLexicalExtension, LexicalExtensionOutput} from 'lexical';
+
+import {useExtensionDependency} from '@lexical/react/useExtensionComponent';
+import {useMemo, useSyncExternalStore} from 'react';
+
+/**
+ * A React hook that subscribes to a signal and returns its current value.
+ * The component will re-render whenever the signal's value changes.
+ *
+ * @param s - The ReadonlySignal to subscribe to
+ * @returns The current value of the signal
+ *
+ * @example
+ * ```tsx
+ * const signal = new Signal(0);
+ * function MyComponent() {
+ *   const value = useSignalValue(signal);
+ *   return <div>Value: {value}</div>;
+ * }
+ * ```
+ */
+export function useSignalValue<V>(s: ReadonlySignal<V>): V {
+  const [subscribe, getSnapshot] = useMemo(
+    () => [s.subscribe.bind(s), s.peek.bind(s)] as const,
+    [s],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Type helper that extracts the value type from a ReadonlySignal.
+ * If the type is not a ReadonlySignal, it returns never.
+ *
+ * @example
+ * ```tsx
+ * type MySignal = ReadonlySignal<number>;
+ * type Value = SignalValue<MySignal>; // number
+ * ```
+ */
+export type SignalValue<S> = S extends ReadonlySignal<infer V> ? V : never;
+
+/**
+ * A React hook that subscribes to a signal property from a Lexical extension's output
+ * and returns its current value. The component will re-render whenever the signal's value changes.
+ *
+ * This hook combines the functionality of useExtensionDependency and useSignalValue,
+ * providing a convenient way to access reactive values from Lexical extensions.
+ *
+ * @param extension - The Lexical extension instance
+ * @param prop - The property name in the extension's output that contains a signal
+ * @returns The current value of the signal property
+ *
+ * @example
+ * ```tsx
+ * import {useExtensionSignalValue} from '@lexical/react/useExtensionSignalValue';
+ * import {MyExtension} from './MyExtension';
+ *
+ * function MyComponent() {
+ *   // Assuming MyExtension has a signal property 'count' in its output
+ *   const count = useExtensionSignalValue(MyExtension, 'count');
+ *   return <div>Count: {count}</div>;
+ * }
+ * ```
+ */
+export function useExtensionSignalValue<
+  Extension extends AnyLexicalExtension,
+  K extends keyof LexicalExtensionOutput<Extension>,
+>(
+  extension: Extension,
+  prop: K,
+): SignalValue<LexicalExtensionOutput<Extension>[K]> {
+  const signal = useExtensionDependency(extension).output[
+    prop
+  ] as ReadonlySignal<SignalValue<LexicalExtensionOutput<Extension>[K]>>;
+  return useSignalValue(signal);
+}

--- a/packages/lexical-website/package.json
+++ b/packages/lexical-website/package.json
@@ -24,9 +24,9 @@
     "@huggingface/transformers": "^4.0.1",
     "@lexical/extension": "workspace:*",
     "@lexical/hashtag": "workspace:*",
-    "@lexical/overflow": "workspace:*",
     "@lexical/history": "workspace:*",
     "@lexical/list": "workspace:*",
+    "@lexical/overflow": "workspace:*",
     "@lexical/plain-text": "workspace:*",
     "@lexical/react": "workspace:*",
     "@lexical/rich-text": "workspace:*",
@@ -51,9 +51,9 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.1",
     "buffer": "^6.0.3",
     "cross-env": "^7.0.3",
-    "@tailwindcss/postcss": "^4.2.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.2.1",
     "typedoc": "^0.28.13",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -168,6 +168,9 @@
       "@lexical/react/useExtensionComponent": [
         "./packages/lexical-react/src/useExtensionComponent.tsx"
       ],
+      "@lexical/react/useExtensionSignalValue": [
+        "./packages/lexical-react/src/useExtensionSignalValue.ts"
+      ],
       "@lexical/react/useLexicalEditable": [
         "./packages/lexical-react/src/useLexicalEditable.ts"
       ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -192,6 +192,9 @@
       "@lexical/react/useExtensionComponent": [
         "./packages/lexical-react/src/useExtensionComponent.tsx"
       ],
+      "@lexical/react/useExtensionSignalValue": [
+        "./packages/lexical-react/src/useExtensionSignalValue.ts"
+      ],
       "@lexical/react/useLexicalEditable": [
         "./packages/lexical-react/src/useLexicalEditable.ts"
       ],


### PR DESCRIPTION
## Description

New `@lexical/react/useExtensionSignalValue` module containing the `useExtensionSignalValue` and `useSignalValue` hooks that were prototyped in the agent-example #8281

## Test plan

New unit test coverage