### PR TITLE
[lexical][lexical-extension] Chore: Remove @experimental flag from Extension and NodeState APIs

### DIFF
--- a/packages/lexical-extension/src/config.ts
+++ b/packages/lexical-extension/src/config.ts
@@ -17,7 +17,6 @@ export interface KnownTypesAndNodes {
   nodes: Set<KlassConstructor<typeof LexicalNode>>;
 }
 /**
- * @experimental
  * Get the sets of nodes and types registered in the
  * {@link InitialEditorConfig}. This is to be used when an extension
  * needs to register optional behavior if some node or type is present.

--- a/packages/lexical-extension/src/getExtensionDependencyFromEditor.ts
+++ b/packages/lexical-extension/src/getExtensionDependencyFromEditor.ts
@@ -16,7 +16,6 @@ import invariant from 'shared/invariant';
 import {LexicalBuilder} from './LexicalBuilder';
 
 /**
- * @experimental
  * Get the finalized config and output of an Extension that was used to build the editor.
  *
  * This is useful in the implementation of a LexicalNode or in other

--- a/packages/lexical-extension/src/getPeerDependencyFromEditor.ts
+++ b/packages/lexical-extension/src/getPeerDependencyFromEditor.ts
@@ -16,7 +16,6 @@ import invariant from 'shared/invariant';
 import {LexicalBuilder} from './LexicalBuilder';
 
 /**
- * @experimental
  * Get the finalized config and output of an Extension that was used to build the
  * editor by name.
  *

--- a/packages/lexical-extension/src/namedSignals.ts
+++ b/packages/lexical-extension/src/namedSignals.ts
@@ -15,7 +15,6 @@ export type NamedSignalsOutput<Defaults> = {
 };
 
 /**
- * @experimental
  * Return an object with the same shape as `defaults` with a {@link Signal}
  * for each value. If specified, the second `opts` argument is a partial
  * of overrides to the defaults and will be used as the initial value.

--- a/packages/lexical-extension/src/watchedSignal.ts
+++ b/packages/lexical-extension/src/watchedSignal.ts
@@ -8,7 +8,6 @@
 import {type Signal, signal} from './signals';
 
 /**
- * @experimental
  * Create a Signal that will subscribe to a value from an external store when watched, similar to
  * React's [useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore).
  *

--- a/packages/lexical-website/docs/concepts/node-state.md
+++ b/packages/lexical-website/docs/concepts/node-state.md
@@ -28,12 +28,6 @@ properties to store the node's data can be [more efficient](#efficiency)
 and will save you from writing a lot of boilerplate in the constructor,
 updateFromJSON, and exportJSON.
 
-## Stability
-
-🧪 This API is experimental, and may evolve without a long deprecation
-period. See also [Capabilities](#capabilities) for notes on what it
-can and can not do out of the box today.
-
 ## Usage
 
 ### createState

--- a/packages/lexical-website/docs/extensions/intro.md
+++ b/packages/lexical-website/docs/extensions/intro.md
@@ -8,13 +8,6 @@ agnostic.
 See [Included Extensions](./included-extensions) for the list of extensions
 that come with Lexical and its associated packages.
 
-## Stability
-
-🧪 This API is experimental, and may evolve with no deprecation
-period. Be prepared to track its development closely if you adopt it early.
-
-Lexical Extension became available in v0.36.1 (September 2025).
-
 ## Use Case
 
 Lexical Extensions allow complex features to be added to your editor

--- a/packages/lexical/src/extension-core/defineExtension.ts
+++ b/packages/lexical/src/extension-core/defineExtension.ts
@@ -16,7 +16,6 @@ import type {
 } from './types';
 
 /**
- * @experimental
  * Define a LexicalExtension from the given object literal. TypeScript will
  * infer Config and Name in most cases, but you may want to use
  * {@link safeCast} for config if there are default fields or varying types.
@@ -64,7 +63,6 @@ export function defineExtension<
 }
 
 /**
- * @experimental
  * Override a partial of the configuration of an Extension, to be used
  * in the dependencies array of another extension, or as
  * an argument to {@link buildEditorFromExtensions}.
@@ -102,7 +100,6 @@ export function configExtension<
 }
 
 /**
- * @experimental
  * Used to declare a peer dependency of an extension in a type-safe way,
  * requires the type parameter. The most common use case for peer dependencies
  * is to avoid a direct import dependency, so you would want to use a


### PR DESCRIPTION
## Description

Lexical Extension can be documented as stable. It has been available for more than six months ([v0.36.1](https://github.com/facebook/lexical/releases/tag/v0.36.1) was released in Sep 2025), now has much more usage in the playground, and hasn't needed any significant API changes.

NodeState has been around for over a year, since Feb 2025 [v0.26.0](https://github.com/facebook/lexical/releases/tag/v0.26.0), so we can remove notes about its stability as well.

## Test plan

Docs-only change