### PR TITLE
[*] Chore: Cache build + playwright before running e2e tests

### DIFF
--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -6,9 +6,9 @@ on:
 permissions: {}
 
 jobs:
-  # Prime playwright browser caches once per OS so parallel test jobs
-  # don't all download browsers simultaneously
-  setup-playwright:
+  # Cache node_modules, playwright browsers, and dev build output once per OS
+  # so parallel test jobs skip install and build entirely
+  setup:
     strategy:
       matrix:
         include:
@@ -28,8 +28,21 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - uses: pnpm/action-setup@v6
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v5
+        id: nm-cache
+        with:
+          path: node_modules
+          key: nm-v1-${{ matrix.node-version }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
+      - name: Save node_modules cache
+        if: steps.nm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: node_modules
+          key: ${{ steps.nm-cache.outputs.cache-primary-key }}
       - name: Restore playwright from cache
         uses: actions/cache/restore@v5
         id: playwright-cache
@@ -46,9 +59,28 @@ jobs:
         with:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+      - name: Restore build cache
+        uses: actions/cache/restore@v5
+        id: build-cache
+        with:
+          path: |
+            packages/lexical-playground/build
+            packages/*/dist
+          key: build-dev-v1-${{ github.sha }}
+      - name: Build
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: pnpm run prepare-ci
+      - name: Save build cache
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            packages/lexical-playground/build
+            packages/*/dist
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}
 
   mac-rich:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         node-version: [24.x]
@@ -62,7 +94,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   mac-plain:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         node-version: [24.x]
@@ -76,7 +108,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   linux:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         node-version: [24.x]
@@ -90,7 +122,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   windows:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         node-version: [24.x]
@@ -104,7 +136,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   collab-mac:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         node-version: [24.x]
@@ -117,7 +149,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   collab-linux:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         node-version: [24.x]
@@ -130,7 +162,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   collab-windows:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         node-version: [24.x]
@@ -143,7 +175,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   prod:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -159,7 +191,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   collab-prod:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -192,7 +224,7 @@ jobs:
   #     override-react-version: beta
 
   flaky:
-    needs: setup-playwright
+    needs: setup
     strategy:
       matrix:
         node-version: [24.x]

--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -32,7 +32,9 @@ jobs:
         uses: actions/cache/restore@v5
         id: nm-cache
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
           key: nm-v1-${{ matrix.node-version }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
@@ -41,7 +43,9 @@ jobs:
         if: steps.nm-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
           key: ${{ steps.nm-cache.outputs.cache-primary-key }}
       - name: Restore playwright from cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -6,9 +6,42 @@ on:
 permissions: {}
 
 jobs:
-  # Cache playwright browsers and dev build output once per OS
-  # so parallel test jobs skip build entirely
-  setup:
+  # Build the dev playground once and cache the output for all test jobs
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Restore build cache
+        uses: actions/cache/restore@v5
+        id: build-cache
+        with:
+          path: |
+            packages/lexical-playground/build
+            packages/*/dist
+          key: build-dev-v1-${{ github.sha }}
+      - name: Build
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: pnpm run prepare-ci
+      - name: Save build cache
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            packages/lexical-playground/build
+            packages/*/dist
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}
+
+  # Prime playwright browser caches once per OS so parallel test jobs
+  # don't all download browsers simultaneously
+  setup-playwright:
     strategy:
       matrix:
         include:
@@ -47,28 +80,9 @@ jobs:
         with:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
-      - name: Restore build cache
-        uses: actions/cache/restore@v5
-        id: build-cache
-        with:
-          path: |
-            packages/lexical-playground/build
-            packages/*/dist
-          key: build-dev-v1-${{ github.sha }}
-      - name: Build
-        if: steps.build-cache.outputs.cache-hit != 'true'
-        run: pnpm run prepare-ci
-      - name: Save build cache
-        if: steps.build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            packages/lexical-playground/build
-            packages/*/dist
-          key: ${{ steps.build-cache.outputs.cache-primary-key }}
 
   mac-rich:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         node-version: [24.x]
