### PR TITLE
[lexical-playground] Bug Fix: Prevent floating link editor from overflowing bottom of editor bounds

### DIFF
--- a/packages/lexical-playground/src/utils/setFloatingElemPositionForLinkEditor.ts
+++ b/packages/lexical-playground/src/utils/setFloatingElemPositionForLinkEditor.ts
@@ -38,6 +38,10 @@ export function setFloatingElemPositionForLinkEditor(
     left = editorScrollerRect.right - floatingElemRect.width - horizontalOffset;
   }
 
+  if (top + floatingElemRect.height > editorScrollerRect.bottom) {
+    top -= floatingElemRect.height + targetRect.height + verticalGap * 2;
+  }
+
   top -= anchorElementRect.top;
   left -= anchorElementRect.left;
 


### PR DESCRIPTION
## Description

Fixes #8362

When a link is near the bottom of the editor, the floating link editor popup overflows the editor scroller's bottom edge and gets clipped. This happens because `setFloatingElemPositionForLinkEditor` checks for top and right boundary collisions but not bottom.

This adds a bottom boundary check that mirrors the existing top boundary check — when the popup would overflow the bottom edge, it flips above the link instead:

```diff
+ if (top + floatingElemRect.height > editorScrollerRect.bottom) {
+   top -= floatingElemRect.height + targetRect.height + verticalGap * 2;
+ }
```

## Test Plan

1. Open the Lexical playground
2. Add text and insert a link near the bottom of the editor
3. Click the link
4. **Before:** Floating link editor overflows below the editor bounds and is clipped
5. **After:** Floating link editor flips above the link and stays within bounds