### PR TITLE
[lexical-list] Bug Fix: Toggle checklist items on mobile tap

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/checkList.test.tsx
+++ b/packages/lexical-list/src/__tests__/unit/checkList.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$getRoot} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+import {$createListItemNode, $createListNode} from '../..';
+import {registerCheckList} from '../../checkList';
+
+// Polyfill PointerEvent for jsdom (mirrors LexicalTableMobileSelection.test.tsx).
+interface PointerEventInit extends EventInit {
+  clientX?: number;
+  clientY?: number;
+  pointerType?: string;
+}
+
+(global as unknown as {PointerEvent: unknown}).PointerEvent =
+  class PointerEventPolyfill extends Event {
+    clientX: number;
+    clientY: number;
+    pointerType: string;
+
+    constructor(type: string, options: PointerEventInit = {}) {
+      super(type, options);
+      this.clientX = options.clientX || 0;
+      this.clientY = options.clientY || 0;
+      this.pointerType = options.pointerType || 'mouse';
+    }
+  };
+
+describe('registerCheckList — mobile tap toggle', () => {
+  // jsdom does not implement getComputedStyle with pseudo-elements (see
+  // https://github.com/jsdom/jsdom/issues/1928), but the checklist hit-test
+  // reads the ::before width to size the marker area. Stub a 16px width so
+  // the bounds check resolves to a concrete number; vi.restoreAllMocks
+  // returns the original implementation afterwards so the mock cannot leak
+  // to other test files in the same worker.
+  const originalGetComputedStyle = window.getComputedStyle;
+  beforeAll(() => {
+    vi.spyOn(window, 'getComputedStyle').mockImplementation(
+      (element: Element, pseudoElement?: string | null) => {
+        if (pseudoElement === '::before') {
+          return {width: '16px'} as unknown as CSSStyleDeclaration;
+        }
+        return originalGetComputedStyle.call(window, element, pseudoElement);
+      },
+    );
+  });
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  initializeUnitTest((testEnv) => {
+    let cleanup: (() => void) | null = null;
+
+    beforeEach(async () => {
+      cleanup = registerCheckList(testEnv.editor);
+      await testEnv.editor.update(
+        () => {
+          const list = $createListNode('check');
+          list.append($createListItemNode(false));
+          $getRoot().clear().append(list);
+        },
+        {discrete: true},
+      );
+    });
+
+    afterEach(() => {
+      cleanup?.();
+      cleanup = null;
+    });
+
+    function getCheckListItem(): HTMLLIElement {
+      const li = testEnv.container.querySelector('li');
+      if (!li) {
+        throw new Error('No <li> rendered');
+      }
+      return li as HTMLLIElement;
+    }
+
+    function isChecked(li: HTMLLIElement): boolean {
+      return li.getAttribute('aria-checked') === 'true';
+    }
+
+    test('touch pointerup over the marker area toggles the item', async () => {
+      const li = getCheckListItem();
+      expect(isChecked(li)).toBe(false);
+
+      // clientX is well inside the marker hit area for any plausible
+      // ::before width / touch padding combination.
+      li.dispatchEvent(
+        new PointerEvent('pointerup', {
+          bubbles: true,
+          cancelable: true,
+          clientX: 10,
+          clientY: 5,
+          pointerType: 'touch',
+        }),
+      );
+
+      // editor.update() reconciles asynchronously — wait for the DOM rather
+      // than assuming a fixed number of microtasks.
+      await vi.waitFor(() => expect(isChecked(li)).toBe(true));
+    });
+
+    test('mouse pointerup is ignored (click stays the desktop path)', () => {
+      const li = getCheckListItem();
+      expect(isChecked(li)).toBe(false);
+
+      li.dispatchEvent(
+        new PointerEvent('pointerup', {
+          bubbles: true,
+          cancelable: true,
+          clientX: 10,
+          clientY: 5,
+          pointerType: 'mouse',
+        }),
+      );
+
+      expect(isChecked(li)).toBe(false);
+    });
+
+    test('pointerup followed by a synthesized click does not double-toggle', async () => {
+      const li = getCheckListItem();
+      expect(isChecked(li)).toBe(false);
+
+      const baseTimeStamp = 1000;
+      const pointerUp = new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 5,
+        pointerType: 'touch',
+      });
+      Object.defineProperty(pointerUp, 'timeStamp', {value: baseTimeStamp});
+      li.dispatchEvent(pointerUp);
+      await vi.waitFor(() => expect(isChecked(li)).toBe(true));
+
+      // Browsers where touchstart preventDefault did not suppress click will
+      // also fire it shortly after. The dedup window must absorb it.
+      const click = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 5,
+      });
+      Object.defineProperty(click, 'timeStamp', {value: baseTimeStamp + 50});
+      li.dispatchEvent(click);
+
+      // Give any queued reconciliation a chance to run, then assert the
+      // state has not flipped back.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(isChecked(li)).toBe(true);
+    });
+  });
+});

