### PR TITLE
[lexical-playground] Bug Fix: Show floating link editor for single-character links

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -14,6 +14,7 @@ import {
   $createLinkNode,
   $isAutoLinkNode,
   $isLinkNode,
+  LinkNode,
   TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -31,6 +32,7 @@ import {
   getDOMSelection,
   KEY_ESCAPE_COMMAND,
   LexicalEditor,
+  RangeSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -39,6 +41,33 @@ import {createPortal} from 'react-dom';
 
 import {getSelectedNode} from '../../utils/getSelectedNode';
 import {sanitizeUrl} from '../../utils/url';
+
+function $getSelectedLinkNode(selection: RangeSelection): LinkNode | null {
+  const node = getSelectedNode(selection);
+  // 1. Node itself is a link
+  if ($isLinkNode(node)) {
+    return node;
+  }
+  // 2. Parent is a link
+  const linkParent = $findMatchingParent(node, $isLinkNode);
+  if ($isLinkNode(linkParent)) {
+    return linkParent;
+  }
+  // 3. Right-biased adjacent link (for single-char links)
+  if (selection.isCollapsed()) {
+    const anchor = selection.anchor;
+    if (anchor.type === 'text') {
+      const anchorNode = anchor.getNode();
+      if (anchor.offset === anchorNode.getTextContentSize()) {
+        const nextSibling = anchorNode.getNextSibling();
+        if ($isLinkNode(nextSibling)) {
+          return nextSibling;
+        }
+      }
+    }
+  }
+  return null;
+}
 
 function preventDefault(
   event: React.KeyboardEvent<HTMLInputElement> | React.MouseEvent<HTMLElement>,
@@ -92,13 +121,9 @@ function FloatingLinkEditor({
   const $updateLinkEditor = useCallback(() => {
     const selection = $getSelection();
     if ($isRangeSelection(selection)) {
-      const node = getSelectedNode(selection);
-      const linkParent = $findMatchingParent(node, $isLinkNode);
-
-      if (linkParent) {
-        setLinkUrl(linkParent.getURL());
-      } else if ($isLinkNode(node)) {
-        setLinkUrl(node.getURL());
+      const linkNode = $getSelectedLinkNode(selection);
+      if (linkNode) {
+        setLinkUrl(linkNode.getURL());
       } else {
         setLinkUrl('');
       }
@@ -356,8 +381,8 @@ function useFloatingLinkEditorToolbar(
     function $updateToolbar() {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
+        const focusLinkNode = $getSelectedLinkNode(selection);
         const focusNode = getSelectedNode(selection);
-        const focusLinkNode = $findMatchingParent(focusNode, $isLinkNode);
         const focusAutoLinkNode = $findMatchingParent(
           focusNode,
           $isAutoLinkNode,


### PR DESCRIPTION
## Description

Fixes #8184

When a link contains only one character, the floating link editor popup never appeared when navigating with arrow keys. The cursor always lands on a node boundary where the browser reports it as outside the link.

Added a `$getAdjacentLinkNode` helper that applies right bias for collapsed selections, as suggested by @etrepum in #8184: when the cursor is at the end of a TextNode and the next sibling is a LinkNode, treat it as being on the link. Applied in `$updateToolbar`, `$updateLinkEditor` (URL), and `$updateLinkEditor` (position).

## Test Plan

1. Type "hello A world", select "A", insert a link
2. Move cursor with arrow keys across the link
3. **Before:** popup never appears for the single-character link
4. **After:** popup appears when cursor enters the link boundary from the left