### PR TITLE
address follow-redirects dependency vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,8 @@
       "@isaacs/brace-expansion": ">=5.0.1",
       "prettier": "3.8.1",
       "yaml@^1": "^1.10.3",
-      "simple-git": ">=3.32.0"
+      "simple-git": ">=3.32.0",
+      "follow-redirects": ">=1.16.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   prettier: 3.8.1
   yaml@^1: ^1.10.3
   simple-git: '>=3.32.0'
+  follow-redirects: '>=1.16.0'
 
 importers:
 
@@ -7795,8 +7796,8 @@ packages:
     resolution: {integrity: sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==}
     engines: {node: '>=10'}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -21511,7 +21512,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  follow-redirects@1.15.11(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
 
@@ -22193,7 +22194,7 @@ snapshots:
   http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*


Updated package.json to manually override the version of the dependency `follow-redirects` from `1.15.11` to `>=1.16.0` to address the security vulnerability.

Package Dependency
Repository: [facebook/lexical](https://github.com/facebook/lexical)
Manifest file: [pnpm-lock.yaml](https://github.com/facebook/lexical/blob/main/pnpm-lock.yaml)
Package name: follow-redirects
Affected versions: <= 1.15.11
Fixed in version: 1.16.0