--- a/packages/lexical-list/src/__tests__/unit/checkList.test.tsx
+++ b/packages/lexical-list/src/__tests__/unit/checkList.test.tsx
@@ -6,8 +6,17 @@
  *
  */
 
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {
+  $createListItemNode,
+  $createListNode,
+  $isListItemNode,
+  $isListNode,
+  CheckListExtension,
+} from '@lexical/list';
+import {RichTextExtension} from '@lexical/rich-text';
 import {$getRoot} from 'lexical';
-import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {invariant} from 'lexical/src/__tests__/utils';
 import {
   afterAll,
   afterEach,
@@ -15,41 +24,15 @@ import {
   beforeEach,
   describe,
   expect,
-  test,
+  it,
   vi,
 } from 'vitest';
 
-import {$createListItemNode, $createListNode} from '../..';
-import {registerCheckList} from '../../checkList';
-
-// Polyfill PointerEvent for jsdom (mirrors LexicalTableMobileSelection.test.tsx).
-interface PointerEventInit extends EventInit {
-  clientX?: number;
-  clientY?: number;
-  pointerType?: string;
-}
-
-(global as unknown as {PointerEvent: unknown}).PointerEvent =
-  class PointerEventPolyfill extends Event {
-    clientX: number;
-    clientY: number;
-    pointerType: string;
-
-    constructor(type: string, options: PointerEventInit = {}) {
-      super(type, options);
-      this.clientX = options.clientX || 0;
-      this.clientY = options.clientY || 0;
-      this.pointerType = options.pointerType || 'mouse';
-    }
-  };
-
-describe('registerCheckList — mobile tap toggle', () => {
-  // jsdom does not implement getComputedStyle with pseudo-elements (see
-  // https://github.com/jsdom/jsdom/issues/1928), but the checklist hit-test
-  // reads the ::before width to size the marker area. Stub a 16px width so
-  // the bounds check resolves to a concrete number; vi.restoreAllMocks
-  // returns the original implementation afterwards so the mock cannot leak
-  // to other test files in the same worker.
+describe('CheckListExtension mobile tap toggle', () => {
+  // jsdom does not implement getComputedStyle with pseudo-elements
+  // (https://github.com/jsdom/jsdom/issues/1928), but the checklist
+  // hit-test reads the ::before width to size the marker area. Stub a
+  // 16px width so the bounds check resolves to a concrete number.
   const originalGetComputedStyle = window.getComputedStyle;
   beforeAll(() => {
     vi.spyOn(window, 'getComputedStyle').mockImplementation(
@@ -65,107 +48,150 @@ describe('registerCheckList — mobile tap toggle', () => {
     vi.restoreAllMocks();
   });
 
-  initializeUnitTest((testEnv) => {
-    let cleanup: (() => void) | null = null;
+  const checkListExtension = defineExtension({
+    $initialEditorState: () => {
+      const list = $createListNode('check');
+      list.append($createListItemNode(false));
+      list.append($createListItemNode(false));
+      $getRoot().append(list);
+    },
+    dependencies: [CheckListExtension, RichTextExtension],
+    name: '[checklist-test]',
+  });
 
-    beforeEach(async () => {
-      cleanup = registerCheckList(testEnv.editor);
-      await testEnv.editor.update(
-        () => {
-          const list = $createListNode('check');
-          list.append($createListItemNode(false));
-          $getRoot().clear().append(list);
-        },
-        {discrete: true},
-      );
+  let container: HTMLDivElement;
+  let rootElement: HTMLDivElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    rootElement = document.createElement('div');
+    rootElement.contentEditable = 'true';
+    container.appendChild(rootElement);
+  });
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function buildEditor() {
+    const editor = buildEditorFromExtensions(checkListExtension);
+    editor.setRootElement(rootElement);
+    return editor;
+  }
+
+  function getCheckListItem(index = 0): HTMLLIElement {
+    const items = rootElement.querySelectorAll('li');
+    const li = items[index];
+    invariant(li !== undefined, `No <li> at index ${index}`);
+    return li as HTMLLIElement;
+  }
+
+  function readChecked(
+    editor: ReturnType<typeof buildEditor>,
+    index: number,
+  ): boolean {
+    return editor.read(() => {
+      const list = $getRoot().getFirstChildOrThrow();
+      invariant($isListNode(list), 'Expected a ListNode at root');
+      const item = list.getChildAtIndex(index);
+      invariant($isListItemNode(item), `Expected ListItemNode at ${index}`);
+      return item.getChecked() === true;
     });
+  }
 
-    afterEach(() => {
-      cleanup?.();
-      cleanup = null;
+  it('touch pointerup over the marker area toggles the item', () => {
+    using editor = buildEditor();
+    expect(readChecked(editor, 0)).toBe(false);
+
+    const li = getCheckListItem(0);
+    // clientX is well inside the marker hit area for any plausible
+    // ::before width / touch padding combination.
+    li.dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 5,
+        pointerType: 'touch',
+      }),
+    );
+
+    expect(readChecked(editor, 0)).toBe(true);
+  });
+
+  it('mouse pointerup is ignored (click stays the desktop path)', () => {
+    using editor = buildEditor();
+    expect(readChecked(editor, 0)).toBe(false);
+
+    const li = getCheckListItem(0);
+    li.dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 5,
+        pointerType: 'mouse',
+      }),
+    );
+
+    expect(readChecked(editor, 0)).toBe(false);
+  });
+
+  it('pointerup followed by a synthesized click does not double-toggle', () => {
+    using editor = buildEditor();
+    expect(readChecked(editor, 0)).toBe(false);
+
+    const li = getCheckListItem(0);
+    const baseTimeStamp = 1000;
+    const pointerUp = new PointerEvent('pointerup', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 10,
+      clientY: 5,
+      pointerType: 'touch',
     });
+    Object.defineProperty(pointerUp, 'timeStamp', {value: baseTimeStamp});
+    li.dispatchEvent(pointerUp);
+    expect(readChecked(editor, 0)).toBe(true);
 
-    function getCheckListItem(): HTMLLIElement {
-      const li = testEnv.container.querySelector('li');
-      if (!li) {
-        throw new Error('No <li> rendered');
-      }
-      return li as HTMLLIElement;
-    }
-
-    function isChecked(li: HTMLLIElement): boolean {
-      return li.getAttribute('aria-checked') === 'true';
-    }
-
-    test('touch pointerup over the marker area toggles the item', async () => {
-      const li = getCheckListItem();
-      expect(isChecked(li)).toBe(false);
-
-      // clientX is well inside the marker hit area for any plausible
-      // ::before width / touch padding combination.
-      li.dispatchEvent(
-        new PointerEvent('pointerup', {
-          bubbles: true,
-          cancelable: true,
-          clientX: 10,
-          clientY: 5,
-          pointerType: 'touch',
-        }),
-      );
-
-      // editor.update() reconciles asynchronously — wait for the DOM rather
-      // than assuming a fixed number of microtasks.
-      await vi.waitFor(() => expect(isChecked(li)).toBe(true));
+    // Browsers where touchstart preventDefault did not suppress click
+    // also fire it shortly after. The dedup window must absorb it.
+    const click = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 10,
+      clientY: 5,
     });
+    Object.defineProperty(click, 'timeStamp', {value: baseTimeStamp + 50});
+    li.dispatchEvent(click);
 
-    test('mouse pointerup is ignored (click stays the desktop path)', () => {
-      const li = getCheckListItem();
-      expect(isChecked(li)).toBe(false);
+    expect(readChecked(editor, 0)).toBe(true);
+  });
 
-      li.dispatchEvent(
-        new PointerEvent('pointerup', {
-          bubbles: true,
-          cancelable: true,
-          clientX: 10,
-          clientY: 5,
-          pointerType: 'mouse',
-        }),
-      );
+  it('rapid taps on two different items toggle both within the dedup window', () => {
+    using editor = buildEditor();
+    expect(readChecked(editor, 0)).toBe(false);
+    expect(readChecked(editor, 1)).toBe(false);
 
-      expect(isChecked(li)).toBe(false);
-    });
-
-    test('pointerup followed by a synthesized click does not double-toggle', async () => {
-      const li = getCheckListItem();
-      expect(isChecked(li)).toBe(false);
-
-      const baseTimeStamp = 1000;
-      const pointerUp = new PointerEvent('pointerup', {
+    const baseTimeStamp = 1000;
+    const tap = (target: HTMLLIElement, offsetMs: number) => {
+      const event = new PointerEvent('pointerup', {
         bubbles: true,
         cancelable: true,
         clientX: 10,
         clientY: 5,
         pointerType: 'touch',
       });
-      Object.defineProperty(pointerUp, 'timeStamp', {value: baseTimeStamp});
-      li.dispatchEvent(pointerUp);
-      await vi.waitFor(() => expect(isChecked(li)).toBe(true));
-
-      // Browsers where touchstart preventDefault did not suppress click will
-      // also fire it shortly after. The dedup window must absorb it.
-      const click = new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-        clientX: 10,
-        clientY: 5,
+      Object.defineProperty(event, 'timeStamp', {
+        value: baseTimeStamp + offsetMs,
       });
-      Object.defineProperty(click, 'timeStamp', {value: baseTimeStamp + 50});
-      li.dispatchEvent(click);
+      target.dispatchEvent(event);
+    };
 
-      // Give any queued reconciliation a chance to run, then assert the
-      // state has not flipped back.
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(isChecked(li)).toBe(true);
-    });
+    tap(getCheckListItem(0), 0);
+    // 100ms later: well inside DEDUP_WINDOW_MS, tap a different box.
+    tap(getCheckListItem(1), 100);
+
+    expect(readChecked(editor, 0)).toBe(true);
+    expect(readChecked(editor, 1)).toBe(true);
   });
 });

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -59,10 +59,41 @@ export function registerCheckList(
       ? () => disableTakeFocusOnClick
       : disableTakeFocusOnClick.peek.bind(disableTakeFocusOnClick);
 
-  const configHandleClick = (event: MouseEvent | TouchEvent) => {
+  // Mobile tap fix: the touchstart listener registered below calls
+  // event.preventDefault() to keep the caret away from the marker. On iOS
+  // Safari and Android Chrome that suppression also cancels the synthesized
+  // click, so handleClick never runs and the checkbox cannot be toggled by
+  // tap. We additionally listen for pointerup with pointerType === 'touch'
+  // and run the same toggle logic, deduplicating against any click that
+  // does fire on browsers where preventDefault doesn't suppress it.
+  let lastHandledTimeStamp = 0;
+  const DEDUP_WINDOW_MS = 500;
+  const configHandleClick = (event: PointerEvent | MouseEvent | TouchEvent) => {
+    if (
+      lastHandledTimeStamp > 0 &&
+      event.timeStamp - lastHandledTimeStamp < DEDUP_WINDOW_MS
+    ) {
+      return;
+    }
+    lastHandledTimeStamp = event.timeStamp;
     handleClick(event, peekDisableTakeFocusOnClick());
   };
-  const configHandleSelectDefaults = (event: MouseEvent | TouchEvent) => {
+  const configHandlePointerUp = (event: PointerEvent) => {
+    if (event.pointerType !== 'touch') {
+      return;
+    }
+    if (
+      lastHandledTimeStamp > 0 &&
+      event.timeStamp - lastHandledTimeStamp < DEDUP_WINDOW_MS
+    ) {
+      return;
+    }
+    lastHandledTimeStamp = event.timeStamp;
+    handleClick(event, peekDisableTakeFocusOnClick());
+  };
+  const configHandleSelectDefaults = (
+    event: PointerEvent | MouseEvent | TouchEvent,
+  ) => {
     handleSelectDefaults(event, peekDisableTakeFocusOnClick());
   };
   return mergeRegister(
@@ -172,6 +203,7 @@ export function registerCheckList(
     editor.registerRootListener((rootElement) => {
       if (rootElement !== null) {
         rootElement.addEventListener('click', configHandleClick);
+        rootElement.addEventListener('pointerup', configHandlePointerUp);
         // Use capture so we run before other listeners that might move focus.
         rootElement.addEventListener(
           'pointerdown',
@@ -192,6 +224,7 @@ export function registerCheckList(
         });
         return () => {
           rootElement.removeEventListener('click', configHandleClick);
+          rootElement.removeEventListener('pointerup', configHandlePointerUp);
           rootElement.removeEventListener(
             'pointerdown',
             configHandleSelectDefaults,
@@ -220,7 +253,7 @@ export function registerCheckList(
 }
 
 function handleCheckItemEvent(
-  event: MouseEvent | TouchEvent,
+  event: PointerEvent | MouseEvent | TouchEvent,
   callback: () => void,
 ) {
   const target = event.target;
@@ -277,7 +310,8 @@ function handleCheckItemEvent(
   // Determine whether this is a touch event; some environments may supply
   // pointerType on PointerEvent while touch events use the `touches` API above.
   const isTouchEvent =
-    pointerType === 'touch' || (event as PointerEvent).pointerType === 'touch';
+    pointerType === 'touch' ||
+    ('pointerType' in event && event.pointerType === 'touch');
   const clickAreaPadding = isTouchEvent ? 32 : 0; // Add 32px padding for touch events
 
   if (
@@ -292,7 +326,7 @@ function handleCheckItemEvent(
 }
 
 function handleClick(
-  event: MouseEvent | TouchEvent,
+  event: PointerEvent | MouseEvent | TouchEvent,
   disableFocusOnClick: boolean,
 ) {
   handleCheckItemEvent(event, () => {
@@ -326,7 +360,7 @@ function handleClick(
  *
  */
 function handleSelectDefaults(
-  event: MouseEvent | TouchEvent,
+  event: PointerEvent | MouseEvent | TouchEvent,
   disableTakeFocusOnClick: boolean,
 ) {
   handleCheckItemEvent(event, () => {

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -66,29 +66,40 @@ export function registerCheckList(
   // tap. We additionally listen for pointerup with pointerType === 'touch'
   // and run the same toggle logic, deduplicating against any click that
   // does fire on browsers where preventDefault doesn't suppress it.
-  let lastHandledTimeStamp = 0;
+  //
+  // Dedup state is per-target: a global window would block tapping a second
+  // checkbox within 500ms of toggling the first.
+  const lastHandledByTarget = new WeakMap<EventTarget, number>();
   const DEDUP_WINDOW_MS = 500;
+  const isWithinDedupWindow = (
+    event: PointerEvent | MouseEvent | TouchEvent,
+  ): boolean => {
+    if (event.target == null) {
+      return false;
+    }
+    const last = lastHandledByTarget.get(event.target);
+    return last !== undefined && event.timeStamp - last < DEDUP_WINDOW_MS;
+  };
+  const recordHandled = (event: PointerEvent | MouseEvent | TouchEvent) => {
+    if (event.target != null) {
+      lastHandledByTarget.set(event.target, event.timeStamp);
+    }
+  };
   const configHandleClick = (event: PointerEvent | MouseEvent | TouchEvent) => {
-    if (
-      lastHandledTimeStamp > 0 &&
-      event.timeStamp - lastHandledTimeStamp < DEDUP_WINDOW_MS
-    ) {
+    if (isWithinDedupWindow(event)) {
       return;
     }
-    lastHandledTimeStamp = event.timeStamp;
+    recordHandled(event);
     handleClick(event, peekDisableTakeFocusOnClick());
   };
   const configHandlePointerUp = (event: PointerEvent) => {
     if (event.pointerType !== 'touch') {
       return;
     }
-    if (
-      lastHandledTimeStamp > 0 &&
-      event.timeStamp - lastHandledTimeStamp < DEDUP_WINDOW_MS
-    ) {
+    if (isWithinDedupWindow(event)) {
       return;
     }
-    lastHandledTimeStamp = event.timeStamp;
+    recordHandled(event);
     handleClick(event, peekDisableTakeFocusOnClick());
   };
   const configHandleSelectDefaults = (

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -67,22 +67,26 @@ export function registerCheckList(
   // and run the same toggle logic, deduplicating against any click that
   // does fire on browsers where preventDefault doesn't suppress it.
   //
-  // Dedup state is per-target: a global window would block tapping a second
-  // checkbox within 500ms of toggling the first.
-  const lastHandledByTarget = new WeakMap<EventTarget, number>();
+  // Dedup state is per-target: recorded as `__lexicalCheckListLastHandled`
+  // on the target element. A global window would
+  // block tapping a second checkbox within 500ms of toggling the first.
   const DEDUP_WINDOW_MS = 500;
   const isWithinDedupWindow = (
     event: PointerEvent | MouseEvent | TouchEvent,
   ): boolean => {
-    if (event.target == null) {
+    const target = event.target;
+    if (!isHTMLElement(target)) {
       return false;
     }
-    const last = lastHandledByTarget.get(event.target);
+    // @ts-ignore internal field
+    const last = target.__lexicalCheckListLastHandled as number | undefined;
     return last !== undefined && event.timeStamp - last < DEDUP_WINDOW_MS;
   };
   const recordHandled = (event: PointerEvent | MouseEvent | TouchEvent) => {
-    if (event.target != null) {
-      lastHandledByTarget.set(event.target, event.timeStamp);
+    const target = event.target;
+    if (isHTMLElement(target)) {
+      // @ts-ignore internal field
+      target.__lexicalCheckListLastHandled = event.timeStamp;
     }
   };
   const configHandleClick = (event: PointerEvent | MouseEvent | TouchEvent) => {

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -119,4 +119,36 @@ if (isJsdom) {
       } as DOMRect;
     };
   }
+
+  // jsdom does not implement PointerEvent. Provide a minimal subclass of
+  // Event carrying the fields our event handlers read (button, buttons,
+  // clientX/Y, pointerType). Tests that need richer behavior can extend
+  // or override per-event.
+  if (
+    typeof (globalThis as {PointerEvent?: unknown}).PointerEvent !== 'function'
+  ) {
+    interface PointerEventLikeInit extends EventInit {
+      button?: number;
+      buttons?: number;
+      clientX?: number;
+      clientY?: number;
+      pointerType?: string;
+    }
+    class PointerEventPolyfill extends Event {
+      button: number;
+      buttons: number;
+      clientX: number;
+      clientY: number;
+      pointerType: string;
+      constructor(type: string, options: PointerEventLikeInit = {}) {
+        super(type, options);
+        this.button = options.button ?? 0;
+        this.buttons = options.buttons ?? 0;
+        this.clientX = options.clientX ?? 0;
+        this.clientY = options.clientY ?? 0;
+        this.pointerType = options.pointerType || 'mouse';
+      }
+    }
+    (globalThis as {PointerEvent: unknown}).PointerEvent = PointerEventPolyfill;
+  }
 }


### PR DESCRIPTION
## Description

You can't tap to toggle a checklist item on iOS Safari or Android Chrome. The bug is reproducible in the [Lexical playground](https://playground.lexical.dev/) and in Chrome DevTools mobile emulation.

The cause: the `touchstart` listener registered by the CheckList plugin calls `event.preventDefault()` to keep the caret away from the marker, which on mobile also cancels the synthesized `click`, and the click is what `handleClick` is wired to. So the toggle path is never reached. PR #7655 widened the touch hit-test, but the click that the hit-test was meant to handle was already gone by then, so taps still did nothing.

The fix is to also listen for `pointerup` and run the toggle from there when `event.pointerType === 'touch'`. To stay safe on browsers where the click does eventually fire, a 500 ms dedup window swallows the second event so we never toggle twice. Desktop click is left alone.

While I was in there, I widened the handler signatures from `MouseEvent | TouchEvent` to `PointerEvent | MouseEvent | TouchEvent` (they were already accepting pointer events at runtime, this just makes it explicit) and replaced the `(event as PointerEvent).pointerType` cast inside `handleCheckItemEvent` with a `'pointerType' in event` guard.

Closes #7651

## Test plan

### Before

Tap a checklist marker in the playground on iOS Safari / Android Chrome / Chrome DevTools mobile emulation : nothing happens.

The new `packages/lexical-list/src/__tests__/unit/checkList.test.tsx` file fails on `main`:

:red_circle:  touch pointerup over the marker area toggles the item
:red_circle: : pointerup followed by a synthesized click does not double-toggle
:green_circle:  mouse pointerup is ignored (click stays the desktop path)

### After

Same tap toggles the checkbox.

The three new tests pass, and the rest of the `lexical-list` suite still does (86/86). `pnpm tsc` and `pnpm lint` are clean.