### PR TITLE
[lexical] Bug Fix: Resolve Firefox arrow key navigation issue in collapsible nodes (#8348)

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -621,7 +621,10 @@ test.describe.parallel('Selection', () => {
     await moveRight(page, 3);
     await deleteForward(page);
 
-    const collapsibleTag = browserName === 'chromium' ? 'div' : 'details';
+    const collapsibleTag =
+      browserName === 'chromium' || browserName === 'firefox'
+        ? 'div'
+        : 'details';
     await assertHTML(
       page,
       html`
@@ -665,7 +668,10 @@ test.describe.parallel('Selection', () => {
     await moveLeft(page, 'after'.length);
     await deleteBackward(page);
 
-    const collapsibleTag = browserName === 'chromium' ? 'div' : 'details';
+    const collapsibleTag =
+      browserName === 'chromium' || browserName === 'firefox'
+        ? 'div'
+        : 'details';
     await assertHTML(
       page,
       html`
@@ -692,6 +698,75 @@ test.describe.parallel('Selection', () => {
         </p>
       `,
     );
+  });
+
+  test('Arrow keys navigate into/out of collapsible content in all browsers (#8348)', async ({
+    page,
+    isPlainText,
+    browserName,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    await page.keyboard.type('before');
+    await insertCollapsible(page);
+    await page.keyboard.type('title');
+    await moveRight(page, 2);
+    await page.keyboard.type('after');
+
+    await moveToEditorBeginning(page);
+    await moveDown(page, 1);
+    await moveDown(page, 1);
+
+    const collapsibleTag =
+      browserName === 'chromium' || browserName === 'firefox'
+        ? 'div'
+        : 'details';
+
+    await assertHTML(
+      page,
+      html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">before</span>
+          </p>
+          <${collapsibleTag} class="Collapsible__container" dir="auto" open="">
+            <summary class="Collapsible__title">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">title</span>
+              </p>
+            </summary>
+            <div class="Collapsible__content">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </div>
+          </${collapsibleTag}>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">after</span>
+          </p>
+        `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [1, 1, 0],
+      focusOffset: 0,
+      focusPath: [1, 1, 0],
+    });
+
+    await moveUp(page, 1);
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [1, 0, 0, 0, 0],
+      focusOffset: 0,
+      focusPath: [1, 0, 0, 0, 0],
+    });
+
+    await moveUp(page, 1);
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 0, 0],
+      focusOffset: 0,
+      focusPath: [0, 0, 0],
+    });
   });
 
   test(`Can't delete forward a Table`, async ({page, isPlainText}) => {

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1664,11 +1664,13 @@ test.describe.parallel('Tables', () => {
     await page.keyboard.press('Enter');
 
     const collapsibleOpeningTag =
-      browserName === 'chromium'
+      browserName === 'chromium' || browserName === 'firefox'
         ? '<div class="Collapsible__container" open="">'
         : '<details class="Collapsible__container" open="">';
     const collapsibleClosingTag =
-      browserName === 'chromium' ? '</div>' : '</details>';
+      browserName === 'chromium' || browserName === 'firefox'
+        ? '</div>'
+        : '</details>';
 
     await assertHTML(
       page,

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {IS_CHROME} from '@lexical/utils';
+import {IS_CHROME, IS_FIREFOX} from '@lexical/utils';
 import {
   $getSiblingCaret,
   $isElementNode,
@@ -85,9 +85,9 @@ export class CollapsibleContainerNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    // details is not well supported in Chrome #5582
+    // details is not well supported in Chrome #5582 and Firefox #8348
     let dom: HTMLElement;
-    if (IS_CHROME) {
+    if (IS_CHROME || IS_FIREFOX) {
       dom = document.createElement('div');
       dom.setAttribute('open', '');
     } else {
@@ -109,8 +109,8 @@ export class CollapsibleContainerNode extends ElementNode {
   updateDOM(prevNode: this, dom: HTMLDetailsElement): boolean {
     const currentOpen = this.__open;
     if (prevNode.__open !== currentOpen) {
-      // details is not well supported in Chrome #5582
-      if (IS_CHROME) {
+      // details is not well supported in Chrome #5582 and Firefox #8348
+      if (IS_CHROME || IS_FIREFOX) {
         const contentDom = dom.children[1];
         if (!isHTMLElement(contentDom)) {
           throw new Error('Expected contentDom to be an HTMLElement');

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContentNode.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {IS_CHROME} from '@lexical/utils';
+import {IS_CHROME, IS_FIREFOX} from '@lexical/utils';
 import {
   DOMConversionMap,
   DOMConversionOutput,
@@ -44,7 +44,7 @@ export class CollapsibleContentNode extends ElementNode {
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('div');
     dom.classList.add('Collapsible__content');
-    if (IS_CHROME) {
+    if (IS_CHROME || IS_FIREFOX) {
       editor.getEditorState().read(() => {
         const containerNode = this.getParentOrThrow();
         if (!$isCollapsibleContainerNode(containerNode)) {

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleTitleNode.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {IS_CHROME} from '@lexical/utils';
+import {IS_CHROME, IS_FIREFOX} from '@lexical/utils';
 import {
   $createParagraphNode,
   $isElementNode,
@@ -54,7 +54,7 @@ export class CollapsibleTitleNode extends ElementNode {
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('summary');
     dom.classList.add('Collapsible__title');
-    if (IS_CHROME) {
+    if (IS_CHROME || IS_FIREFOX) {
       dom.addEventListener('click', () => {
         editor.update(() => {
           const collapsibleContainer = this.getLatest().getParentOrThrow();


### PR DESCRIPTION
## Description

This PR fixes a Firefox-specific issue where arrow key navigation skips over collapsible content inside `<details>` elements.

### Current Behavior
- In Firefox, pressing the down arrow from the collapsible title (`<summary>`) skips the content inside the collapsible.
- Similarly, arrow up from the next paragraph skips the entire collapsible block.
- This results in inconsistent navigation compared to Chrome and Safari.

### Changes Made
- Implemented a fix to ensure arrow key navigation correctly moves between blocks inside collapsible nodes in Firefox.
- Added handling to prevent skipping of collapsible content during keyboard navigation.

### Result
- Arrow key navigation now behaves consistently across browsers.
- Users can navigate into and out of collapsible content as expected.


### Before

https://github.com/user-attachments/assets/5d8d26d8-f5f5-4e82-b96f-7557fbc8566d

### After

https://github.com/user-attachments/assets/7ab5f207-9a54-4933-af99-149e3cbc04d2


Closes #8348