### PR TITLE
[Breaking Change][lexical-code] Bug Fix: move code block escape logic to KEY_ENTER_COMMAND listener

### DIFF
--- a/packages/lexical-code-core/package.json
+++ b/packages/lexical-code-core/package.json
@@ -12,6 +12,7 @@
   "main": "LexicalCodeCore.js",
   "types": "index.d.ts",
   "dependencies": {
+    "@lexical/extension": "workspace:*",
     "lexical": "workspace:*"
   },
   "repository": {

--- a/packages/lexical-code-core/src/CodeExtension.ts
+++ b/packages/lexical-code-core/src/CodeExtension.ts
@@ -27,7 +27,7 @@ export const CodeExtension = defineExtension({
   register(editor) {
     return editor.registerCommand<KeyboardEvent>(
       KEY_ENTER_COMMAND,
-      () => {
+      (event) => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
           return false;
@@ -48,6 +48,7 @@ export const CodeExtension = defineExtension({
           children[childrenLength - 2].getTextContent() === '\n' &&
           anchor.offset === childrenLength
         ) {
+          event.preventDefault();
           children[childrenLength - 1].remove();
           children[childrenLength - 2].remove();
           const newElement = $createParagraphNode();

--- a/packages/lexical-code-core/src/CodeExtension.ts
+++ b/packages/lexical-code-core/src/CodeExtension.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  $createParagraphNode,
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_LOW,
@@ -16,7 +15,7 @@ import {
 } from 'lexical';
 
 import {CodeHighlightNode} from './CodeHighlightNode';
-import {$isCodeNode, CodeNode} from './CodeNode';
+import {$exitCodeNodeOnEnter, CodeNode} from './CodeNode';
 
 /**
  * Add code blocks to the editor (syntax highlighting provided separately)
@@ -29,31 +28,8 @@ export const CodeExtension = defineExtension({
       KEY_ENTER_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
-          return false;
-        }
-        const {anchor} = selection;
-        if (anchor.type !== 'element') {
-          return false;
-        }
-        const codeNode = anchor.getNode();
-        if (!$isCodeNode(codeNode)) {
-          return false;
-        }
-        const children = codeNode.getChildren();
-        const childrenLength = children.length;
-        if (
-          childrenLength >= 2 &&
-          children[childrenLength - 1].getTextContent() === '\n' &&
-          children[childrenLength - 2].getTextContent() === '\n' &&
-          anchor.offset === childrenLength
-        ) {
+        if ($isRangeSelection(selection) && $exitCodeNodeOnEnter(selection)) {
           event.preventDefault();
-          children[childrenLength - 1].remove();
-          children[childrenLength - 2].remove();
-          const newElement = $createParagraphNode();
-          codeNode.insertAfter(newElement, true);
-          newElement.select();
           return true;
         }
         return false;

--- a/packages/lexical-code-core/src/CodeExtension.ts
+++ b/packages/lexical-code-core/src/CodeExtension.ts
@@ -5,10 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {defineExtension} from 'lexical';
+
+import {
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  defineExtension,
+  KEY_ENTER_COMMAND,
+} from 'lexical';
 
 import {CodeHighlightNode} from './CodeHighlightNode';
-import {CodeNode} from './CodeNode';
+import {$isCodeNode, CodeNode} from './CodeNode';
 
 /**
  * Add code blocks to the editor (syntax highlighting provided separately)
@@ -16,4 +24,40 @@ import {CodeNode} from './CodeNode';
 export const CodeExtension = defineExtension({
   name: '@lexical/code',
   nodes: () => [CodeNode, CodeHighlightNode],
+  register(editor) {
+    return editor.registerCommand<KeyboardEvent>(
+      KEY_ENTER_COMMAND,
+      () => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+          return false;
+        }
+        const {anchor} = selection;
+        if (anchor.type !== 'element') {
+          return false;
+        }
+        const codeNode = anchor.getNode();
+        if (!$isCodeNode(codeNode)) {
+          return false;
+        }
+        const children = codeNode.getChildren();
+        const childrenLength = children.length;
+        if (
+          childrenLength >= 2 &&
+          children[childrenLength - 1].getTextContent() === '\n' &&
+          children[childrenLength - 2].getTextContent() === '\n' &&
+          anchor.offset === childrenLength
+        ) {
+          children[childrenLength - 1].remove();
+          children[childrenLength - 2].remove();
+          const newElement = $createParagraphNode();
+          codeNode.insertAfter(newElement, true);
+          newElement.select();
+          return true;
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+  },
 });

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -28,6 +28,7 @@ import {
   $createLineBreakNode,
   $createParagraphNode,
   $createTabNode,
+  $hasUpdateTag,
   $isTabNode,
   $isTextNode,
   addClassNamesToElement,
@@ -298,7 +299,8 @@ export class CodeNode extends ElementNode {
       children[childrenLength - 2].getTextContent() === '\n' &&
       selection.isCollapsed() &&
       selection.anchor.key === this.__key &&
-      selection.anchor.offset === childrenLength
+      selection.anchor.offset === childrenLength &&
+      !$hasUpdateTag('paste')
     ) {
       children[childrenLength - 1].remove();
       children[childrenLength - 2].remove();

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -28,7 +28,6 @@ import {
   $createLineBreakNode,
   $createParagraphNode,
   $createTabNode,
-  $hasUpdateTag,
   $isTabNode,
   $isTextNode,
   addClassNamesToElement,
@@ -290,25 +289,6 @@ export class CodeNode extends ElementNode {
     selection: RangeSelection,
     restoreSelection = true,
   ): null | ParagraphNode | CodeHighlightNode | TabNode {
-    const children = this.getChildren();
-    const childrenLength = children.length;
-
-    if (
-      childrenLength >= 2 &&
-      children[childrenLength - 1].getTextContent() === '\n' &&
-      children[childrenLength - 2].getTextContent() === '\n' &&
-      selection.isCollapsed() &&
-      selection.anchor.key === this.__key &&
-      selection.anchor.offset === childrenLength &&
-      !$hasUpdateTag('paste')
-    ) {
-      children[childrenLength - 1].remove();
-      children[childrenLength - 2].remove();
-      const newElement = $createParagraphNode();
-      this.insertAfter(newElement, restoreSelection);
-      return newElement;
-    }
-
     // If the selection is within the codeblock, find all leading tabs and
     // spaces of the current line. Create a new line that has all those
     // tabs and spaces, such that leading indentation is preserved.

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import type {CodeExtension} from './CodeExtension';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
@@ -38,7 +39,6 @@ import {
 } from 'lexical';
 import warnOnlyOnce from 'shared/warnOnlyOnce';
 
-import {CodeExtension} from './CodeExtension';
 import {
   $createCodeHighlightNode,
   $isCodeHighlightNode,

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import type {CodeHighlightNode} from '@lexical/code';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
@@ -23,21 +22,27 @@ import type {
   TabNode,
 } from 'lexical';
 
+import {getPeerDependencyFromEditor} from '@lexical/extension';
 import {
   $create,
   $createLineBreakNode,
   $createParagraphNode,
   $createTabNode,
+  $getEditor,
+  $isLineBreakNode,
   $isTabNode,
   $isTextNode,
   addClassNamesToElement,
   ElementNode,
   isHTMLElement,
 } from 'lexical';
+import warnOnlyOnce from 'shared/warnOnlyOnce';
 
+import {CodeExtension} from './CodeExtension';
 import {
   $createCodeHighlightNode,
   $isCodeHighlightNode,
+  type CodeHighlightNode,
 } from './CodeHighlightNode';
 import {$getFirstCodeNodeOfLine} from './FlatStructureUtils';
 
@@ -65,6 +70,10 @@ function hasChildDOMNodeTag(node: Node, tagName: string) {
 const LANGUAGE_DATA_ATTRIBUTE = 'data-language';
 const HIGHLIGHT_LANGUAGE_DATA_ATTRIBUTE = 'data-highlight-language';
 const THEME_DATA_ATTRIBUTE = 'data-theme';
+
+const noExtensionDeprecation = warnOnlyOnce(
+  'Using CodeNode without CodeExtension is deprecated',
+);
 
 /** @noInheritDoc */
 export class CodeNode extends ElementNode {
@@ -289,6 +298,18 @@ export class CodeNode extends ElementNode {
     selection: RangeSelection,
     restoreSelection = true,
   ): null | ParagraphNode | CodeHighlightNode | TabNode {
+    if (
+      !getPeerDependencyFromEditor<typeof CodeExtension>(
+        $getEditor(),
+        '@lexical/code',
+      )
+    ) {
+      noExtensionDeprecation();
+      const el = $exitCodeNodeOnEnter(selection);
+      if (el) {
+        return el;
+      }
+    }
     // If the selection is within the codeblock, find all leading tabs and
     // spaces of the current line. Create a new line that has all those
     // tabs and spaces, such that leading indentation is preserved.
@@ -452,4 +473,31 @@ function isGitHubCodeCell(
 
 function isGitHubCodeTable(table: HTMLTableElement): table is HTMLTableElement {
   return table.classList.contains('js-file-line-container');
+}
+
+export function $exitCodeNodeOnEnter(
+  selection: RangeSelection,
+): null | ParagraphNode {
+  const {anchor} = selection;
+  if (selection.isCollapsed() && anchor.type === 'element') {
+    const codeNode = anchor.getNode();
+    if ($isCodeNode(codeNode)) {
+      const childrenSize = codeNode.getChildrenSize();
+      if (childrenSize >= 2 && anchor.offset === childrenSize) {
+        const lastChild = codeNode.getLastChild();
+        if (
+          $isLineBreakNode(lastChild) &&
+          $isLineBreakNode(lastChild.getPreviousSibling())
+        ) {
+          const newElement = $createParagraphNode();
+          codeNode
+            .splice(childrenSize - 2, 2, [])
+            .insertAfter(newElement, false);
+          newElement.select();
+          return newElement;
+        }
+      }
+    }
+  }
+  return null;
 }

--- a/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
@@ -18,7 +18,7 @@ import {
 import {describe, expect, it} from 'vitest';
 
 import {$createCodeHighlightNode} from '../../CodeHighlightNode';
-import {$isCodeNode} from '../../CodeNode';
+import {$isCodeNode, CodeNode} from '../../CodeNode';
 
 describe('CodeExtension', () => {
   it('should not escape code block when content has consecutive blank lines (paste scenario)', () => {
@@ -67,8 +67,7 @@ describe('CodeExtension', () => {
     using editor = buildEditorFromExtensions(ext);
     editor.update(
       () => {
-        const root = $getRoot();
-        const codeNode = root.getFirstChildOrThrow();
+        const codeNode = $getRoot().getFirstChildOrThrow<CodeNode>();
         codeNode.select(codeNode.getChildrenSize(), codeNode.getChildrenSize());
       },
       {discrete: true},
@@ -109,8 +108,7 @@ describe('CodeExtension', () => {
     using editor = buildEditorFromExtensions(ext);
     editor.update(
       () => {
-        const root = $getRoot();
-        const codeNode = root.getFirstChildOrThrow();
+        const codeNode = $getRoot().getFirstChildOrThrow<CodeNode>();
         codeNode.select(codeNode.getChildrenSize(), codeNode.getChildrenSize());
       },
       {discrete: true},
@@ -124,7 +122,6 @@ describe('CodeExtension', () => {
     editor.update(
       () => {
         const root = $getRoot();
-        // Should still be just one code node, no paragraph created
         expect(root.getChildrenSize()).toBe(1);
         expect($isCodeNode(root.getFirstChildOrThrow())).toBe(true);
       },
@@ -151,9 +148,7 @@ describe('CodeExtension', () => {
     using editor = buildEditorFromExtensions(ext);
     editor.update(
       () => {
-        const root = $getRoot();
-        const codeNode = root.getFirstChildOrThrow();
-        // Select at position 1, not at the end
+        const codeNode = $getRoot().getFirstChildOrThrow<CodeNode>();
         codeNode.select(1, 1);
       },
       {discrete: true},
@@ -167,7 +162,6 @@ describe('CodeExtension', () => {
     editor.update(
       () => {
         const root = $getRoot();
-        // Should still be just one code node
         expect(root.getChildrenSize()).toBe(1);
         expect($isCodeNode(root.getFirstChildOrThrow())).toBe(true);
       },

--- a/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createCodeNode, CodeExtension} from '@lexical/code';
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createLineBreakNode,
+  $getRoot,
+  $isElementNode,
+  KEY_ENTER_COMMAND,
+} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+import {$createCodeHighlightNode} from '../../CodeHighlightNode';
+import {$isCodeNode} from '../../CodeNode';
+
+describe('CodeExtension', () => {
+  it('should not escape code block when content has consecutive blank lines (paste scenario)', () => {
+    const ext = defineExtension({
+      $initialEditorState: () => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append(
+          $createCodeHighlightNode('line1'),
+          $createLineBreakNode(),
+          $createLineBreakNode(),
+          $createLineBreakNode(),
+          $createCodeHighlightNode('line2'),
+        );
+        $getRoot().append(codeNode);
+      },
+      dependencies: [CodeExtension, RichTextExtension],
+      name: '[root]',
+    });
+
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        expect(root.getChildrenSize()).toBe(1);
+        expect($isCodeNode(root.getFirstChildOrThrow())).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+
+  it('should escape code block on Enter when cursor is after two trailing blank lines', () => {
+    const ext = defineExtension({
+      $initialEditorState: () => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append(
+          $createCodeHighlightNode('hello'),
+          $createLineBreakNode(),
+          $createLineBreakNode(),
+        );
+        $getRoot().append(codeNode);
+      },
+      dependencies: [CodeExtension, RichTextExtension],
+      name: '[root-escape]',
+    });
+
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const codeNode = root.getFirstChildOrThrow();
+        codeNode.select(codeNode.getChildrenSize(), codeNode.getChildrenSize());
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(
+      KEY_ENTER_COMMAND,
+      new KeyboardEvent('keydown', {key: 'Enter'}),
+    );
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        expect(root.getChildrenSize()).toBe(2);
+        expect($isCodeNode(root.getFirstChildOrThrow())).toBe(true);
+        const secondChild = root.getLastChildOrThrow();
+        expect($isElementNode(secondChild)).toBe(true);
+        expect(secondChild.getType()).toBe('paragraph');
+      },
+      {discrete: true},
+    );
+  });
+
+  it('should not escape code block on Enter with only one trailing blank line', () => {
+    const ext = defineExtension({
+      $initialEditorState: () => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append(
+          $createCodeHighlightNode('hello'),
+          $createLineBreakNode(),
+        );
+        $getRoot().append(codeNode);
+      },
+      dependencies: [CodeExtension, RichTextExtension],
+      name: '[root-one-blank]',
+    });
+
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const codeNode = root.getFirstChildOrThrow();
+        codeNode.select(codeNode.getChildrenSize(), codeNode.getChildrenSize());
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(
+      KEY_ENTER_COMMAND,
+      new KeyboardEvent('keydown', {key: 'Enter'}),
+    );
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        // Should still be just one code node, no paragraph created
+        expect(root.getChildrenSize()).toBe(1);
+        expect($isCodeNode(root.getFirstChildOrThrow())).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+
+  it('should not escape code block on Enter when cursor is not at the end', () => {
+    const ext = defineExtension({
+      $initialEditorState: () => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append(
+          $createCodeHighlightNode('hello'),
+          $createLineBreakNode(),
+          $createLineBreakNode(),
+          $createCodeHighlightNode('world'),
+        );
+        $getRoot().append(codeNode);
+      },
+      dependencies: [CodeExtension, RichTextExtension],
+      name: '[root-middle]',
+    });
+
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const codeNode = root.getFirstChildOrThrow();
+        // Select at position 1, not at the end
+        codeNode.select(1, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(
+      KEY_ENTER_COMMAND,
+      new KeyboardEvent('keydown', {key: 'Enter'}),
+    );
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        // Should still be just one code node
+        expect(root.getChildrenSize()).toBe(1);
+        expect($isCodeNode(root.getFirstChildOrThrow())).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+});

--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@lexical/code-core": "workspace:*",
     "@lexical/code-prism": "workspace:*",
+    "@lexical/extension": "workspace:*",
     "lexical": "workspace:*"
   },
   "repository": {

--- a/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
@@ -8,11 +8,13 @@
 
 import {$insertGeneratedNodes} from '@lexical/clipboard';
 import {CodeNode} from '@lexical/code';
+import {buildEditorFromExtensions} from '@lexical/extension';
 import {createHeadlessEditor} from '@lexical/headless';
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {JSDOM} from 'jsdom';
 import {
   $createParagraphNode,
   $createRangeSelection,
@@ -267,17 +269,16 @@ describe('HTML', () => {
 
   describe('$generateNodesFromDOM: CSS class style inlining', () => {
     test('HTML with <style> tags inlines styles by class', () => {
-      const editor = createHeadlessEditor();
-      const parser = new DOMParser();
-
+      const editor = buildEditorFromExtensions();
+      // workaround for https://github.com/jsdom/jsdom/issues/3179 - DOMParser does not work correctly
+      const dom = new JSDOM(
+        `<html><head><style>.highlight { font-weight: bold; }</style></head>` +
+          `<body><p><span class="highlight">Hello</span></p></body></html>`,
+      ).window.document;
+      expect(dom.styleSheets).toHaveLength(1);
       editor.update(
         () => {
           const root = $getRoot();
-          const dom = parser.parseFromString(
-            `<html><head><style>.highlight { font-weight: bold; }</style></head>` +
-              `<body><p><span class="highlight">Hello</span></p></body></html>`,
-            'text/html',
-          );
           const nodes = $generateNodesFromDOM(editor, dom);
           $insertGeneratedNodes(editor, nodes, root.select(0));
           expect(root.getTextContent()).toBe('Hello');

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -17,7 +17,6 @@ import type {
 } from 'lexical';
 
 import {$sliceSelectedTextNodeContent} from '@lexical/selection';
-import {isBlockDomNode, isHTMLElement} from '@lexical/utils';
 import {
   $createLineBreakNode,
   $createParagraphNode,
@@ -29,10 +28,16 @@ import {
   ArtificialNode__DO_NOT_USE,
   ElementNode,
   getRegisteredNode,
+  isBlockDomNode,
   isDocumentFragment,
   isDOMDocumentNode,
+  isHTMLElement,
   isInlineDomNode,
 } from 'lexical';
+
+function isStyleRule(rule: CSSRule): rule is CSSStyleRule {
+  return rule.constructor.name === CSSStyleRule.name;
+}
 
 /**
  * Inlines CSS rules from <style> tags onto matching elements as inline styles.
@@ -72,7 +77,7 @@ function inlineStylesFromStyleSheets(doc: Document): void {
         continue;
       }
       for (const rule of Array.from(rules)) {
-        if (!(rule instanceof CSSStyleRule)) {
+        if (!isStyleRule(rule)) {
           continue;
         }
         let elements: NodeListOf<Element>;
@@ -82,7 +87,7 @@ function inlineStylesFromStyleSheets(doc: Document): void {
           continue;
         }
         for (const el of Array.from(elements)) {
-          if (!(el instanceof HTMLElement)) {
+          if (!isHTMLElement(el)) {
             continue;
           }
           const originalProps = getOriginalInlineProps(el);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,12 +292,18 @@ importers:
       '@lexical/code-prism':
         specifier: workspace:*
         version: link:../lexical-code-prism
+      '@lexical/extension':
+        specifier: workspace:*
+        version: link:../lexical-extension
       lexical:
         specifier: workspace:*
         version: link:../lexical
 
   packages/lexical-code-core:
     dependencies:
+      '@lexical/extension':
+        specifier: workspace:*
+        version: link:../lexical-extension
       lexical:
         specifier: workspace:*
         version: link:../lexical


### PR DESCRIPTION
## Breaking Changes

The "press enter three times to exit the CodeNode" logic has been moved from `CodeNode.insertNewAfter` to a `KEY_ENTER_COMMAND` listener registered by `CodeExtension`.

Using `CodeNode` without `CodeExtension` is now deprecated to allow this functionality to be moved to a command listener. There is a shim in the implementation that will provide backwards compatible behavior and log a warning (in dev) when this scenario is encountered, but you should expect that the node will eventually stop working correctly in a future version if your editor uses `CodeNode` without `CodeExtension`.

## Description

When pasting text containing consecutive blank lines into a code block, 
content after the blank lines incorrectly escapes the code block and 
appears as top-level paragraphs.

The root cause was that the escape-to-paragraph logic in 
`CodeNode.insertNewAfter` ran on all content changes, including paste.

Per maintainer feedback, this fix takes the preferred approach of moving 
the escape logic out of `insertNewAfter` entirely and into a 
`KEY_ENTER_COMMAND` listener registered in `CodeExtension`. This ensures 
the escape behavior only triggers on keyboard input, not paste or other 
programmatic changes.

Closes #8351

## Test plan

### Before
Paste text with consecutive blank lines into a code block — content 
after the blank lines escapes to a top-level paragraph.

### After
- Pasted content stays inside the code block
- Pressing Enter at the end of a code block after two blank lines 
  still correctly exits to a new paragraph
- Four unit tests added covering: escape on Enter, no escape on paste, 
  no escape with single blank line, no escape when cursor is not at end