### PR TITLE
[lexical-react] Bug Fix: Fall back to root node in NodeContextMenuPlugin when click target has no Lexical node

### DIFF
--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -208,7 +208,8 @@ const NodeContextMenuPlugin = forwardRef<
       let visibleItems: ContextMenuType[] = [];
       if (items) {
         editor.read(() => {
-          const node = $getNearestNodeFromDOMNode(e.target as Element) ?? $getRoot();
+          const node =
+            $getNearestNodeFromDOMNode(e.target as Element) ?? $getRoot();
           if (node) {
             visibleItems = items!.filter((option) =>
               option.$showOn ? option.$showOn(node) : true,

--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -22,7 +22,7 @@ import {
   useTypeahead,
 } from '@floating-ui/react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getNearestNodeFromDOMNode, LexicalNode} from 'lexical';
+import {$getNearestNodeFromDOMNode, $getRoot, LexicalNode} from 'lexical';
 import {forwardRef, JSX, RefObject, useEffect, useRef, useState} from 'react';
 
 class MenuOption {
@@ -208,7 +208,7 @@ const NodeContextMenuPlugin = forwardRef<
       let visibleItems: ContextMenuType[] = [];
       if (items) {
         editor.read(() => {
-          const node = $getNearestNodeFromDOMNode(e.target as Element);
+          const node = $getNearestNodeFromDOMNode(e.target as Element) ?? $getRoot();
           if (node) {
             visibleItems = items!.filter((option) =>
               option.$showOn ? option.$showOn(node) : true,


### PR DESCRIPTION
## Description

Fixes #8257

`NodeContextMenuPlugin` always calls `preventDefault()` on `contextmenu` events, but when right-clicking on "empty" editor chrome (placeholder, padding, or DOM that doesn't map to a Lexical node), `$getNearestNodeFromDOMNode` returns `null`. This results in an empty custom menu while the native context menu is suppressed.

As suggested by @etrepum in #8257, this falls back to `$getRoot()` when no node is found:

```diff
- const node = $getNearestNodeFromDOMNode(e.target as Element);
+ const node = $getNearestNodeFromDOMNode(e.target as Element) ?? $getRoot();
```

This means:
- Right-clicking on text/blocks works exactly as before (`$getRoot()` fallback is never reached)
- Right-clicking on empty areas now uses the root node for `$showOn` filtering, so items without `$showOn` (e.g. Paste) are shown instead of an empty menu
- No changes to the plugin's public API

## Test Plan

1. Open the Lexical playground
2. Right-click on text inside the editor → context menu shows items as before
3. Right-click on the placeholder or empty padding below content → **Before:** empty menu appears, native menu suppressed. **After:** menu shows applicable items (e.g. Paste)