### PR TITLE
[lexical-playground] Refactor: Use @floating-ui/react for FloatingLinkEditorPlugin positioning

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
@@ -1,15 +1,11 @@
 .link-editor {
   display: flex;
-  position: absolute;
-  top: 0;
-  left: 0;
   z-index: 10;
   max-width: 400px;
   width: 100%;
-  opacity: 0;
   background-color: #fff;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.3);
-  border-radius: 0 0 8px 8px;
+  border-radius: 8px;
   transition: opacity 0.5s;
   will-change: transform;
 }

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -9,6 +9,7 @@ import type {JSX} from 'react';
 
 import './index.css';
 
+import {autoUpdate, flip, offset, shift, useFloating} from '@floating-ui/react';
 import {
   $createLinkNode,
   $isAutoLinkNode,
@@ -37,7 +38,6 @@ import {Dispatch, useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 
 import {getSelectedNode} from '../../utils/getSelectedNode';
-import {setFloatingElemPositionForLinkEditor} from '../../utils/setFloatingElemPositionForLinkEditor';
 import {sanitizeUrl} from '../../utils/url';
 
 function preventDefault(
@@ -68,6 +68,26 @@ function FloatingLinkEditor({
   const [lastSelection, setLastSelection] = useState<BaseSelection | null>(
     null,
   );
+
+  const scrollerElem = anchorElem.parentElement;
+
+  const {refs, floatingStyles} = useFloating({
+    middleware: [
+      offset(10),
+      flip({
+        boundary: scrollerElem || undefined,
+        padding: 10,
+      }),
+      shift({
+        boundary: scrollerElem || undefined,
+        padding: 10,
+      }),
+    ],
+    placement: 'bottom-start',
+    strategy: 'absolute',
+    whileElementsMounted: (...args) =>
+      autoUpdate(...args, {ancestorScroll: false}),
+  });
 
   const $updateLinkEditor = useCallback(() => {
     const selection = $getSelection();
@@ -103,13 +123,8 @@ function FloatingLinkEditor({
       }
     }
 
-    const editorElem = editorRef.current;
     const nativeSelection = getDOMSelection(editor._window);
     const activeElement = document.activeElement;
-
-    if (editorElem === null) {
-      return;
-    }
 
     const rootElement = editor.getRootElement();
 
@@ -126,52 +141,26 @@ function FloatingLinkEditor({
         }
       } else if (
         nativeSelection !== null &&
+        nativeSelection.rangeCount > 0 &&
         rootElement.contains(nativeSelection.anchorNode)
       ) {
-        domRect =
-          nativeSelection.focusNode?.parentElement?.getBoundingClientRect();
+        domRect = nativeSelection.getRangeAt(0).getBoundingClientRect();
       }
 
       if (domRect) {
-        domRect.y += 40;
-        setFloatingElemPositionForLinkEditor(domRect, editorElem, anchorElem);
+        refs.setPositionReference({
+          getBoundingClientRect: () => domRect,
+        });
       }
       setLastSelection(selection);
     } else if (!activeElement || activeElement.className !== 'link-input') {
-      if (rootElement !== null) {
-        setFloatingElemPositionForLinkEditor(null, editorElem, anchorElem);
-      }
       setLastSelection(null);
       setIsLinkEditMode(false);
       setLinkUrl('');
     }
 
     return true;
-  }, [anchorElem, editor, setIsLinkEditMode, isLinkEditMode, linkUrl]);
-
-  useEffect(() => {
-    const scrollerElem = anchorElem.parentElement;
-
-    const update = () => {
-      editor.getEditorState().read(() => {
-        $updateLinkEditor();
-      });
-    };
-
-    window.addEventListener('resize', update);
-
-    if (scrollerElem) {
-      scrollerElem.addEventListener('scroll', update);
-    }
-
-    return () => {
-      window.removeEventListener('resize', update);
-
-      if (scrollerElem) {
-        scrollerElem.removeEventListener('scroll', update);
-      }
-    };
-  }, [anchorElem.parentElement, editor, $updateLinkEditor]);
+  }, [editor, setIsLinkEditMode, isLinkEditMode, linkUrl, refs]);
 
   useEffect(() => {
     return mergeRegister(
@@ -276,7 +265,17 @@ function FloatingLinkEditor({
   };
 
   return (
-    <div ref={editorRef} className="link-editor">
+    <div
+      ref={(el) => {
+        editorRef.current = el;
+        refs.setFloating(el);
+      }}
+      className="link-editor"
+      style={{
+        ...floatingStyles,
+        opacity: isLink ? 1 : 0,
+        pointerEvents: isLink ? 'auto' : 'none',
+      }}>
       {!isLink ? null : isLinkEditMode ? (
         <>
           <input

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -448,7 +448,7 @@ function useFloatingTextFormatToolbar(
     );
   }, [editor, updatePopup]);
 
-  if (!isText) {
+  if (!isText || isLink) {
     return null;
   }
 


### PR DESCRIPTION
## Description

Fixes #8362

Refactors FloatingLinkEditorPlugin to use `@floating-ui/react` for positioning, as suggested by @etrepum in #8387.

### What changed

- Replaced manual position calculation (`setFloatingElemPositionForLinkEditor`) with `useFloating` hook using `offset`, `flip`, and `shift` middleware
- Removed manual `scroll`/`resize` event listeners (replaced by `autoUpdate`)
- Used `getRangeAt(0).getBoundingClientRect()` instead of `focusNode.parentElement.getBoundingClientRect()` for reference positioning — on Linux Firefox, `focusNode.parentElement` can return a large element (like `<p>`) that fills the entire editor, causing the popup to overflow outside the editor bounds
- Hidden `FloatingTextFormatToolbar` when a link is selected to prevent overlap when the link editor flips above the text

### Why

The previous implementation manually handled boundary checks for top and right edges but missed bottom and viewport boundaries. Rather than patching each edge case individually, this refactors to `@floating-ui/react` which handles all boundary cases automatically. This is consistent with other playground plugins (DateTimeComponent, TableHoverActionsV2, NodeContextMenuPlugin) that already use the library.

### Note on FloatingTextFormatToolbar change

The `flip` middleware introduces a new scenario that didn't exist before: when a link is near the bottom of the editor, the link editor popup flips above the text, overlapping with the FloatingTextFormatToolbar that also appears above the selected text.

To prevent this overlap, this PR hides the FloatingTextFormatToolbar when a link is selected (`isLink`). The tradeoff is that users can no longer apply text formatting (bold, italic, etc.) via the floating toolbar while a link is selected — though this is still possible via the main toolbar or keyboard shortcuts.

Open to alternative approaches if this tradeoff is not acceptable.

## Test Plan

1. Click a link in the middle of the editor → popup appears below the link
2. Click a link near the bottom of the editor → popup flips above the link
3. Click a link near the right edge → popup shifts left
4. Resize browser window so editor is near viewport edge → popup stays within bounds
5. Click a link and scroll → popup stays attached to the link
6. Edit/delete link via popup buttons → works as before
7. Press ESC → popup closes
8. Select link text → FloatingTextFormatToolbar is hidden, only link popup shows