### PR TITLE
[*] Bug Fix: Fix post-release workflow by enabling branch creation

### DIFF
--- a/.github/workflows/call-post-release.yml
+++ b/.github/workflows/call-post-release.yml
@@ -41,4 +41,5 @@ jobs:
           commit_message: 'Update examples for ${{ steps.latest.outputs.release }}'
           commit_user_name: 'Lexical GitHub Actions Bot'
           branch: post-release-${{ steps.latest.outputs.release }}
+          create_branch: true
           push_options: '--force'


### PR DESCRIPTION
## Description

The post-release workflow creates a branch to update all of the examples after a release, it was failing because it couldn't create the branch.

## Test plan

## Before

```
fatal: invalid reference: post-release-v0.43.0
Error: Invalid status code: 128
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v7/index.js:17:19)
    at ChildProcess.emit (node:events:508:28)
    at maybeClose (node:internal/child_process:1100:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5) {
  code: 128
}
Error: Invalid status code: 128
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v7/index.js:17:19)
    at ChildProcess.emit (node:events:508:28)
    at maybeClose (node:internal/child_process:1100:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
 ```

## After

Should be able to run it and verify that it succeeds and creates the branch:
https://github.com/facebook/lexical/actions/runs/24207609533/job/70667537819
