### PR TITLE
[lexical][lexical-playground] Fix: Use the fallback matching for number keys in keyboard shortcuts

### DIFF
--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {TOGGLE_LINK_COMMAND} from '@lexical/link';
-import {HeadingTagType} from '@lexical/rich-text';
 import {
   COMMAND_PRIORITY_NORMAL,
   FORMAT_ELEMENT_COMMAND,
@@ -36,6 +35,7 @@ import {
   UpdateFontSizeType,
 } from '../ToolbarPlugin/utils';
 import {
+  getFormatHeading,
   isAddComment,
   isCapitalize,
   isCenterAlign,
@@ -44,7 +44,6 @@ import {
   isFormatBulletList,
   isFormatCheckList,
   isFormatCode,
-  isFormatHeading,
   isFormatNumberedList,
   isFormatParagraph,
   isFormatQuote,
@@ -77,12 +76,12 @@ export default function ShortcutsPlugin({
       // Short-circuit, a least one modifier must be set
       if (isModifierMatch(event, {})) {
         return false;
+      }
+      const headingSize = getFormatHeading(event);
+      if (headingSize) {
+        formatHeading(editor, toolbarState.blockType, headingSize);
       } else if (isFormatParagraph(event)) {
         formatParagraph(editor);
-      } else if (isFormatHeading(event)) {
-        const level = /^\d$/.test(event.key) ? event.key : event.code.slice(5);
-        const headingSize = `h${level}` as HeadingTagType;
-        formatHeading(editor, toolbarState.blockType, headingSize);
       } else if (isFormatBulletList(event)) {
         formatBulletList(editor, toolbarState.blockType);
       } else if (isFormatNumberedList(event)) {

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
@@ -80,7 +80,8 @@ export default function ShortcutsPlugin({
       } else if (isFormatParagraph(event)) {
         formatParagraph(editor);
       } else if (isFormatHeading(event)) {
-        const headingSize = `h${event.key}` as HeadingTagType;
+        const level = /^\d$/.test(event.key) ? event.key : event.code.slice(5);
+        const headingSize = `h${level}` as HeadingTagType;
         formatHeading(editor, toolbarState.blockType, headingSize);
       } else if (isFormatBulletList(event)) {
         formatBulletList(editor, toolbarState.blockType);

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -7,7 +7,7 @@
  */
 
 import {IS_APPLE} from '@lexical/utils';
-import {isExactShortcutMatch, isModifierMatch} from 'lexical';
+import {isExactShortcutMatch} from 'lexical';
 
 //disable eslint sorting rule for quick reference to shortcuts
 /* eslint-disable sort-keys-fix/sort-keys-fix */
@@ -61,12 +61,9 @@ export function isFormatParagraph(event: KeyboardEvent): boolean {
 }
 
 export function isFormatHeading(event: KeyboardEvent): boolean {
-  const {key} = event;
-
-  return (
-    ['1', '2', '3'].includes(key) &&
-    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
-  );
+  return ['1', '2', '3'].some((key) => {
+    return isExactShortcutMatch(event, key, {...CONTROL_OR_META, altKey: true});
+  });
 }
 
 export function isFormatNumberedList(event: KeyboardEvent): boolean {

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {HeadingTagType} from '@lexical/rich-text';
 import {IS_APPLE} from '@lexical/utils';
 import {isExactShortcutMatch} from 'lexical';
 
@@ -60,10 +61,14 @@ export function isFormatParagraph(event: KeyboardEvent): boolean {
   });
 }
 
-export function isFormatHeading(event: KeyboardEvent): boolean {
-  return ['1', '2', '3'].some((key) => {
-    return isExactShortcutMatch(event, key, {...CONTROL_OR_META, altKey: true});
-  });
+export function getFormatHeading(
+  event: KeyboardEvent,
+): HeadingTagType | undefined {
+  for (const key of ['1', '2', '3'] as const) {
+    if (isExactShortcutMatch(event, key, {...CONTROL_OR_META, altKey: true})) {
+      return `h${key}`;
+    }
+  }
 }
 
 export function isFormatNumberedList(event: KeyboardEvent): boolean {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1014,6 +1014,11 @@ export function isExactShortcutMatch(
     return false;
   }
 
+  // Fallback for number keys
+  if (event.code.startsWith('Digit') && /^\d$/.test(expectedKey)) {
+    return event.code === `Digit${expectedKey}`;
+  }
+
   const expectedCode = 'Key' + expectedKey.toUpperCase();
 
   // For default keys with not English-based keyboard layouts where `event.key` is non-ASCII, match by `event.code`.


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Added a fallback check for number keys to the `isExactShortcutMatch` function. On macOS, the English keyboard layout produces the following characters when the Option key is pressed in combination with numbers:
- `1` → `¡`
- `2` → `™`
- `£` → `£`

This became apparent after the changes in this PR https://github.com/facebook/lexical/pull/8260, as the keyboard shortcuts for headings in the playground stopped working

## Test plan

### Before

The Option key didn't work with numbers on the English keyboard layout in macOS

### After

Support for the Option + Num hotkeys has been added for macOS. Alternative keyboard layouts, such as Dvorak or other languages, continue working