### PR TITLE
[lexical-text] Chore: Add deprecation notice to $findTextIntersectionFromCharacters

### DIFF
--- a/packages/lexical-text/src/findTextIntersectionFromCharacters.ts
+++ b/packages/lexical-text/src/findTextIntersectionFromCharacters.ts
@@ -13,6 +13,7 @@ import {$isElementNode, $isTextNode, RootNode, TextNode} from 'lexical';
  * @param root - The RootNode.
  * @param targetCharacters - The number of characters whose TextNode must be larger than.
  * @returns The TextNode and the intersections offset, or null if no TextNode is found.
+ * @deprecated $findTextIntersectionFromCharacters has never worked correctly and will be removed
  */
 export function $findTextIntersectionFromCharacters(
   root: RootNode,


### PR DESCRIPTION
## Description

`$findTextIntersectionFromCharacters` doesn't work correctly and has no tests, usage, or documentation. Like the situation with `@lexical/offset`, it would be nice to have something like this, but it should be implemented correctly with an in-repo use case, tests, and documentation.

## Test plan

N/A