### PR TITLE
[lexical-table] Bug Fix: Read background-color from shorthand style a…

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -379,8 +379,12 @@ export function $convertTableCellNodeElement(
   );
 
   tableCellNode.__rowSpan = domNode_.rowSpan;
-  const backgroundColor = domNode_.style.backgroundColor;
-  if (backgroundColor !== '') {
+  const backgroundColor =
+    domNode_.style.backgroundColor ||
+    domNode_.style.background ||
+    domNode_.getAttribute('bgcolor') ||
+    null;
+  if (backgroundColor !== null) {
     tableCellNode.__backgroundColor = backgroundColor;
   }
   const verticalAlign = domNode_.style.verticalAlign;

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -368,5 +368,65 @@ describe('LexicalTableCellNode tests', () => {
         expect(node.getHeaderStyles()).toBe(TableCellHeaderStates.ROW);
       });
     });
+
+    test('DOM Conversion: <td> with style.backgroundColor reads inline background-color', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const td = document.createElement('td');
+        td.style.backgroundColor = '#F4B084';
+
+        const result = convertHTMLTag(td);
+        const node = expectTableCellNode(result);
+
+        // Browsers normalize hex to rgb when set via .style
+        expect(node.getBackgroundColor()).toBe(td.style.backgroundColor);
+      });
+    });
+
+    test('DOM Conversion: <td> with style.background shorthand (Excel/Outlook) reads background color', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const td = document.createElement('td');
+        td.style.background = '#F4B084';
+
+        const result = convertHTMLTag(td);
+        const node = expectTableCellNode(result);
+
+        // Browsers normalize hex to rgb; background may expand to backgroundColor
+        const expected =
+          td.style.backgroundColor || td.style.background || null;
+        expect(node.getBackgroundColor()).toBe(expected);
+        expect(node.getBackgroundColor()).not.toBeNull();
+      });
+    });
+
+    test('DOM Conversion: <td> with bgcolor attribute (legacy HTML) reads background color', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const td = document.createElement('td');
+        td.setAttribute('bgcolor', '#F4B084');
+
+        const result = convertHTMLTag(td);
+        const node = expectTableCellNode(result);
+
+        expect(node.getBackgroundColor()).toBe('#F4B084');
+      });
+    });
+
+    test('DOM Conversion: <td> with no background color sets backgroundColor to null', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const td = document.createElement('td');
+
+        const result = convertHTMLTag(td);
+        const node = expectTableCellNode(result);
+
+        expect(node.getBackgroundColor()).toBeNull();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

  `$convertTableCellNodeElement` only read `style.backgroundColor` when importing table cells from HTML, which misses the two most common ways Excel and some email encode cell background colors:

  - `style="background:#F4B084"` — the CSS `background` shorthand. Browsers do compute this into `style.backgroundColor` on a live DOM, but on detached/fragment DOMs (as used by Lexical's paste engine) some parsers leave `style.backgroundColor` empty.
  - `bgcolor="#F4B084"` — the legacy HTML attribute used by older Excel/Outlook versions.

  The fix reads all three sources in priority order: `style.backgroundColor || style.background ||
  getAttribute('bgcolor')`.

  ### Before

  Pasting a table from Excel or some email clients with background color cells would lose all cell background colors. We use the editor in a ticketing system so there is a lot of copy/paste from Excel

  ### After

  - `style.backgroundColor` (explicit `background-color:`) — preserved ✓
  - `style.background` shorthand — preserved ✓
  - `bgcolor` HTML attribute — preserved ✓
  - Unit tests added covering all four cases (including no background color → `null`)