### PR TITLE
[lexical-markdown] Bug Fix: Code spans take precedence over inline formatting in shortcuts

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -391,22 +391,6 @@ function $isInsideUnclosedCodeSpan(node: TextNode, offset: number): boolean {
     }
   }
 
-  let sibling = node.getPreviousSibling();
-  while (sibling !== null) {
-    if ($isLineBreakNode(sibling)) {
-      break;
-    }
-    if ($isTextNode(sibling)) {
-      const siblingText = sibling.getTextContent();
-      for (let i = 0; i < siblingText.length; i++) {
-        if (siblingText[i] === '`') {
-          backtickCount++;
-        }
-      }
-    }
-    sibling = sibling.getPreviousSibling();
-  }
-
   return backtickCount % 2 !== 0;
 }
 

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -316,6 +316,14 @@ function $runTextFormatTransformers(
       continue;
     }
 
+    // Per CommonMark, code spans take precedence over other inline formatting
+    if (
+      !matcher.format.includes('code') &&
+      $isInsideUnclosedCodeSpan(openNode, openTagStartIndex)
+    ) {
+      continue;
+    }
+
     // Clean text from opening and closing tags (starting from closing tag
     // to prevent any offset shifts if we start from opening one)
     const prevCloseNodeText = closeNode.getTextContent();
@@ -367,6 +375,39 @@ function $runTextFormatTransformers(
   }
 
   return false;
+}
+
+// Per CommonMark spec, code spans take precedence over other inline
+// formatting. Returns true if there is an unclosed backtick (code span
+// opener) in the text preceding the given offset, which means the offset
+// is inside a code span that hasn't been closed yet.
+function $isInsideUnclosedCodeSpan(node: TextNode, offset: number): boolean {
+  let backtickCount = 0;
+
+  const text = node.getTextContent();
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === '`') {
+      backtickCount++;
+    }
+  }
+
+  let sibling = node.getPreviousSibling();
+  while (sibling !== null) {
+    if ($isLineBreakNode(sibling)) {
+      break;
+    }
+    if ($isTextNode(sibling)) {
+      const siblingText = sibling.getTextContent();
+      for (let i = 0; i < siblingText.length; i++) {
+        if (siblingText[i] === '`') {
+          backtickCount++;
+        }
+      }
+    }
+    sibling = sibling.getPreviousSibling();
+  }
+
+  return backtickCount % 2 !== 0;
 }
 
 function getOpenTagStartIndex(

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
@@ -19,6 +19,7 @@ import {
   $getSelection,
   $isParagraphNode,
   $isRangeSelection,
+  $isTextNode,
   defineExtension,
   LexicalEditor,
   UNDO_COMMAND,
@@ -156,6 +157,89 @@ describe('LINK', () => {
       assert($isLinkNode(linkNode), 'First child must be a LinkNode');
       expect(linkNode.getTextContent()).toBe('hell[world](www)o');
       expect(linkNode.getURL()).toBe('link');
+    });
+  });
+});
+
+describe('CODE_SPAN_PRECEDENCE', () => {
+  test('__bold__ inside backticks is not formatted as bold', () => {
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    typeMarkdown(editor, '`__bold__`');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const children = paragraph.getChildren();
+      expect(children).toHaveLength(1);
+      const textNode = children[0];
+      assert($isTextNode(textNode), 'Child must be a TextNode');
+      expect(textNode.getTextContent()).toBe('__bold__');
+      expect(textNode.hasFormat('code')).toBe(true);
+      expect(textNode.hasFormat('bold')).toBe(false);
+    });
+  });
+
+  test('**bold** inside backticks is not formatted as bold', () => {
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    typeMarkdown(editor, '`**bold**`');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const children = paragraph.getChildren();
+      expect(children).toHaveLength(1);
+      const textNode = children[0];
+      assert($isTextNode(textNode), 'Child must be a TextNode');
+      expect(textNode.getTextContent()).toBe('**bold**');
+      expect(textNode.hasFormat('code')).toBe(true);
+      expect(textNode.hasFormat('bold')).toBe(false);
+    });
+  });
+
+  test('*italic* inside backticks is not formatted as italic', () => {
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    typeMarkdown(editor, '`*italic*`');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const children = paragraph.getChildren();
+      expect(children).toHaveLength(1);
+      const textNode = children[0];
+      assert($isTextNode(textNode), 'Child must be a TextNode');
+      expect(textNode.getTextContent()).toBe('*italic*');
+      expect(textNode.hasFormat('code')).toBe(true);
+      expect(textNode.hasFormat('italic')).toBe(false);
+    });
+  });
+
+  test('__bold__ without backticks still formats as bold', () => {
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    typeMarkdown(editor, '__bold__');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const children = paragraph.getChildren();
+      expect(children).toHaveLength(1);
+      const textNode = children[0];
+      assert($isTextNode(textNode), 'Child must be a TextNode');
+      expect(textNode.getTextContent()).toBe('bold');
+      expect(textNode.hasFormat('bold')).toBe(true);
+    });
+  });
+
+  test('__bold__ after a completed code span still formats as bold', () => {
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    typeMarkdown(editor, '`code` __bold__');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const textNodes = paragraph
+        .getChildren()
+        .filter((node) => $isTextNode(node));
+      const boldNode = textNodes.find(
+        (node) => $isTextNode(node) && node.hasFormat('bold'),
+      );
+      expect(boldNode).toBeDefined();
+      assert($isTextNode(boldNode!), 'Bold node must be a TextNode');
+      expect(boldNode!.getTextContent()).toBe('bold');
     });
   });
 });


### PR DESCRIPTION
## Description
Per CommonMark spec, code spans (backticks) should take precedence over other inline formatting. Previously, typing `__bold__` would trigger the bold transformer before the closing backtick could complete the code span. Now, text format transformers skip matches that fall inside an unclosed code span.



## Test plan

### Before


https://github.com/user-attachments/assets/7d4b08f6-3257-49e6-a566-9f3062ab57c3



### After

https://github.com/user-attachments/assets/b99e1873-a5de-4718-b1d1-bd150df6a572