### PR TITLE
[lexical-react] Bug Fix: Prevent error when editorRef is null

### DIFF
--- a/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
+++ b/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
@@ -30,7 +30,7 @@ export function EditorRefPlugin({
   React.useEffect(() => {
     if (typeof editorRef === 'function') {
       editorRef(editor);
-    } else if (typeof editorRef === 'object') {
+    } else if (typeof editorRef === 'object' && editorRef !== null) {
       editorRef.current = editor;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
editorRef is allowed to be null and must be checked on this type before value allocation. This PR adds that check.

Closes #8327

## Test plan
Add a LexicalEditor with a LexicalEditorRefPlugin where editorRef is value `null`. 

Old situation: error
New situation: line of error skipped