### PR TITLE
[lexical-react] Bug Fix: Add 'yjs' as optional peer dependency for Yarn PnP compatibility

### DIFF
--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -32,7 +32,13 @@
   },
   "peerDependencies": {
     "react": ">=17.x",
-    "react-dom": ">=17.x"
+    "react-dom": ">=17.x",
+    "yjs": ">=13.5.22"
+  },
+  "peerDependenciesMeta": {
+    "yjs": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,6 +828,9 @@ importers:
       react-error-boundary:
         specifier: ^6.0.0
         version: 6.0.0(react@19.2.5)
+      yjs:
+        specifier: '>=13.5.22'
+        version: 13.6.27
     devDependencies:
       '@types/jest-axe':
         specifier: ^3.5.9
@@ -8712,11 +8715,6 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
-
-  lib0@0.2.114:
-    resolution: {integrity: sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==}
-    engines: {node: '>=16'}
-    hasBin: true
 
   lib0@0.2.117:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
@@ -21984,10 +21982,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lib0@0.2.114:
-    dependencies:
-      isomorphic.js: 0.2.5
-
   lib0@0.2.117:
     dependencies:
       isomorphic.js: 0.2.5
@@ -26941,7 +26935,7 @@ snapshots:
 
   yjs@13.6.27:
     dependencies:
-      lib0: 0.2.114
+      lib0: 0.2.117
 
   yjs@14.0.0-16:
     dependencies:


### PR DESCRIPTION
## Description

 Re-submission of #8053 (closed due to unsigned CLA). 
 @flex-jonghyen is my own work account, but I'm unable to sign the CLA under it — so I'm re-opening this from my personal account.

**Current problem:**
- `@lexical/react` includes `@lexical/yjs` as a dependency
- `@lexical/yjs` requires `yjs` as a peer dependency (`>=13.5.22`)
- However, `yjs` is not declared in `@lexical/react`
- In strict dependency management environments like Yarn PnP, this causes a resolution error for `yjs`

**Changes:**
- Added `yjs` as an optional peer dependency in `@lexical/react` (version range matches `@lexical/yjs`: `>=13.5.22`)
- Users who don't use collaboration features are not affected

## Test plan

### Before

Yarn PnP environment fails to resolve `yjs`.

**Workaround required in `.yarnrc.yml`:**
```yaml
packageExtensions:
  '@lexical/react@*':
    peerDependencies:
      'yjs': '*'
```

This workaround confirms that adding `yjs` as a peer dependency resolves the issue.

### After

Works without the workaround.