### PR TITLE
[lexical-website] Bug Fix: Fix tailwindcss docusaurus config regression

### DIFF
--- a/packages/lexical-website/docusaurus.config.ts
+++ b/packages/lexical-website/docusaurus.config.ts
@@ -9,6 +9,7 @@
 import type {Options as DocsPluginOptions} from '@docusaurus/plugin-content-docs';
 import type {Config} from '@docusaurus/types';
 
+import tailwindcssPostcss from '@tailwindcss/postcss';
 import fs from 'node:fs';
 import {createRequire} from 'node:module';
 import path from 'node:path';
@@ -385,10 +386,8 @@ const config: Config = {
     ['docusaurus-plugin-typedoc', docusaurusPluginTypedocConfig],
     async function tailwindcss() {
       return {
-        async configurePostCss(postcssOptions: {plugins: unknown[]}) {
-          postcssOptions.plugins.push(
-            (await import('@tailwindcss/postcss')).default,
-          );
+        configurePostCss(postcssOptions: {plugins: unknown[]}) {
+          postcssOptions.plugins.push(tailwindcssPostcss);
           return postcssOptions;
         },
         name: 'docusaurus-tailwindcss',


### PR DESCRIPTION
## Description

The #8355 refactor caused a regression in the docusaurus config where the tailwindcss config was defined async when it needed to be sync.

As a follow-up the type checking must not be running in here because it would have been caught otherwise #8370

## Test plan

Check website build for correct CSS