### PR TITLE
[lexical][lexical-utils][lexical-list] Bug Fix: Clean up and test $insertNodeToNearestRootAtCaret edge cases

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -36,6 +36,7 @@ import {
   $isParagraphNode,
   $isRangeSelection,
   $isRootOrShadowRoot,
+  $rewindSiblingCaret,
   buildImportMap,
   ElementNode,
   getStyleObjectFromCSS,
@@ -123,15 +124,10 @@ export class ListItemNode extends ElementNode {
           node.insertBefore(newParent);
           newParent.splice(0, 0, children);
           if (!$isRootOrShadowRoot(parent)) {
-            const prevSibling = newParent.getPreviousSibling();
-            const nextSibling = newParent.getNextSibling();
             $insertNodeToNearestRootAtCaret(
               newParent,
-              prevSibling
-                ? nextSibling
-                  ? $getSiblingCaret(prevSibling, 'next')
-                  : $getSiblingCaret(parent, 'next')
-                : $getSiblingCaret(parent, 'previous'),
+              $rewindSiblingCaret($getSiblingCaret(newParent, 'next')),
+              {$shouldSplit: () => false, removeEmptyDestination: true},
             );
             if (parent.isEmpty() && parent.isAttached()) {
               parent.remove();

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRootAtCaret.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRootAtCaret.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getChildCaret,
+  $getRoot,
+  $getSiblingCaret,
+  $getTextPointCaret,
+  $isElementNode,
+  LexicalNode,
+  SplitAtPointCaretNextOptions,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+import {$insertNodeToNearestRootAtCaret} from '../..';
+
+function $serialize(node: LexicalNode): string {
+  if (!$isElementNode(node)) {
+    return node.getTextContent();
+  }
+  const children = node.getChildren().map($serialize).join('');
+  return `[${children}]`;
+}
+
+function $rootSerialize(): string {
+  return $getRoot().getChildren().map($serialize).join('');
+}
+
+type NodeKind = 'ParagraphNode' | 'TextNode';
+
+function $createLiftable(kind: NodeKind, text: string): LexicalNode {
+  return kind === 'ParagraphNode'
+    ? $createParagraphNode().append($createTextNode(text))
+    : $createTextNode(text);
+}
+
+// Each option variant records how $shouldSplit responds on the 'first' and
+// 'last' edges; scenarios whose expected output depends on the option
+// consume these flags directly rather than invoking $shouldSplit in a
+// non-editor context.
+type SplitFlags = {
+  first: boolean;
+  last: boolean;
+  removeEmptyDestination: boolean;
+};
+
+type Scenario = {
+  label: string;
+  $run: (kind: NodeKind, options?: SplitAtPointCaretNextOptions) => void;
+  // For scenarios where the outcome depends on the $shouldSplit option,
+  // `expected` can be a function that returns the expected serialization
+  // based on the option's split flags.
+  expected: string | ((flags: SplitFlags) => string);
+};
+
+const scenarios: Scenario[] = [
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      $getRoot().append($createParagraphNode().append(x));
+      $insertNodeToNearestRootAtCaret(
+        x,
+        $getSiblingCaret(x, 'previous'),
+        options,
+      );
+    },
+    expected: ({first, last, removeEmptyDestination}) =>
+      removeEmptyDestination
+        ? '[x]'
+        : `${first ? '[]' : ''}[x]${last || !first ? '[]' : ''}`,
+    label: 'sole child, caret on node (previous) — caret.origin === node',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      $getRoot().append($createParagraphNode().append(x));
+      $insertNodeToNearestRootAtCaret(x, $getSiblingCaret(x, 'next'), options);
+    },
+    expected: ({first, last, removeEmptyDestination}) =>
+      removeEmptyDestination
+        ? '[x]'
+        : `${first ? '[]' : ''}[x]${last || !first ? '[]' : ''}`,
+    label: 'sole child, caret on node (next) — caret.origin === node',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      const p = $createParagraphNode();
+      $getRoot().append(p);
+      $insertNodeToNearestRootAtCaret(x, $getChildCaret(p, 'next'), options);
+    },
+    expected: ({first, last, removeEmptyDestination}) =>
+      removeEmptyDestination
+        ? '[x]'
+        : `${first ? '[]' : ''}[x]${last || !first ? '[]' : ''}`,
+    label: 'empty, caret on paragraph (next)',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      const p = $createParagraphNode();
+      $getRoot().append(p);
+      $insertNodeToNearestRootAtCaret(
+        x,
+        $getChildCaret(p, 'previous'),
+        options,
+      );
+    },
+    expected: ({first, last, removeEmptyDestination}) =>
+      removeEmptyDestination
+        ? '[x]'
+        : `${first ? '[]' : ''}[x]${last || !first ? '[]' : ''}`,
+    label: 'empty, caret on paragraph (previous)',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      $insertNodeToNearestRootAtCaret(
+        x,
+        $getChildCaret($getRoot(), 'next'),
+        options,
+      );
+    },
+    expected: '[x]',
+    label: 'caret on root (next)',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      $getRoot().append($createParagraphNode().append($createTextNode('a'), x));
+      $insertNodeToNearestRootAtCaret(x, $getSiblingCaret(x, 'next'), options);
+    },
+    expected: ({last, removeEmptyDestination}) =>
+      `[a][x]${last && !removeEmptyDestination ? '[]' : ''}`,
+    label: 'sibling before, caret on node (next) — caret.origin === node',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      $getRoot().append($createParagraphNode().append($createTextNode('a'), x));
+      $insertNodeToNearestRootAtCaret(
+        x,
+        $getSiblingCaret(x, 'previous'),
+        options,
+      );
+    },
+    expected: ({last, removeEmptyDestination}) =>
+      `[a][x]${last && !removeEmptyDestination ? '[]' : ''}`,
+    label: 'sibling before, caret on node (previous) — caret.origin === node',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      const sib = $createTextNode('a');
+      $getRoot().append($createParagraphNode().append(sib, x));
+      $insertNodeToNearestRootAtCaret(
+        x,
+        $getSiblingCaret(sib, 'previous'),
+        options,
+      );
+    },
+    expected: ({first}) => `${first ? '[]' : ''}[x][a]`,
+    label: 'sibling before, caret on sibling (previous)',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      const sib = $createTextNode('ab');
+      $getRoot().append($createParagraphNode().append(sib, x));
+      $insertNodeToNearestRootAtCaret(
+        x,
+        $getTextPointCaret(sib, 'next', 0),
+        options,
+      );
+    },
+    expected: ({first}) => `${first ? '[]' : ''}[x][ab]`,
+    label: 'sibling before, caret on text start (next)',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      const sib = $createTextNode('ab');
+      $getRoot().append($createParagraphNode().append(sib, x));
+      $insertNodeToNearestRootAtCaret(
+        x,
+        $getTextPointCaret(sib, 'next', 1),
+        options,
+      );
+    },
+    expected: `[a][x][b]`,
+    label: 'sibling before, caret on text middle (next)',
+  },
+  {
+    $run: (kind, options) => {
+      const x = $createLiftable(kind, 'x');
+      const sib = $createTextNode('ab');
+      $getRoot().append($createParagraphNode().append(sib, x));
+      $insertNodeToNearestRootAtCaret(
+        x,
+        $getTextPointCaret(sib, 'next', 'next'),
+        options,
+      );
+    },
+    expected: ({last, removeEmptyDestination}) =>
+      `[ab][x]${!removeEmptyDestination && last ? '[]' : ''}`,
+    label: 'sibling before, caret on text end (next)',
+  },
+];
+
+const optionVariants: {
+  options: SplitAtPointCaretNextOptions;
+  splits: SplitFlags;
+}[] = [true, false].flatMap((first) =>
+  [true, false].flatMap((last) =>
+    [true, false].flatMap((removeEmptyDestination) => [
+      {
+        options: {
+          $shouldSplit: (_node, edge) =>
+            (first && edge === 'first') || (last && edge === 'last'),
+          removeEmptyDestination,
+        },
+        splits: {first, last, removeEmptyDestination},
+      },
+    ]),
+  ),
+);
+
+describe('$insertNodeToNearestRootAtCaret edge cases', () => {
+  for (const variant of optionVariants) {
+    for (const kind of ['ParagraphNode'] as const) {
+      describe(`${kind} with ${
+        Object.entries(variant.splits)
+          .flatMap(([k, v]) => (v ? [k] : []))
+          .join(' ') || 'no-splits-or-remove'
+      }`, () => {
+        for (const scenario of scenarios) {
+          test(scenario.label, () => {
+            using editor = buildEditorFromExtensions(
+              defineExtension({
+                $initialEditorState: () => scenario.$run(kind, variant.options),
+                dependencies: [RichTextExtension],
+                name: '[insert-to-nearest-root]',
+              }),
+            );
+            const expected =
+              typeof scenario.expected === 'function'
+                ? scenario.expected(variant.splits)
+                : scenario.expected;
+            expect(editor.read($rootSerialize)).toBe(expected);
+          });
+        }
+      });
+    }
+  }
+});

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -546,6 +546,34 @@ export function $insertNodeToNearestRootAtCaret<
   options?: SplitAtPointCaretNextOptions,
 ): NodeCaret<D> {
   let insertCaret: PointCaret<'next'> = $getCaretInDirection(caret, 'next');
+  // Normalize boundary cases for TextPointCaret
+  if ($isTextPointCaret(insertCaret)) {
+    if (insertCaret.offset === 0) {
+      insertCaret = $getSiblingCaret(
+        insertCaret.origin,
+        'previous',
+      ).getFlipped();
+    } else if (insertCaret.offset === insertCaret.origin.getTextContentSize()) {
+      insertCaret = $getSiblingCaret(insertCaret.origin, 'next');
+    }
+  }
+  // Make sure we have a distinct node as the origin
+  if (insertCaret.origin.is(node)) {
+    invariant(
+      $isSiblingCaret(insertCaret),
+      '$insertNodeToNearestRootAtCaret node %s of type %s can not be inserted into itself',
+      node.getKey(),
+      node.getType(),
+    );
+    insertCaret = $rewindSiblingCaret(insertCaret);
+  }
+  // Handle split boundary conditions where node is being inserted adjacent to itself
+  if (
+    node.is(insertCaret.getNodeAtCaret()) ||
+    node.is(insertCaret.getFlipped().getNodeAtCaret())
+  ) {
+    node.remove(true);
+  }
   for (
     let nextCaret: null | PointCaret<'next'> = insertCaret;
     nextCaret;

--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -676,11 +676,16 @@ export interface SplitAtPointCaretNextOptions {
   /** If the parent matches rootMode a split will not occur, default is 'shadowRoot' */
   rootMode?: RootMode;
   /**
-   * If element.canBeEmpty() and would create an empty split, this function will be
+   * If `element.canBeEmpty()` and it would create an empty split, this function will be
    * called with the element and 'first' | 'last'. If it returns false, the empty
    * split will not be created. Default is `() => true` to always split when possible.
    */
   $shouldSplit?: (node: ElementNode, edge: 'first' | 'last') => boolean;
+  /**
+   * If the destination would create an empty split on both sides, then
+   * remove it instead of splitting. Default `false`.
+   */
+  removeEmptyDestination?: boolean;
 }
 
 function $alwaysSplit(_node: ElementNode, _edge: 'first' | 'last'): true {
@@ -700,6 +705,7 @@ export function $splitAtPointCaretNext(
     $splitTextPointCaretNext = $splitTextPointCaret,
     rootMode = 'shadowRoot',
     $shouldSplit = $alwaysSplit,
+    removeEmptyDestination = false,
   }: SplitAtPointCaretNextOptions = {},
 ): null | NodeCaret<'next'> {
   if ($isTextPointCaret(pointCaret)) {
@@ -708,17 +714,22 @@ export function $splitAtPointCaretNext(
   const parentCaret = pointCaret.getParentCaret(rootMode);
   if (parentCaret) {
     const {origin} = parentCaret;
-    if (
-      $isChildCaret(pointCaret) &&
-      !(origin.canBeEmpty() && $shouldSplit(origin, 'first'))
-    ) {
-      // No split necessary, the left side would be empty
-      return $rewindSiblingCaret(parentCaret);
+    if ($isChildCaret(pointCaret)) {
+      const beforeParentCaret = $rewindSiblingCaret(parentCaret);
+      if (removeEmptyDestination && origin.isEmpty()) {
+        origin.remove();
+        return beforeParentCaret;
+      }
+      if (!(origin.canBeEmpty() && $shouldSplit(origin, 'first'))) {
+        return beforeParentCaret;
+      }
     }
     const siblings = $getAdjacentNodes(pointCaret);
     if (
       siblings.length > 0 ||
-      (origin.canBeEmpty() && $shouldSplit(origin, 'last'))
+      (!removeEmptyDestination &&
+        origin.canBeEmpty() &&
+        $shouldSplit(origin, 'last'))
     ) {
       // Split and insert the siblings into the new tree
       parentCaret.insert($copyElementNode(origin).splice(0, 0, siblings));


### PR DESCRIPTION
## Description

In some cases when inserting to the nearest root you want even more control over which side(s) are split and if the destination is replaced entirely when empty. This adds a removeEmptyDestination to the SplitAtPointCaretNextOptions type used by $insertNodeToNearestRootAtCaret and $splitAtPointCaretNext and a battery of tests. This allows the ListItemNode transform to be simplified (some of that code was working around this inflexibility)

Follow-up to #8382

## Test plan

New unit tests