### PR TITLE
[*] Fix Flow type errors in flow definition files

### DIFF
--- a/packages/lexical-extension/flow/LexicalExtension.js.flow
+++ b/packages/lexical-extension/flow/LexicalExtension.js.flow
@@ -191,7 +191,7 @@ export type SerializedDecoratorTextNode = {
   format: number,
   ...
 };
-declare export class DecoratorTextNode extends DecoratorNode<mixed> {
+declare export class DecoratorTextNode extends DecoratorNode<unknown> {
   createDOM(): HTMLElement;
   getFormat(): number;
   getFormatFlags(type: TextFormatType, alignWithFormat: null | number): number;

--- a/packages/lexical-html/flow/LexicalHtml.js.flow
+++ b/packages/lexical-html/flow/LexicalHtml.js.flow
@@ -23,32 +23,36 @@ import type {
 
 type AnyContextSymbol = symbol;
 
-type ContextRecord<K: symbol> = {+[string | symbol]: mixed};
+type ContextRecord<K extends symbol> = {+[string | symbol]: unknown};
 
-type ContextConfig<Sym: symbol, V> = StateConfig<symbol, V>;
+type ContextConfig<Sym extends symbol, V> = StateConfig<symbol, V>;
 
-type ContextConfigUpdater<Ctx: AnyContextSymbol, V> = {
+type ContextConfigUpdater<Ctx extends AnyContextSymbol, V> = {
   +cfg: ContextConfig<Ctx, V>,
   +updater: (prev: V) => V,
 };
 
-type ContextConfigPair<Ctx: AnyContextSymbol, V> = $ReadOnly<
+type ContextConfigPair<Ctx extends AnyContextSymbol, V> = Readonly<
   [ContextConfig<Ctx, V>, V],
 >;
 
-export type ContextPairOrUpdater<Ctx: AnyContextSymbol, V> =
+export type ContextPairOrUpdater<Ctx extends AnyContextSymbol, V> =
   | ContextConfigPair<Ctx, V>
   | ContextConfigUpdater<Ctx, V>;
 
 // $FlowFixMe[unclear-type]
-type AnyContextConfigPairOrUpdater<Ctx: AnyContextSymbol> = ContextPairOrUpdater<Ctx, any>;
+type AnyContextConfigPairOrUpdater<Ctx extends AnyContextSymbol> =
+  // $FlowFixMe[unclear-type]
+  ContextPairOrUpdater<Ctx, any>;
 
 // Render types
 
 export type RenderStateConfig<V> = ContextConfig<symbol, V>;
 
 // $FlowFixMe[unclear-type]
-export type AnyRenderStateConfigPairOrUpdater = AnyContextConfigPairOrUpdater<any>;
+export type AnyRenderStateConfigPairOrUpdater =
+  // $FlowFixMe[unclear-type]
+  AnyContextConfigPairOrUpdater<any>;
 
 // $FlowFixMe[unclear-type]
 export type AnyRenderStateConfig = RenderStateConfig<any>;
@@ -65,13 +69,13 @@ export type DOMRenderConfig = {
 // $FlowFixMe[unclear-type]
 export type AnyDOMRenderMatch = DOMRenderMatch<any>;
 
-export type NodeMatch<T: LexicalNode> =
+export type NodeMatch<T extends LexicalNode> =
   | Class<T>
   | ((node: LexicalNode) => boolean);
 
-export type DOMRenderMatch<T: LexicalNode> = {
-  +nodes: '*' | $ReadOnlyArray<NodeMatch<T>>,
-  +$getDOMSlot?: <N: LexicalNode>(
+export type DOMRenderMatch<T extends LexicalNode> = {
+  +nodes: '*' | ReadonlyArray<NodeMatch<T>>,
+  +$getDOMSlot?: <N extends LexicalNode>(
     node: N,
     dom: HTMLElement,
     $next: () => ElementDOMSlot<HTMLElement>,
@@ -124,12 +128,12 @@ export type DOMRenderMatch<T: LexicalNode> = {
 
 // contextUpdater, contextValue
 
-declare export function contextUpdater<Ctx: AnyContextSymbol, V>(
+declare export function contextUpdater<Ctx extends AnyContextSymbol, V>(
   cfg: ContextConfig<Ctx, V>,
   updater: (prev: V) => V,
 ): ContextConfigUpdater<Ctx, V>;
 
-declare export function contextValue<Ctx: AnyContextSymbol, V>(
+declare export function contextValue<Ctx extends AnyContextSymbol, V>(
   cfg: ContextConfig<Ctx, V>,
   value: V,
 ): ContextConfigPair<Ctx, V>;
@@ -140,8 +144,8 @@ declare export function domOverride(
   nodes: '*',
   config: Omit<DOMRenderMatch<LexicalNode>, 'nodes'>,
 ): DOMRenderMatch<LexicalNode>;
-declare export function domOverride<T: LexicalNode>(
-  nodes: $ReadOnlyArray<NodeMatch<T>>,
+declare export function domOverride<T extends LexicalNode>(
+  nodes: ReadonlyArray<NodeMatch<T>>,
   config: Omit<DOMRenderMatch<T>, 'nodes'>,
 ): DOMRenderMatch<T>;
 
@@ -165,7 +169,7 @@ declare export function $getRenderContextValue<V>(
 ): V;
 
 declare export function $withRenderContext(
-  cfg: $ReadOnlyArray<AnyRenderStateConfigPairOrUpdater>,
+  cfg: ReadonlyArray<AnyRenderStateConfigPairOrUpdater>,
   editor?: LexicalEditor,
 ): <T>(f: () => T) => T;
 
@@ -177,16 +181,16 @@ declare export function $generateNodesFromDOM(
 ): Array<LexicalNode>;
 
 declare export function $generateDOMFromNodes<
-  T: HTMLElement | DocumentFragment,
+  T extends HTMLElement | DocumentFragment,
 >(
   container: T,
   selection?: null | BaseSelection,
   editor?: LexicalEditor,
 ): T;
 
-declare export function $generateDOMFromRoot<
-  T: HTMLElement | DocumentFragment,
->(container: T, root?: LexicalNode): T;
+declare export function $generateDOMFromRoot<T extends HTMLElement | DocumentFragment>(
+  container: T, root?: LexicalNode,
+): T;
 
 declare export function $generateHtmlFromNodes(
   editor: LexicalEditor,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -138,12 +138,17 @@ declare class DequeSet<T> {
   addFront(v: T): this;
   delete(v: T): boolean;
   toArray(): T[];
-  toReadonlyArray(): $ReadOnlyArray<T>;
+  toReadonlyArray(): ReadonlyArray<T>;
   @@iterator(): Iterator<T>;
 }
-type Tuple5<T> = $ReadOnly<[T, T, T, T, T]>;
+type Tuple5<T> = Readonly<[T, T, T, T, T]>;
 // $FlowFixMe[unclear-type]
-type Commands = Map<LexicalCommand<any>, Tuple5<DequeSet<CommandListener<any>>>>;
+type Commands = Map<
+  // $FlowFixMe[unclear-type]
+  LexicalCommand<any>,
+  // $FlowFixMe[unclear-type]
+  Tuple5<DequeSet<CommandListener<any>>>,
+>;
 type RegisteredNodes = Map<string, RegisteredNode>;
 type RegisteredNode = {
   klass: Class<LexicalNode>,
@@ -158,23 +163,23 @@ type DOMConversionCache = Map<
 
 export type EditorDOMRenderConfig = {
   /** @internal @experimental */
-  $createDOM: <T: LexicalNode>(
+  $createDOM: <T extends LexicalNode>(
     node: T,
     editor: LexicalEditor,
   ) => HTMLElement;
   /** @internal @experimental */
-  $getDOMSlot: <T: LexicalNode>(
+  $getDOMSlot: <T extends LexicalNode>(
     node: T,
     dom: HTMLElement,
     editor: LexicalEditor,
   ) => ElementDOMSlot<HTMLElement>;
   /** @internal @experimental */
-  $exportDOM: <T: LexicalNode>(
+  $exportDOM: <T extends LexicalNode>(
     node: T,
     editor: LexicalEditor,
   ) => DOMExportOutput;
   /** @internal @experimental */
-  $extractWithChild: <T: LexicalNode>(
+  $extractWithChild: <T extends LexicalNode>(
     node: T,
     childNode: LexicalNode,
     selection: null | BaseSelection,
@@ -182,20 +187,20 @@ export type EditorDOMRenderConfig = {
     editor: LexicalEditor,
   ) => boolean;
   /** @internal @experimental */
-  $updateDOM: <T: LexicalNode>(
+  $updateDOM: <T extends LexicalNode>(
     nextNode: T,
     prevNode: T,
     dom: HTMLElement,
     editor: LexicalEditor,
   ) => boolean;
   /** @internal @experimental */
-  $shouldInclude: <T: LexicalNode>(
+  $shouldInclude: <T extends LexicalNode>(
     node: T,
     selection: null | BaseSelection,
     editor: LexicalEditor,
   ) => boolean;
   /** @internal @experimental */
-  $shouldExclude: <T: LexicalNode>(
+  $shouldExclude: <T extends LexicalNode>(
     node: T,
     selection: null | BaseSelection,
     editor: LexicalEditor,


### PR DESCRIPTION
## Summary
- Replace deprecated `$ReadOnly`/`$ReadOnlyArray` with `Readonly`/`ReadonlyArray`
- Use `extends` instead of `:` for generic type bounds (e.g. `<T: LexicalNode>` → `<T extends LexicalNode>`)
- Replace `mixed` with `unknown` in `DecoratorTextNode`
- Add missing `$FlowFixMe[unclear-type]` annotations where `any` is used on a separate line

## Test plan
- [x] Verified flow fixes pass flow (from D102550285)