### PR TITLE
[lexical-playground] Feature: Format HTML conversion with prettier

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/HTML.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HTML.spec.mjs
@@ -16,6 +16,8 @@ import {
 import {
   assertHTML,
   click,
+  evaluate,
+  expect,
   focusEditor,
   html,
   initialize,
@@ -49,7 +51,7 @@ test.describe('HTML', () => {
         class="PlaygroundEditorTheme__code"
         dir="auto"
         spellcheck="false"
-        data-gutter="1"
+        data-gutter="*"
         data-highlight-language="javascript"
         data-language="javascript">
         <span class="PlaygroundEditorTheme__tokenAttr" data-lexical-text="true">
@@ -92,6 +94,7 @@ test.describe('HTML', () => {
       // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
       (actualHtml) =>
         actualHtml
+          .replace(/data-gutter="[^"]*"/g, 'data-gutter="*"')
           .replace(/(<div[^>]*>)(.*?)(<\/div>)/, '$1*$3')
           .replace(
             /data-lexical-datetime="[^"]*"/,
@@ -108,7 +111,7 @@ test.describe('HTML', () => {
           class="PlaygroundEditorTheme__code"
           dir="auto"
           spellcheck="false"
-          data-gutter="1"
+          data-gutter="*"
           data-highlight-language="html"
           data-language="html">
           *
@@ -117,7 +120,9 @@ test.describe('HTML', () => {
       undefined,
       {ignoreInlineStyles: true},
       (actualHtml) =>
-        actualHtml.replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, '$1\n  *\n$3'),
+        actualHtml
+          .replace(/data-gutter="[^"]*"/g, 'data-gutter="*"')
+          .replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, '$1\n  *\n$3'),
     );
 
     await click(page, '.action-button .html');
@@ -130,9 +135,10 @@ test.describe('HTML', () => {
       // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
       (actualHtml) =>
         actualHtml
-          .replace(/(<div[^>]*>)(.*?)(<\/div>)/, '$1*$3')
+          .replace(/data-gutter="[^"]*"/g, 'data-gutter="*"')
+          .replace(/(<div[^>]*>)(.*?)(<\/div>)/g, '$1*$3')
           .replace(
-            /data-lexical-datetime="[^"]*"/,
+            /data-lexical-datetime="[^"]*"/g,
             'data-lexical-datetime="*"',
           ),
     );
@@ -151,7 +157,7 @@ test.describe('HTML', () => {
           class="PlaygroundEditorTheme__code"
           dir="auto"
           spellcheck="false"
-          data-gutter="1"
+          data-gutter="*"
           data-highlight-language="html"
           data-language="html">
           *
@@ -160,7 +166,9 @@ test.describe('HTML', () => {
       undefined,
       {ignoreInlineStyles: true},
       (actualHtml) =>
-        actualHtml.replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, '$1\n  *\n$3'),
+        actualHtml
+          .replace(/data-gutter="[^"]*"/g, 'data-gutter="*"')
+          .replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, '$1\n  *\n$3'),
     );
 
     await selectAll(page);
@@ -184,7 +192,7 @@ test.describe('HTML', () => {
           class="PlaygroundEditorTheme__code"
           dir="auto"
           spellcheck="false"
-          data-gutter="1"
+          data-gutter="*"
           data-highlight-language="javascript"
           data-language="javascript">
           <span
@@ -221,6 +229,38 @@ test.describe('HTML', () => {
       `,
       undefined,
       {ignoreInlineStyles: true},
+      (actualHtml) =>
+        actualHtml.replace(/data-gutter="[^"]*"/g, 'data-gutter="*"'),
     );
+  });
+
+  test(`Formats a terse HTML export with prettier`, async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await applyHeading(page, 1);
+    await page.keyboard.type('Foo');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Hello world');
+
+    await click(page, '.action-button .html');
+
+    const expectedPrettyHtml = [
+      '<h1><span>Foo</span></h1>',
+      '<p><span>Hello world</span></p>',
+    ].join('\n');
+
+    await expect(async () => {
+      const codeText = await evaluate(page, () => {
+        const editor = window.lexicalEditor;
+        return window.lexicalEditor.read(() =>
+          editor.getEditorState()._nodeMap.get('root').getTextContent(),
+        );
+      });
+      expect(codeText).toBe(expectedPrettyHtml);
+    }).toPass({intervals: [100, 250, 500], timeout: 5000});
   });
 });

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -49,6 +49,7 @@ import useFlashMessage from '../../hooks/useFlashMessage';
 import useModal from '../../hooks/useModal';
 import Button from '../../ui/Button';
 import {docFromHash, docToHash} from '../../utils/docSerialization';
+import {formatCodeWithPrettier} from '../CodeActionMenuPlugin/components/PrettierButton';
 import {PLAYGROUND_TRANSFORMERS} from '../MarkdownTransformers';
 import {
   SPEECH_TO_TEXT_COMMAND,
@@ -103,6 +104,26 @@ async function shareDoc(doc: SerializedDocument): Promise<void> {
   await window.navigator.clipboard.writeText(newUrl);
 }
 
+function handlePrettierResponse(
+  editor: LexicalEditor,
+  originalHtml: string,
+  formattedHtml: string,
+): void {
+  editor.update(() => {
+    const rootNode = $getRoot();
+    const codeNode = rootNode.getChildren().find($isCodeNode);
+    if (
+      !codeNode ||
+      codeNode.getLanguage() !== 'html' ||
+      rootNode.getChildrenSize() !== 1 ||
+      codeNode.getTextContent() !== originalHtml
+    ) {
+      return;
+    }
+    codeNode.select(0).insertRawText(formattedHtml.trimEnd());
+  });
+}
+
 export default function ActionsPlugin({
   shouldPreserveNewLinesInMarkdown,
   useCollabV2,
@@ -122,6 +143,7 @@ export default function ActionsPlugin({
   const isMarkdown = mode === 'markdown';
   const isHtml = mode === 'html';
   const unregisterTransformRef = useRef(() => {});
+
   useEffect(() => {
     if (mode !== 'wysiwyg') {
       const unregister = editor.registerNodeTransform(RootNode, (rootNode) => {
@@ -252,6 +274,15 @@ export default function ActionsPlugin({
         codeNode.select().insertRawText(html);
         codeNode.select(0, 0);
         setMode('html');
+        if (html) {
+          formatCodeWithPrettier(html, 'html')
+            .then((formattedCode) =>
+              editor.update(() =>
+                handlePrettierResponse(editor, html, formattedCode),
+              ),
+            )
+            .catch((err: Error) => console.error(err));
+        }
       }
     });
   }, [editor]);

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -132,6 +132,25 @@ export default function ActionsPlugin({
   const unregisterTransformRef = useRef(() => {});
   const [mode, dispatchMode, isPending] = useActionState(
     async (prevMode: EditorMode, nextMode: EditorMode): Promise<EditorMode> => {
+      if (prevMode === 'wysiwyg') {
+        // handle transitions from wysiwyg -> nextMode -> wysiwyg when there's a single
+        // root child CodeNode that is the nextMode language. e2e tests assume you can
+        // do this.
+        editor.read(() => {
+          const root = $getRoot();
+          const codeNode =
+            root.getChildrenSize() === 1
+              ? root.getChildren().find($isCodeNode)
+              : null;
+          if (codeNode) {
+            const language = codeNode.getLanguage();
+            if (language === nextMode) {
+              prevMode = nextMode;
+              nextMode = 'wysiwyg';
+            }
+          }
+        });
+      }
       if (nextMode === 'wysiwyg') {
         unregisterTransformRef.current();
         editor.update(() => {

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -32,6 +32,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {CONNECTED_COMMAND, TOGGLE_CONNECT_COMMAND} from '@lexical/yjs';
 import {
+  $createParagraphNode,
   $getRoot,
   $insertNodes,
   $isParagraphNode,
@@ -261,8 +262,11 @@ export default function ActionsPlugin({
         const parser = new DOMParser();
         const dom = parser.parseFromString(htmlString, 'text/html');
         const nodes = $generateNodesFromDOM(editor, dom);
-        $getRoot().clear().select();
+        root.clear().select();
         $insertNodes(nodes);
+        if (root.isEmpty()) {
+          root.append($createParagraphNode()).select();
+        }
         setMode('wysiwyg');
       } else {
         const html = $withRenderContext(

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -186,7 +186,7 @@ export default function ActionsPlugin({
         editor.update(() => {
           const codeNode = $createCodeNode('html');
           $getRoot().clear().append(codeNode);
-          codeNode.select().insertRawText(html);
+          codeNode.select().insertRawText(html.trimEnd());
           codeNode.select(0, 0);
         });
       }

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -43,14 +43,21 @@ import {
   HISTORIC_TAG,
   RootNode,
 } from 'lexical';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {
+  startTransition,
+  useActionState,
+  useEffect,
+  useOptimistic,
+  useRef,
+  useState,
+} from 'react';
 
 import {INITIAL_SETTINGS} from '../../appSettings';
 import useFlashMessage from '../../hooks/useFlashMessage';
 import useModal from '../../hooks/useModal';
 import Button from '../../ui/Button';
 import {docFromHash, docToHash} from '../../utils/docSerialization';
-import {formatCodeWithPrettier} from '../CodeActionMenuPlugin/components/PrettierButton';
+import {formatCodeWithPrettier} from '../CodeActionMenuPlugin/formatCodeWithPrettier';
 import {PLAYGROUND_TRANSFORMERS} from '../MarkdownTransformers';
 import {
   SPEECH_TO_TEXT_COMMAND,
@@ -105,25 +112,7 @@ async function shareDoc(doc: SerializedDocument): Promise<void> {
   await window.navigator.clipboard.writeText(newUrl);
 }
 
-function handlePrettierResponse(
-  editor: LexicalEditor,
-  originalHtml: string,
-  formattedHtml: string,
-): void {
-  editor.update(() => {
-    const rootNode = $getRoot();
-    const codeNode = rootNode.getChildren().find($isCodeNode);
-    if (
-      !codeNode ||
-      codeNode.getLanguage() !== 'html' ||
-      rootNode.getChildrenSize() !== 1 ||
-      codeNode.getTextContent() !== originalHtml
-    ) {
-      return;
-    }
-    codeNode.select(0).insertRawText(formattedHtml.trimEnd());
-  });
-}
+type EditorMode = 'wysiwyg' | 'markdown' | 'html';
 
 export default function ActionsPlugin({
   shouldPreserveNewLinesInMarkdown,
@@ -140,10 +129,74 @@ export default function ActionsPlugin({
   const [modal, showModal] = useModal();
   const showFlashMessage = useFlashMessage();
   const {isCollabActive} = useCollaborationContext();
-  const [mode, setMode] = useState<'wysiwyg' | 'markdown' | 'html'>('wysiwyg');
-  const isMarkdown = mode === 'markdown';
-  const isHtml = mode === 'html';
   const unregisterTransformRef = useRef(() => {});
+  const [mode, dispatchMode, isPending] = useActionState(
+    async (prevMode: EditorMode, nextMode: EditorMode): Promise<EditorMode> => {
+      if (nextMode === 'wysiwyg') {
+        unregisterTransformRef.current();
+        editor.update(() => {
+          if (prevMode === 'html') {
+            const root = $getRoot();
+            const parser = new DOMParser();
+            const content = root.getTextContent();
+            const dom = parser.parseFromString(content, 'text/html');
+            const nodes = $generateNodesFromDOM(editor, dom);
+            root.clear().select();
+            $insertNodes(nodes);
+            if (root.isEmpty()) {
+              root.append($createParagraphNode()).select();
+            }
+          } else if (prevMode === 'markdown') {
+            const root = $getRoot();
+            const firstChild = root.getFirstChild();
+            if (
+              $isCodeNode(firstChild) &&
+              firstChild.getLanguage() === 'markdown'
+            ) {
+              unregisterTransformRef.current();
+              $convertFromMarkdownString(
+                firstChild.getTextContent(),
+                PLAYGROUND_TRANSFORMERS,
+                undefined, // node
+                shouldPreserveNewLinesInMarkdown,
+              );
+            }
+          }
+        });
+      } else if (nextMode === 'markdown') {
+        editor.update(() => {
+          const markdown = $convertToMarkdownString(
+            PLAYGROUND_TRANSFORMERS,
+            undefined, //node
+            shouldPreserveNewLinesInMarkdown,
+          );
+          const codeNode = $createCodeNode('markdown');
+          $getRoot().clear().append(codeNode);
+          codeNode.select().insertRawText(markdown);
+          codeNode.select(0, 0);
+        });
+      } else if (nextMode === 'html') {
+        const rawHtml = editor.read(() =>
+          $withRenderContext(
+            [contextValue(RenderContextTerse, true)],
+            editor,
+          )(() => $generateHtmlFromNodes(editor)),
+        );
+        const html = await formatCodeWithPrettier(rawHtml, 'html');
+        editor.update(() => {
+          const codeNode = $createCodeNode('html');
+          $getRoot().clear().append(codeNode);
+          codeNode.select().insertRawText(html);
+          codeNode.select(0, 0);
+        });
+      }
+      return nextMode;
+    },
+    'wysiwyg',
+  );
+  const [optimisticMode, setOptimisticMode] = useOptimistic<EditorMode>(mode);
+  const isMarkdown = optimisticMode === 'markdown';
+  const isHtml = optimisticMode === 'html';
 
   useEffect(() => {
     if (mode !== 'wysiwyg') {
@@ -224,72 +277,21 @@ export default function ActionsPlugin({
     );
   }, [editor, isEditable]);
 
-  const handleMarkdownToggle = useCallback(() => {
-    editor.update(() => {
-      const root = $getRoot();
-      const firstChild = root.getFirstChild();
-      if ($isCodeNode(firstChild) && firstChild.getLanguage() === 'markdown') {
-        unregisterTransformRef.current();
-        $convertFromMarkdownString(
-          firstChild.getTextContent(),
-          PLAYGROUND_TRANSFORMERS,
-          undefined, // node
-          shouldPreserveNewLinesInMarkdown,
-        );
-        setMode('wysiwyg');
-      } else {
-        const markdown = $convertToMarkdownString(
-          PLAYGROUND_TRANSFORMERS,
-          undefined, //node
-          shouldPreserveNewLinesInMarkdown,
-        );
-        const codeNode = $createCodeNode('markdown');
-        root.clear().append(codeNode);
-        codeNode.select().insertRawText(markdown);
-        codeNode.select(0, 0);
-        setMode('markdown');
+  const toggleMode = (targetMode: 'html' | 'markdown') => {
+    startTransition(() => {
+      const nextMode =
+        mode === 'wysiwyg'
+          ? targetMode
+          : mode === targetMode
+            ? 'wysiwyg'
+            : mode;
+      if (mode === nextMode) {
+        return;
       }
+      setOptimisticMode(nextMode);
+      dispatchMode(nextMode);
     });
-  }, [editor, shouldPreserveNewLinesInMarkdown]);
-
-  const handleHtmlToggle = useCallback(() => {
-    editor.update(() => {
-      const root = $getRoot();
-      const firstChild = root.getFirstChild();
-      if ($isCodeNode(firstChild) && firstChild.getLanguage() === 'html') {
-        unregisterTransformRef.current();
-        const htmlString = firstChild.getTextContent();
-        const parser = new DOMParser();
-        const dom = parser.parseFromString(htmlString, 'text/html');
-        const nodes = $generateNodesFromDOM(editor, dom);
-        root.clear().select();
-        $insertNodes(nodes);
-        if (root.isEmpty()) {
-          root.append($createParagraphNode()).select();
-        }
-        setMode('wysiwyg');
-      } else {
-        const html = $withRenderContext(
-          [contextValue(RenderContextTerse, true)],
-          editor,
-        )(() => $generateHtmlFromNodes(editor));
-        const codeNode = $createCodeNode('html');
-        root.clear().append(codeNode);
-        codeNode.select().insertRawText(html);
-        codeNode.select(0, 0);
-        setMode('html');
-        if (html) {
-          formatCodeWithPrettier(html, 'html')
-            .then((formattedCode) =>
-              editor.update(() =>
-                handlePrettierResponse(editor, html, formattedCode),
-              ),
-            )
-            .catch((err: Error) => console.error(err));
-        }
-      }
-    });
-  }, [editor]);
+  };
 
   return (
     <div className="actions">
@@ -375,8 +377,8 @@ export default function ActionsPlugin({
       <button
         className="action-button"
         data-active={isMarkdown}
-        disabled={isHtml}
-        onClick={handleMarkdownToggle}
+        disabled={isHtml || isPending}
+        onClick={() => toggleMode('markdown')}
         title={isMarkdown ? 'Convert From Markdown' : 'Convert To Markdown'}
         aria-label={
           isMarkdown ? 'Convert from markdown' : 'Convert To Markdown'
@@ -386,8 +388,8 @@ export default function ActionsPlugin({
       <button
         className="action-button"
         data-active={isHtml}
-        disabled={isMarkdown}
-        onClick={handleHtmlToggle}
+        disabled={isMarkdown || isPending}
+        onClick={() => toggleMode('html')}
         title={isHtml ? 'Convert From HTML' : ' Convert To HTML'}
         aria-label={isHtml ? 'Convert from html' : 'Convert to html'}>
         <i className="html" />

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.tsx
@@ -9,75 +9,14 @@ import './index.css';
 
 import {$isCodeNode} from '@lexical/code';
 import {$getNearestNodeFromDOMNode, LexicalEditor} from 'lexical';
-import {Options} from 'prettier';
 import {useState} from 'react';
+
+import {formatCodeWithPrettier} from '../../formatCodeWithPrettier';
 
 interface Props {
   lang: string;
   editor: LexicalEditor;
   getCodeDOMNode: () => HTMLElement | null;
-}
-
-const PRETTIER_PARSER_MODULES = {
-  css: [() => import('prettier/parser-postcss')],
-  html: [() => import('prettier/parser-html')],
-  js: [
-    () => import('prettier/parser-babel'),
-    () => import('prettier/plugins/estree'),
-  ],
-  markdown: [() => import('prettier/parser-markdown')],
-  typescript: [
-    () => import('prettier/parser-typescript'),
-    () => import('prettier/plugins/estree'),
-  ],
-} as const;
-
-type LanguagesType = keyof typeof PRETTIER_PARSER_MODULES;
-
-async function loadPrettierParserByLang(lang: string) {
-  const dynamicImports = PRETTIER_PARSER_MODULES[lang as LanguagesType];
-  const modules = await Promise.all(
-    dynamicImports.map((dynamicImport) => dynamicImport()),
-  );
-  return modules;
-}
-
-async function loadPrettierFormat() {
-  const {format} = await import('prettier/standalone');
-  return format;
-}
-
-export async function formatCodeWithPrettier(content: string, lang: string) {
-  const format = await loadPrettierFormat();
-  const options = getPrettierOptions(lang);
-  const prettierParsers = await loadPrettierParserByLang(lang);
-  options.plugins = prettierParsers.map((parser) => parser.default || parser);
-  return await format(content, options);
-}
-
-const PRETTIER_OPTIONS_BY_LANG: Record<string, Options> = {
-  css: {parser: 'css'},
-  html: {parser: 'html'},
-  js: {parser: 'babel'},
-  markdown: {parser: 'markdown'},
-  typescript: {parser: 'typescript'},
-};
-
-const LANG_CAN_BE_PRETTIER = Object.keys(PRETTIER_OPTIONS_BY_LANG);
-
-export function canBePrettier(lang: string): boolean {
-  return LANG_CAN_BE_PRETTIER.includes(lang);
-}
-
-function getPrettierOptions(lang: string): Options {
-  const options = PRETTIER_OPTIONS_BY_LANG[lang];
-  if (!options) {
-    throw new Error(
-      `CodeActionMenuPlugin: Prettier does not support this language: ${lang}`,
-    );
-  }
-
-  return options;
 }
 
 export function PrettierButton({lang, editor, getCodeDOMNode}: Props) {

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.tsx
@@ -47,6 +47,14 @@ async function loadPrettierFormat() {
   return format;
 }
 
+export async function formatCodeWithPrettier(content: string, lang: string) {
+  const format = await loadPrettierFormat();
+  const options = getPrettierOptions(lang);
+  const prettierParsers = await loadPrettierParserByLang(lang);
+  options.plugins = prettierParsers.map((parser) => parser.default || parser);
+  return await format(content, options);
+}
+
 const PRETTIER_OPTIONS_BY_LANG: Record<string, Options> = {
   css: {parser: 'css'},
   html: {parser: 'html'},
@@ -94,14 +102,7 @@ export function PrettierButton({lang, editor, getCodeDOMNode}: Props) {
     }
 
     try {
-      const format = await loadPrettierFormat();
-      const options = getPrettierOptions(lang);
-      const prettierParsers = await loadPrettierParserByLang(lang);
-      options.plugins = prettierParsers.map(
-        (parser) => parser.default || parser,
-      );
-      const formattedCode = await format(content, options);
-
+      const formattedCode = await formatCodeWithPrettier(content, lang);
       editor.update(() => {
         const codeNode = $getNearestNodeFromDOMNode(codeDOMNode);
         if ($isCodeNode(codeNode)) {

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/formatCodeWithPrettier.ts
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/formatCodeWithPrettier.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {Options} from 'prettier';
+
+const PRETTIER_PARSER_MODULES = {
+  css: [() => import('prettier/parser-postcss')],
+  html: [() => import('prettier/parser-html')],
+  js: [
+    () => import('prettier/parser-babel'),
+    () => import('prettier/plugins/estree'),
+  ],
+  markdown: [() => import('prettier/parser-markdown')],
+  typescript: [
+    () => import('prettier/parser-typescript'),
+    () => import('prettier/plugins/estree'),
+  ],
+} as const;
+
+type LanguagesType = keyof typeof PRETTIER_PARSER_MODULES;
+
+async function loadPrettierParserByLang(lang: string) {
+  const dynamicImports = PRETTIER_PARSER_MODULES[lang as LanguagesType];
+  const modules = await Promise.all(
+    dynamicImports.map((dynamicImport) => dynamicImport()),
+  );
+  return modules;
+}
+
+async function loadPrettierFormat() {
+  const {format} = await import('prettier/standalone');
+  return format;
+}
+
+const PRETTIER_OPTIONS_BY_LANG: Record<string, Options> = {
+  css: {parser: 'css'},
+  html: {parser: 'html'},
+  js: {parser: 'babel'},
+  markdown: {parser: 'markdown'},
+  typescript: {parser: 'typescript'},
+};
+
+const LANG_CAN_BE_PRETTIER = Object.keys(PRETTIER_OPTIONS_BY_LANG);
+
+export function canBePrettier(lang: string): boolean {
+  return LANG_CAN_BE_PRETTIER.includes(lang);
+}
+
+function getPrettierOptions(lang: string): Options {
+  const options = PRETTIER_OPTIONS_BY_LANG[lang];
+  if (!options) {
+    throw new Error(
+      `CodeActionMenuPlugin: Prettier does not support this language: ${lang}`,
+    );
+  }
+
+  return options;
+}
+
+export async function formatCodeWithPrettier(content: string, lang: string) {
+  const format = await loadPrettierFormat();
+  const options = getPrettierOptions(lang);
+  const prettierParsers = await loadPrettierParserByLang(lang);
+  options.plugins = prettierParsers.map((parser) => parser.default || parser);
+  if (lang === 'html') {
+    content = content.replace(
+      /(<[a-z][^>]*\bstyle\s*=\s*["'][^"']*white-space\s*:\s*pre[^"']*["'][^>]*>)/gi,
+      '<!-- prettier-ignore -->$1',
+    );
+  }
+  let formatted = await format(content, options);
+  if (lang === 'html') {
+    formatted = formatted.replaceAll(/<!-- prettier-ignore -->/g, '');
+  }
+  return formatted;
+}

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
@@ -22,7 +22,8 @@ import {useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 
 import {CopyButton} from './components/CopyButton';
-import {canBePrettier, PrettierButton} from './components/PrettierButton';
+import {PrettierButton} from './components/PrettierButton';
+import {canBePrettier} from './formatCodeWithPrettier';
 import {useDebounce} from './utils';
 
 const CODE_PADDING = 8;


### PR DESCRIPTION
## Description

Format the "Convert to HTML" view with prettier, while being careful to only format it if the content hasn't changed in the meantime.

Follow-up to #8379

## Test plan

New e2e test and existing specs changed to ignore the data-gutter attribute