### PR TITLE
[lexical][lexical-code-core][lexical-list][lexical-table][lexical-yjs] Refactor: make runtime style updates CSP-safe

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -465,7 +465,8 @@ export async function copyToClipboard(
     return false;
   }
   const element = windowDocument.createElement('span');
-  element.style.cssText = 'position: fixed; top: -1000px;';
+  element.style.position = 'fixed';
+  element.style.top = '-1000px';
   element.append(windowDocument.createTextNode('#'));
   rootElement.append(element);
   const range = new Range();

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -36,6 +36,7 @@ import {
   addClassNamesToElement,
   ElementNode,
   isHTMLElement,
+  setDOMStyleFromCSS,
 } from 'lexical';
 import warnOnlyOnce from 'shared/warnOnlyOnce';
 
@@ -126,7 +127,7 @@ export class CodeNode extends ElementNode {
 
     const style = this.getStyle();
     if (style) {
-      element.setAttribute('style', style);
+      setDOMStyleFromCSS(element.style, style);
     }
     return element;
   }
@@ -171,12 +172,8 @@ export class CodeNode extends ElementNode {
 
     const style = this.__style;
     const prevStyle = prevNode.__style;
-    if (style) {
-      if (style !== prevStyle) {
-        dom.setAttribute('style', style);
-      }
-    } else if (prevStyle) {
-      dom.removeAttribute('style');
+    if (style !== prevStyle) {
+      setDOMStyleFromCSS(dom.style, style, prevStyle);
     }
 
     return false;
@@ -202,7 +199,7 @@ export class CodeNode extends ElementNode {
 
     const style = this.getStyle();
     if (style) {
-      element.setAttribute('style', style);
+      setDOMStyleFromCSS(element.style, style);
     }
     return {element};
   }

--- a/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {EditorConfig} from 'lexical';
+
+import {$getRoot} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
+
+import {$createCodeNode} from '../../CodeNode';
+
+const editorConfig = {
+  namespace: '',
+  theme: {
+    code: 'editor-code',
+  },
+} as EditorConfig;
+
+describe('CodeNode', () => {
+  initializeUnitTest(
+    (testEnv) => {
+      it('applies and replaces styles through DOM style properties', async () => {
+        const {editor} = testEnv;
+
+        let dom!: HTMLElement;
+        let prevNode!: ReturnType<typeof $createCodeNode>;
+
+        await editor.update(() => {
+          const codeNode = $createCodeNode('javascript');
+          codeNode.setStyle('color: red; margin: 0 !important;');
+          prevNode = codeNode;
+          dom = codeNode.createDOM(editorConfig);
+        });
+
+        expect(dom!.style.color).toBe('red');
+        expect(dom!.style.getPropertyPriority('margin')).toBe('important');
+
+        await editor.update(() => {
+          const codeNode = $createCodeNode('javascript');
+          codeNode.setStyle('padding: 1px; --custom: value;');
+
+          expect(codeNode.updateDOM(prevNode, dom, editorConfig)).toBe(false);
+        });
+
+        expect(dom.style.color).toBe('');
+        expect(dom.style.margin).toBe('');
+        expect(dom.style.padding).toBe('1px');
+        expect(dom.style.getPropertyValue('--custom')).toBe('value');
+      });
+
+      it('exports styles through DOM style properties', async () => {
+        const {editor} = testEnv;
+
+        let exportedElement: HTMLElement | null = null;
+
+        await editor.update(() => {
+          const codeNode = $createCodeNode('javascript');
+          codeNode.setStyle('padding: 1px; color: blue;');
+          $getRoot().append(codeNode);
+
+          const {element} = codeNode.exportDOM(editor);
+          exportedElement = element as HTMLElement;
+        });
+
+        expect(exportedElement).not.toBeNull();
+        expect(exportedElement!.style.padding).toBe('1px');
+        expect(exportedElement!.style.color).toBe('blue');
+      });
+    },
+    {
+      namespace: 'test',
+      nodes: [],
+      theme: editorConfig.theme,
+    },
+  );
+});

--- a/packages/lexical-list/package.json
+++ b/packages/lexical-list/package.json
@@ -13,7 +13,6 @@
   "types": "index.d.ts",
   "dependencies": {
     "@lexical/extension": "workspace:*",
-    "@lexical/selection": "workspace:*",
     "@lexical/utils": "workspace:*",
     "lexical": "workspace:*"
   },

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -22,7 +22,6 @@ import type {
   Spread,
 } from 'lexical';
 
-import {getStyleObjectFromCSS} from '@lexical/selection';
 import {
   addClassNamesToElement,
   removeClassNamesFromElement,
@@ -36,8 +35,10 @@ import {
   $isRangeSelection,
   buildImportMap,
   ElementNode,
+  getStyleObjectFromCSS,
   LexicalEditor,
   normalizeClassNames,
+  setDOMStyleFromCSS,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
@@ -140,11 +141,7 @@ export class ListItemNode extends ElementNode {
     const nextStyle = this.__style;
 
     if (prevStyle !== nextStyle) {
-      if (nextStyle === '') {
-        dom.removeAttribute('style');
-      } else {
-        dom.style.cssText = nextStyle;
-      }
+      setDOMStyleFromCSS(dom.style, nextStyle, prevStyle);
     }
     applyMarkerStyles(dom, this, prevNode);
   }

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -59,14 +59,20 @@ function applyMarkerStyles(
   node: ListItemNode,
   prevNode: ListItemNode | null,
 ): void {
-  const styles: Record<string, string> = getStyleObjectFromCSS(
-    node.__textStyle,
-  );
+  const nextTextStyle = node.__textStyle;
+  const prevTextStyle = prevNode ? prevNode.__textStyle : '';
+
+  if (prevNode !== null && prevTextStyle === nextTextStyle) {
+    return;
+  }
+
+  const styles: Record<string, string> = getStyleObjectFromCSS(nextTextStyle);
   for (const k in styles) {
     dom.style.setProperty(`--listitem-marker-${k}`, styles[k]);
   }
-  if (prevNode) {
-    for (const k in getStyleObjectFromCSS(prevNode.__textStyle)) {
+
+  if (prevTextStyle !== '') {
+    for (const k in getStyleObjectFromCSS(prevTextStyle)) {
       if (!(k in styles)) {
         dom.style.removeProperty(`--listitem-marker-${k}`);
       }

--- a/packages/lexical-playground/split/index.html
+++ b/packages/lexical-playground/split/index.html
@@ -14,14 +14,26 @@
         const {port, hostname, protocol} = window.location;
         const leftIframe = document.createElement('iframe');
         leftIframe.src = `${protocol}//${hostname}:${port}${window.location.search}`;
-        leftIframe.style.cssText =
-          'border: 0; width: calc(50% - 1px); position: fixed; top: 0; left: 0; height: 100%;';
+        Object.assign(leftIframe.style, {
+          border: '0',
+          height: '100%',
+          left: '0',
+          position: 'fixed',
+          top: '0',
+          width: 'calc(50% - 1px)',
+        });
         leftIframe.setAttribute('name', 'left');
         document.body.appendChild(leftIframe);
         const rightIframe = document.createElement('iframe');
         rightIframe.src = `${protocol}//${hostname}:${port}${window.location.search}`;
-        rightIframe.style.cssText =
-          'border: 0; width: calc(50% - 1px); position: fixed; top: 0; left: calc(50% + 1px); height: 100%;';
+        Object.assign(rightIframe.style, {
+          border: '0',
+          height: '100%',
+          left: 'calc(50% + 1px)',
+          position: 'fixed',
+          top: '0',
+          width: 'calc(50% - 1px)',
+        });
         rightIframe.setAttribute('name', 'right');
         document.body.appendChild(rightIframe);
       })();

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -45,7 +45,7 @@ function $convertMentionElement(
   return null;
 }
 
-const mentionStyle = 'background-color: rgba(24, 119, 232, 0.2)';
+const mentionBackgroundColor = 'rgba(24, 119, 232, 0.2)';
 export class MentionNode extends TextNode {
   __mention: string;
 
@@ -76,7 +76,7 @@ export class MentionNode extends TextNode {
 
   createDOM(config: EditorConfig): HTMLElement {
     const dom = super.createDOM(config);
-    dom.style.cssText = mentionStyle;
+    dom.style.backgroundColor = mentionBackgroundColor;
     dom.className = 'mention';
     dom.spellcheck = false;
 

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -279,15 +279,17 @@ function CommentInputBox({
               container.appendChild(elem);
             }
             const color = '255, 212, 0';
-            const style = `position:absolute;top:${
+            elem.style.position = 'absolute';
+            elem.style.top = `${
               selectionRect.top +
               (window.pageYOffset || document.documentElement.scrollTop)
-            }px;left:${selectionRect.left}px;height:${
-              selectionRect.height
-            }px;width:${
-              selectionRect.width
-            }px;background-color:rgba(${color}, 0.3);pointer-events:none;z-index:5;`;
-            elem.style.cssText = style;
+            }px`;
+            elem.style.left = `${selectionRect.left}px`;
+            elem.style.height = `${selectionRect.height}px`;
+            elem.style.width = `${selectionRect.width}px`;
+            elem.style.backgroundColor = `rgba(${color}, 0.3)`;
+            elem.style.pointerEvents = 'none';
+            elem.style.zIndex = '5';
           }
           for (let i = elementsLength - 1; i >= selectionRectsLength; i--) {
             const elem = elements[i];

--- a/packages/lexical-selection/flow/LexicalSelection.js.flow
+++ b/packages/lexical-selection/flow/LexicalSelection.js.flow
@@ -18,6 +18,7 @@ import type {
   TextNode,
 } from 'lexical';
 declare export function $cloneWithProperties<T extends LexicalNode>(node: T): T;
+/** @deprecated moved to the lexical package */
 declare export function getStyleObjectFromCSS(css: string): {
   [string]: string,
 };

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -2556,6 +2556,64 @@ describe('LexicalSelection tests', () => {
     });
   });
 
+  describe('Testing that getStyleObjectFromRawCSS handles comments and semicolons inside values', () => {
+    test('', async () => {
+      const testEditor = createTestEditor();
+      const element = document.createElement('div');
+      testEditor.setRootElement(element);
+
+      await testEditor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const textNode = $createTextNode('Hello, World!');
+        textNode.setStyle(
+          'background-image: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'></svg>"); /* ignored */ content: "semi;colon:value"; color: red;',
+        );
+        $addNodeStyle(textNode);
+        paragraph.append(textNode);
+        root.append(paragraph);
+
+        const selection = $createRangeSelection();
+        $setSelection(selection);
+        selection.insertParagraph();
+        $setAnchorPoint({
+          key: textNode.getKey(),
+          offset: 0,
+          type: 'text',
+        });
+
+        $setFocusPoint({
+          key: textNode.getKey(),
+          offset: 10,
+          type: 'text',
+        });
+
+        const cssBackgroundImageValue = $getSelectionStyleValueForProperty(
+          selection,
+          'background-image',
+          '',
+        );
+        expect(cssBackgroundImageValue).toBe(
+          'url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'></svg>")',
+        );
+
+        const cssContentValue = $getSelectionStyleValueForProperty(
+          selection,
+          'content',
+          '',
+        );
+        expect(cssContentValue).toBe('"semi;colon:value"');
+
+        const cssColorValue = $getSelectionStyleValueForProperty(
+          selection,
+          'color',
+          '',
+        );
+        expect(cssColorValue).toBe('red');
+      });
+    });
+  });
+
   describe('$patchStyle', () => {
     it('should patch the style with the new style object', async () => {
       await ReactTestUtils.act(async () => {

--- a/packages/lexical-selection/src/constants.ts
+++ b/packages/lexical-selection/src/constants.ts
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- */
-export const CSS_TO_STYLES: Map<string, Record<string, string>> = new Map();

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import {getStyleObjectFromCSS as getStyleObjectFromCSS_} from 'lexical';
+
 import {$trimTextContentFromAnchor} from './lexical-node';
 
 export {
@@ -34,8 +36,9 @@ export {
   createDOMRange,
   createRectsFromDOMRange,
   getCSSFromStyleObject,
-  /** @deprecated moved to the lexical package */ getStyleObjectFromCSS,
 } from './utils';
+/** @deprecated moved to the `lexical` package */
+export const getStyleObjectFromCSS = getStyleObjectFromCSS_;
 /** @deprecated renamed to {@link $trimTextContentFromAnchor} by @lexical/eslint-plugin rules-of-lexical */
 export const trimTextContentFromAnchor = $trimTextContentFromAnchor;
 export {

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -34,7 +34,7 @@ export {
   createDOMRange,
   createRectsFromDOMRange,
   getCSSFromStyleObject,
-  getStyleObjectFromCSS,
+  /** @deprecated moved to the lexical package */ getStyleObjectFromCSS,
 } from './utils';
 /** @deprecated renamed to {@link $trimTextContentFromAnchor} by @lexical/eslint-plugin rules-of-lexical */
 export const trimTextContentFromAnchor = $trimTextContentFromAnchor;

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -20,6 +20,7 @@ import {
   $isTokenOrSegmented,
   BaseSelection,
   ElementNode,
+  getStyleObjectFromCSS,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -28,8 +29,9 @@ import {
   TextNode,
 } from 'lexical';
 import invariant from 'shared/invariant';
+import warnOnlyOnce from 'shared/warnOnlyOnce';
 
-import {getCSSFromStyleObject, getStyleObjectFromCSS} from './utils';
+import {getCSSFromStyleObject} from './utils';
 
 /**
  * Generally used to append text content to HTML and JSON. Grabs the text content and "slices"
@@ -239,9 +241,11 @@ export function $trimTextContentFromAnchor(
 }
 
 /**
- * Kept for backwards compatibility. Styles are parsed on demand now.
+ * @deprecated node styles are parsed on demand and not cached eternally
  */
-export function $addNodeStyle(_node: TextNode): void {}
+export const $addNodeStyle: (_node: TextNode) => void = warnOnlyOnce(
+  '$addNodeStyle is a deprecated no-op and calls should be removed',
+);
 
 /**
  * Applies the provided styles to the given TextNode, ElementNode, or

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -29,10 +29,7 @@ import {
 } from 'lexical';
 import invariant from 'shared/invariant';
 
-import {
-  getCSSFromStyleObject,
-  getStyleObjectFromCSS,
-} from './utils';
+import {getCSSFromStyleObject, getStyleObjectFromCSS} from './utils';
 
 /**
  * Generally used to append text content to HTML and JSON. Grabs the text content and "slices"

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -29,11 +29,9 @@ import {
 } from 'lexical';
 import invariant from 'shared/invariant';
 
-import {CSS_TO_STYLES} from './constants';
 import {
   getCSSFromStyleObject,
   getStyleObjectFromCSS,
-  getStyleObjectFromRawCSS,
 } from './utils';
 
 /**
@@ -244,14 +242,9 @@ export function $trimTextContentFromAnchor(
 }
 
 /**
- * Gets the TextNode's style object and adds the styles to the CSS.
- * @param node - The TextNode to add styles to.
+ * Kept for backwards compatibility. Styles are parsed on demand now.
  */
-export function $addNodeStyle(node: TextNode): void {
-  const CSSText = node.getStyle();
-  const styles = getStyleObjectFromRawCSS(CSSText);
-  CSS_TO_STYLES.set(CSSText, styles);
-}
+export function $addNodeStyle(_node: TextNode): void {}
 
 /**
  * Applies the provided styles to the given TextNode, ElementNode, or
@@ -301,7 +294,6 @@ export function $patchStyle(
   } else {
     target.setTextStyle(newCSSText);
   }
-  CSS_TO_STYLES.set(newCSSText, newStyles);
 }
 
 /**

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -34,15 +34,12 @@ import {
   $isRootOrShadowRoot,
   $isTextNode,
   $setSelection,
+  getStyleObjectFromCSS,
   INTERNAL_$isBlock,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
-import {
-  $getComputedStyleForElement,
-  $getComputedStyleForParent,
-  getStyleObjectFromCSS,
-} from './utils';
+import {$getComputedStyleForElement, $getComputedStyleForParent} from './utils';
 
 export function $copyBlockFormatIndent(
   srcNode: ElementNode,

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -186,13 +186,6 @@ export function getStyleObjectFromRawCSS(css: string): Record<string, string> {
  * @param css - The CSS property as a string.
  * @returns The value of the given CSS property.
  */
-export {getStyleObjectFromCSS};
-
-/**
- * Gets the CSS styles from the style object.
- * @param styles - The style object containing the styles to get.
- * @returns A string containing the CSS styles and their values.
- */
 export function getCSSFromStyleObject(styles: Record<string, string>): string {
   let css = '';
 

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -7,9 +7,12 @@
  */
 import type {ElementNode, LexicalEditor, LexicalNode} from 'lexical';
 
-import {$getEditor, $isRootNode, $isTextNode} from 'lexical';
-
-import {CSS_TO_STYLES} from './constants';
+import {
+  $getEditor,
+  $isRootNode,
+  $isTextNode,
+  getStyleObjectFromCSS,
+} from 'lexical';
 
 function getDOMTextNode(element: Node | null): Text | null {
   let node = element;
@@ -175,43 +178,15 @@ export function createRectsFromDOMRange(
  * @returns The styleObject containing all the styles and their values.
  */
 export function getStyleObjectFromRawCSS(css: string): Record<string, string> {
-  const styleObject: Record<string, string> = {};
-  if (!css) {
-    return styleObject;
-  }
-  const styles = css.split(';');
-
-  for (const style of styles) {
-    if (style !== '') {
-      const [key, value] = style.split(/:([^]+)/); // split on first colon
-      if (key && value) {
-        styleObject[key.trim()] = value.trim();
-      }
-    }
-  }
-
-  return styleObject;
+  return getStyleObjectFromCSS(css);
 }
 
 /**
- * Given a CSS string, returns an object from the style cache.
+ * Given a CSS string, returns the parsed style object.
  * @param css - The CSS property as a string.
  * @returns The value of the given CSS property.
  */
-export function getStyleObjectFromCSS(css: string): Record<string, string> {
-  let value = CSS_TO_STYLES.get(css);
-  if (value === undefined) {
-    value = getStyleObjectFromRawCSS(css);
-    CSS_TO_STYLES.set(css, value);
-  }
-
-  if (__DEV__) {
-    // Freeze the value in DEV to prevent accidental mutations
-    Object.freeze(value);
-  }
-
-  return value;
-}
+export {getStyleObjectFromCSS};
 
 /**
  * Gets the CSS styles from the style object.

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -29,6 +29,7 @@ import {
   LexicalUpdateJSON,
   NodeKey,
   SerializedElementNode,
+  setDOMStyleFromCSS,
   setDOMUnmanaged,
   Spread,
 } from 'lexical';
@@ -274,7 +275,7 @@ export class TableNode extends ElementNode {
   createDOM(config: EditorConfig, editor?: LexicalEditor): HTMLElement {
     const tableElement = document.createElement('table');
     if (this.__style) {
-      tableElement.style.cssText = this.__style;
+      setDOMStyleFromCSS(tableElement.style, this.__style);
     }
     const colGroup = document.createElement('colgroup');
     tableElement.appendChild(colGroup);
@@ -287,7 +288,7 @@ export class TableNode extends ElementNode {
       if (classes) {
         addClassNamesToElement(wrapperElement, classes);
       } else {
-        wrapperElement.style.cssText = 'overflow-x: auto;';
+        wrapperElement.style.overflowX = 'auto';
       }
       wrapperElement.appendChild(tableElement);
       this.updateTableWrapper(null, wrapperElement, tableElement, config);
@@ -323,7 +324,11 @@ export class TableNode extends ElementNode {
     config: EditorConfig,
   ): void {
     if (this.__style !== (prevNode ? prevNode.__style : '')) {
-      tableElement.style.cssText = this.__style;
+      setDOMStyleFromCSS(
+        tableElement.style,
+        this.__style,
+        prevNode ? prevNode.__style : '',
+      );
     }
     if (this.__rowStriping !== (prevNode ? prevNode.__rowStriping : false)) {
       setRowStriping(tableElement, config, this.__rowStriping);

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -707,8 +707,10 @@ function needsManualZoom(): boolean {
     // https://chromestatus.com/feature/5198254868529152
     // https://github.com/facebook/lexical/issues/6863
     const div = document.createElement('div');
-    div.style.cssText =
-      'position: absolute; opacity: 0; width: 100px; left: -1000px;';
+    div.style.position = 'absolute';
+    div.style.opacity = '0';
+    div.style.width = '100px';
+    div.style.left = '-1000px';
     document.body.appendChild(div);
     const noZoom = div.getBoundingClientRect();
     div.style.setProperty('zoom', '2');

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -22,6 +22,7 @@ import {
   $isLineBreakNode,
   $isRangeSelection,
   $isTextNode,
+  setDOMStyleObject,
 } from 'lexical';
 import invariant from 'shared/invariant';
 import {
@@ -220,17 +221,42 @@ function createCursorSelection(
   const caret = document.createElement('span');
   if (theme.cursor) {
     caret.className = theme.cursor;
-    caret.style.cssText = `position:absolute;top:0;bottom:0;right:-1px;`;
-    caret.style.setProperty('--lexical-cursor-color', color);
+    setDOMStyleObject(caret.style, {
+      '--lexical-cursor-color': color,
+      bottom: '0',
+      position: 'absolute',
+      right: '-1px',
+      top: '0',
+    });
   } else {
-    caret.style.cssText = `position:absolute;top:0;bottom:0;right:-1px;width:1px;background-color:${color};z-index:10;`;
+    setDOMStyleObject(caret.style, {
+      'background-color': color,
+      bottom: '0',
+      position: 'absolute',
+      right: '-1px',
+      top: '0',
+      width: '1px',
+      'z-index': '10',
+    });
   }
   const name = document.createElement('span');
   name.textContent = cursor.name;
   if (theme.cursorName) {
     name.className = theme.cursorName;
   } else {
-    name.style.cssText = `position:absolute;left:-2px;top:-16px;background-color:${color};color:#fff;line-height:12px;font-size:12px;padding:2px;font-family:Arial;font-weight:bold;white-space:nowrap;`;
+    setDOMStyleObject(name.style, {
+      'background-color': color,
+      color: '#fff',
+      'font-family': 'Arial',
+      'font-size': '12px',
+      'font-weight': 'bold',
+      left: '-2px',
+      'line-height': '12px',
+      padding: '2px',
+      position: 'absolute',
+      top: '-16px',
+      'white-space': 'nowrap',
+    });
   }
   caret.appendChild(name);
   return {
@@ -344,18 +370,38 @@ function updateCursor(
 
     const top = selectionRect.top - containerRect.top;
     const left = selectionRect.left - containerRect.left;
-    const posStyle = `position:absolute;top:${top}px;left:${left}px;height:${selectionRect.height}px;width:${selectionRect.width}px;pointer-events:none;`;
+    const positionStyle = {
+      height: `${selectionRect.height}px`,
+      left: `${left}px`,
+      'pointer-events': 'none',
+      position: 'absolute',
+      top: `${top}px`,
+      width: `${selectionRect.width}px`,
+    };
 
     if (theme.selection) {
       selection.className = theme.selection;
-      selection.style.cssText = posStyle;
-      selection.style.setProperty('--lexical-cursor-color', color);
-      (selection.firstChild as HTMLSpanElement).style.cssText =
-        `position:absolute;left:0;top:0;width:100%;height:100%;`;
+      setDOMStyleObject(selection.style, {
+        ...positionStyle,
+        '--lexical-cursor-color': color,
+      });
+      setDOMStyleObject((selection.firstChild as HTMLSpanElement).style, {
+        height: '100%',
+        left: '0',
+        position: 'absolute',
+        top: '0',
+        width: '100%',
+      });
     } else {
-      selection.style.cssText = posStyle;
-      (selection.firstChild as HTMLSpanElement).style.cssText =
-        `${posStyle}left:0;top:0;background-color:${color};opacity:0.3;z-index:5;`;
+      setDOMStyleObject(selection.style, positionStyle);
+      setDOMStyleObject((selection.firstChild as HTMLSpanElement).style, {
+        ...positionStyle,
+        'background-color': color,
+        left: '0',
+        opacity: '0.3',
+        top: '0',
+        'z-index': '5',
+      });
     }
 
     if (i === selectionRectsLength - 1) {

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1768,3 +1768,15 @@ declare export function removeClassNamesFromElement(
 ): void;
 declare export function mergeRegister(...func: Array<() => void>): () => void;
 declare export function normalizeClassNames(...classNames: Array<typeof undefined | boolean | null | string>): Array<string>;
+declare export function getStyleObjectFromCSS(css: string): {
+  [string]: string,
+};
+declare export function setDOMStyleObject(
+  domStyle: CSSStyleDeclaration,
+  styleObject: {[string]: string | null | void},
+): void;
+declare export function setDOMStyleFromCSS(
+  domStyle: CSSStyleDeclaration,
+  cssText: string,
+  prevCSSText?: string,
+): void;

--- a/packages/lexical/src/__tests__/unit/setDOMStyle.test.ts
+++ b/packages/lexical/src/__tests__/unit/setDOMStyle.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  getStyleObjectFromCSS,
+  setDOMStyleFromCSS,
+  setDOMStyleObject,
+} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+describe('setDOMStyle', () => {
+  it('parses CSS text into a style object', () => {
+    expect(
+      getStyleObjectFromCSS(
+        'color: red; margin: 0 !important; --custom: example;',
+      ),
+    ).toEqual({
+      '--custom': 'example',
+      color: 'red',
+      margin: '0 !important',
+    });
+  });
+
+  it('parses values with comments, semicolons and colons inside quotes and parentheses', () => {
+    expect(
+      getStyleObjectFromCSS(
+        'background-image: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'></svg>"); /* ignored */ content: "semi;colon:value"; color: red;',
+      ),
+    ).toEqual({
+      'background-image':
+        'url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'></svg>")',
+      color: 'red',
+      content: '"semi;colon:value"',
+    });
+  });
+
+  it('returns a fresh style object for each parse', () => {
+    const styleObject = getStyleObjectFromCSS('color: red;');
+    styleObject.color = 'blue';
+
+    expect(getStyleObjectFromCSS('color: red;')).toEqual({color: 'red'});
+  });
+
+  it('applies CSS text without cssText', () => {
+    const element = document.createElement('div');
+
+    setDOMStyleFromCSS(
+      element.style,
+      'color: red; margin: 0 !IMPORTANT; --custom: example;',
+    );
+
+    expect(element.style.color).toBe('red');
+    expect(element.style.getPropertyPriority('margin')).toBe('important');
+    expect(element.style.getPropertyValue('--custom')).toBe('example');
+  });
+
+  it('replaces previous inline styles when CSS text changes', () => {
+    const element = document.createElement('div');
+
+    setDOMStyleFromCSS(
+      element.style,
+      'color: red; margin: 0 !important; --custom: example;',
+    );
+    setDOMStyleFromCSS(
+      element.style,
+      'padding: 1px;',
+      'color: red; margin: 0 !important; --custom: example;',
+    );
+
+    expect(element.style.color).toBe('');
+    expect(element.style.margin).toBe('');
+    expect(element.style.getPropertyValue('--custom')).toBe('');
+    expect(element.style.padding).toBe('1px');
+  });
+
+  it('applies direct style objects', () => {
+    const element = document.createElement('div');
+
+    setDOMStyleObject(element.style, {
+      color: 'red',
+      margin: '0 !IMPORTANT',
+      padding: null,
+    });
+
+    expect(element.style.color).toBe('red');
+    expect(element.style.getPropertyPriority('margin')).toBe('important');
+    expect(element.style.padding).toBe('');
+  });
+});

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -395,3 +395,8 @@ export {
   removeClassNamesFromElement,
 } from './utils/classNames';
 export {mergeRegister} from './utils/mergeRegister';
+export {
+  getStyleObjectFromCSS,
+  setDOMStyleFromCSS,
+  setDOMStyleObject,
+} from './utils/setDOMStyle';

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -6,12 +6,6 @@
  *
  */
 
-import {
-  getStyleObjectFromCSS as getStyleObjectFromCSS_,
-  setDOMStyleFromCSS as setDOMStyleFromCSS_,
-  setDOMStyleObject as setDOMStyleObject_,
-} from './utils/setDOMStyle';
-
 export type {
   BaseCaret,
   CaretDirection,
@@ -401,27 +395,8 @@ export {
   removeClassNamesFromElement,
 } from './utils/classNames';
 export {mergeRegister} from './utils/mergeRegister';
-/**
- * Parses inline CSS text into an object that is compatible with
- * `CSSStyleDeclaration.setProperty()`.
- *
- * Property names are expected to be kebab-case, such as `font-size`, and
- * values are expected to include explicit units where needed, such as `12px`.
- */
-export const getStyleObjectFromCSS = getStyleObjectFromCSS_;
-/**
- * Applies inline CSS text to a DOM style declaration using
- * `CSSStyleDeclaration.setProperty()`.
- *
- * Property names are expected to be kebab-case, such as `font-size`, and
- * values are expected to include explicit units where needed, such as `12px`.
- */
-export const setDOMStyleFromCSS = setDOMStyleFromCSS_;
-/**
- * Applies a style object to a DOM style declaration using
- * `CSSStyleDeclaration.setProperty()`.
- *
- * Property names are expected to be kebab-case, such as `font-size`, and
- * values are expected to include explicit units where needed, such as `12px`.
- */
-export const setDOMStyleObject = setDOMStyleObject_;
+export {
+  getStyleObjectFromCSS,
+  setDOMStyleFromCSS,
+  setDOMStyleObject,
+} from './utils/setDOMStyle';

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -6,6 +6,12 @@
  *
  */
 
+import {
+  getStyleObjectFromCSS as getStyleObjectFromCSS_,
+  setDOMStyleFromCSS as setDOMStyleFromCSS_,
+  setDOMStyleObject as setDOMStyleObject_,
+} from './utils/setDOMStyle';
+
 export type {
   BaseCaret,
   CaretDirection,
@@ -395,8 +401,27 @@ export {
   removeClassNamesFromElement,
 } from './utils/classNames';
 export {mergeRegister} from './utils/mergeRegister';
-export {
-  getStyleObjectFromCSS,
-  setDOMStyleFromCSS,
-  setDOMStyleObject,
-} from './utils/setDOMStyle';
+/**
+ * Parses inline CSS text into an object that is compatible with
+ * `CSSStyleDeclaration.setProperty()`.
+ *
+ * Property names are expected to be kebab-case, such as `font-size`, and
+ * values are expected to include explicit units where needed, such as `12px`.
+ */
+export const getStyleObjectFromCSS = getStyleObjectFromCSS_;
+/**
+ * Applies inline CSS text to a DOM style declaration using
+ * `CSSStyleDeclaration.setProperty()`.
+ *
+ * Property names are expected to be kebab-case, such as `font-size`, and
+ * values are expected to include explicit units where needed, such as `12px`.
+ */
+export const setDOMStyleFromCSS = setDOMStyleFromCSS_;
+/**
+ * Applies a style object to a DOM style declaration using
+ * `CSSStyleDeclaration.setProperty()`.
+ *
+ * Property names are expected to be kebab-case, such as `font-size`, and
+ * values are expected to include explicit units where needed, such as `12px`.
+ */
+export const setDOMStyleObject = setDOMStyleObject_;

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -228,8 +228,9 @@ export class ElementDOMSlot<T extends HTMLElement = HTMLElement> {
     if (webkitHack) {
       const img = document.createElement('img');
       img.setAttribute('data-lexical-linebreak', 'true');
-      img.style.cssText =
-        'display: inline !important; border: 0px !important; margin: 0px !important;';
+      img.style.setProperty('display', 'inline', 'important');
+      img.style.setProperty('border', '0px', 'important');
+      img.style.setProperty('margin', '0px', 'important');
       img.alt = '';
       element.insertBefore(img, br);
       element.__lexicalLineBreak = img;

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -71,6 +71,7 @@ import {
   isInlineDomNode,
   toggleTextFormatType,
 } from '../LexicalUtils';
+import {setDOMStyleFromCSS} from '../utils/setDOMStyle';
 import {$createLineBreakNode} from './LexicalLineBreakNode';
 import {$createTabNode} from './LexicalTabNode';
 
@@ -502,7 +503,7 @@ export class TextNode extends LexicalNode {
     createTextInnerDOM(innerDOM, this, innerTag, format, text, config);
     const style = this.__style;
     if (style !== '') {
-      dom.style.cssText = style;
+      setDOMStyleFromCSS(dom.style, style);
     }
     return dom;
   }
@@ -565,7 +566,7 @@ export class TextNode extends LexicalNode {
     const prevStyle = prevNode.__style;
     const nextStyle = this.__style;
     if (prevStyle !== nextStyle) {
-      dom.style.cssText = nextStyle;
+      setDOMStyleFromCSS(dom.style, nextStyle, prevStyle);
     }
     return false;
   }

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -789,6 +789,24 @@ describe('LexicalTextNode tests', () => {
       });
     });
 
+    test('applies styles with direct DOM property updates', async () => {
+      await update(() => {
+        const textNode = $createTextNode('My text node');
+        textNode.setStyle(
+          'color: red; background-color: blue !important; --custom: value;',
+        );
+
+        const element = textNode.createDOM(editorConfig);
+
+        expect(element.style.color).toBe('red');
+        expect(element.style.backgroundColor).toBe('blue');
+        expect(element.style.getPropertyPriority('background-color')).toBe(
+          'important',
+        );
+        expect(element.style.getPropertyValue('--custom')).toBe('value');
+      });
+    });
+
     describe('has parent node', () => {
       test.each([
         ['no formatting', 0, 'My text node', '<span>My text node</span>'],
@@ -909,6 +927,25 @@ describe('LexicalTextNode tests', () => {
         });
       },
     );
+
+    test('updates and removes styles with direct DOM property updates', async () => {
+      await update(() => {
+        const prevTextNode = $createTextNode('My text node');
+        prevTextNode.setStyle('color: red; --custom: value;');
+
+        const element = prevTextNode.createDOM(editorConfig);
+
+        const nextTextNode = $createTextNode('My text node');
+        nextTextNode.setStyle('padding: 1px;');
+
+        expect(
+          nextTextNode.updateDOM(prevTextNode, element, editorConfig),
+        ).toBe(false);
+        expect(element.style.color).toBe('');
+        expect(element.style.getPropertyValue('--custom')).toBe('');
+        expect(element.style.padding).toBe('1px');
+      });
+    });
   });
 
   describe('exportDOM()', () => {

--- a/packages/lexical/src/utils/setDOMStyle.ts
+++ b/packages/lexical/src/utils/setDOMStyle.ts
@@ -7,6 +7,40 @@
  */
 
 const IMPORTANT_REG_EXP = /\s*!important\s*$/i;
+const CSS_TO_STYLE_OBJECT_CACHE_MAX_SIZE = 100;
+const CSS_TO_STYLE_OBJECT_CACHE: Map<
+  string,
+  Record<string, string>
+> = new Map();
+
+function getCachedStyleObjectFromCSS(
+  css: string,
+): Record<string, string> | undefined {
+  const cachedStyleObject = CSS_TO_STYLE_OBJECT_CACHE.get(css);
+
+  if (cachedStyleObject !== undefined) {
+    CSS_TO_STYLE_OBJECT_CACHE.delete(css);
+    CSS_TO_STYLE_OBJECT_CACHE.set(css, cachedStyleObject);
+    return {...cachedStyleObject};
+  }
+
+  return undefined;
+}
+
+function setCachedStyleObjectFromCSS(
+  css: string,
+  styleObject: Record<string, string>,
+): void {
+  CSS_TO_STYLE_OBJECT_CACHE.set(css, styleObject);
+
+  if (CSS_TO_STYLE_OBJECT_CACHE.size > CSS_TO_STYLE_OBJECT_CACHE_MAX_SIZE) {
+    const oldestKey = CSS_TO_STYLE_OBJECT_CACHE.keys().next().value;
+
+    if (oldestKey !== undefined) {
+      CSS_TO_STYLE_OBJECT_CACHE.delete(oldestKey);
+    }
+  }
+}
 
 function getStyleDeclarations(css: string): Array<string> {
   const declarations: Array<string> = [];
@@ -164,6 +198,12 @@ function getStylePropertyAndValue(
 }
 
 export function getStyleObjectFromCSS(css: string): Record<string, string> {
+  const cachedStyleObject = getCachedStyleObjectFromCSS(css);
+
+  if (cachedStyleObject !== undefined) {
+    return cachedStyleObject;
+  }
+
   const styleObject: Record<string, string> = {};
 
   for (const styleDeclaration of getStyleDeclarations(css)) {
@@ -175,7 +215,13 @@ export function getStyleObjectFromCSS(css: string): Record<string, string> {
     }
   }
 
-  return styleObject;
+  if (__DEV__) {
+    Object.freeze(styleObject);
+  }
+
+  setCachedStyleObjectFromCSS(css, styleObject);
+
+  return {...styleObject};
 }
 
 function setDOMStyleProperty(

--- a/packages/lexical/src/utils/setDOMStyle.ts
+++ b/packages/lexical/src/utils/setDOMStyle.ts
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const IMPORTANT_REG_EXP = /\s*!important\s*$/i;
+
+function getStyleDeclarations(css: string): Array<string> {
+  const declarations: Array<string> = [];
+
+  if (!css) {
+    return declarations;
+  }
+
+  let currentDeclaration = '';
+  let currentQuote: '"' | "'" | null = null;
+  let inComment = false;
+  let isEscaped = false;
+  let parenthesisDepth = 0;
+
+  for (let i = 0; i < css.length; i++) {
+    const char = css[i];
+
+    if (inComment) {
+      if (char === '*' && css[i + 1] === '/') {
+        inComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (isEscaped) {
+      currentDeclaration += char;
+      isEscaped = false;
+      continue;
+    }
+
+    if (currentQuote !== null) {
+      currentDeclaration += char;
+
+      if (char === '\\') {
+        isEscaped = true;
+      } else if (char === currentQuote) {
+        currentQuote = null;
+      }
+
+      continue;
+    }
+
+    if (char === '/' && css[i + 1] === '*') {
+      inComment = true;
+      i++;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      currentQuote = char;
+      currentDeclaration += char;
+      continue;
+    }
+
+    if (char === '(') {
+      parenthesisDepth++;
+      currentDeclaration += char;
+      continue;
+    }
+
+    if (char === ')') {
+      parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+      currentDeclaration += char;
+      continue;
+    }
+
+    if (char === ';' && parenthesisDepth === 0) {
+      const declaration = currentDeclaration.trim();
+
+      if (declaration !== '') {
+        declarations.push(declaration);
+      }
+
+      currentDeclaration = '';
+      continue;
+    }
+
+    currentDeclaration += char;
+  }
+
+  const declaration = currentDeclaration.trim();
+
+  if (declaration !== '') {
+    declarations.push(declaration);
+  }
+
+  return declarations;
+}
+
+function getStylePropertyAndValue(
+  styleDeclaration: string,
+): [string, string] | null {
+  let currentQuote: '"' | "'" | null = null;
+  let inComment = false;
+  let isEscaped = false;
+  let parenthesisDepth = 0;
+
+  for (let i = 0; i < styleDeclaration.length; i++) {
+    const char = styleDeclaration[i];
+
+    if (inComment) {
+      if (char === '*' && styleDeclaration[i + 1] === '/') {
+        inComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (isEscaped) {
+      isEscaped = false;
+      continue;
+    }
+
+    if (currentQuote !== null) {
+      if (char === '\\') {
+        isEscaped = true;
+      } else if (char === currentQuote) {
+        currentQuote = null;
+      }
+
+      continue;
+    }
+
+    if (char === '/' && styleDeclaration[i + 1] === '*') {
+      inComment = true;
+      i++;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      currentQuote = char;
+      continue;
+    }
+
+    if (char === '(') {
+      parenthesisDepth++;
+      continue;
+    }
+
+    if (char === ')') {
+      parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+      continue;
+    }
+
+    if (char === ':' && parenthesisDepth === 0) {
+      const property = styleDeclaration.slice(0, i).trim();
+      const value = styleDeclaration.slice(i + 1).trim();
+
+      return property !== '' && value !== '' ? [property, value] : null;
+    }
+  }
+
+  return null;
+}
+
+export function getStyleObjectFromCSS(css: string): Record<string, string> {
+  const styleObject: Record<string, string> = {};
+
+  for (const styleDeclaration of getStyleDeclarations(css)) {
+    const propertyAndValue = getStylePropertyAndValue(styleDeclaration);
+
+    if (propertyAndValue !== null) {
+      const [property, value] = propertyAndValue;
+      styleObject[property] = value;
+    }
+  }
+
+  return styleObject;
+}
+
+function setDOMStyleProperty(
+  domStyle: CSSStyleDeclaration,
+  property: string,
+  value: string,
+): void {
+  const priority = IMPORTANT_REG_EXP.test(value) ? 'important' : '';
+  const nextValue =
+    priority === '' ? value : value.replace(IMPORTANT_REG_EXP, '').trim();
+
+  domStyle.setProperty(property, nextValue, priority);
+}
+
+export function setDOMStyleObject(
+  domStyle: CSSStyleDeclaration,
+  styleObject: Record<string, string | null | undefined>,
+): void {
+  for (const [property, value] of Object.entries(styleObject)) {
+    if (value == null) {
+      domStyle.removeProperty(property);
+    } else {
+      setDOMStyleProperty(domStyle, property, value);
+    }
+  }
+}
+
+export function setDOMStyleFromCSS(
+  domStyle: CSSStyleDeclaration,
+  cssText: string,
+  prevCSSText: string = '',
+): void {
+  if (cssText === prevCSSText) {
+    return;
+  }
+
+  for (const property in getStyleObjectFromCSS(prevCSSText)) {
+    domStyle.removeProperty(property);
+  }
+
+  setDOMStyleObject(domStyle, getStyleObjectFromCSS(cssText));
+}

--- a/packages/lexical/src/utils/setDOMStyle.ts
+++ b/packages/lexical/src/utils/setDOMStyle.ts
@@ -7,40 +7,6 @@
  */
 
 const IMPORTANT_REG_EXP = /\s*!important\s*$/i;
-const CSS_TO_STYLE_OBJECT_CACHE_MAX_SIZE = 100;
-const CSS_TO_STYLE_OBJECT_CACHE: Map<
-  string,
-  Record<string, string>
-> = new Map();
-
-function getCachedStyleObjectFromCSS(
-  css: string,
-): Record<string, string> | undefined {
-  const cachedStyleObject = CSS_TO_STYLE_OBJECT_CACHE.get(css);
-
-  if (cachedStyleObject !== undefined) {
-    CSS_TO_STYLE_OBJECT_CACHE.delete(css);
-    CSS_TO_STYLE_OBJECT_CACHE.set(css, cachedStyleObject);
-    return {...cachedStyleObject};
-  }
-
-  return undefined;
-}
-
-function setCachedStyleObjectFromCSS(
-  css: string,
-  styleObject: Record<string, string>,
-): void {
-  CSS_TO_STYLE_OBJECT_CACHE.set(css, styleObject);
-
-  if (CSS_TO_STYLE_OBJECT_CACHE.size > CSS_TO_STYLE_OBJECT_CACHE_MAX_SIZE) {
-    const oldestKey = CSS_TO_STYLE_OBJECT_CACHE.keys().next().value;
-
-    if (oldestKey !== undefined) {
-      CSS_TO_STYLE_OBJECT_CACHE.delete(oldestKey);
-    }
-  }
-}
 
 function getStyleDeclarations(css: string): Array<string> {
   const declarations: Array<string> = [];
@@ -197,31 +163,28 @@ function getStylePropertyAndValue(
   return null;
 }
 
-export function getStyleObjectFromCSS(css: string): Record<string, string> {
-  const cachedStyleObject = getCachedStyleObjectFromCSS(css);
-
-  if (cachedStyleObject !== undefined) {
-    return cachedStyleObject;
-  }
-
-  const styleObject: Record<string, string> = {};
-
+function forEachStylePropertyInCSS(
+  css: string,
+  callback: (property: string, value: string) => void,
+): void {
   for (const styleDeclaration of getStyleDeclarations(css)) {
     const propertyAndValue = getStylePropertyAndValue(styleDeclaration);
 
     if (propertyAndValue !== null) {
       const [property, value] = propertyAndValue;
-      styleObject[property] = value;
+      callback(property, value);
     }
   }
+}
 
-  if (__DEV__) {
-    Object.freeze(styleObject);
-  }
+export function getStyleObjectFromCSS(css: string): Record<string, string> {
+  const styleObject: Record<string, string> = {};
 
-  setCachedStyleObjectFromCSS(css, styleObject);
+  forEachStylePropertyInCSS(css, (property, value) => {
+    styleObject[property] = value;
+  });
 
-  return {...styleObject};
+  return styleObject;
 }
 
 function setDOMStyleProperty(
@@ -258,9 +221,10 @@ export function setDOMStyleFromCSS(
     return;
   }
 
-  for (const property in getStyleObjectFromCSS(prevCSSText)) {
+  forEachStylePropertyInCSS(prevCSSText, (property) => {
     domStyle.removeProperty(property);
-  }
-
-  setDOMStyleObject(domStyle, getStyleObjectFromCSS(cssText));
+  });
+  forEachStylePropertyInCSS(cssText, (property, value) => {
+    setDOMStyleProperty(domStyle, property, value);
+  });
 }

--- a/packages/lexical/src/utils/setDOMStyle.ts
+++ b/packages/lexical/src/utils/setDOMStyle.ts
@@ -8,17 +8,26 @@
 
 const IMPORTANT_REG_EXP = /\s*!important\s*$/i;
 
-function getStyleDeclarations(css: string): Array<string> {
-  const declarations: Array<string> = [];
+/**
+ * Parses inline CSS text into an object that is compatible with
+ * `CSSStyleDeclaration.setProperty()`.
+ *
+ * Property names are expected to be kebab-case, such as `font-size`, and
+ * values are expected to include explicit units where needed, such as `12px`.
+ */
+export function getStyleObjectFromCSS(css: string): Record<string, string> {
+  const styles: Record<string, string> = {};
 
   if (!css) {
-    return declarations;
+    return styles;
   }
 
-  let currentDeclaration = '';
+  let currentProperty = '';
+  let currentValue = '';
   let currentQuote: '"' | "'" | null = null;
   let inComment = false;
   let isEscaped = false;
+  let isParsingValue = false;
   let parenthesisDepth = 0;
 
   for (let i = 0; i < css.length; i++) {
@@ -33,13 +42,21 @@ function getStyleDeclarations(css: string): Array<string> {
     }
 
     if (isEscaped) {
-      currentDeclaration += char;
+      if (isParsingValue) {
+        currentValue += char;
+      } else {
+        currentProperty += char;
+      }
       isEscaped = false;
       continue;
     }
 
     if (currentQuote !== null) {
-      currentDeclaration += char;
+      if (isParsingValue) {
+        currentValue += char;
+      } else {
+        currentProperty += char;
+      }
 
       if (char === '\\') {
         isEscaped = true;
@@ -58,133 +75,68 @@ function getStyleDeclarations(css: string): Array<string> {
 
     if (char === '"' || char === "'") {
       currentQuote = char;
-      currentDeclaration += char;
+      if (isParsingValue) {
+        currentValue += char;
+      } else {
+        currentProperty += char;
+      }
       continue;
     }
 
     if (char === '(') {
       parenthesisDepth++;
-      currentDeclaration += char;
+      if (isParsingValue) {
+        currentValue += char;
+      } else {
+        currentProperty += char;
+      }
       continue;
     }
 
     if (char === ')') {
       parenthesisDepth = Math.max(0, parenthesisDepth - 1);
-      currentDeclaration += char;
+      if (isParsingValue) {
+        currentValue += char;
+      } else {
+        currentProperty += char;
+      }
+      continue;
+    }
+
+    if (!isParsingValue && char === ':' && parenthesisDepth === 0) {
+      isParsingValue = true;
       continue;
     }
 
     if (char === ';' && parenthesisDepth === 0) {
-      const declaration = currentDeclaration.trim();
+      const property = currentProperty.trim();
+      const value = currentValue.trim();
 
-      if (declaration !== '') {
-        declarations.push(declaration);
+      if (property !== '' && value !== '') {
+        styles[property] = value;
       }
 
-      currentDeclaration = '';
+      currentProperty = '';
+      currentValue = '';
+      isParsingValue = false;
       continue;
     }
 
-    currentDeclaration += char;
-  }
-
-  const declaration = currentDeclaration.trim();
-
-  if (declaration !== '') {
-    declarations.push(declaration);
-  }
-
-  return declarations;
-}
-
-function getStylePropertyAndValue(
-  styleDeclaration: string,
-): [string, string] | null {
-  let currentQuote: '"' | "'" | null = null;
-  let inComment = false;
-  let isEscaped = false;
-  let parenthesisDepth = 0;
-
-  for (let i = 0; i < styleDeclaration.length; i++) {
-    const char = styleDeclaration[i];
-
-    if (inComment) {
-      if (char === '*' && styleDeclaration[i + 1] === '/') {
-        inComment = false;
-        i++;
-      }
-      continue;
-    }
-
-    if (isEscaped) {
-      isEscaped = false;
-      continue;
-    }
-
-    if (currentQuote !== null) {
-      if (char === '\\') {
-        isEscaped = true;
-      } else if (char === currentQuote) {
-        currentQuote = null;
-      }
-
-      continue;
-    }
-
-    if (char === '/' && styleDeclaration[i + 1] === '*') {
-      inComment = true;
-      i++;
-      continue;
-    }
-
-    if (char === '"' || char === "'") {
-      currentQuote = char;
-      continue;
-    }
-
-    if (char === '(') {
-      parenthesisDepth++;
-      continue;
-    }
-
-    if (char === ')') {
-      parenthesisDepth = Math.max(0, parenthesisDepth - 1);
-      continue;
-    }
-
-    if (char === ':' && parenthesisDepth === 0) {
-      const property = styleDeclaration.slice(0, i).trim();
-      const value = styleDeclaration.slice(i + 1).trim();
-
-      return property !== '' && value !== '' ? [property, value] : null;
+    if (isParsingValue) {
+      currentValue += char;
+    } else {
+      currentProperty += char;
     }
   }
 
-  return null;
-}
+  const property = currentProperty.trim();
+  const value = currentValue.trim();
 
-function forEachStylePropertyInCSS(
-  css: string,
-  callback: (property: string, value: string) => void,
-): void {
-  for (const styleDeclaration of getStyleDeclarations(css)) {
-    const propertyAndValue = getStylePropertyAndValue(styleDeclaration);
-
-    if (propertyAndValue !== null) {
-      const [property, value] = propertyAndValue;
-      callback(property, value);
-    }
+  if (property !== '' && value !== '') {
+    styles[property] = value;
   }
-}
 
-export function getStyleObjectFromCSS(css: string): Record<string, string> {
-  const styleObject: Record<string, string> = {};
-
-  forEachStylePropertyInCSS(css, (property, value) => {
-    styleObject[property] = value;
-  });
-
-  return styleObject;
+  return styles;
 }
 
 function setDOMStyleProperty(
@@ -199,11 +151,19 @@ function setDOMStyleProperty(
   domStyle.setProperty(property, nextValue, priority);
 }
 
+/**
+ * Applies a style object to a DOM style declaration using
+ * `CSSStyleDeclaration.setProperty()`.
+ *
+ * Property names are expected to be kebab-case, such as `font-size`, and
+ * values are expected to include explicit units where needed, such as `12px`.
+ */
 export function setDOMStyleObject(
   domStyle: CSSStyleDeclaration,
   styleObject: Record<string, string | null | undefined>,
 ): void {
-  for (const [property, value] of Object.entries(styleObject)) {
+  for (const property in styleObject) {
+    const value = styleObject[property];
     if (value == null) {
       domStyle.removeProperty(property);
     } else {
@@ -212,6 +172,13 @@ export function setDOMStyleObject(
   }
 }
 
+/**
+ * Applies inline CSS text to a DOM style declaration using
+ * `CSSStyleDeclaration.setProperty()`.
+ *
+ * Property names are expected to be kebab-case, such as `font-size`, and
+ * values are expected to include explicit units where needed, such as `12px`.
+ */
 export function setDOMStyleFromCSS(
   domStyle: CSSStyleDeclaration,
   cssText: string,
@@ -221,10 +188,15 @@ export function setDOMStyleFromCSS(
     return;
   }
 
-  forEachStylePropertyInCSS(prevCSSText, (property) => {
+  const prevCSS = getStyleObjectFromCSS(prevCSSText);
+  const nextCSS = getStyleObjectFromCSS(cssText);
+
+  for (const property in nextCSS) {
+    delete prevCSS[property];
+    setDOMStyleProperty(domStyle, property, nextCSS[property]);
+  }
+
+  for (const property in prevCSS) {
     domStyle.removeProperty(property);
-  });
-  forEachStylePropertyInCSS(cssText, (property, value) => {
-    setDOMStyleProperty(domStyle, property, value);
-  });
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,9 +660,6 @@ importers:
       '@lexical/extension':
         specifier: workspace:*
         version: link:../lexical-extension
-      '@lexical/selection':
-        specifier: workspace:*
-        version: link:../lexical-selection
       '@lexical/utils':
         specifier: workspace:*
         version: link:../lexical-utils


### PR DESCRIPTION
## Description
This replaces runtime style string writes in Lexical's DOM update paths with property-based style updates.

- add a shared helper to parse stored style strings and apply or remove individual properties
- update text, code, list, table, yjs cursor, and playground paths that previously used `cssText` or `setAttribute('style', ...)`
- add unit coverage for style creation and update behavior

Closes #8363

## Test plan

### Before
- Runtime DOM updates used `.style.cssText` and `setAttribute('style', ...)` in editor paths.

### After
- `env COREPACK_HOME=/tmp/corepack corepack pnpm run test-unit`
- `env COREPACK_HOME=/tmp/corepack corepack pnpm run tsc`
- `env COREPACK_HOME=/tmp/corepack corepack pnpm --filter @lexical/devtools run compile`
- `env COREPACK_HOME=/tmp/corepack corepack pnpm run build-types`
- `env COREPACK_HOME=/tmp/corepack corepack pnpm run lint`
- `env COREPACK_HOME=/tmp/corepack corepack pnpm run prettier`
