### PR TITLE
[lexical-playground] Feature: HTML conversion button

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/HTML.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HTML.spec.mjs
@@ -26,9 +26,10 @@ import {
 
 test.describe('HTML', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(`Can export HTML using the button`, async ({page}) => {
-    await focusEditor(page);
+  test(`Can export HTML using the button`, async ({page, isPlainText}) => {
+    test.skip(isPlainText);
 
+    await focusEditor(page);
     await page.keyboard.type('Foo');
     await applyHeading(page, 1);
     await page.keyboard.press('Enter');
@@ -135,7 +136,9 @@ test.describe('HTML', () => {
     );
   });
 
-  test(`Can import HTML using the button`, async ({page}) => {
+  test(`Can import HTML using the button`, async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+
     await focusEditor(page);
     await click(page, '.action-button .html');
 

--- a/packages/lexical-playground/__tests__/e2e/HTML.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HTML.spec.mjs
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  applyCodeBlock,
+  applyHeading,
+  selectAll,
+  toggleBold,
+  toggleItalic,
+} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  click,
+  focusEditor,
+  html,
+  initialize,
+  insertDateTime,
+  repeat,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('HTML', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test(`Can export HTML using the button`, async ({page}) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Foo');
+    await applyHeading(page, 1);
+    await page.keyboard.press('Enter');
+    await applyCodeBlock(page);
+    await page.keyboard.type('const x = "hello world";');
+    await repeat(3, async () => await page.keyboard.press('Enter'));
+    await page.keyboard.type('Today ');
+    await toggleBold(page);
+    await toggleItalic(page);
+    await insertDateTime(page);
+
+    const expectedViewHtml = `<h1 class="PlaygroundEditorTheme__h1" dir="auto">
+      <span data-lexical-text="true">Foo</span>
+    </h1>
+    <code
+      class="PlaygroundEditorTheme__code"
+      dir="auto"
+      spellcheck="false"
+      data-gutter="1"
+      data-highlight-language="javascript"
+      data-language="javascript">
+      <span class="PlaygroundEditorTheme__tokenAttr" data-lexical-text="true">
+        const
+      </span>
+      <span data-lexical-text="true">x</span>
+      <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+        =
+      </span>
+      <span data-lexical-text="true"></span>
+      <span class="PlaygroundEditorTheme__tokenSelector" data-lexical-text="true">
+        "hello world"
+      </span>
+      <span
+        class="PlaygroundEditorTheme__tokenPunctuation"
+        data-lexical-text="true">
+        ;
+      </span>
+    </code>
+    <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+      <span data-lexical-text="true">Today</span>
+        <span
+          contenteditable="false"
+          data-lexical-datetime="*"
+          data-lexical-decorator="true">
+          <div class="dateTimePill bold italic">*</div>
+        </span>
+      <br />
+    </p>`;
+    await await assertHTML(
+      page,
+      html`
+        ${expectedViewHtml}
+      `,
+      undefined,
+      {ignoreInlineStyles: true},
+      // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
+      (actualHtml) =>
+        actualHtml
+          .replace(/(<div[^>]*>)(.*?)(<\/div>)/, '$1*$3')
+          .replace(
+            /data-lexical-datetime="[^"]*"/,
+            'data-lexical-datetime="*"',
+          ),
+    );
+
+    await click(page, '.action-button .html');
+
+    await await assertHTML(
+      page,
+      html`
+        <code
+          class="PlaygroundEditorTheme__code"
+          dir="auto"
+          spellcheck="false"
+          data-gutter="1"
+          data-highlight-language="html"
+          data-language="html">
+          *
+        </code>
+      `,
+      undefined,
+      {ignoreInlineStyles: true},
+      (actualHtml) =>
+        actualHtml.replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, '$1\n  *\n$3'),
+    );
+
+    await click(page, '.action-button .html');
+    // same view after import html
+    await await assertHTML(
+      page,
+      html`
+        ${expectedViewHtml}
+      `,
+      undefined,
+      {ignoreInlineStyles: true},
+      // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
+      (actualHtml) =>
+        actualHtml
+          .replace(/(<div[^>]*>)(.*?)(<\/div>)/, '$1*$3')
+          .replace(
+            /data-lexical-datetime="[^"]*"/,
+            'data-lexical-datetime="*"',
+          ),
+    );
+  });
+
+  test(`Can import HTML using the button`, async ({page}) => {
+    await focusEditor(page);
+    await click(page, '.action-button .html');
+
+    await await assertHTML(
+      page,
+      html`
+        <code
+          class="PlaygroundEditorTheme__code"
+          dir="auto"
+          spellcheck="false"
+          data-gutter="1"
+          data-highlight-language="html"
+          data-language="html">
+          *
+        </code>
+      `,
+      undefined,
+      {ignoreInlineStyles: true},
+      (actualHtml) =>
+        actualHtml.replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, '$1\n  *\n$3'),
+    );
+
+    await selectAll(page);
+    await page.keyboard.type(html`
+      <h1>Foo</h1>
+      <pre>const x = "hello world";</pre>
+      <p>
+        Hello
+        <b><i>world</i></b>
+      </p>
+    `);
+    await click(page, '.action-button .html');
+
+    await await assertHTML(
+      page,
+      html`
+        <h1 class="PlaygroundEditorTheme__h1" dir="auto">
+          <span data-lexical-text="true">Foo</span>
+        </h1>
+        <code
+          class="PlaygroundEditorTheme__code"
+          dir="auto"
+          spellcheck="false"
+          data-gutter="1"
+          data-highlight-language="javascript"
+          data-language="javascript">
+          <span
+            class="PlaygroundEditorTheme__tokenAttr"
+            data-lexical-text="true">
+            const
+          </span>
+          <span data-lexical-text="true">x</span>
+          <span
+            class="PlaygroundEditorTheme__tokenOperator"
+            data-lexical-text="true">
+            =
+          </span>
+          <span data-lexical-text="true"></span>
+          <span
+            class="PlaygroundEditorTheme__tokenSelector"
+            data-lexical-text="true">
+            "hello world"
+          </span>
+          <span
+            class="PlaygroundEditorTheme__tokenPunctuation"
+            data-lexical-text="true">
+            ;
+          </span>
+        </code>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Hello</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            world
+          </strong>
+        </p>
+      `,
+      undefined,
+      {ignoreInlineStyles: true},
+    );
+  });
+});

--- a/packages/lexical-playground/src/images/icons/filetype-html.svg
+++ b/packages/lexical-playground/src/images/icons/filetype-html.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-filetype-html" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M14 4.5V11h-1V4.5h-2A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v9H2V2a2 2 0 0 1 2-2h5.5zm-9.736 7.35v3.999h-.791v-1.714H1.79v1.714H1V11.85h.791v1.626h1.682V11.85h.79Zm2.251.662v3.337h-.794v-3.337H4.588v-.662h3.064v.662zm2.176 3.337v-2.66h.038l.952 2.159h.516l.946-2.16h.038v2.661h.715V11.85h-.8l-1.14 2.596H9.93L8.79 11.85h-.805v3.999zm4.71-.674h1.696v.674H12.61V11.85h.79v3.325Z"/>
+</svg>

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -992,7 +992,21 @@ i.page-setup,
   position: fixed;
   left: 10px;
   bottom: 70px;
+  max-height: calc(100svh - 70px);
+  overflow-y: auto;
+  scrollbar-width: thin;
   animation: slide-in 0.4s ease;
+}
+
+.switches::after {
+  content: '';
+  position: sticky;
+  bottom: 0;
+  display: block;
+  height: 60px;
+  margin-top: -60px;
+  background: linear-gradient(to bottom, transparent, #eee);
+  pointer-events: none;
 }
 
 @keyframes slide-in {

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -578,6 +578,10 @@ i.markdown {
   background-image: url(images/icons/markdown.svg);
 }
 
+i.html {
+  background-image: url(images/icons/filetype-html.svg);
+}
+
 i.outdent {
   background-image: url(images/icons/outdent.svg);
 }
@@ -1384,6 +1388,14 @@ i.chevron-down {
   color: #222;
   display: inline-block;
   cursor: pointer;
+}
+
+.action-button[data-active='true'] {
+  filter: invert(90%);
+}
+
+.action-button[data-active='true']:hover {
+  filter: invert(100%);
 }
 
 .action-button:hover {

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -17,6 +17,7 @@ import {
   SerializedDocument,
   serializedDocumentFromEditorState,
 } from '@lexical/file';
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {
   $convertFromMarkdownString,
   $convertToMarkdownString,
@@ -28,6 +29,7 @@ import {CONNECTED_COMMAND, TOGGLE_CONNECT_COMMAND} from '@lexical/yjs';
 import {
   $createTextNode,
   $getRoot,
+  $insertNodes,
   $isParagraphNode,
   CLEAR_EDITOR_COMMAND,
   CLEAR_HISTORY_COMMAND,
@@ -110,6 +112,10 @@ export default function ActionsPlugin({
   const [modal, showModal] = useModal();
   const showFlashMessage = useFlashMessage();
   const {isCollabActive} = useCollaborationContext();
+  const [mode, setMode] = useState<'wysiwyg' | 'markdown' | 'html'>('wysiwyg');
+  const isMarkdown = mode === 'markdown';
+  const isHtml = mode === 'html';
+
   useEffect(() => {
     if (INITIAL_SETTINGS.isCollab) {
       return;
@@ -181,6 +187,7 @@ export default function ActionsPlugin({
           undefined, // node
           shouldPreserveNewLinesInMarkdown,
         );
+        setMode('wysiwyg');
       } else {
         const markdown = $convertToMarkdownString(
           PLAYGROUND_TRANSFORMERS,
@@ -193,9 +200,35 @@ export default function ActionsPlugin({
         if (markdown.length === 0) {
           codeNode.select();
         }
+        setMode('markdown');
       }
     });
   }, [editor, shouldPreserveNewLinesInMarkdown]);
+
+  const handleHtmlToggle = useCallback(() => {
+    editor.update(() => {
+      const root = $getRoot();
+      const firstChild = root.getFirstChild();
+      if ($isCodeNode(firstChild) && firstChild.getLanguage() === 'html') {
+        const htmlString = firstChild.getTextContent();
+        const parser = new DOMParser();
+        const dom = parser.parseFromString(htmlString, 'text/html');
+        const nodes = $generateNodesFromDOM(editor, dom);
+        $getRoot().clear().select();
+        $insertNodes(nodes);
+        setMode('wysiwyg');
+      } else {
+        const html = $generateHtmlFromNodes(editor);
+        const codeNode = $createCodeNode('html');
+        codeNode.append($createTextNode(html));
+        root.clear().append(codeNode);
+        if (html.length === 0) {
+          codeNode.select();
+        }
+        setMode('html');
+      }
+    });
+  }, [editor]);
 
   return (
     <div className="actions">
@@ -280,10 +313,23 @@ export default function ActionsPlugin({
       </button>
       <button
         className="action-button"
+        data-active={isMarkdown}
+        disabled={isHtml}
         onClick={handleMarkdownToggle}
-        title="Convert From Markdown"
-        aria-label="Convert from markdown">
+        title={isMarkdown ? 'Convert From Markdown' : 'Convert To Markdown'}
+        aria-label={
+          isMarkdown ? 'Convert from markdown' : 'Convert To Markdown'
+        }>
         <i className="markdown" />
+      </button>
+      <button
+        className="action-button"
+        data-active={isHtml}
+        disabled={isMarkdown}
+        onClick={handleHtmlToggle}
+        title={isHtml ? 'Convert From HTML' : ' Convert To HTML'}
+        aria-label={isHtml ? 'Convert from html' : 'Convert to html'}>
+        <i className="html" />
       </button>
       {isCollabActive && (
         <>


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Here are some minor UI improvements to the lexical-playground:
- The Markdown mode button now has an active state.
- The settings block can be scrolled, as not all buttons are visible at small viewport, especially with the DevTools panel open at the bottom

I also added a button for converting to and from HTML, similar to Markdown. Unlike the _"export DOM"_ button in the _"debug view"_ panel, this mode clearly demonstrates how serialization to and from HTML works, enabling debugging of `exportDOM`/`importDOM` operations and providing a new way to write tests.

## Test plan

### Before

https://github.com/user-attachments/assets/3e489c71-a251-41c6-ad1c-1808c8231f5d

### After

https://github.com/user-attachments/assets/c2d4aee2-33df-49e9-982c-0fb6ba8f7baa