@@ -82,7 +96,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   mac-plain:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         node-version: [24.x]
@@ -96,7 +110,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   linux:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         node-version: [24.x]
@@ -110,7 +124,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   windows:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         node-version: [24.x]
@@ -124,7 +138,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   collab-mac:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         node-version: [24.x]
@@ -137,7 +151,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   collab-linux:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         node-version: [24.x]
@@ -150,7 +164,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   collab-windows:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         node-version: [24.x]
@@ -163,7 +177,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   prod:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -179,7 +193,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   collab-prod:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -212,7 +226,7 @@ jobs:
   #     override-react-version: beta
 
   flaky:
-    needs: setup
+    needs: [build, setup-playwright]
     strategy:
       matrix:
         node-version: [24.x]

--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -6,8 +6,8 @@ on:
 permissions: {}
 
 jobs:
-  # Cache node_modules, playwright browsers, and dev build output once per OS
-  # so parallel test jobs skip install and build entirely
+  # Cache playwright browsers and dev build output once per OS
+  # so parallel test jobs skip build entirely
   setup:
     strategy:
       matrix:
@@ -23,30 +23,14 @@ jobs:
       cache_playwright_path: ${{ matrix.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || matrix.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright' }}
     steps:
       - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v6
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@v5
-        id: nm-cache
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-          key: nm-v1-${{ matrix.node-version }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install dependencies
-        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
-      - name: Save node_modules cache
-        if: steps.nm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-          key: ${{ steps.nm-cache.outputs.cache-primary-key }}
       - name: Restore playwright from cache
         uses: actions/cache/restore@v5
         id: playwright-cache

--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -6,7 +6,49 @@ on:
 permissions: {}
 
 jobs:
+  # Prime playwright browser caches once per OS so parallel test jobs
+  # don't all download browsers simultaneously
+  setup-playwright:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node-version: 24.x
+          - os: macos-latest
+            node-version: 24.x
+          - os: windows-latest
+            node-version: 24.x
+    runs-on: ${{ matrix.os }}
+    env:
+      cache_playwright_path: ${{ matrix.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || matrix.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright' }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: pnpm/action-setup@v6
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Restore playwright from cache
+        uses: actions/cache/restore@v5
+        id: playwright-cache
+        with:
+          path: ${{ env.cache_playwright_path }}
+          key: playwright-v2-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Install playwright
+        run: |
+          pnpm exec playwright install
+          pnpm exec playwright install --list
+      - name: Save playwright to cache
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ env.cache_playwright_path }}
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+
   mac-rich:
+    needs: setup-playwright
     strategy:
       matrix:
         node-version: [24.x]
@@ -20,6 +62,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   mac-plain:
+    needs: setup-playwright
     strategy:
       matrix:
         node-version: [24.x]
@@ -33,6 +76,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   linux:
+    needs: setup-playwright
     strategy:
       matrix:
         node-version: [24.x]
@@ -46,6 +90,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   windows:
+    needs: setup-playwright
     strategy:
       matrix:
         node-version: [24.x]
@@ -59,6 +104,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   collab-mac:
+    needs: setup-playwright
     strategy:
       matrix:
         node-version: [24.x]
@@ -71,6 +117,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   collab-linux:
+    needs: setup-playwright
     strategy:
       matrix:
         node-version: [24.x]
@@ -83,6 +130,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   collab-windows:
+    needs: setup-playwright
     strategy:
       matrix:
         node-version: [24.x]
@@ -95,6 +143,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
 
   prod:
+    needs: setup-playwright
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -110,6 +159,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
 
   collab-prod:
+    needs: setup-playwright
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -142,6 +192,7 @@ jobs:
   #     override-react-version: beta
 
   flaky:
+    needs: setup-playwright
     strategy:
       matrix:
         node-version: [24.x]

--- a/.github/workflows/call-e2e-test.yml
+++ b/.github/workflows/call-e2e-test.yml
@@ -51,15 +51,11 @@ jobs:
         id: playwright-cache
         with:
           path: ${{ env.cache_playwright_path }}
-          key: playwright-${{ inputs.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: playwright-v2-${{ inputs.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install playwright
-        run: pnpm exec playwright install
-      - name: Save playwright to cache
-        uses: actions/cache/save@v5
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ env.cache_playwright_path }}
-          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+        run: |
+          pnpm exec playwright install
+          pnpm exec playwright install --list
       - name: Run tests
         run: pnpm run ${{ env.test_script }}
       - name: Upload Artifacts

--- a/.github/workflows/call-e2e-test.yml
+++ b/.github/workflows/call-e2e-test.yml
@@ -28,30 +28,21 @@ jobs:
       test_results_path: 'test-results/'
     steps:
       - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
-      - uses: pnpm/action-setup@v6
+          cache: 'pnpm'
       - name: Install required ubuntu-latest packages
         if: inputs.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install xvfb
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@v5
-        id: nm-cache
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-          key: nm-v1-${{ inputs.node-version }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install dependencies
-        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
       - name: Install React ${{ inputs.override-react-version }}
         if: inputs.override-react-version != ''
-        # Safe: test jobs only restore (never save) node_modules, so overrides don't persist
         run: |
           node ./scripts/override-react.js --version=${{ inputs.override-react-version }}
           grep version node_modules/{react,react-dom}/package.json

--- a/.github/workflows/call-e2e-test.yml
+++ b/.github/workflows/call-e2e-test.yml
@@ -42,7 +42,9 @@ jobs:
         uses: actions/cache/restore@v5
         id: nm-cache
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
           key: nm-v1-${{ inputs.node-version }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/call-e2e-test.yml
+++ b/.github/workflows/call-e2e-test.yml
@@ -22,10 +22,10 @@ jobs:
     env:
       CI: true
       E2E_EDITOR_MODE: ${{ inputs.editor-mode }}
+      E2E_PORT: 4000
       OVERRIDE_REACT_VERSION: ${{ inputs.override-react-version }}
       cache_playwright_path: ${{ inputs.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || inputs.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright' }}
       test_results_path: 'test-results/'
-      test_script: test-e2e-${{ inputs.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}${{ inputs.prod && 'prod-' || '' }}ci-${{ inputs.browser }}
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ inputs.node-version }}
@@ -38,11 +38,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install xvfb
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v5
+        id: nm-cache
+        with:
+          path: node_modules
+          key: nm-v1-${{ inputs.node-version }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
       - name: Install React ${{ inputs.override-react-version }}
         if: inputs.override-react-version != ''
-        # This should be safe since we are caching pnpm store and not node_modules
+        # Safe: test jobs only restore (never save) node_modules, so overrides don't persist
         run: |
           node ./scripts/override-react.js --version=${{ inputs.override-react-version }}
           grep version node_modules/{react,react-dom}/package.json
@@ -56,8 +63,27 @@ jobs:
         run: |
           pnpm exec playwright install
           pnpm exec playwright install --list
+      - name: Restore build cache
+        uses: actions/cache/restore@v5
+        id: build-cache
+        with:
+          path: |
+            packages/lexical-playground/build
+            packages/*/dist
+          key: build-${{ inputs.prod && 'prod' || 'dev' }}-v1-${{ github.sha }}
+      - name: Build
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: pnpm run ${{ inputs.prod && 'prepare-ci-prod' || 'prepare-ci' }}
       - name: Run tests
-        run: pnpm run ${{ env.test_script }}
+        if: inputs.editor-mode != 'rich-text-with-collab'
+        run: pnpm run test-e2e-${{ inputs.prod && 'prod-' || '' }}${{ inputs.browser }} --grep-invert "@flaky"
+      - name: Run collab tests
+        if: inputs.editor-mode == 'rich-text-with-collab'
+        shell: bash
+        run: |
+          pnpm exec concurrently -k -s first \
+            "pnpm run collab" \
+            "pnpm run test-e2e-collab-${{ inputs.prod && 'prod-' || '' }}${{ inputs.browser }} --grep-invert @flaky"
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Description

Previously each e2e slot in the matrix would do a full build of the packages + playground + install playwright, this moves that step outside of the matrix and ensures the caches are populated before running the full e2e suite. populating the cache in a job that all of the e2e runs depend on we can ensure the caches are hot, should save a bit of time when the keys change.

Previously there was some caching for playwright and installation, but it was likely to be stale due to the stampede of all the jobs starting at once.

## Test plan

This is only a change to the e2e workflows, so it should test itself