### PR TITLE
[lexical] Bug Fix: Workaround for synchronous firefox focus edge case behavior

### DIFF
--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -588,6 +588,7 @@ describe('SharedHistoryExtension', () => {
       html`
         <p dir="auto"><span data-lexical-text="true">parent editor</span></p>
         <div
+          contenteditable="false"
           style="user-select: text; white-space: pre-wrap; word-break: break-word"
           data-lexical-decorator="true"
           data-lexical-editor="true">
@@ -610,6 +611,7 @@ describe('SharedHistoryExtension', () => {
       html`
         <p dir="auto"><span data-lexical-text="true">parent editor</span></p>
         <div
+          contenteditable="false"
           style="user-select: text; white-space: pre-wrap; word-break: break-word"
           data-lexical-decorator="true"
           data-lexical-editor="true">
@@ -644,6 +646,7 @@ describe('SharedHistoryExtension', () => {
       html`
         <p dir="auto"><span data-lexical-text="true">parent editor</span></p>
         <div
+          contenteditable="false"
           style="user-select: text; white-space: pre-wrap; word-break: break-word"
           data-lexical-decorator="true"
           data-lexical-editor="true">

--- a/packages/lexical-react/src/__tests__/unit/LexicalExtensionComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalExtensionComposer.test.tsx
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import {
+  AutoFocusExtension,
+  buildEditorFromExtensions,
+} from '@lexical/extension';
+import {PlainTextExtension} from '@lexical/plain-text';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
 import {RichTextExtension} from '@lexical/rich-text';
@@ -56,6 +61,51 @@ describe('LexicalExtensionComposer', () => {
       `<div contenteditable="true" role="textbox" spellcheck="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><br></p></div>`,
     );
   });
+  it('$commitPendingUpdates flushes deferred callbacks even with no pending state', async () => {
+    // Reproduces the Firefox Focus tab bug. When editor.focus() runs
+    // while activeEditor === editor (the inline updateEditorSync path),
+    // its $onUpdate callback is added to _deferred without creating a
+    // new pending state or microtask. The callback depends on the outer
+    // update's microtask to flush it. If that microtask finds
+    // _pendingEditorState === null (consumed by a synchronous commit),
+    // the fix ensures it still flushes _deferred.
+    //
+    // We reproduce this by calling setRootElement inside editor.update()
+    // so that the AutoFocusExtension root listener fires with
+    // activeEditor === editor, triggering the inline path.
+
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [PlainTextExtension, AutoFocusExtension],
+        name: '[test]',
+      }),
+    );
+
+    const rootElement = document.createElement('div');
+    rootElement.contentEditable = 'true';
+    container.appendChild(rootElement);
+
+    // Flush InitialStateExtension's microtask before setRootElement.
+    await Promise.resolve();
+
+    // Call setRootElement inside editor.update() so that when the
+    // root listener fires and calls editor.focus(), activeEditor ===
+    // editor. This makes editor.focus() → updateEditorSync take the
+    // inline path: $onUpdate pushes to _deferred, but NO $beginUpdate,
+    // NO pending state, NO microtask. The callback is orphaned.
+    editor.update(() => {
+      editor.setRootElement(rootElement);
+    });
+
+    // _deferred has the stuck focus callback.
+    expect(editor._deferred.length).toBeGreaterThan(0);
+
+    // After microtasks flush, _deferred must be empty. Without the
+    // fix, the orphaned microtask finds null and returns early.
+    await Promise.resolve();
+    expect(editor._deferred).toHaveLength(0);
+  });
+
   it('Provides a context', async () => {
     function InitialPlugin() {
       const [editor] = useLexicalComposerContext();

--- a/packages/lexical-react/src/__tests__/unit/LexicalExtensionEditorComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalExtensionEditorComposer.test.tsx
@@ -164,7 +164,7 @@ describe('LexicalExtensionEditorComposer', () => {
           style="user-select: text; white-space: pre-wrap; word-break: break-word"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="true"
               role="textbox"

--- a/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
@@ -188,7 +188,7 @@ describe('LexicalNestedComposer', () => {
           style="user-select: text; white-space: pre-wrap; word-break: break-word"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="true"
               role="textbox"
@@ -287,7 +287,7 @@ describe('LexicalNestedComposer', () => {
           style="user-select: text; white-space: pre-wrap; word-break: break-word"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="true"
               role="textbox"
@@ -384,7 +384,7 @@ describe('LexicalNestedComposer', () => {
           style="user-select: text; white-space: pre-wrap; word-break: break-word"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="true"
               role="textbox"
@@ -486,7 +486,7 @@ describe('LexicalNestedComposer', () => {
           style="user-select: text; white-space: pre-wrap; word-break: break-word"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="true"
               role="textbox"
@@ -591,7 +591,7 @@ describe('LexicalNestedComposer', () => {
           aria-label="parent"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="true"
               role="textbox"
@@ -626,7 +626,7 @@ describe('LexicalNestedComposer', () => {
           aria-readonly="true"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="false"
               role="textbox"
@@ -742,7 +742,7 @@ describe('LexicalNestedComposer', () => {
           aria-label="parent"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="false"
               role="textbox"
@@ -779,7 +779,7 @@ describe('LexicalNestedComposer', () => {
           aria-readonly="true"
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">parent</span></p>
-          <div data-lexical-decorator="true">
+          <div contenteditable="false" data-lexical-decorator="true">
             <div
               contenteditable="false"
               role="textbox"

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -511,6 +511,13 @@ export function $commitPendingUpdates(
   const shouldSkipDOM = editor._headless || rootElement === null;
 
   if (pendingEditorState === null) {
+    // Even without a pending state, flush any deferred callbacks that
+    // may have been added by a prior update (e.g. via $onUpdate inside
+    // editor.focus()). This can happen when another commit consumed
+    // the pending editor state before this scheduled commit ran.
+    if (editor._deferred.length > 0) {
+      triggerDeferredUpdateCallbacks(editor, editor._deferred);
+    }
     return;
   }
 

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1421,7 +1421,7 @@ describe('LexicalEditor tests', () => {
       expect(listener).toHaveBeenCalledTimes(1);
       expect(container.innerHTML).toBe(
         '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto">' +
-          '<span data-lexical-decorator="true"><span>Hello world</span></span><br></p></div>',
+          '<span data-lexical-decorator="true" contenteditable="false"><span>Hello world</span></span><br></p></div>',
       );
     });
 

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -68,6 +68,37 @@ if (isJsdom) {
   }
   HTMLElement.prototype.focus = focusPreservingSelection;
 
+  // jsdom's HTMLElement.contentEditable is a plain property that doesn't
+  // synchronize with the 'contenteditable' DOM attribute. Real browsers
+  // (and the spec) require them to stay in sync, so override the
+  // property to delegate to getAttribute/setAttribute.
+  const ceDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'contentEditable',
+  );
+  if (!ceDescriptor || ceDescriptor.configurable !== false) {
+    Object.defineProperty(HTMLElement.prototype, 'contentEditable', {
+      configurable: true,
+      get(this: HTMLElement) {
+        const attr = this.getAttribute('contenteditable');
+        if (attr === 'true' || attr === '') {
+          return 'true';
+        }
+        if (attr === 'false') {
+          return 'false';
+        }
+        return 'inherit';
+      },
+      set(this: HTMLElement, value: string) {
+        if (value === 'inherit') {
+          this.removeAttribute('contenteditable');
+        } else {
+          this.setAttribute('contenteditable', value);
+        }
+      },
+    });
+  }
+
   if (typeof Range.prototype.getBoundingClientRect !== 'function') {
     // jsdom does not implement layout, so a zero-rect stub is sufficient
     // for code paths that only need a DOMRect-shaped value (like


### PR DESCRIPTION
## Description

Workaround a bug where `$commitPendingUpdates` would silently discard deferred callbacks when `pendingEditorState` was null. This happens in Firefox when `editor.focus()` runs via the inline updateEditorSync path (`activeEditor === editor`): the `$onUpdate` callback is added to `_deferred` but no new pending state or microtask is created. Add a unit test that reproduces this scenario using `AutoFocusExtension` with `setRootElement` inside `editor.update()`.

I think there's a better fix, but unblocks other work.

## Test plan

New unit test to cover this edge case

jsdom's HTMLElement.contentEditable property doesn't synchronize with the 'contenteditable' DOM attribute. This causes test snapshot mismatches where contenteditable="false" on decorator nodes was invisible. Patch the property globally in vitest.setup.mts to delegate to getAttribute/setAttribute matching real browser behavior, and update all affected test expectations.
