### PR TITLE
[lexical-list] Bug Fix: Ensure that ListItemNode always has a ListItem parent

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {ListType} from './';
+import type {ListNode, ListType} from './';
 import type {
   BaseSelection,
   DOMConversionOutput,
@@ -24,6 +24,7 @@ import type {
 
 import {getStyleObjectFromCSS} from '@lexical/selection';
 import {
+  $insertNodeToNearestRootAtCaret,
   addClassNamesToElement,
   removeClassNamesFromElement,
 } from '@lexical/utils';
@@ -31,9 +32,11 @@ import {
   $applyNodeReplacement,
   $copyNode,
   $createParagraphNode,
+  $getSiblingCaret,
   $isElementNode,
   $isParagraphNode,
   $isRangeSelection,
+  $isRootOrShadowRoot,
   buildImportMap,
   ElementNode,
   LexicalEditor,
@@ -84,13 +87,48 @@ export class ListItemNode extends ElementNode {
   $config() {
     return this.config('listitem', {
       $transform: (node: ListItemNode): void => {
-        if (node.__checked == null) {
-          return;
-        }
         const parent = node.getParent();
         if ($isListNode(parent)) {
           if (parent.getListType() !== 'check' && node.getChecked() != null) {
             node.setChecked(undefined);
+          }
+        } else if (parent) {
+          const newParent = node.createParentElementNode();
+          invariant(
+            $isListNode(newParent),
+            'ListItemNode.createParentElementNode() must return a ListNode',
+          );
+          // Insert an empty ListNode at the orphan's position, splitting
+          // any enclosing non-shadow-root blocks so the ListNode lifts to
+          // a valid container before we move the orphan in. The ListNode
+          // $transform merges adjacent same-type lists, so neighbouring
+          // orphans will coalesce once their own transforms run.
+          const children = [node];
+          for (const dir of ['previous', 'next'] as const) {
+            children.reverse();
+            for (const {origin} of $getSiblingCaret(node, dir)) {
+              if (!$isListItemNode(origin)) {
+                break;
+              }
+              children.push(origin);
+            }
+          }
+          node.insertBefore(newParent);
+          newParent.splice(0, 0, children);
+          if (!$isRootOrShadowRoot(parent)) {
+            const prevSibling = newParent.getPreviousSibling();
+            const nextSibling = newParent.getNextSibling();
+            $insertNodeToNearestRootAtCaret(
+              newParent,
+              prevSibling
+                ? nextSibling
+                  ? $getSiblingCaret(prevSibling, 'next')
+                  : $getSiblingCaret(parent, 'next')
+                : $getSiblingCaret(parent, 'previous'),
+            );
+            if (parent.isEmpty() && parent.isAttached()) {
+              parent.remove();
+            }
           }
         }
       },
@@ -462,7 +500,7 @@ export class ListItemNode extends ElementNode {
     return true;
   }
 
-  createParentElementNode(): ElementNode {
+  createParentElementNode(): ListNode {
     return $createListNode('bullet');
   }
 

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -6,11 +6,22 @@
  *
  */
 
+import {$generateNodesFromDOM} from '@lexical/html';
+import {
+  $createTableCellNode,
+  $createTableNode,
+  $createTableRowNode,
+} from '@lexical/table';
 import {
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
   $getRoot,
+  $getSelection,
+  $insertNodes,
+  $isElementNode,
+  $isParagraphNode,
+  $isRangeSelection,
   TextNode,
 } from 'lexical';
 import {
@@ -18,12 +29,13 @@ import {
   html,
   initializeUnitTest,
 } from 'lexical/src/__tests__/utils';
-import {beforeEach, describe, expect, it, test} from 'vitest';
+import {assert, beforeEach, describe, expect, it, test} from 'vitest';
 
 import {
   $createListItemNode,
   $createListNode,
   $isListItemNode,
+  $isListNode,
   ListItemNode,
   ListNode,
 } from '../..';
@@ -1489,6 +1501,353 @@ describe('LexicalListItemNode tests', () => {
           '</ol>' +
           '</div>',
       );
+    });
+
+    describe('ListItemNode $transform wraps orphan ListItemNodes', () => {
+      test('wraps a single orphan ListItemNode under root in a ListNode', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            $getRoot().append(
+              $createListItemNode().append($createTextNode('orphan')),
+            );
+          },
+          {discrete: true},
+        );
+
+        editor.read(() => {
+          const wrapper = $getRoot().getFirstChild();
+          assert($isListNode(wrapper), 'orphan <li> should be wrapped in list');
+          expect(wrapper.getListType()).toBe('bullet');
+        });
+
+        expectHtmlToBeEqual(
+          testEnv.innerHTML,
+          html`
+            <ul dir="auto">
+              <li value="1">
+                <span data-lexical-text="true">orphan</span>
+              </li>
+            </ul>
+          `,
+        );
+      });
+
+      test('wraps adjacent orphan ListItemNodes in a single ListNode', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            $getRoot().append(
+              $createListItemNode().append($createTextNode('a')),
+              $createListItemNode().append($createTextNode('b')),
+              $createListItemNode().append($createTextNode('c')),
+            );
+          },
+          {discrete: true},
+        );
+
+        expectHtmlToBeEqual(
+          testEnv.innerHTML,
+          html`
+            <ul dir="auto">
+              <li value="1"><span data-lexical-text="true">a</span></li>
+              <li value="2"><span data-lexical-text="true">b</span></li>
+              <li value="3"><span data-lexical-text="true">c</span></li>
+            </ul>
+          `,
+        );
+      });
+
+      test('does not merge orphan ListItemNodes separated by a ParagraphNode', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            $getRoot().append(
+              $createListItemNode().append($createTextNode('a')),
+              $createParagraphNode().append($createTextNode('middle')),
+              $createListItemNode().append($createTextNode('b')),
+            );
+          },
+          {discrete: true},
+        );
+
+        expectHtmlToBeEqual(
+          testEnv.innerHTML,
+          html`
+            <ul dir="auto">
+              <li value="1"><span data-lexical-text="true">a</span></li>
+            </ul>
+            <p dir="auto"><span data-lexical-text="true">middle</span></p>
+            <ul dir="auto">
+              <li value="1"><span data-lexical-text="true">b</span></li>
+            </ul>
+          `,
+        );
+      });
+
+      test('parses HTML with orphan <li> outside of <ul>', () => {
+        const {editor} = testEnv;
+        const parser = new DOMParser();
+        const input = html`
+          <div>
+            <ul>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+            </ul>
+            hello world
+            <li>test</li>
+          </div>
+        `;
+
+        editor.update(
+          () => {
+            $getRoot().clear().select();
+            const dom = parser.parseFromString(input, 'text/html');
+            $insertNodes($generateNodesFromDOM(editor, dom));
+          },
+          {discrete: true},
+        );
+
+        expectHtmlToBeEqual(
+          testEnv.innerHTML,
+          html`
+            <ul dir="auto">
+              <li value="1"><span data-lexical-text="true">test</span></li>
+              <li value="2"><span data-lexical-text="true">test</span></li>
+              <li value="3"><span data-lexical-text="true">test</span></li>
+            </ul>
+            <p dir="auto">
+              <span data-lexical-text="true">hello world</span>
+            </p>
+            <ul dir="auto">
+              <li value="1"><span data-lexical-text="true">test</span></li>
+            </ul>
+          `,
+        );
+      });
+
+      test('preserves the selection on the orphan when it is wrapped', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            const text = $createTextNode('orphan');
+            $getRoot()
+              .clear()
+              .append(
+                $createParagraphNode().append($createTextNode('hello world')),
+                $createListItemNode().append(text),
+              );
+            text.select(2, 4);
+          },
+          {discrete: true},
+        );
+
+        editor.read(() => {
+          const selection = $getSelection();
+          assert(
+            $isRangeSelection(selection),
+            'selection should be a RangeSelection',
+          );
+          const {anchor, focus} = selection;
+          expect(anchor.getNode().getTextContent()).toBe('orphan');
+          expect(anchor.offset).toBe(2);
+          expect(focus.getNode().getTextContent()).toBe('orphan');
+          expect(focus.offset).toBe(4);
+        });
+      });
+
+      test('preserves a selection anchored outside the orphan', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            const helloText = $createTextNode('hello world');
+            $getRoot()
+              .clear()
+              .append(
+                $createParagraphNode().append(helloText),
+                $createListItemNode().append($createTextNode('orphan')),
+              );
+            helloText.select(3, 5);
+          },
+          {discrete: true},
+        );
+
+        editor.read(() => {
+          const selection = $getSelection();
+          assert(
+            $isRangeSelection(selection),
+            'selection should be a RangeSelection',
+          );
+          const {anchor, focus} = selection;
+          expect(anchor.getNode().getTextContent()).toBe('hello world');
+          expect(anchor.offset).toBe(3);
+          expect(focus.getNode().getTextContent()).toBe('hello world');
+          expect(focus.offset).toBe(5);
+        });
+      });
+
+      test('wraps orphan ListItemNode inside a paragraph with no siblings', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            $getRoot()
+              .clear()
+              .append(
+                $createParagraphNode().append(
+                  $createListItemNode().append($createTextNode('item')),
+                ),
+              );
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          const [list] = root.getChildren();
+          assert($isListNode(list));
+          expect(list.getChildrenSize()).toBe(1);
+          const [listItem] = list.getChildren();
+          assert($isListItemNode(listItem));
+          expect(listItem.getTextContent()).toBe('item');
+        });
+      });
+
+      test('wraps orphan ListItemNode inside a paragraph with prev siblings', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            $getRoot()
+              .clear()
+              .append(
+                $createParagraphNode().append(
+                  $createTextNode('before'),
+                  $createListItemNode().append($createTextNode('item')),
+                ),
+              );
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(2);
+          const [p, list] = root.getChildren();
+          assert($isParagraphNode(p));
+          expect(p.getTextContent()).toBe('before');
+          assert($isListNode(list));
+          expect(list.getChildrenSize()).toBe(1);
+          const [listItem] = list.getChildren();
+          assert($isListItemNode(listItem));
+          expect(listItem.getTextContent()).toBe('item');
+        });
+      });
+
+      test('wraps orphan ListItemNode inside a paragraph with next siblings', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            $getRoot()
+              .clear()
+              .append(
+                $createParagraphNode().append(
+                  $createListItemNode().append($createTextNode('item')),
+                  $createTextNode('after'),
+                ),
+              );
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(2);
+          const [list, p] = root.getChildren();
+          assert($isParagraphNode(p));
+          expect(p.getTextContent()).toBe('after');
+          assert($isListNode(list));
+          expect(list.getChildrenSize()).toBe(1);
+          const [listItem] = list.getChildren();
+          assert($isListItemNode(listItem));
+          expect(listItem.getTextContent()).toBe('item');
+        });
+      });
+
+      test('wraps orphan ListItemNode inside a paragraph with both siblings', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            $getRoot()
+              .clear()
+              .append(
+                $createParagraphNode().append(
+                  $createTextNode('before'),
+                  $createListItemNode().append($createTextNode('item')),
+                  $createTextNode('after'),
+                ),
+              );
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(3);
+          const [p0, list, p1] = root.getChildren();
+          assert($isParagraphNode(p0));
+          expect(p0.getTextContent()).toBe('before');
+          assert($isParagraphNode(p1));
+          expect(p1.getTextContent()).toBe('after');
+          assert($isListNode(list));
+          expect(list.getChildrenSize()).toBe(1);
+          const [listItem] = list.getChildren();
+          assert($isListItemNode(listItem));
+          expect(listItem.getTextContent()).toBe('item');
+        });
+      });
+
+      test('wraps orphan ListItemNode inside a shadow-root table cell', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            const cell = $createTableCellNode().append(
+              $createListItemNode().append($createTextNode('orphan')),
+            );
+            $getRoot()
+              .clear()
+              .append(
+                $createTableNode().append($createTableRowNode().append(cell)),
+              );
+          },
+          {discrete: true},
+        );
+
+        editor.read(() => {
+          const table = $getRoot().getFirstChild();
+          assert($isElementNode(table), 'root first child is an element');
+          const row = table.getFirstChild();
+          assert($isElementNode(row), 'table first child is an element');
+          const cell = row.getFirstChild();
+          assert($isElementNode(cell), 'row first child is an element');
+          expect(cell.getChildrenSize()).toBe(1);
+          const wrapper = cell.getFirstChild();
+          assert(
+            $isListNode(wrapper),
+            'orphan <li> should be wrapped inside the table cell',
+          );
+          expect(wrapper.getChildrenSize()).toBe(1);
+          expect(wrapper.getFirstChildOrThrow().getTextContent()).toBe(
+            'orphan',
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Adds code to the ListItemNode transform to ensure that it has a ListNode parent. Merges runs of orphaned ListItemNode and if they were in a parent that can't hold the ListItem (e.g. a ParagraphNode) it will float out to the root and delete the parent if they were the only child.

Closes #3951

## Test plan

New unit tests