### PR TITLE
[lexical-extension] Fix: Remove JSX dependency from DecoratorTextNode

### DIFF
--- a/packages/lexical-extension/flow/LexicalExtension.js.flow
+++ b/packages/lexical-extension/flow/LexicalExtension.js.flow
@@ -191,7 +191,7 @@ export type SerializedDecoratorTextNode = {
   format: number,
   ...
 };
-declare export class DecoratorTextNode<T> extends DecoratorNode<T> {
+declare export class DecoratorTextNode extends DecoratorNode<mixed> {
   createDOM(): HTMLElement;
   getFormat(): number;
   getFormatFlags(type: TextFormatType, alignWithFormat: null | number): number;
@@ -203,7 +203,7 @@ declare export class DecoratorTextNode<T> extends DecoratorNode<T> {
 
 declare export function $isDecoratorTextNode(
   node: ?LexicalNode,
-): node is DecoratorTextNode<{...}>;
+): node is DecoratorTextNode;
 
 declare export var DecoratorTextExtension: LexicalExtension<ExtensionConfigBase, "@lexical/extension/DecoratorText", void, void>;
 

--- a/packages/lexical-extension/src/DecoratorTextExtension.ts
+++ b/packages/lexical-extension/src/DecoratorTextExtension.ts
@@ -14,7 +14,6 @@ import type {
   StateValueOrUpdater,
   TextFormatType,
 } from 'lexical';
-import type {JSX} from 'react';
 
 import {
   $getSelection,
@@ -42,7 +41,7 @@ const formatState = createState('format', {
   parse: (value) => (typeof value === 'number' ? value : 0),
 });
 
-export class DecoratorTextNode extends DecoratorNode<JSX.Element> {
+export class DecoratorTextNode extends DecoratorNode<unknown> {
   $config() {
     return this.config('decorator-text', {
       extends: DecoratorNode,


### PR DESCRIPTION
## Description
`DecoratorTextNode` previously extended `DecoratorNode<JSX.Element>`, which pulled in a type-only `import type {JSX} from 'react'` in `@lexical/extension`. `@lexical/extension` does not declare a dependency on React, so this coupled a framework-agnostic package to React's JSX types for no runtime reason.

This PR changes `DecoratorTextNode` to extend `DecoratorNode<unknown>` and removes the `JSX` import. Subclasses (e.g. `EntityNode`, `DateTimeNode`) can still return `JSX.Element` from their own `decorate()` overrides because any value is assignable to `null | unknown`. The corresponding `.flow` declaration is updated to match (`DecoratorTextNode extends DecoratorNode<mixed>`, no longer generic).

`DecoratorTextNode` could be generic itself, but there's basically no value to having any `DecoratorNode` use a generic since `$isDecoratorNode` is unsound and effectively just casts to whatever since there's no runtime reflection of this generic that it could use to verify the intended host environment. We should really just deprecate all DecoratorNode generics.

Closes #8325

## Test plan

Existing tests and type check should still work (including react decorator subclasses of DecoratorTextNode). 