### PR TITLE
[lexical-offset] Bug Fix: Use child index instead of offset value for inline node selection

### DIFF
--- a/packages/lexical-offset/src/__tests__/unit/LexicalOffset.test.ts
+++ b/packages/lexical-offset/src/__tests__/unit/LexicalOffset.test.ts
@@ -98,10 +98,12 @@ describe('LexicalOffset', () => {
         expect(selection.anchor.type).toBe('element');
         const anchorNode = selection.anchor.getNode();
         expect($isElementNode(anchorNode)).toBe(true);
-        // Offset should be a valid child index, not the raw offset value
-        expect(selection.anchor.offset).toBeLessThanOrEqual(
-          anchorNode.getChildrenSize(),
-        );
+        if ($isElementNode(anchorNode)) {
+          // Offset should be a valid child index, not the raw offset value
+          expect(selection.anchor.offset).toBeLessThanOrEqual(
+            anchorNode.getChildrenSize(),
+          );
+        }
       }
     });
   });

--- a/packages/lexical-offset/src/__tests__/unit/LexicalOffset.test.ts
+++ b/packages/lexical-offset/src/__tests__/unit/LexicalOffset.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {EditorConfig, SerializedLexicalNode} from 'lexical';
+
+import {$createOffsetView} from '@lexical/offset';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  $isRangeSelection,
+  createEditor,
+  DecoratorNode,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+class InlineImageNode extends DecoratorNode<null> {
+  static getType(): string {
+    return 'inline-image';
+  }
+
+  static clone(node: InlineImageNode): InlineImageNode {
+    return new InlineImageNode(node.__key);
+  }
+
+  static importJSON(): InlineImageNode {
+    return new InlineImageNode();
+  }
+
+  exportJSON(): SerializedLexicalNode {
+    return {...super.exportJSON()};
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    return document.createElement('span');
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  isInline(): true {
+    return true;
+  }
+
+  getTextContent(): string {
+    return ' ';
+  }
+
+  decorate(): null {
+    return null;
+  }
+}
+
+function $createInlineImageNode(): InlineImageNode {
+  return new InlineImageNode();
+}
+
+describe('LexicalOffset', () => {
+  test('createSelectionFromOffsets handles inline decorator node without throwing (Regression #7580)', () => {
+    const editor = createEditor({
+      nodes: [InlineImageNode],
+      onError: (e) => {
+        throw e;
+      },
+    });
+    const root = document.createElement('div');
+    editor.setRootElement(root);
+
+    editor.update(
+      () => {
+        const rootNode = $getRoot();
+        const paragraph = $createParagraphNode();
+        const text1 = $createTextNode('ab');
+        const image = $createInlineImageNode();
+        const text2 = $createTextNode('cd');
+        paragraph.append(text1, image, text2);
+        rootNode.clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const offsetView = $createOffsetView(editor);
+      // text1("ab"): offsets 0-2, image: offsets 2-3, text2("cd"): offsets 3-5
+      // Offset 3 lands on inline image in the search (text1 search-end=3, image search-end=4)
+      // Before the fix, this would throw "There is no child at offset N"
+      const selection = offsetView.createSelectionFromOffsets(3, 3);
+      expect(selection).not.toBe(null);
+      if ($isRangeSelection(selection)) {
+        // Selection should be element-type pointing to the parent paragraph
+        expect(selection.anchor.type).toBe('element');
+        const anchorNode = selection.anchor.getNode();
+        expect($isElementNode(anchorNode)).toBe(true);
+        // Offset should be a valid child index, not the raw offset value
+        expect(selection.anchor.offset).toBeLessThanOrEqual(
+          anchorNode.getChildrenSize(),
+        );
+      }
+    });
+  });
+
+  test('createSelectionFromOffsets returns correct child index for inline node', () => {
+    const editor = createEditor({
+      nodes: [InlineImageNode],
+      onError: (e) => {
+        throw e;
+      },
+    });
+    const root = document.createElement('div');
+    editor.setRootElement(root);
+
+    let imageIndex: number;
+    editor.update(
+      () => {
+        const rootNode = $getRoot();
+        const paragraph = $createParagraphNode();
+        const text1 = $createTextNode('ab');
+        const image = $createInlineImageNode();
+        const text2 = $createTextNode('cd');
+        paragraph.append(text1, image, text2);
+        rootNode.clear().append(paragraph);
+        imageIndex = image.getIndexWithinParent();
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const offsetView = $createOffsetView(editor);
+      // Offset 3 hits image (end > start), should place cursor after image
+      const selection = offsetView.createSelectionFromOffsets(3, 3);
+      expect(selection).not.toBe(null);
+      if ($isRangeSelection(selection)) {
+        expect(selection.anchor.type).toBe('element');
+        expect(selection.anchor.offset).toBe(imageIndex + 1);
+      }
+    });
+  });
+});

--- a/packages/lexical-offset/src/index.ts
+++ b/packages/lexical-offset/src/index.ts
@@ -161,8 +161,8 @@ export class OffsetView {
       startKey = startNode.getParentOrThrow().getKey();
       startOffset =
         end > startOffsetNode.start
-          ? startOffsetNode.end
-          : startOffsetNode.start;
+          ? startNode.getIndexWithinParent() + 1
+          : startNode.getIndexWithinParent();
     }
 
     if (endOffsetNode.type === 'text') {
@@ -171,7 +171,9 @@ export class OffsetView {
     } else if (endOffsetNode.type === 'inline') {
       endKey = endNode.getParentOrThrow().getKey();
       endOffset =
-        end > endOffsetNode.start ? endOffsetNode.end : endOffsetNode.start;
+        end > endOffsetNode.start
+          ? endNode.getIndexWithinParent() + 1
+          : endNode.getIndexWithinParent();
     }
 
     const selection = $createRangeSelection();


### PR DESCRIPTION
## Description

When `createSelectionFromOffsets` resolves an offset to an inline node (e.g. a DecoratorNode), it used the raw cumulative offset value as the element selection offset. This caused `IndexSizeError: There is no child at offset N` because the parent element might only have 2-3 children while the offset value could be much larger.

Fixed by using the inline node's actual index within its parent (`getIndexWithinParent()`) instead of the raw offset value.

Closes #7580

## Test plan

### Before

Setting an offset that lands on an inline decorator node throws:
```
IndexSizeError: Failed to execute 'setBaseAndExtent' on 'Selection': There is no child at offset 6.
```

### After

Selection is created correctly using the node's child index within its parent.

Added the first unit tests for the `@lexical/offset` package, covering inline node selection at both start and end boundaries.

All existing tests pass (2741 passed, 0 failed).