### PR TITLE
[lexical-website] Set prettier arrowParens to avoid

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "arrowParens": "avoid",
   "bracketSpacing": false,
   "singleQuote": true,
   "bracketSameLine": true,

--- a/dev-examples/dev-node-state-style/src/plugins/ShikiViewPlugin.tsx
+++ b/dev-examples/dev-node-state-style/src/plugins/ShikiViewPlugin.tsx
@@ -50,7 +50,7 @@ export function ShikiViewPlugin({lang}: ShikiViewPluginProps) {
   const [editorState, setEditorState] = useState(() => editor.getEditorState());
   useEffect(
     () =>
-      editor.registerUpdateListener((payload) =>
+      editor.registerUpdateListener(payload =>
         setEditorState(payload.editorState),
       ),
     [editor],
@@ -64,9 +64,7 @@ export function ShikiViewPlugin({lang}: ShikiViewPluginProps) {
       (async () => {
         const prettified = await prettier.format(rawCode, {
           parser: lang,
-          plugins: (await Promise.all(prettierPlugins)).map(
-            (mod) => mod.default,
-          ),
+          plugins: (await Promise.all(prettierPlugins)).map(mod => mod.default),
         });
         return (await shikiPromise).codeToHtml(prettified, {
           lang,
@@ -78,7 +76,7 @@ export function ShikiViewPlugin({lang}: ShikiViewPluginProps) {
   const [html, setHtml] = useState('');
   useEffect(() => {
     let canceled = false;
-    htmlPromise.then((formatted) => canceled || setHtml(formatted));
+    htmlPromise.then(formatted => canceled || setHtml(formatted));
     return () => {
       canceled = true;
     };

--- a/dev-examples/dev-node-state-style/src/plugins/StyleViewPlugin.tsx
+++ b/dev-examples/dev-node-state-style/src/plugins/StyleViewPlugin.tsx
@@ -153,7 +153,7 @@ function NodeLabel({node}: {node: LexicalNode}) {
       <button
         className="style-view-node-button"
         title={`Select ${type} node`}
-        onClick={(event) => {
+        onClick={event => {
           event.preventDefault();
           editor.update(() => {
             const caretRange = $isElementNode(node)
@@ -399,7 +399,7 @@ function StyleValuePlugin(props: StyleValueEditorProps) {
       }
     }
     return mergeRegister(
-      editor.registerUpdateListener((payload) => {
+      editor.registerUpdateListener(payload => {
         if (payload.editorState !== payload.prevEditorState) {
           handleInput();
         }
@@ -414,7 +414,7 @@ function StyleValuePlugin(props: StyleValueEditorProps) {
       ),
       editor.registerCommand(
         KEY_DOWN_COMMAND,
-        (e) => {
+        e => {
           if (e.key === 'Enter') {
             e.preventDefault();
             editor.blur();
@@ -448,7 +448,7 @@ function StyleValueEditor(props: StyleValueEditorProps) {
           $patchParsedTextAtRoot(parseRawText(props.value));
         },
         namespace: 'style-view-value',
-        onError: (err) => {
+        onError: err => {
           throw err;
         },
       }}>
@@ -510,7 +510,7 @@ function LexicalTextSelectionPaneContents({node}: {node: LexicalNode}) {
           <button
             className="style-view-node-button style-view-node-button-delete"
             title={`Remove ${k} style`}
-            onClick={(e) => {
+            onClick={e => {
               e.preventDefault();
               editor.update(
                 () => {
@@ -526,7 +526,7 @@ function LexicalTextSelectionPaneContents({node}: {node: LexicalNode}) {
             prop={k}
             value={v || ''}
             onChange={handleChange}
-            ref={(el) => {
+            ref={el => {
               if (el === null) {
                 registeredNodes.delete(k);
                 return;
@@ -607,7 +607,7 @@ function getSuggestedStyleKeys(): readonly (keyof StyleObject)[] {
     for (const k in style) {
       if (typeof style[k] === 'string') {
         const kebab = k
-          .replace(/[A-Z]/g, (s) => '-' + s.toLowerCase())
+          .replace(/[A-Z]/g, s => '-' + s.toLowerCase())
           .replace(/^(webkit|moz|ms|o)-/, '-$1-')
           .replace(/^css-/, '');
         keys.add(kebab as keyof StyleObject);
@@ -638,7 +638,7 @@ function useSuggestedStylesCombobox(props: CSSPropertyComboBoxProps) {
       initialItems
         .filter(
           search
-            ? (item) => item.toLowerCase().startsWith(search)
+            ? item => item.toLowerCase().startsWith(search)
             : isNotVendorProperty,
         )
         .join('\n'),
@@ -672,7 +672,7 @@ const CSSPropertyComboBox = (props: CSSPropertyComboBoxProps) => {
   const {onAddProperty} = props;
   const combobox = useSuggestedStylesCombobox(props);
   const handleKeydown = useCallback<KeyboardEventHandler<HTMLInputElement>>(
-    (event) => {
+    event => {
       const {inputValue} = combobox;
       if (event.key === 'Enter') {
         event.preventDefault();
@@ -703,7 +703,7 @@ const CSSPropertyComboBox = (props: CSSPropertyComboBoxProps) => {
         <Combobox.Positioner>
           <Combobox.Content>
             <Combobox.ItemGroup>
-              {combobox.collection.items.map((item) => (
+              {combobox.collection.items.map(item => (
                 <Combobox.Item key={item} item={item}>
                   <Combobox.ItemText>{item}</Combobox.ItemText>
                   <Combobox.ItemIndicator>✓</Combobox.ItemIndicator>
@@ -801,13 +801,13 @@ function initEditorCollection(
   return Object.assign(state, {
     collection: createTreeCollection<NodeKey>({
       isNodeDisabled: () => false,
-      nodeToChildren: (nodeKey) =>
+      nodeToChildren: nodeKey =>
         state.editorState.read(() => {
           const node = $getNodeByKey(nodeKey);
           return $isElementNode(node) ? node.getChildrenKeys() : [];
         }),
-      nodeToString: (nodeKey) => nodeKey,
-      nodeToValue: (nodeKey) => nodeKey,
+      nodeToString: nodeKey => nodeKey,
+      nodeToValue: nodeKey => nodeKey,
       rootNode: 'root',
     }),
     focusNodeKey: null,

--- a/dev-examples/dev-node-state-style/src/plugins/ToolbarPlugin.tsx
+++ b/dev-examples/dev-node-state-style/src/plugins/ToolbarPlugin.tsx
@@ -70,7 +70,7 @@ export function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanUndo(payload);
           return false;
         },
@@ -78,7 +78,7 @@ export function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanRedo(payload);
           return false;
         },

--- a/dev-examples/dev-node-state-style/src/styleState.ts
+++ b/dev-examples/dev-node-state-style/src/styleState.ts
@@ -143,7 +143,7 @@ export function $removeStyleProperty<
   T extends LexicalNode,
   Prop extends keyof StyleObject,
 >(node: T, prop: Prop): T {
-  return $setStyleObject(node, (prevStyle) => {
+  return $setStyleObject(node, prevStyle => {
     if (prop in prevStyle) {
       const {[prop]: _ignore, ...nextStyle} = prevStyle;
       return nextStyle;
@@ -156,7 +156,7 @@ export function $setStyleProperty<
   T extends LexicalNode,
   Prop extends keyof StyleObject,
 >(node: T, prop: Prop, value: ValueOrUpdater<StyleObject[Prop]>): T {
-  return $setStyleObject(node, (prevStyle) => {
+  return $setStyleObject(node, prevStyle => {
     const prevValue = prevStyle[prop];
     const nextValue = typeof value === 'function' ? value(prevValue) : value;
     return prevValue === nextValue
@@ -270,7 +270,7 @@ export function $patchSelectedTextStyle(
       $setStyleObject(node, styleCallback);
     }
   } else {
-    $forEachSelectedTextNode((node) => $setStyleObject(node, styleCallback));
+    $forEachSelectedTextNode(node => $setStyleObject(node, styleCallback));
   }
   return true;
 }
@@ -321,21 +321,21 @@ export type StyleMapping = (input: StyleObject) => StyleObject;
 
 // TODO there's no reasonable way to hook into importDOM from a plug-in https://github.com/facebook/lexical/issues/7259
 export function constructStyleImportMap(
-  styleMapping: StyleMapping = (input) => input,
+  styleMapping: StyleMapping = input => input,
 ): DOMConversionMap {
   const importMap: DOMConversionMap = {};
 
   // Wrap all TextNode importers with a function that also imports
   // styles that are not otherwise imported
   for (const [tag, fn] of Object.entries(TextNode.importDOM() || {})) {
-    importMap[tag] = (importNode) => {
+    importMap[tag] = importNode => {
       const importer = fn(importNode);
       if (!importer) {
         return null;
       }
       return {
         ...importer,
-        conversion: (element) => {
+        conversion: element => {
           const output = importer.conversion(element);
           if (
             output === null ||
@@ -429,7 +429,7 @@ export const StyleStateExtension = defineExtension({
               if (output.after) {
                 return {
                   ...output,
-                  after: (generatedElement) => {
+                  after: generatedElement => {
                     const el = output.after
                       ? output.after(generatedElement)
                       : generatedElement;
@@ -453,7 +453,7 @@ export const StyleStateExtension = defineExtension({
     import: constructStyleImportMap(),
   },
   name: '@lexical/examples/node-state-style/StyleState',
-  register: (editor) =>
+  register: editor =>
     editor.registerCommand(
       PATCH_TEXT_STYLE_COMMAND,
       $patchSelectedTextStyle,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -319,7 +319,7 @@ export default [
   },
 
   // Override: TypeScript files
-  ...tseslint.configs.recommended.map((config) => ({
+  ...tseslint.configs.recommended.map(config => ({
     ...config,
     files: ['**/*.ts', '**/*.tsx', '**/*.mts'],
   })),

--- a/examples/agent-example/src/ThemeToggle.tsx
+++ b/examples/agent-example/src/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
     <button
       type="button"
       onClick={() => {
-        setIsDark((prev) => {
+        setIsDark(prev => {
           const next = !prev;
           document.documentElement.classList.toggle('dark', next);
           return next;

--- a/examples/agent-example/src/ToolbarExtension.tsx
+++ b/examples/agent-example/src/ToolbarExtension.tsx
@@ -104,7 +104,7 @@ function $getToolbarState(): {
 
   const anchorNode = selection.anchor.getNode();
   const topLevelElement =
-    $findMatchingParent(anchorNode, (e) => {
+    $findMatchingParent(anchorNode, e => {
       const parent = e.getParent();
       return parent !== null && $isRootOrShadowRoot(parent);
     }) || anchorNode.getTopLevelElementOrThrow();
@@ -151,7 +151,7 @@ export const ToolbarExtension = defineExtension({
       }),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           output.canUndo.value = payload;
           return false;
         },
@@ -159,7 +159,7 @@ export const ToolbarExtension = defineExtension({
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           output.canRedo.value = payload;
           return false;
         },
@@ -214,7 +214,7 @@ export function Toolbar(): JSX.Element {
       <select
         className="cursor-pointer appearance-none rounded-md border border-solid border-transparent bg-transparent px-2 py-1 text-sm font-medium text-zinc-700 transition-colors duration-150 hover:bg-zinc-200 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-zinc-200 dark:hover:bg-zinc-700"
         value={toolbar.blockType}
-        onChange={(e) => applyBlockType(editor, e.target.value)}
+        onChange={e => applyBlockType(editor, e.target.value)}
         aria-label="Block type">
         {BLOCK_TYPES.map(({label, value}) => (
           <option key={value} value={value}>

--- a/examples/agent-example/src/__tests__/unit/extractEntityNodes.test.ts
+++ b/examples/agent-example/src/__tests__/unit/extractEntityNodes.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../../utils/extractEntityNodes';
 
 const labelState = createState('label', {
-  parse: (v) => (typeof v === 'string' ? v : ''),
+  parse: v => (typeof v === 'string' ? v : ''),
 });
 
 // Minimal inline decorator node for testing replacements
@@ -472,13 +472,13 @@ describe('extractEntityNodes', () => {
               {end: 21, entity: 'ORG', start: 17, text: 'Meta'},
             ],
             {
-              LOC: replaceWithEntity((text) =>
+              LOC: replaceWithEntity(text =>
                 $createTestEntityNode(`loc:${text}`),
               ),
-              ORG: replaceWithEntity((text) =>
+              ORG: replaceWithEntity(text =>
                 $createTestEntityNode(`org:${text}`),
               ),
-              PER: replaceWithEntity((text) =>
+              PER: replaceWithEntity(text =>
                 $createTestEntityNode(`per:${text}`),
               ),
             },

--- a/examples/agent-example/src/__tests__/unit/mergeEntities.test.ts
+++ b/examples/agent-example/src/__tests__/unit/mergeEntities.test.ts
@@ -170,7 +170,7 @@ describe('computeTokenOffsets', () => {
 
     // Second "London" (should find the second occurrence)
     const london2 = result.find(
-      (t) => t.word === 'London' && t.start > london1.start,
+      t => t.word === 'London' && t.start > london1.start,
     );
     expect(london2).toBeDefined();
     expect(SAMPLE_TEXT.slice(london2!.start, london2!.end)).toBe('London');
@@ -258,7 +258,7 @@ describe('mergeEntities', () => {
     const result = mergeEntities(RAW_NER_TOKENS, SAMPLE_TEXT);
 
     // Extract just entity+text for readability
-    const summary = result.map((e) => ({entity: e.entity, text: e.text}));
+    const summary = result.map(e => ({entity: e.entity, text: e.text}));
 
     expect(summary).toEqual([
       {entity: 'PER', text: 'Dominic Gannaway'},

--- a/examples/agent-example/src/ai/AIExtension.ts
+++ b/examples/agent-example/src/ai/AIExtension.ts
@@ -337,9 +337,9 @@ function createAIState(editor: LexicalEditor, config: AIExtensionConfig) {
     editor.update(
       () => {
         $replaceTextWithEntityNodes(textInfo.textNodes, entities, {
-          LOC: replaceWithEntity((text) => $createEntityNode('LOC', text)),
-          ORG: replaceWithEntity((text) => $createEntityNode('ORG', text)),
-          PER: replaceWithEntity((text) => $createEntityNode('PER', text)),
+          LOC: replaceWithEntity(text => $createEntityNode('LOC', text)),
+          ORG: replaceWithEntity(text => $createEntityNode('ORG', text)),
+          PER: replaceWithEntity(text => $createEntityNode('PER', text)),
         });
       },
       {tag: AI_ENTITIES_TAG},

--- a/examples/agent-example/src/ai/mergeEntities.ts
+++ b/examples/agent-example/src/ai/mergeEntities.ts
@@ -133,7 +133,7 @@ export function mergeEntities(
     }
   }
 
-  return merged.map((m) => ({
+  return merged.map(m => ({
     end: m.end,
     entity: m.entity,
     score: m.minScore,

--- a/examples/agent-example/src/nodes/EntityNode.tsx
+++ b/examples/agent-example/src/nodes/EntityNode.tsx
@@ -47,27 +47,27 @@ const ENTITY_STYLES = {
   LOC: {
     className:
       'bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950 dark:text-emerald-300 dark:hover:bg-emerald-900',
-    getHref: (text) =>
+    getHref: text =>
       `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(text)}`,
-    getTitle: (text) => `View ${text} on Google Maps`,
+    getTitle: text => `View ${text} on Google Maps`,
     iconPath:
       'M8 0C5.2 0 3 2.3 3 5.2 3 9.1 8 16 8 16s5-6.9 5-10.8C13 2.3 10.8 0 8 0zm0 7.5a2.2 2.2 0 110-4.4 2.2 2.2 0 010 4.4z',
   },
   ORG: {
     className:
       'bg-violet-50 text-violet-700 hover:bg-violet-100 dark:bg-violet-950 dark:text-violet-300 dark:hover:bg-violet-900',
-    getHref: (text) =>
+    getHref: text =>
       `https://www.google.com/search?q=${encodeURIComponent(text)}`,
-    getTitle: (text) => `Search for ${text}`,
+    getTitle: text => `Search for ${text}`,
     iconPath:
       'M3 1a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1v14H3V1zm2 2h2v2H5V3zm4 0h2v2H9V3zM5 7h2v2H5V7zm4 0h2v2H9V7zm-2 4h2v4H7v-4z',
   },
   PER: {
     className:
       'bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900',
-    getHref: (text) =>
+    getHref: text =>
       `https://www.google.com/search?q=${encodeURIComponent(text)}`,
-    getTitle: (text) => `Search for ${text}`,
+    getTitle: text => `Search for ${text}`,
     iconPath:
       'M8 0a3 3 0 1 1 0 6 3 3 0 0 1 0-6zm0 8c-4 0-6 2-6 3.5V13a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-1.5C14 10 12 8 8 8z',
   },
@@ -80,7 +80,7 @@ export function isEntityType(v: unknown): v is EntityType {
 }
 
 const entityTextState = createState('entityText', {
-  parse: (v) => (typeof v === 'string' ? v : ''),
+  parse: v => (typeof v === 'string' ? v : ''),
 });
 
 const entityTypeState = createState('entityType', {
@@ -99,7 +99,7 @@ function $convertEntityElement(
   const text = domNode.textContent || '';
   const node = $createEntityNode(entityType, text);
   return {
-    after: (children) => {
+    after: children => {
       const firstChild = children[0];
       if ($isTextNode(firstChild)) {
         node.setFormat(firstChild.getFormat());
@@ -115,7 +115,7 @@ export class EntityNode extends DecoratorTextNode {
     return this.config('entity', {
       extends: DecoratorTextNode,
       importDOM: buildImportMap({
-        span: (domNode) =>
+        span: domNode =>
           domNode.hasAttribute(DATA_ATTRIBUTE)
             ? {conversion: $convertEntityElement, priority: 1}
             : null,

--- a/examples/agent-example/src/utils/extractEntityNodes.ts
+++ b/examples/agent-example/src/utils/extractEntityNodes.ts
@@ -90,7 +90,7 @@ export function $collectTextNodeOffsets(): {
 export function replaceWithEntity(
   create: (text: string) => DecoratorTextNode,
 ): (textNode: TextNode) => void {
-  return (textNode) => {
+  return textNode => {
     const entity = create(textNode.getTextContent());
     entity.setFormat(textNode.getFormat());
     textNode.replace(entity);

--- a/examples/extension-react-table/src/plugins/ToolbarPlugin.tsx
+++ b/examples/extension-react-table/src/plugins/ToolbarPlugin.tsx
@@ -63,7 +63,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanUndo(payload);
           return false;
         },
@@ -71,7 +71,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanRedo(payload);
           return false;
         },

--- a/examples/extension-vanilla-react-plugin-host/src/stackblitz-workaround/index.ts
+++ b/examples/extension-vanilla-react-plugin-host/src/stackblitz-workaround/index.ts
@@ -114,7 +114,7 @@ const theme: EditorThemeClasses = {
       'list-[lower-alpha]',
       'list-[upper-roman]',
       'list-[lower-roman]',
-    ].map((cls) => join(listCommonClasses, cls)),
+    ].map(cls => join(listCommonClasses, cls)),
     ul: join(listCommonClasses, 'list-disc'),
   },
   // mark: 'PlaygroundEditorTheme__mark',

--- a/examples/extension-vanilla-tailwind/src/main.ts
+++ b/examples/extension-vanilla-tailwind/src/main.ts
@@ -48,7 +48,7 @@ const LazyExtension = defineExtension({
   name: '@lexical/extension-vanilla-tailwind-example/Lazy',
   register(editor, _config, state) {
     let dispose: undefined | (() => void);
-    import('./lazyLoaded').then((mod) => {
+    import('./lazyLoaded').then(mod => {
       if (!state.getSignal().aborted) {
         dispose = mod.registerLazyLoaded(editor);
       }

--- a/examples/extension-vanilla-tailwind/src/stackblitz-workaround/index.ts
+++ b/examples/extension-vanilla-tailwind/src/stackblitz-workaround/index.ts
@@ -114,7 +114,7 @@ const theme: EditorThemeClasses = {
       'list-[lower-alpha]',
       'list-[upper-roman]',
       'list-[lower-roman]',
-    ].map((cls) => join(listCommonClasses, cls)),
+    ].map(cls => join(listCommonClasses, cls)),
     ul: join(listCommonClasses, 'list-disc'),
   },
   // mark: 'PlaygroundEditorTheme__mark',

--- a/examples/node-replacement/src/plugins/ToolbarPlugin.tsx
+++ b/examples/node-replacement/src/plugins/ToolbarPlugin.tsx
@@ -63,7 +63,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanUndo(payload);
           return false;
         },
@@ -71,7 +71,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanRedo(payload);
           return false;
         },

--- a/examples/node-state-style/src/plugins/ShikiViewPlugin.tsx
+++ b/examples/node-state-style/src/plugins/ShikiViewPlugin.tsx
@@ -50,7 +50,7 @@ export function ShikiViewPlugin({lang}: ShikiViewPluginProps) {
   const [editorState, setEditorState] = useState(() => editor.getEditorState());
   useEffect(
     () =>
-      editor.registerUpdateListener((payload) =>
+      editor.registerUpdateListener(payload =>
         setEditorState(payload.editorState),
       ),
     [editor],
@@ -64,9 +64,7 @@ export function ShikiViewPlugin({lang}: ShikiViewPluginProps) {
       (async () => {
         const prettified = await prettier.format(rawCode, {
           parser: lang,
-          plugins: (await Promise.all(prettierPlugins)).map(
-            (mod) => mod.default,
-          ),
+          plugins: (await Promise.all(prettierPlugins)).map(mod => mod.default),
         });
         return (await shikiPromise).codeToHtml(prettified, {
           lang,
@@ -78,7 +76,7 @@ export function ShikiViewPlugin({lang}: ShikiViewPluginProps) {
   const [html, setHtml] = useState('');
   useEffect(() => {
     let canceled = false;
-    htmlPromise.then((formatted) => canceled || setHtml(formatted));
+    htmlPromise.then(formatted => canceled || setHtml(formatted));
     return () => {
       canceled = true;
     };

--- a/examples/node-state-style/src/plugins/StyleViewPlugin.tsx
+++ b/examples/node-state-style/src/plugins/StyleViewPlugin.tsx
@@ -153,7 +153,7 @@ function NodeLabel({node}: {node: LexicalNode}) {
       <button
         className="style-view-node-button"
         title={`Select ${type} node`}
-        onClick={(event) => {
+        onClick={event => {
           event.preventDefault();
           editor.update(() => {
             const caretRange = $isElementNode(node)
@@ -399,7 +399,7 @@ function StyleValuePlugin(props: StyleValueEditorProps) {
       }
     }
     return mergeRegister(
-      editor.registerUpdateListener((payload) => {
+      editor.registerUpdateListener(payload => {
         if (payload.editorState !== payload.prevEditorState) {
           handleInput();
         }
@@ -414,7 +414,7 @@ function StyleValuePlugin(props: StyleValueEditorProps) {
       ),
       editor.registerCommand(
         KEY_DOWN_COMMAND,
-        (e) => {
+        e => {
           if (e.key === 'Enter') {
             e.preventDefault();
             editor.blur();
@@ -448,7 +448,7 @@ function StyleValueEditor(props: StyleValueEditorProps) {
           $patchParsedTextAtRoot(parseRawText(props.value));
         },
         namespace: 'style-view-value',
-        onError: (err) => {
+        onError: err => {
           throw err;
         },
       }}>
@@ -510,7 +510,7 @@ function LexicalTextSelectionPaneContents({node}: {node: LexicalNode}) {
           <button
             className="style-view-node-button style-view-node-button-delete"
             title={`Remove ${k} style`}
-            onClick={(e) => {
+            onClick={e => {
               e.preventDefault();
               editor.update(
                 () => {
@@ -526,7 +526,7 @@ function LexicalTextSelectionPaneContents({node}: {node: LexicalNode}) {
             prop={k}
             value={v || ''}
             onChange={handleChange}
-            ref={(el) => {
+            ref={el => {
               if (el === null) {
                 registeredNodes.delete(k);
                 return;
@@ -607,7 +607,7 @@ function getSuggestedStyleKeys(): readonly (keyof StyleObject)[] {
     for (const k in style) {
       if (typeof style[k] === 'string') {
         const kebab = k
-          .replace(/[A-Z]/g, (s) => '-' + s.toLowerCase())
+          .replace(/[A-Z]/g, s => '-' + s.toLowerCase())
           .replace(/^(webkit|moz|ms|o)-/, '-$1-')
           .replace(/^css-/, '');
         keys.add(kebab as keyof StyleObject);
@@ -638,7 +638,7 @@ function useSuggestedStylesCombobox(props: CSSPropertyComboBoxProps) {
       initialItems
         .filter(
           search
-            ? (item) => item.toLowerCase().startsWith(search)
+            ? item => item.toLowerCase().startsWith(search)
             : isNotVendorProperty,
         )
         .join('\n'),
@@ -672,7 +672,7 @@ const CSSPropertyComboBox = (props: CSSPropertyComboBoxProps) => {
   const {onAddProperty} = props;
   const combobox = useSuggestedStylesCombobox(props);
   const handleKeydown = useCallback<KeyboardEventHandler<HTMLInputElement>>(
-    (event) => {
+    event => {
       const {inputValue} = combobox;
       if (event.key === 'Enter') {
         event.preventDefault();
@@ -703,7 +703,7 @@ const CSSPropertyComboBox = (props: CSSPropertyComboBoxProps) => {
         <Combobox.Positioner>
           <Combobox.Content>
             <Combobox.ItemGroup>
-              {combobox.collection.items.map((item) => (
+              {combobox.collection.items.map(item => (
                 <Combobox.Item key={item} item={item}>
                   <Combobox.ItemText>{item}</Combobox.ItemText>
                   <Combobox.ItemIndicator>✓</Combobox.ItemIndicator>
@@ -801,13 +801,13 @@ function initEditorCollection(
   return Object.assign(state, {
     collection: createTreeCollection<NodeKey>({
       isNodeDisabled: () => false,
-      nodeToChildren: (nodeKey) =>
+      nodeToChildren: nodeKey =>
         state.editorState.read(() => {
           const node = $getNodeByKey(nodeKey);
           return $isElementNode(node) ? node.getChildrenKeys() : [];
         }),
-      nodeToString: (nodeKey) => nodeKey,
-      nodeToValue: (nodeKey) => nodeKey,
+      nodeToString: nodeKey => nodeKey,
+      nodeToValue: nodeKey => nodeKey,
       rootNode: 'root',
     }),
     focusNodeKey: null,

--- a/examples/node-state-style/src/plugins/ToolbarPlugin.tsx
+++ b/examples/node-state-style/src/plugins/ToolbarPlugin.tsx
@@ -70,7 +70,7 @@ export function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanUndo(payload);
           return false;
         },
@@ -78,7 +78,7 @@ export function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanRedo(payload);
           return false;
         },

--- a/examples/node-state-style/src/styleState.ts
+++ b/examples/node-state-style/src/styleState.ts
@@ -146,7 +146,7 @@ export function $removeStyleProperty<
   T extends LexicalNode,
   Prop extends keyof StyleObject,
 >(node: T, prop: Prop): T {
-  return $setStyleObject(node, (prevStyle) => {
+  return $setStyleObject(node, prevStyle => {
     if (prop in prevStyle) {
       const {[prop]: _ignore, ...nextStyle} = prevStyle;
       return nextStyle;
@@ -159,7 +159,7 @@ export function $setStyleProperty<
   T extends LexicalNode,
   Prop extends keyof StyleObject,
 >(node: T, prop: Prop, value: ValueOrUpdater<StyleObject[Prop]>): T {
-  return $setStyleObject(node, (prevStyle) => {
+  return $setStyleObject(node, prevStyle => {
     const prevValue = prevStyle[prop];
     const nextValue = typeof value === 'function' ? value(prevValue) : value;
     return prevValue === nextValue
@@ -273,7 +273,7 @@ export function $patchSelectedTextStyle(
       $setStyleObject(node, styleCallback);
     }
   } else {
-    $forEachSelectedTextNode((node) => $setStyleObject(node, styleCallback));
+    $forEachSelectedTextNode(node => $setStyleObject(node, styleCallback));
   }
   return true;
 }
@@ -320,7 +320,7 @@ function makeStyleUpdateListener(editor: LexicalEditor): () => void {
       // UpdateListener will only get the mutatedNodes payload when
       // at least one MutationListener is registered
     }),
-    editor.registerUpdateListener((payload) => {
+    editor.registerUpdateListener(payload => {
       const {prevEditorState, mutatedNodes} = payload;
       editor.getEditorState().read(
         () => {
@@ -371,7 +371,7 @@ export function $exportNodeStyle(
   }
   return {
     ...output,
-    after: (generatedElement) => {
+    after: generatedElement => {
       const el = output.after
         ? output.after(generatedElement)
         : generatedElement;
@@ -399,21 +399,21 @@ export type StyleMapping = (input: StyleObject) => StyleObject;
 
 // TODO there's no reasonable way to hook into importDOM/exportDOM from a plug-in https://github.com/facebook/lexical/issues/7259
 export function constructStyleImportMap(
-  styleMapping: StyleMapping = (input) => input,
+  styleMapping: StyleMapping = input => input,
 ): DOMConversionMap {
   const importMap: DOMConversionMap = {};
 
   // Wrap all TextNode importers with a function that also imports
   // styles that are not otherwise imported
   for (const [tag, fn] of Object.entries(TextNode.importDOM() || {})) {
-    importMap[tag] = (importNode) => {
+    importMap[tag] = importNode => {
       const importer = fn(importNode);
       if (!importer) {
         return null;
       }
       return {
         ...importer,
-        conversion: (element) => {
+        conversion: element => {
           const output = importer.conversion(element);
           if (
             output === null ||

--- a/examples/react-rich-collab/src/App.tsx
+++ b/examples/react-rich-collab/src/App.tsx
@@ -86,7 +86,7 @@ export default function App() {
         providerName === 'webrtc'
           ? createWebRTCProvider(id, yjsDocMap)
           : createWebsocketProvider(id, yjsDocMap);
-      provider.on('status', (event) => {
+      provider.on('status', event => {
         setConnected(
           // Websocket provider
           event.status === 'connected' ||
@@ -131,15 +131,15 @@ export default function App() {
         <input
           type="text"
           value={userProfile.name}
-          onChange={(e) =>
-            setUserProfile((profile) => ({...profile, name: e.target.value}))
+          onChange={e =>
+            setUserProfile(profile => ({...profile, name: e.target.value}))
           }
         />{' '}
         <input
           type="color"
           value={userProfile.color}
-          onChange={(e) =>
-            setUserProfile((profile) => ({...profile, color: e.target.value}))
+          onChange={e =>
+            setUserProfile(profile => ({...profile, color: e.target.value}))
           }
         />
       </p>

--- a/examples/react-rich-collab/src/plugins/ToolbarPlugin.tsx
+++ b/examples/react-rich-collab/src/plugins/ToolbarPlugin.tsx
@@ -63,7 +63,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanUndo(payload);
           return false;
         },
@@ -71,7 +71,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanRedo(payload);
           return false;
         },

--- a/examples/react-rich/src/App.tsx
+++ b/examples/react-rich/src/App.tsx
@@ -85,14 +85,14 @@ const constructImportMap = (): DOMConversionMap => {
   // Wrap all TextNode importers with a function that also imports
   // the custom styles implemented by the playground
   for (const [tag, fn] of Object.entries(TextNode.importDOM() || {})) {
-    importMap[tag] = (importNode) => {
+    importMap[tag] = importNode => {
       const importer = fn(importNode);
       if (!importer) {
         return null;
       }
       return {
         ...importer,
-        conversion: (element) => {
+        conversion: element => {
           const output = importer.conversion(element);
           if (
             output === null ||

--- a/examples/react-rich/src/plugins/ToolbarPlugin.tsx
+++ b/examples/react-rich/src/plugins/ToolbarPlugin.tsx
@@ -66,7 +66,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanUndo(payload);
           return false;
         },
@@ -74,7 +74,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanRedo(payload);
           return false;
         },

--- a/examples/react-table/src/plugins/ToolbarPlugin.tsx
+++ b/examples/react-table/src/plugins/ToolbarPlugin.tsx
@@ -63,7 +63,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanUndo(payload);
           return false;
         },
@@ -71,7 +71,7 @@ export default function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanRedo(payload);
           return false;
         },

--- a/examples/vanilla-js-plugin/src/emoji-plugin/EmojiNode.ts
+++ b/examples/vanilla-js-plugin/src/emoji-plugin/EmojiNode.ts
@@ -34,7 +34,7 @@ export class EmojiNode extends TextNode {
 
   constructor(unifiedID: string, key?: NodeKey) {
     const unicodeEmoji = String.fromCodePoint(
-      ...unifiedID.split('-').map((v) => parseInt(v, 16)),
+      ...unifiedID.split('-').map(v => parseInt(v, 16)),
     );
     super(unicodeEmoji, key);
 

--- a/examples/vanilla-js-plugin/src/emoji-plugin/findEmoji.ts
+++ b/examples/vanilla-js-plugin/src/emoji-plugin/findEmoji.ts
@@ -28,7 +28,7 @@ const emojiReplacementMap = emojis.reduce<Map<string, string>>((acc, row) => {
     acc.set(row.text, row.unified);
   }
   if (row.texts != null) {
-    row.texts.forEach((text) => acc.set(text, row.unified));
+    row.texts.forEach(text => acc.set(text, row.unified));
   }
 
   return acc;

--- a/examples/website-chat/src/Editor.tsx
+++ b/examples/website-chat/src/Editor.tsx
@@ -52,7 +52,7 @@ export default function Editor() {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
 
   const onSubmit = useCallback((editorState: EditorState) => {
-    setMessages((prev) => [
+    setMessages(prev => [
       ...prev,
       {author: 'me', id: Date.now(), initialState: editorState},
     ]);
@@ -89,7 +89,7 @@ export default function Editor() {
       <div
         ref={messagesContainerRef}
         className="flex h-[288px] flex-col gap-1.5 overflow-y-auto px-3.5 pt-3.5 pb-1.5 max-[996px]:h-[228px]">
-        {messages.map((msg) => (
+        {messages.map(msg => (
           <div
             key={msg.id}
             className={`flex max-w-[78%] items-end gap-1.5 ${msg.author === 'me' ? 'flex-row-reverse self-end' : 'self-start'}`}>

--- a/examples/website-chat/src/ThemeToggle.tsx
+++ b/examples/website-chat/src/ThemeToggle.tsx
@@ -15,7 +15,7 @@ export function ThemeToggle() {
   );
 
   const toggle = useCallback(() => {
-    setIsDark((prev) => {
+    setIsDark(prev => {
       const next = !prev;
       document.documentElement.classList.toggle('dark', next);
       return next;

--- a/examples/website-chat/src/plugins/EmojiPlugin.tsx
+++ b/examples/website-chat/src/plugins/EmojiPlugin.tsx
@@ -182,7 +182,7 @@ export function EmojiPlugin() {
         type="button"
         className={`flex h-[34px] w-[34px] shrink-0 cursor-pointer items-center justify-center rounded-full border-0 text-[1.1rem] leading-none transition-[background-color,transform] duration-150 active:scale-[0.92] ${open ? 'bg-indigo-100 dark:bg-indigo-900' : 'bg-zinc-100 hover:bg-zinc-200 dark:bg-[#3a3a3c] dark:hover:bg-zinc-600'}`}
         title="Add emoji"
-        onClick={() => setOpen((v) => !v)}>
+        onClick={() => setOpen(v => !v)}>
         😊
       </button>
 
@@ -193,7 +193,7 @@ export function EmojiPlugin() {
           <div
             className="flex gap-0.5 border-b [border-bottom-style:solid] border-zinc-100 px-1 pt-1 pb-0 dark:border-white/[0.07]"
             role="tablist">
-            {Object.keys(EMOJI_CATEGORIES).map((cat) => (
+            {Object.keys(EMOJI_CATEGORIES).map(cat => (
               <button
                 key={cat}
                 type="button"
@@ -209,7 +209,7 @@ export function EmojiPlugin() {
           <div
             className="grid max-h-[168px] grid-cols-8 gap-0.5 overflow-y-auto p-1.5"
             role="listbox">
-            {EMOJI_CATEGORIES[activeTab].map((emoji) => (
+            {EMOJI_CATEGORIES[activeTab].map(emoji => (
               <button
                 key={emoji}
                 type="button"

--- a/examples/website-chat/src/plugins/SubmitOnEnterPlugin.tsx
+++ b/examples/website-chat/src/plugins/SubmitOnEnterPlugin.tsx
@@ -26,7 +26,7 @@ export function SubmitOnEnterPlugin({onSubmit}: SubmitOnEnterPluginProps) {
   useEffect(() => {
     return editor.registerCommand(
       KEY_ENTER_COMMAND,
-      (event) => {
+      event => {
         if (event !== null && event.shiftKey) {
           return false;
         }

--- a/examples/website-notion/src/ThemeToggle.tsx
+++ b/examples/website-notion/src/ThemeToggle.tsx
@@ -15,7 +15,7 @@ export function ThemeToggle() {
   );
 
   const toggle = useCallback(() => {
-    setIsDark((prev) => {
+    setIsDark(prev => {
       const next = !prev;
       document.documentElement.classList.toggle('dark', next);
       return next;

--- a/examples/website-notion/src/plugins/DragPlugin.tsx
+++ b/examples/website-notion/src/plugins/DragPlugin.tsx
@@ -61,7 +61,7 @@ export function DragPlugin({anchorElem}: DragPluginProps) {
     }
     const regex = new RegExp(queryString, 'i');
     return base.filter(
-      (o) => regex.test(o.title) || o.keywords.some((k) => regex.test(k)),
+      o => regex.test(o.title) || o.keywords.some(k => regex.test(k)),
     );
   }, [editor, queryString]);
 
@@ -120,7 +120,7 @@ export function DragPlugin({anchorElem}: DragPluginProps) {
       return;
     }
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setHighlightedIndex((i) => Math.min(i, Math.max(options.length - 1, 0)));
+    setHighlightedIndex(i => Math.min(i, Math.max(options.length - 1, 0)));
   }, [isPickerOpen, options.length]);
 
   useEffect(() => {
@@ -151,10 +151,10 @@ export function DragPlugin({anchorElem}: DragPluginProps) {
       }
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setHighlightedIndex((i) => (i + 1) % options.length);
+        setHighlightedIndex(i => (i + 1) % options.length);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        setHighlightedIndex((i) => (i - 1 + options.length) % options.length);
+        setHighlightedIndex(i => (i - 1 + options.length) % options.length);
       } else if (e.key === 'Enter') {
         e.preventDefault();
         selectOption(options[highlightedIndex]);
@@ -225,7 +225,7 @@ export function DragPlugin({anchorElem}: DragPluginProps) {
                 className="block w-full border-0 border-b [border-bottom-style:solid] border-zinc-200 bg-transparent px-3 py-2 text-[0.85rem] text-inherit outline-none dark:border-zinc-700"
                 placeholder="Filter blocks..."
                 value={queryString}
-                onChange={(e) => setQueryString(e.target.value)}
+                onChange={e => setQueryString(e.target.value)}
               />
               <ul className="m-0 max-h-[220px] list-none overflow-y-auto p-1">
                 {options.map((option, i) => (
@@ -267,7 +267,7 @@ export function DragPlugin({anchorElem}: DragPluginProps) {
               className="flex h-[18px] w-[18px] shrink-0 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent [background-size:14px_14px] bg-center bg-no-repeat opacity-50 hover:bg-zinc-100 hover:opacity-100 dark:invert dark:hover:bg-[#ffffdd]"
               style={{backgroundImage: "url('/img/plus.svg')"}}
               title="Click to add below (Alt/Option to add above)"
-              onMouseDown={(e) => {
+              onMouseDown={e => {
                 e.preventDefault();
                 e.stopPropagation();
               }}

--- a/examples/website-notion/src/plugins/SlashMenuPlugin.tsx
+++ b/examples/website-notion/src/plugins/SlashMenuPlugin.tsx
@@ -28,7 +28,7 @@ export function SlashMenuPlugin() {
     }
     const regex = new RegExp(queryString, 'i');
     return base.filter(
-      (o) => regex.test(o.title) || o.keywords.some((k) => regex.test(k)),
+      o => regex.test(o.title) || o.keywords.some(k => regex.test(k)),
     );
   }, [editor, queryString]);
 

--- a/examples/website-rich-input/src/ThemeToggle.tsx
+++ b/examples/website-rich-input/src/ThemeToggle.tsx
@@ -15,7 +15,7 @@ export function ThemeToggle() {
   );
 
   const toggle = useCallback(() => {
-    setIsDark((prev) => {
+    setIsDark(prev => {
       const next = !prev;
       document.documentElement.classList.toggle('dark', next);
       return next;

--- a/examples/website-toolbar/src/ThemeToggle.tsx
+++ b/examples/website-toolbar/src/ThemeToggle.tsx
@@ -15,7 +15,7 @@ export function ThemeToggle() {
   );
 
   const toggle = useCallback(() => {
-    setIsDark((prev) => {
+    setIsDark(prev => {
       const next = !prev;
       document.documentElement.classList.toggle('dark', next);
       return next;

--- a/examples/website-toolbar/src/plugins/ToolbarPlugin.tsx
+++ b/examples/website-toolbar/src/plugins/ToolbarPlugin.tsx
@@ -102,7 +102,7 @@ export function ToolbarPlugin() {
     const selection = $getSelection();
     if ($isRangeSelection(selection)) {
       const anchorNode = selection.anchor.getNode();
-      let topLevelElement = $findMatchingParent(anchorNode, (e) => {
+      let topLevelElement = $findMatchingParent(anchorNode, e => {
         const parent = e.getParent();
         return parent !== null && $isRootOrShadowRoot(parent);
       });
@@ -133,7 +133,7 @@ export function ToolbarPlugin() {
       }),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanUndo(payload);
           return false;
         },
@@ -141,7 +141,7 @@ export function ToolbarPlugin() {
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           setCanRedo(payload);
           return false;
         },
@@ -166,7 +166,7 @@ export function ToolbarPlugin() {
       <select
         className="cursor-pointer appearance-none rounded-md border border-solid border-transparent bg-transparent px-2 py-1 text-sm font-medium text-zinc-700 transition-colors duration-150 hover:bg-zinc-200 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-zinc-200 dark:hover:bg-zinc-700"
         value={blockType}
-        onChange={(e) => applyBlockType(editor, e.target.value)}
+        onChange={e => applyBlockType(editor, e.target.value)}
         aria-label="Block type">
         {BLOCK_TYPES.map(({label, value}) => (
           <option key={value} value={value}>

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -449,7 +449,7 @@ export function $handlePlainTextDrop(
 function trustHTML(html: string): string | TrustedHTML {
   if (window.trustedTypes && window.trustedTypes.createPolicy) {
     const policy = window.trustedTypes.createPolicy('lexical', {
-      createHTML: (input) => input,
+      createHTML: input => input,
     });
     return policy.createHTML(html);
   }
@@ -715,7 +715,7 @@ export async function copyToClipboard(
   return new Promise((resolve, reject) => {
     const removeListener = editor.registerCommand(
       COPY_COMMAND,
-      (secondEvent) => {
+      secondEvent => {
         if (objectKlassEquals(secondEvent, ClipboardEvent)) {
           removeListener();
           if (clipboardEventTimeout !== null) {

--- a/packages/lexical-code-core/src/CodeExtension.ts
+++ b/packages/lexical-code-core/src/CodeExtension.ts
@@ -26,7 +26,7 @@ export const CodeExtension = defineExtension({
   register(editor) {
     return editor.registerCommand<KeyboardEvent>(
       KEY_ENTER_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if ($isRangeSelection(selection) && $exitCodeNodeOnEnter(selection)) {
           event.preventDefault();

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -371,7 +371,7 @@ export class CodeNode extends ElementNode {
   collapseAtStart(): boolean {
     const paragraph = $createParagraphNode();
     const children = this.getChildren();
-    children.forEach((child) => paragraph.append(child));
+    children.forEach(child => paragraph.append(child));
     this.replace(paragraph);
     return true;
   }

--- a/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
@@ -23,7 +23,7 @@ const editorConfig = {
 
 describe('CodeNode', () => {
   initializeUnitTest(
-    (testEnv) => {
+    testEnv => {
       it('applies and replaces styles through DOM style properties', async () => {
         const {editor} = testEnv;
 

--- a/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
@@ -257,7 +257,7 @@ function $updateAndRetainSelection(
 
   // If it was non-element anchor then we walk through child nodes
   // and looking for a position of original text offset
-  node.getChildren().some((_node) => {
+  node.getChildren().some(_node => {
     const isText = $isTextNode(_node);
     if (isText || $isLineBreakNode(_node)) {
       const textContentSize = _node.getTextContentSize();
@@ -676,14 +676,14 @@ function $handleShiftLines(
   let insertionPoint =
     maybeInsertionPoint != null ? maybeInsertionPoint : sibling;
   linebreak.remove();
-  range.forEach((node) => node.remove());
+  range.forEach(node => node.remove());
   if (type === KEY_ARROW_UP_COMMAND) {
-    range.forEach((node) => insertionPoint.insertBefore(node));
+    range.forEach(node => insertionPoint.insertBefore(node));
     insertionPoint.insertBefore(linebreak);
   } else {
     insertionPoint.insertAfter(linebreak);
     insertionPoint = linebreak;
-    range.forEach((node) => {
+    range.forEach(node => {
       insertionPoint.insertAfter(node);
       insertionPoint = node;
     });
@@ -774,7 +774,7 @@ export function registerCodeHighlighting(
     registrations.push(
       editor.registerMutationListener(
         CodeNode,
-        (mutations) => {
+        mutations => {
           editor.getEditorState().read(() => {
             for (const [key, type] of mutations) {
               if (type !== 'destroyed') {
@@ -811,7 +811,7 @@ export function registerCodeHighlighting(
     ),
     editor.registerCommand(
       KEY_TAB_COMMAND,
-      (event) => {
+      event => {
         const command = $handleTab(event.shiftKey);
         if (command === null) {
           return false;
@@ -846,7 +846,7 @@ export function registerCodeHighlighting(
     ),
     editor.registerCommand(
       KEY_ARROW_UP_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection) || !$isSelectionInCode(selection)) {
           return false;
@@ -867,7 +867,7 @@ export function registerCodeHighlighting(
     ),
     editor.registerCommand(
       KEY_ARROW_DOWN_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection) || !$isSelectionInCode(selection)) {
           return false;
@@ -888,12 +888,12 @@ export function registerCodeHighlighting(
     ),
     editor.registerCommand(
       MOVE_TO_START,
-      (event) => $handleMoveTo(MOVE_TO_START, event),
+      event => $handleMoveTo(MOVE_TO_START, event),
       COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand(
       MOVE_TO_END,
-      (event) => $handleMoveTo(MOVE_TO_END, event),
+      event => $handleMoveTo(MOVE_TO_END, event),
       COMMAND_PRIORITY_LOW,
     ),
   );

--- a/packages/lexical-code-prism/src/FacadePrism.ts
+++ b/packages/lexical-code-prism/src/FacadePrism.ts
@@ -85,7 +85,7 @@ export const getCodeLanguages = (): Array<string> =>
     .filter(
       // Prism has several language helpers mixed into languages object
       // so filtering them out here to get langs list
-      (language) => typeof Prism.languages[language] !== 'function',
+      language => typeof Prism.languages[language] !== 'function',
     )
     .sort();
 
@@ -177,7 +177,7 @@ export function tokenizeDiffHighlight(
     };
 
     const withoutPrefixes = token.content.filter(
-      (t) => typeof t === 'string' || t.type !== 'prefix',
+      t => typeof t === 'string' || t.type !== 'prefix',
     );
     const prefixCount = token.content.length - withoutPrefixes.length;
     const diffTokens = Prism.tokenize(

--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -278,7 +278,7 @@ function $updateAndRetainSelection(
 
   // If it was non-element anchor then we walk through child nodes
   // and looking for a position of original text offset
-  node.getChildren().some((_node) => {
+  node.getChildren().some(_node => {
     const isText = $isTextNode(_node);
     if (isText || $isLineBreakNode(_node)) {
       const textContentSize = _node.getTextContentSize();
@@ -698,14 +698,14 @@ function $handleShiftLines(
   let insertionPoint =
     maybeInsertionPoint != null ? maybeInsertionPoint : sibling;
   linebreak.remove();
-  range.forEach((node) => node.remove());
+  range.forEach(node => node.remove());
   if (type === KEY_ARROW_UP_COMMAND) {
-    range.forEach((node) => insertionPoint.insertBefore(node));
+    range.forEach(node => insertionPoint.insertBefore(node));
     insertionPoint.insertBefore(linebreak);
   } else {
     insertionPoint.insertAfter(linebreak);
     insertionPoint = linebreak;
-    range.forEach((node) => {
+    range.forEach(node => {
       insertionPoint.insertAfter(node);
       insertionPoint = node;
     });
@@ -787,7 +787,7 @@ export function registerCodeHighlighting(
     registrations.push(
       editor.registerMutationListener(
         CodeNode,
-        (mutations) => {
+        mutations => {
           editor.getEditorState().read(() => {
             for (const [key, type] of mutations) {
               if (type !== 'destroyed') {
@@ -824,7 +824,7 @@ export function registerCodeHighlighting(
     ),
     editor.registerCommand(
       KEY_TAB_COMMAND,
-      (event) => {
+      event => {
         const command = $handleTab(event.shiftKey);
         if (command === null) {
           return false;
@@ -859,7 +859,7 @@ export function registerCodeHighlighting(
     ),
     editor.registerCommand(
       KEY_ARROW_UP_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;
@@ -885,7 +885,7 @@ export function registerCodeHighlighting(
     ),
     editor.registerCommand(
       KEY_ARROW_DOWN_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;
@@ -911,12 +911,12 @@ export function registerCodeHighlighting(
     ),
     editor.registerCommand(
       MOVE_TO_START,
-      (event) => $handleMoveTo(MOVE_TO_START, event),
+      event => $handleMoveTo(MOVE_TO_START, event),
       COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand(
       MOVE_TO_END,
-      (event) => $handleMoveTo(MOVE_TO_END, event),
+      event => $handleMoveTo(MOVE_TO_END, event),
       COMMAND_PRIORITY_LOW,
     ),
   );

--- a/packages/lexical-code-shiki/src/FacadeShiki.ts
+++ b/packages/lexical-code-shiki/src/FacadeShiki.ts
@@ -57,7 +57,7 @@ export function loadCodeLanguage(
   const langId = diffedLanguage ? diffedLanguage : language;
   if (!isCodeLanguageLoaded(langId)) {
     const languageInfo = bundledLanguagesInfo.find(
-      (desc) =>
+      desc =>
         desc.id === langId || (desc.aliases && desc.aliases.includes(langId)),
     );
     if (languageInfo) {
@@ -100,7 +100,7 @@ export function loadCodeTheme(
   codeNodeKey?: NodeKey,
 ) {
   if (!isCodeThemeLoaded(theme)) {
-    const themeInfo = bundledThemesInfo.find((info) => info.id === theme);
+    const themeInfo = bundledThemesInfo.find(info => info.id === theme);
     if (themeInfo) {
       return shiki.loadTheme(themeInfo.import()).then(() => {
         if (editor && codeNodeKey) {
@@ -117,16 +117,16 @@ export function loadCodeTheme(
 }
 
 export function getCodeLanguageOptions(): [string, string][] {
-  return bundledLanguagesInfo.map((i) => [i.id, i.name]);
+  return bundledLanguagesInfo.map(i => [i.id, i.name]);
 }
 export function getCodeThemeOptions(): [string, string][] {
-  return bundledThemesInfo.map((i) => [i.id, i.displayName]);
+  return bundledThemesInfo.map(i => [i.id, i.displayName]);
 }
 
 export function normalizeCodeLanguage(language: string): string {
   const langId = language;
   const languageInfo = bundledLanguagesInfo.find(
-    (desc) =>
+    desc =>
       desc.id === langId || (desc.aliases && desc.aliases.includes(langId)),
   );
   if (languageInfo) {

--- a/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -45,7 +45,7 @@ import {describe, expect, test} from 'vitest';
 import {isCodeThemeLoaded} from '../../FacadeShiki';
 
 describe('LexicalCodeNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('Tabs', () => {
       // Tests are described using the following convention
       // > is the beginning of a line
@@ -91,8 +91,8 @@ describe('LexicalCodeNode tests', () => {
         ['>-li|ne1>>-li|ne2', '>li|ne1>>li|ne2', 'outdent'],
         ['>|-line1>->-line2|', '>|--line1>-->--line2|', 'tab'],
       ];
-      suite.forEach((scenario) => {
-        ['forwards', 'backwards'].forEach((direction) => {
+      suite.forEach(scenario => {
+        ['forwards', 'backwards'].forEach(direction => {
           test(`testing ${scenario[2]}: ${scenario[0]} => ${scenario[1]} (${direction})`, async () => {
             const {editor} = testEnv;
 
@@ -148,7 +148,7 @@ describe('LexicalCodeNode tests', () => {
                 codeNodes[0]
                   .getChildren()
                   .filter(
-                    (node) =>
+                    node =>
                       !(
                         $isCodeHighlightNode(node) ||
                         $isLineBreakNode(node) ||

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
@@ -58,7 +58,7 @@ const editorConfig = Object.freeze({
 const SPACES4 = ' '.repeat(4);
 
 describe('LexicalCodeNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('CodeNode.constructor', async () => {
       const {editor} = testEnv;
 
@@ -672,7 +672,7 @@ describe('LexicalCodeNode tests', () => {
             'caret at start of line (second line)',
             () => {
               const nodes = $dfs();
-              const linebreak = nodes.filter((dfsNode) =>
+              const linebreak = nodes.filter(dfsNode =>
                 $isLineBreakNode(dfsNode.node),
               )[0].node;
               linebreak.selectNext(0, 0);
@@ -747,7 +747,7 @@ describe('LexicalCodeNode tests', () => {
             'caret immediately before code (second line)',
             () => {
               const nodes = $dfs();
-              const linebreak = nodes.filter((dfsNode) =>
+              const linebreak = nodes.filter(dfsNode =>
                 $isLineBreakNode(dfsNode.node),
               )[0].node;
               if (tabOrSpaces === 'tab') {
@@ -766,7 +766,7 @@ describe('LexicalCodeNode tests', () => {
               expect(selection.isCollapsed()).toBe(true);
               if (moveTo === 'start') {
                 const nodes = $dfs();
-                const linebreak = nodes.filter((dfsNode) =>
+                const linebreak = nodes.filter(dfsNode =>
                   $isLineBreakNode(dfsNode.node),
                 )[0].node;
                 const tabOrSpace = linebreak.getNextSibling();
@@ -829,7 +829,7 @@ describe('LexicalCodeNode tests', () => {
             'caret in between space (second line)',
             () => {
               const nodes = $dfs();
-              const linebreak = nodes.filter((dfsNode) =>
+              const linebreak = nodes.filter(dfsNode =>
                 $isLineBreakNode(dfsNode.node),
               )[0].node;
               if (tabOrSpaces === 'tab') {
@@ -874,7 +874,7 @@ describe('LexicalCodeNode tests', () => {
             'caret in between code',
             () => {
               const nodes = $dfs();
-              const codeHighlight = nodes.filter((dfsNode) =>
+              const codeHighlight = nodes.filter(dfsNode =>
                 $isCodeHighlightNode(dfsNode.node),
               )[tabOrSpaces === 'tab' ? 0 : 1].node;
               const index = codeHighlight.getTextContent().indexOf('tion');
@@ -916,7 +916,7 @@ describe('LexicalCodeNode tests', () => {
             'caret in between code (after space)',
             () => {
               const nodes = $dfs();
-              const codeHighlight = nodes.filter((dfsNode) =>
+              const codeHighlight = nodes.filter(dfsNode =>
                 $isCodeHighlightNode(dfsNode.node),
               )[tabOrSpaces === 'tab' ? 1 : 2].node;
               const index = codeHighlight.getTextContent().indexOf('oo');
@@ -958,7 +958,7 @@ describe('LexicalCodeNode tests', () => {
             'non-collapsed multi-line selection',
             () => {
               const nodes = $dfs();
-              const codeHighlightDFSNodes = nodes.filter((dfsNode) =>
+              const codeHighlightDFSNodes = nodes.filter(dfsNode =>
                 $isCodeHighlightNode(dfsNode.node),
               );
               const secondCodeHighlight = codeHighlightDFSNodes[1].node;

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -32,7 +32,7 @@ import {
 import {describe, expect, test} from 'vitest';
 
 describe('LexicalCodeNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('Tabs', () => {
       // Tests are described using the following convention
       // > is the beginning of a line
@@ -78,8 +78,8 @@ describe('LexicalCodeNode tests', () => {
         ['>-li|ne1>>-li|ne2', '>li|ne1>>li|ne2', 'outdent'],
         ['>|-line1>->-line2|', '>|--line1>-->--line2|', 'tab'],
       ];
-      suite.forEach((scenario) => {
-        ['forwards', 'backwards'].forEach((direction) => {
+      suite.forEach(scenario => {
+        ['forwards', 'backwards'].forEach(direction => {
           test(`testing ${scenario[2]}: ${scenario[0]} => ${scenario[1]} (${direction})`, async () => {
             const {editor} = testEnv;
 

--- a/packages/lexical-devtools-core/src/TreeView.tsx
+++ b/packages/lexical-devtools-core/src/TreeView.tsx
@@ -65,12 +65,12 @@ export const TreeView = forwardRef<
     (exportDOM: boolean) => {
       const myID = ++lastGenerationID.current;
       generateContent(exportDOM)
-        .then((treeText) => {
+        .then(treeText => {
           if (myID === lastGenerationID.current) {
             setContent(treeText);
           }
         })
-        .catch((err) => {
+        .catch(err => {
           if (myID === lastGenerationID.current) {
             setContent(
               `Error rendering tree: ${err.message}\n\nStack:\n${err.stack}`,
@@ -105,7 +105,7 @@ export const TreeView = forwardRef<
 
       // Only record in time travel if there was an actual editor state change
       if (!timeTravelEnabled && isEditorStateChange) {
-        setTimeStampedEditorStates((currentEditorStates) => [
+        setTimeStampedEditorStates(currentEditorStates => [
           ...currentEditorStates,
           [Date.now(), editorState],
         ]);
@@ -225,7 +225,7 @@ export const TreeView = forwardRef<
           <input
             className={timeTravelPanelSliderClassName}
             ref={inputRef}
-            onChange={(event) => {
+            onChange={event => {
               const editorStateIndex = Number(event.target.value);
               const timeStampedEditorState =
                 timeStampedEditorStates[editorStateIndex];

--- a/packages/lexical-devtools-core/src/generateContent.ts
+++ b/packages/lexical-devtools-core/src/generateContent.ts
@@ -302,7 +302,7 @@ function printNode(
 }
 
 function printTextFormatProperties(nodeOrSelection: ParagraphNode) {
-  let str = FORMAT_PREDICATES_PARAGRAPH.map((predicate) =>
+  let str = FORMAT_PREDICATES_PARAGRAPH.map(predicate =>
     predicate(nodeOrSelection),
   )
     .filter(Boolean)
@@ -339,7 +339,7 @@ function printAllLinkNodeProperties(node: LinkNode) {
 }
 
 function printDetailProperties(nodeOrSelection: TextNode) {
-  let str = DETAIL_PREDICATES.map((predicate) => predicate(nodeOrSelection))
+  let str = DETAIL_PREDICATES.map(predicate => predicate(nodeOrSelection))
     .filter(Boolean)
     .join(', ')
     .toLocaleLowerCase();
@@ -352,7 +352,7 @@ function printDetailProperties(nodeOrSelection: TextNode) {
 }
 
 function printModeProperties(nodeOrSelection: TextNode) {
-  let str = MODE_PREDICATES.map((predicate) => predicate(nodeOrSelection))
+  let str = MODE_PREDICATES.map(predicate => predicate(nodeOrSelection))
     .filter(Boolean)
     .join(', ')
     .toLocaleLowerCase();
@@ -365,7 +365,7 @@ function printModeProperties(nodeOrSelection: TextNode) {
 }
 
 function printFormatProperties(nodeOrSelection: TextNode | RangeSelection) {
-  let str = FORMAT_PREDICATES.map((predicate) => predicate(nodeOrSelection))
+  let str = FORMAT_PREDICATES.map(predicate => predicate(nodeOrSelection))
     .filter(Boolean)
     .join(', ')
     .toLocaleLowerCase();

--- a/packages/lexical-devtools-core/src/useLexicalCommandsLog.ts
+++ b/packages/lexical-devtools-core/src/useLexicalCommandsLog.ts
@@ -29,14 +29,14 @@ export function registerLexicalCommandLogger(
     unregisterCommandListeners.push(
       editor.registerCommand(
         command,
-        (payload) => {
+        payload => {
           index += 1;
           const entry: LexicalCommandEntry = {
             index,
             payload,
             type: command.type ? command.type : 'UNKNOWN',
           };
-          setLoggedCommands((state) => [...state.slice(-9), entry]);
+          setLoggedCommands(state => [...state.slice(-9), entry]);
           return false;
         },
         COMMAND_PRIORITY_CRITICAL,
@@ -44,7 +44,7 @@ export function registerLexicalCommandLogger(
     );
   }
 
-  return () => unregisterCommandListeners.forEach((unregister) => unregister());
+  return () => unregisterCommandListeners.forEach(unregister => unregister());
 }
 
 export function useLexicalCommandsLog(

--- a/packages/lexical-devtools/src/components/EditorsRefreshCTA.tsx
+++ b/packages/lexical-devtools/src/components/EditorsRefreshCTA.tsx
@@ -31,7 +31,7 @@ function EditorsRefreshCTA({tabID, setErrorMessage}: Props) {
 
     injectedPegasusService
       .refreshLexicalEditors()
-      .catch((err) => {
+      .catch(err => {
         setErrorMessage(err.message);
         console.error(err);
       })

--- a/packages/lexical-devtools/src/entrypoints/background/ActionIconWatchdog.ts
+++ b/packages/lexical-devtools/src/entrypoints/background/ActionIconWatchdog.ts
@@ -26,7 +26,7 @@ export default class ActionIconWatchdog {
       tabs.map(this.checkAndHandleRestrictedPageIfSo.bind(this)),
     );
 
-    browser.tabs.onCreated.addListener((tab) => {
+    browser.tabs.onCreated.addListener(tab => {
       this.checkAndHandleRestrictedPageIfSo(tab);
     });
 

--- a/packages/lexical-devtools/src/entrypoints/background/index.ts
+++ b/packages/lexical-devtools/src/entrypoints/background/index.ts
@@ -23,7 +23,7 @@ export default defineBackground(() => {
 
   // Store initialization so other extension surfaces can use it
   // as all changes go through background SW
-  initExtensionStoreBackend().catch((err) =>
+  initExtensionStoreBackend().catch(err =>
     console.error('Failed to initialize extension store', err),
   );
 

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
@@ -31,7 +31,7 @@ export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
     injectedPegasusService
       .refreshLexicalEditors()
       .then(() => injectedPegasusService.toggleEditorPicker())
-      .catch((err) => {
+      .catch(err => {
         setErrorMessage(err.message);
         console.error(err);
       });

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorsList.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorsList.tsx
@@ -37,7 +37,7 @@ export function EditorsList({tabID, setErrorMessage}: Props) {
   const {lexicalState, selectedEditorKey} = useExtensionStore();
   const states = lexicalState[tabID] ?? {};
   const selectedEditorIdx = Object.keys(states).findIndex(
-    (key) => key === selectedEditorKey[tabID],
+    key => key === selectedEditorKey[tabID],
   );
 
   useEffect(() => {
@@ -74,7 +74,7 @@ export function EditorsList({tabID, setErrorMessage}: Props) {
       {Object.entries(states).map(([key, state], idx) => (
         <AccordionItem
           key={key}
-          ref={(el) => {
+          ref={el => {
             tabRefs.current.set(idx, el);
           }}>
           <h2>
@@ -93,18 +93,18 @@ export function EditorsList({tabID, setErrorMessage}: Props) {
               timeTravelButtonClassName="debug-timetravel-button"
               timeTravelPanelSliderClassName="debug-timetravel-panel-slider"
               timeTravelPanelButtonClassName="debug-timetravel-panel-button"
-              setEditorReadOnly={(isReadonly) =>
+              setEditorReadOnly={isReadonly =>
                 injectedPegasusService
                   .setEditorReadOnly(key, isReadonly)
-                  .catch((e) => setErrorMessage(e.stack))
+                  .catch(e => setErrorMessage(e.stack))
               }
               editorState={state as EditorState}
-              setEditorState={(editorState) =>
+              setEditorState={editorState =>
                 injectedPegasusService
                   .setEditorState(key, editorState as SerializedRawEditorState)
-                  .catch((e) => setErrorMessage(e.stack))
+                  .catch(e => setErrorMessage(e.stack))
               }
-              generateContent={(exportDOM) =>
+              generateContent={exportDOM =>
                 injectedPegasusService.generateTreeViewContent(key, exportDOM)
               }
             />

--- a/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
@@ -96,7 +96,7 @@ export class InjectedPegasusService implements IPegasusRPCService<InjectedPegasu
 
     this.pickerActive = new ElementPicker({style: ELEMENT_PICKER_STYLE});
     this.pickerActive.start({
-      elementFilter: (el) => {
+      elementFilter: el => {
         let parent: HTMLElement | null = el;
         while (parent !== null && parent.tagName !== 'BODY') {
           if ('__lexicalEditor' in parent) {
@@ -108,7 +108,7 @@ export class InjectedPegasusService implements IPegasusRPCService<InjectedPegasu
         return false;
       },
 
-      onClick: (el) => {
+      onClick: el => {
         this.deactivatePicker();
         if (isLexicalNode(el)) {
           this.extensionStore

--- a/packages/lexical-devtools/src/entrypoints/injected/index.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/index.ts
@@ -18,10 +18,8 @@ import main from './main';
 export default defineUnlistedScript({
   main() {
     initPegasusTransport({namespace: EXTENSION_NAME});
-    getRPCService<ITabIDService>('getTabID', 'background')().then((tabID) =>
-      extensionStoreReady().then((extensionStore) =>
-        main(tabID, extensionStore),
-      ),
+    getRPCService<ITabIDService>('getTabID', 'background')().then(tabID =>
+      extensionStoreReady().then(extensionStore => main(tabID, extensionStore)),
     );
   },
 });

--- a/packages/lexical-devtools/src/entrypoints/injected/scanAndListenForEditors.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/scanAndListenForEditors.ts
@@ -26,23 +26,23 @@ export default function scanAndListenForEditors(
   const {setStatesForTab, lexicalState} = extensionStore.getState();
   const states = lexicalState[tabID] ?? {};
 
-  const editors = queryLexicalNodes().map((node) => node.__lexicalEditor);
+  const editors = queryLexicalNodes().map(node => node.__lexicalEditor);
 
   setStatesForTab(
     tabID,
     Object.fromEntries(
-      editors.map((e) => {
+      editors.map(e => {
         return [e._key, serializeEditorState(e.getEditorState())];
       }),
     ),
   );
 
-  editors.forEach((editor) => {
+  editors.forEach(editor => {
     if (states[editor._key] !== undefined) {
       // already registered
       return;
     }
-    editor.registerUpdateListener((event) => {
+    editor.registerUpdateListener(event => {
       const oldVal = extensionStore.getState().lexicalState[tabID];
       setStatesForTab(tabID, {
         ...oldVal,
@@ -50,7 +50,7 @@ export default function scanAndListenForEditors(
       });
     });
     // TODO: validate that this will be garbage collected when the editor node is destroyed
-    registerLexicalCommandLogger(editor, (setter) => {
+    registerLexicalCommandLogger(editor, setter => {
       const oldVal = commandLog.get(editor) ?? [];
       commandLog.set(editor, setter(oldVal));
     });

--- a/packages/lexical-devtools/src/entrypoints/injected/utils/queryLexicalByKey.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/utils/queryLexicalByKey.ts
@@ -15,12 +15,12 @@ export function queryLexicalEditorByKey(
   key: string,
 ): LexicalEditor | undefined {
   return queryLexicalNodes()
-    .map((node) => node.__lexicalEditor)
-    .find((lexicalEditor) => lexicalEditor._key === key);
+    .map(node => node.__lexicalEditor)
+    .find(lexicalEditor => lexicalEditor._key === key);
 }
 
 export function queryLexicalNodeByKey(
   key: string,
 ): LexicalHTMLElement | undefined {
-  return queryLexicalNodes().find((node) => node.__lexicalEditor._key === key);
+  return queryLexicalNodes().find(node => node.__lexicalEditor._key === key);
 }

--- a/packages/lexical-devtools/src/entrypoints/popup/main.tsx
+++ b/packages/lexical-devtools/src/entrypoints/popup/main.tsx
@@ -21,7 +21,7 @@ import App from './App.tsx';
 initPegasusTransport();
 
 getRPCService<ITabIDService>('getTabID', 'background')()
-  .then((tabID) =>
+  .then(tabID =>
     extensionStoreReady().then(() =>
       ReactDOM.createRoot(document.getElementById('root')!).render(
         <React.StrictMode>

--- a/packages/lexical-devtools/src/store.ts
+++ b/packages/lexical-devtools/src/store.ts
@@ -35,11 +35,11 @@ export interface ExtensionState {
 }
 
 export const useExtensionStore = create<ExtensionState>()(
-  subscribeWithSelector((set) => ({
+  subscribeWithSelector(set => ({
     isSelecting: {},
     lexicalState: {},
     markTabAsRestricted: (tabID: number) =>
-      set((state) => ({
+      set(state => ({
         lexicalState: {
           ...state.lexicalState,
           [tabID]: null,
@@ -47,14 +47,14 @@ export const useExtensionStore = create<ExtensionState>()(
       })),
     selectedEditorKey: {},
     setIsSelecting: (tabID: number, isSelecting: boolean) =>
-      set((state) => ({
+      set(state => ({
         isSelecting: {
           ...state.isSelecting,
           [tabID]: isSelecting,
         },
       })),
     setSelectedEditorKey: (tabID: number, editorKey: string | null) =>
-      set((state) => ({
+      set(state => ({
         selectedEditorKey: {
           ...state.selectedEditorKey,
           [tabID]: editorKey,
@@ -64,7 +64,7 @@ export const useExtensionStore = create<ExtensionState>()(
       id: number,
       states: {[editorKey: string]: SerializedRawEditorState},
     ) =>
-      set((state) => ({
+      set(state => ({
         lexicalState: {
           ...state.lexicalState,
           [id]: states,

--- a/packages/lexical-devtools/wxt.config.ts
+++ b/packages/lexical-devtools/wxt.config.ts
@@ -19,7 +19,7 @@ import moduleResolution from '../shared/viteModuleResolution';
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   debug: !!process.env.DEBUG_WXT,
-  manifest: (configEnv) => {
+  manifest: configEnv => {
     const browserName =
       configEnv.browser.charAt(0).toUpperCase() + configEnv.browser.slice(1);
 
@@ -80,7 +80,7 @@ export default defineConfig({
     return manifestConf;
   },
   srcDir: './src',
-  vite: (configEnv) => {
+  vite: configEnv => {
     const isProd = configEnv.mode !== 'development';
     const {version} = JSON.parse(
       fs.readFileSync(path.resolve(__dirname, 'package.json'), {

--- a/packages/lexical-eslint-plugin-internal/src/rules/no-imports-from-self.js
+++ b/packages/lexical-eslint-plugin-internal/src/rules/no-imports-from-self.js
@@ -94,7 +94,7 @@ const rule = {
               suggestedModuleName: `'${invalidPackage.getNpmName()}'`,
             };
             /** @type {import('eslint').Rule.ReportFixer} */
-            const fix = (fixer) =>
+            const fix = fixer =>
               fixer.replaceText(node.source, data.suggestedModuleName);
             context.report({
               data,
@@ -122,7 +122,7 @@ const rule = {
             )}'`,
           };
           /** @type {import('eslint').Rule.ReportFixer} */
-          const fix = (fixer) =>
+          const fix = fixer =>
             fixer.replaceText(node.source, data.suggestedModuleName);
           context.report({
             data,

--- a/packages/lexical-eslint-plugin/__tests__/integration/integration-test.mjs
+++ b/packages/lexical-eslint-plugin/__tests__/integration/integration-test.mjs
@@ -194,7 +194,7 @@ function testESLint10Flat() {
 function setupFixtures() {
   log(`\n${BOLD}${BLUE}Setting up test fixtures...${RESET}`);
 
-  [ESLINT8_DIR, ESLINT8_DEPRECATED_DIR, ESLINT10_DIR].forEach((cwd) => {
+  [ESLINT8_DIR, ESLINT8_DEPRECATED_DIR, ESLINT10_DIR].forEach(cwd => {
     try {
       log(`  Installing dependencies for ${path.basename(cwd)} fixture...`);
       execSync('pnpm install --no-lockfile', {

--- a/packages/lexical-eslint-plugin/src/__tests__/unit/rules-of-lexical.test.ts
+++ b/packages/lexical-eslint-plugin/src/__tests__/unit/rules-of-lexical.test.ts
@@ -110,7 +110,7 @@ describe('LexicalEslintPlugin', () => {
     );
   });
 });
-(['rules-of-lexical'] as const).forEach((ruleName) => {
+(['rules-of-lexical'] as const).forEach(ruleName => {
   const namedRules = [
     fmt`const ${NAME} = () => $getRoot();`,
     fmt`const ${NAME} = () => { return $getRoot(); }`,

--- a/packages/lexical-eslint-plugin/src/rules/rules-of-lexical.js
+++ b/packages/lexical-eslint-plugin/src/rules/rules-of-lexical.js
@@ -40,7 +40,7 @@ function getIdentifierVariable(sourceCode, identifier) {
   ) {
     const variable = scopeManager
       .getDeclaredVariables(node)
-      .find((v) => v.identifiers.includes(identifier));
+      .find(v => v.identifiers.includes(identifier));
     if (variable) {
       return variable;
     }
@@ -323,7 +323,7 @@ module.exports.rulesOfLexical = {
     return {
       ArrowFunctionExpression: pushFunction,
       'ArrowFunctionExpression:exit': popFunction,
-      CallExpression: (node) => {
+      CallExpression: node => {
         if (shouldIgnore()) {
           return;
         }
@@ -354,7 +354,7 @@ module.exports.rulesOfLexical = {
           suggestName,
         };
         /** @type {ReportFixer} */
-        const fix = (fixer) => {
+        const fix = fixer => {
           /** @type {Set<Identifier>} */
           const replaced = new Set();
           /** @type {Fix[]} */

--- a/packages/lexical-eslint-plugin/src/util/buildMatcher.js
+++ b/packages/lexical-eslint-plugin/src/util/buildMatcher.js
@@ -47,7 +47,7 @@ module.exports.buildMatcher = function buildMatcher(...toMatchers) {
       regExpSources.push(/^[(^]/.test(arg) ? arg : `^${escapeRegExp(arg)}$`);
     } else if (arg && arg instanceof RegExp) {
       if (arg.flags) {
-        matchFuns.push((s) => arg.test(s));
+        matchFuns.push(s => arg.test(s));
       } else {
         regExpSources.push(arg.source);
       }
@@ -55,12 +55,12 @@ module.exports.buildMatcher = function buildMatcher(...toMatchers) {
       matchFuns.push(arg);
     }
   }
-  const pattern = regExpSources.map((s) => `(?:${s})`).join('|');
+  const pattern = regExpSources.map(s => `(?:${s})`).join('|');
   if (pattern) {
     const re = new RegExp(pattern);
-    matchFuns.push((s) => re.test(s));
+    matchFuns.push(s => re.test(s));
   }
-  return (node) => {
+  return node => {
     if (node) {
       if (node.type !== 'Identifier') {
         // Runtime type invariant check

--- a/packages/lexical-extension/src/AutoFocusExtension.ts
+++ b/packages/lexical-extension/src/AutoFocusExtension.ts
@@ -42,7 +42,7 @@ export const AutoFocusExtension = defineExtension({
     return effect(() =>
       stores.disabled.value
         ? undefined
-        : editor.registerRootListener((rootElement) => {
+        : editor.registerRootListener(rootElement => {
             editor.focus(
               () => {
                 // If we try and move selection to the same point with setBaseAndExtent, it won't

--- a/packages/lexical-extension/src/ClearEditorExtension.ts
+++ b/packages/lexical-extension/src/ClearEditorExtension.ts
@@ -46,7 +46,7 @@ export function registerClearEditor(
 ): () => void {
   return editor.registerCommand(
     CLEAR_EDITOR_COMMAND,
-    (payload) => {
+    payload => {
       editor.update($onClear);
       return true;
     },

--- a/packages/lexical-extension/src/DecoratorTextExtension.ts
+++ b/packages/lexical-extension/src/DecoratorTextExtension.ts
@@ -38,7 +38,7 @@ export type SerializedDecoratorTextNode = Spread<
 >;
 
 const formatState = createState('format', {
-  parse: (value) => (typeof value === 'number' ? value : 0),
+  parse: value => (typeof value === 'number' ? value : 0),
 });
 
 export class DecoratorTextNode extends DecoratorNode<unknown> {
@@ -198,7 +198,7 @@ export const DecoratorTextExtension = defineExtension({
   register(editor, config, state) {
     return editor.registerCommand<TextFormatType>(
       FORMAT_TEXT_COMMAND,
-      (formatType) => {
+      formatType => {
         const selection = $getSelection();
         if ($isNodeSelection(selection) || $isRangeSelection(selection)) {
           for (const node of selection.getNodes()) {

--- a/packages/lexical-extension/src/EditorStateExtension.ts
+++ b/packages/lexical-extension/src/EditorStateExtension.ts
@@ -16,8 +16,8 @@ export const EditorStateExtension = defineExtension({
   build(editor) {
     return watchedSignal(
       () => editor.getEditorState(),
-      (editorStateSignal) =>
-        editor.registerUpdateListener((payload) => {
+      editorStateSignal =>
+        editor.registerUpdateListener(payload => {
           editorStateSignal.value = payload.editorState;
         }),
     );

--- a/packages/lexical-extension/src/HorizontalRuleExtension.ts
+++ b/packages/lexical-extension/src/HorizontalRuleExtension.ts
@@ -154,7 +154,7 @@ export const HorizontalRuleExtension = defineExtension({
     return mergeRegister(
       editor.registerCommand(
         INSERT_HORIZONTAL_RULE_COMMAND,
-        (type) => {
+        type => {
           const selection = $getSelection();
 
           if (!$isRangeSelection(selection)) {

--- a/packages/lexical-extension/src/LexicalBuilder.ts
+++ b/packages/lexical-extension/src/LexicalBuilder.ts
@@ -184,7 +184,7 @@ export class LexicalBuilder {
         ...editorConfig,
         ...(onError
           ? {
-              onError: (err) => {
+              onError: err => {
                 onError(err, editor);
               },
             }

--- a/packages/lexical-extension/src/TabIndentationExtension.ts
+++ b/packages/lexical-extension/src/TabIndentationExtension.ts
@@ -41,7 +41,7 @@ function $indentOverTab(selection: RangeSelection): boolean {
   // const handled = new Set();
   const nodes = selection.getNodes();
   const canIndentBlockNodes = nodes.filter(
-    (node) => $isBlockElementNode(node) && node.canIndent(),
+    node => $isBlockElementNode(node) && node.canIndent(),
   );
   // 1. If selection spans across canIndent block nodes: indent
   if (canIndentBlockNodes.length > 0) {
@@ -83,7 +83,7 @@ export function registerTabIndentation(
   return mergeRegister(
     editor.registerCommand<KeyboardEvent>(
       KEY_TAB_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;
@@ -117,7 +117,7 @@ export function registerTabIndentation(
         const $currentCanIndent =
           typeof $canIndent === 'function' ? $canIndent : $canIndent.peek();
 
-        return $handleIndentAndOutdent((block) => {
+        return $handleIndentAndOutdent(block => {
           if ($currentCanIndent(block)) {
             const newIndent = block.getIndent() + 1;
             if (!currentMaxIndent || newIndent < currentMaxIndent) {

--- a/packages/lexical-extension/src/__tests__/unit/LexicalBuilder.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/LexicalBuilder.test.ts
@@ -48,7 +48,7 @@ describe('LexicalBuilder', () => {
     );
     const reps = builder.sortedExtensionReps();
     expect(reps.length).toBe(3);
-    const rep = reps.find((r) => r.extension === ConfigExtension);
+    const rep = reps.find(r => r.extension === ConfigExtension);
     assert(rep, 'ConfigExtension not found');
     expect(rep.extension).toBe(ConfigExtension);
     expect(rep.getState().config).toEqual({a: 1, b: null});
@@ -67,7 +67,7 @@ describe('LexicalBuilder', () => {
     );
     const reps = builder.sortedExtensionReps();
     expect(reps.length).toBe(4);
-    const rep = reps.find((r) => r.extension === ConfigExtension);
+    const rep = reps.find(r => r.extension === ConfigExtension);
     assert(rep, 'ConfigExtension not found');
     expect(rep.extension).toBe(ConfigExtension);
     expect(rep.getState().config).toEqual({a: 1, b: null});
@@ -86,7 +86,7 @@ describe('LexicalBuilder', () => {
     );
     const reps = builder.sortedExtensionReps();
     expect(reps.length).toBe(4);
-    const rep = reps.find((r) => r.extension === ConfigExtension);
+    const rep = reps.find(r => r.extension === ConfigExtension);
     assert(rep, 'ConfigExtension not found');
     expect(rep.extension).toBe(ConfigExtension);
     expect(rep.getState().config).toEqual({a: 1, b: null});
@@ -136,7 +136,7 @@ describe('LexicalBuilder', () => {
         expect(
           $getRoot()
             .getAllTextNodes()
-            .map((node) => ({[node.getType()]: node.getTextContent()})),
+            .map(node => ({[node.getType()]: node.getTextContent()})),
         ).toEqual([{'node-a': 'defer'}, {'node-b': 'direct'}]);
       });
     });
@@ -153,7 +153,7 @@ describe('LexicalBuilder', () => {
         buildEditorFromExtensions(ExtensionA, ConfigExtension),
       );
       const reps = builder.sortedExtensionReps();
-      expect(reps.map((rep) => rep.extension.name)).toEqual([
+      expect(reps.map(rep => rep.extension.name)).toEqual([
         InitialStateExtensionName,
         'Config',
         'A',
@@ -168,7 +168,7 @@ describe('LexicalBuilder', () => {
         buildEditorFromExtensions(ExtensionA, ConfigExtension),
       );
       const reps = builder.sortedExtensionReps();
-      expect(reps.map((rep) => rep.extension.name)).toEqual([
+      expect(reps.map(rep => rep.extension.name)).toEqual([
         InitialStateExtensionName,
         'Config',
         'A',

--- a/packages/lexical-file/src/fileImportExport.ts
+++ b/packages/lexical-file/src/fileImportExport.ts
@@ -67,7 +67,7 @@ export function editorStateFromSerializedDocument(
  * @param editor - The lexical editor.
  */
 export function importFile(editor: LexicalEditor) {
-  readTextFileFromSystem((text) => {
+  readTextFileFromSystem(text => {
     editor.setEditorState(editorStateFromSerializedDocument(editor, text));
     editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
   });
@@ -85,7 +85,7 @@ function readTextFileFromSystem(callback: (text: string) => void) {
       const reader = new FileReader();
       reader.readAsText(file, 'UTF-8');
 
-      reader.onload = (readerEvent) => {
+      reader.onload = readerEvent => {
         if (readerEvent.target) {
           const content = readerEvent.target.result;
           callback(content as string);

--- a/packages/lexical-hashtag/src/LexicalHashtagExtension.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagExtension.ts
@@ -276,7 +276,7 @@ export function registerLexicalHashtag(
       editor,
       config.getHashtagMatch,
       HashtagNode,
-      (textNode) => $createHashtagNode(textNode.getTextContent()),
+      textNode => $createHashtagNode(textNode.getTextContent()),
     ),
   );
 }

--- a/packages/lexical-hashtag/src/__tests__/unit/LexicalHashtagNode.test.ts
+++ b/packages/lexical-hashtag/src/__tests__/unit/LexicalHashtagNode.test.ts
@@ -11,7 +11,7 @@ import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 import {describe, expect, test} from 'vitest';
 
 describe('LexicalHashtagNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('HashtagNode.exportJSON() should return and object conforming to the expected schema', () => {
       const {editor} = testEnv;
       editor.update(() => {

--- a/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
+++ b/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
@@ -49,14 +49,14 @@ describe('LexicalHeadlessEditor', () => {
   ) {
     const nodesFromState = Array.from(editorState._nodeMap.values());
     expect(nodesFromState).toEqual(
-      nodes.map((node) => expect.objectContaining(node)),
+      nodes.map(node => expect.objectContaining(node)),
     );
   }
 
   beforeEach(() => {
     editor = createHeadlessEditor({
       namespace: '',
-      onError: (error) => {
+      onError: error => {
         throw error;
       },
     });

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -179,7 +179,7 @@ class ChildEditorNode extends DecoratorNode<null> {
 const ChildEditorExtension = defineExtension({
   name: '@lexical/test/ChildEditor',
   nodes: [ChildEditorNode],
-  register: (editor) =>
+  register: editor =>
     editor.registerMutationListener(
       ChildEditorNode,
       (nodes, {prevEditorState}) => {
@@ -255,7 +255,7 @@ describe('LexicalHistory tests', () => {
 
     editor.registerCommand<boolean>(
       CAN_REDO_COMMAND,
-      (payload) => {
+      payload => {
         canRedo = payload;
         return false;
       },
@@ -264,7 +264,7 @@ describe('LexicalHistory tests', () => {
 
     editor.registerCommand<boolean>(
       CAN_UNDO_COMMAND,
-      (payload) => {
+      payload => {
         canUndo = payload;
         return false;
       },
@@ -359,7 +359,7 @@ describe('LexicalHistory tests', () => {
 
     editor.registerCommand<boolean>(
       CAN_REDO_COMMAND,
-      (payload) => {
+      payload => {
         canRedo = payload;
         return false;
       },
@@ -368,7 +368,7 @@ describe('LexicalHistory tests', () => {
 
     editor.registerCommand<boolean>(
       CAN_UNDO_COMMAND,
-      (payload) => {
+      payload => {
         canUndo = payload;
         return false;
       },

--- a/packages/lexical-html/src/ContextRecord.ts
+++ b/packages/lexical-html/src/ContextRecord.ts
@@ -203,7 +203,7 @@ export function $withContext<Ctx extends AnyContextSymbol>(
     cfg: readonly AnyContextConfigPairOrUpdater<Ctx>[],
     editor = $getEditor(),
   ): (<T>(f: () => T) => T) => {
-    return (f) => {
+    return f => {
       const parentEditorContext = getEditorContext(editor);
       const parentContextRecord =
         parentEditorContext && parentEditorContext[sym];

--- a/packages/lexical-html/src/__tests__/unit/DOMRenderExtension.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/DOMRenderExtension.test.ts
@@ -33,7 +33,7 @@ import {expectHtmlToBeEqual, html} from 'lexical/src/__tests__/utils';
 import {describe, expect, test} from 'vitest';
 
 const idState = createState('id', {
-  parse: (v) => (typeof v === 'string' ? v : null),
+  parse: v => (typeof v === 'string' ? v : null),
 });
 
 describe('DOMRenderExtension', () => {
@@ -100,9 +100,7 @@ describe('DOMRenderExtension', () => {
       () =>
         $getRoot()
           .getAllTextNodes()
-          .forEach((node) =>
-            $setState(node, idState, (prev) => `${prev}-updated`),
-          ),
+          .forEach(node => $setState(node, idState, prev => `${prev}-updated`)),
       {discrete: true},
     );
     // Update works too
@@ -122,7 +120,7 @@ describe('DOMRenderExtension', () => {
       () =>
         $getRoot()
           .getAllTextNodes()
-          .forEach((node) => $setState(node, idState, null)),
+          .forEach(node => $setState(node, idState, null)),
       {discrete: true},
     );
     expect(
@@ -266,7 +264,7 @@ describe('DOMRenderExtension', () => {
       () =>
         $getRoot()
           .getAllTextNodes()
-          .forEach((node) => $setState(node, idState, 'updated')),
+          .forEach(node => $setState(node, idState, 'updated')),
       {discrete: true},
     );
     expect(calls).toHaveLength(2);

--- a/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
@@ -358,7 +358,7 @@ describe('HTML', () => {
             root
               .getAllTextNodes()
               .map(
-                (node) =>
+                node =>
                   [node.getTextContent(), node.hasFormat('bold')] as const,
               ),
           ).toEqual([['Hello world', false]]);

--- a/packages/lexical-html/src/compileDOMRenderConfigOverrides.ts
+++ b/packages/lexical-html/src/compileDOMRenderConfigOverrides.ts
@@ -244,7 +244,7 @@ function compilePrerenderKey<K extends keyof PreEditorDOMRenderConfig>(
       const [$predicate, $override] = pair;
       acc = mergeFunction(
         acc,
-        (node) => ($predicate(node) && $override) || undefined,
+        node => ($predicate(node) && $override) || undefined,
       );
     } else {
       const typeOverrides = pair[1];
@@ -258,7 +258,7 @@ function compilePrerenderKey<K extends keyof PreEditorDOMRenderConfig>(
           );
         }
       }
-      acc = mergeFunction(acc, (node) => {
+      acc = mergeFunction(acc, node => {
         const f = compiled[node.getType()];
         return f && ignoreNextFunction(f);
       });

--- a/packages/lexical-link/src/ClickableLinkExtension.ts
+++ b/packages/lexical-link/src/ClickableLinkExtension.ts
@@ -112,7 +112,7 @@ export function registerClickableLink(
     }
   };
 
-  return editor.registerRootListener((rootElement) => {
+  return editor.registerRootListener(rootElement => {
     if (rootElement) {
       rootElement.addEventListener('click', onClick, eventOptions);
       rootElement.addEventListener('mouseup', onMouseUp, eventOptions);

--- a/packages/lexical-link/src/LexicalAutoLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalAutoLinkExtension.ts
@@ -50,7 +50,7 @@ export type LinkMatcher = (text: string) => LinkMatcherResult | null;
 
 export function createLinkMatcherWithRegExp(
   regExp: RegExp,
-  urlTransformer: (text: string) => string = (text) => text,
+  urlTransformer: (text: string) => string = text => text,
 ) {
   return (text: string) => {
     const match = regExp.exec(text);
@@ -305,9 +305,7 @@ function $handleLinkCreation(
   }
 
   let currentNodes = [...nodes];
-  const initialText = currentNodes
-    .map((node) => node.getTextContent())
-    .join('');
+  const initialText = currentNodes.map(node => node.getTextContent()).join('');
   let text = initialText;
   let match;
   let invalidMatchEnd = 0;
@@ -503,7 +501,7 @@ function replaceWithChildren(node: ElementNode): Array<LexicalNode> {
   }
 
   node.remove();
-  return children.map((child) => child.getLatest());
+  return children.map(child => child.getLatest());
 }
 
 function getTextNodesToMatch(textNode: TextNode): TextNode[] {
@@ -567,7 +565,7 @@ export function registerAutoLink(
         handleLinkEdit(parent, matchers, onChange, separatorRegex);
       } else if (
         !$isLinkNode(parent) &&
-        !excludeParents.some((pred) => pred(parent))
+        !excludeParents.some(pred => pred(parent))
       ) {
         if (
           textNode.isSimpleText() &&
@@ -588,13 +586,13 @@ export function registerAutoLink(
     }),
     editor.registerCommand(
       TOGGLE_LINK_COMMAND,
-      (payload) => {
+      payload => {
         const selection = $getSelection();
         if (payload !== null || !$isRangeSelection(selection)) {
           return false;
         }
         const nodes = selection.extract();
-        nodes.forEach((node) => {
+        nodes.forEach(node => {
           const parent = node.getParent();
 
           if ($isAutoLinkNode(parent)) {

--- a/packages/lexical-link/src/LexicalLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalLinkExtension.ts
@@ -61,7 +61,7 @@ export function registerLink(
     editor.registerNodeTransform(LinkNode, $linkNodeTransform),
     editor.registerCommand(
       TOGGLE_LINK_COMMAND,
-      (payload) => {
+      payload => {
         const validateUrl = stores.validateUrl.peek();
         const attributes = stores.attributes.peek();
         if (payload === null) {
@@ -94,7 +94,7 @@ export function registerLink(
       const attributes = stores.attributes.value;
       return editor.registerCommand(
         PASTE_COMMAND,
-        (event) => {
+        event => {
           const selection = $getSelection();
           if (
             !$isRangeSelection(selection) ||
@@ -111,7 +111,7 @@ export function registerLink(
             return false;
           }
           // If we select nodes that are elements then avoid applying the link.
-          if (!selection.getNodes().some((node) => $isElementNode(node))) {
+          if (!selection.getNodes().some(node => $isElementNode(node))) {
             editor.dispatchCommand(TOGGLE_LINK_COMMAND, {
               ...attributes,
               url: clipboardText,

--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -683,9 +683,7 @@ function $splitLinkAtSelection(
   extractedNodes: LexicalNode[],
 ): void {
   const extractedKeys = new Set(
-    extractedNodes
-      .filter((n) => parentLink.isParentOf(n))
-      .map((n) => n.getKey()),
+    extractedNodes.filter(n => parentLink.isParentOf(n)).map(n => n.getKey()),
   );
 
   const allChildren = parentLink.getChildren();
@@ -695,13 +693,13 @@ function $splitLinkAtSelection(
     extractedKeys.has(child.getKey()) ||
     ($isElementNode(child) &&
       extractedNodes.some(
-        (n) => parentLink.isParentOf(n) && child.isParentOf(n),
+        n => parentLink.isParentOf(n) && child.isParentOf(n),
       ));
 
   const extractedChildren = allChildren.filter(isExtractedChild);
 
   if (extractedChildren.length === allChildren.length) {
-    allChildren.forEach((child) => parentLink.insertBefore(child));
+    allChildren.forEach(child => parentLink.insertBefore(child));
     parentLink.remove();
     return;
   }
@@ -713,7 +711,7 @@ function $splitLinkAtSelection(
   const isAtEnd = lastExtractedIndex === allChildren.length - 1;
 
   if (isAtStart) {
-    extractedChildren.forEach((child) => parentLink.insertBefore(child));
+    extractedChildren.forEach(child => parentLink.insertBefore(child));
   } else if (isAtEnd) {
     for (let i = extractedChildren.length - 1; i >= 0; i--) {
       parentLink.insertAfter(extractedChildren[i]);
@@ -728,7 +726,7 @@ function $splitLinkAtSelection(
       const newLink = $copyNode(parentLink);
 
       extractedChildren[extractedChildren.length - 1].insertAfter(newLink);
-      trailingChildren.forEach((child) => newLink.append(child));
+      trailingChildren.forEach(child => newLink.append(child));
     }
   }
 }
@@ -769,7 +767,7 @@ export function $toggleLink(
     }
 
     // Handle all selected nodes
-    nodes.forEach((node) => {
+    nodes.forEach(node => {
       if (url === null) {
         // Remove link
         const linkParent = $findMatchingParent(
@@ -816,7 +814,7 @@ export function $toggleLink(
           !$isAutoLinkNode(parent) && $isLinkNode(parent),
       );
       if (parentLink !== null) {
-        parentLink.getChildren().forEach((child) => {
+        parentLink.getChildren().forEach(child => {
           parentLink.insertBefore(child);
         });
         parentLink.remove();
@@ -831,7 +829,7 @@ export function $toggleLink(
   if (url === null) {
     const processedLinks = new Set<NodeKey>();
 
-    nodes.forEach((node) => {
+    nodes.forEach(node => {
       const parentLink = $findMatchingParent(
         node,
         (parent): parent is LinkNode =>

--- a/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts
@@ -42,7 +42,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalAutoAutoLinkNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('AutoLinkNode.constructor', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -61,7 +61,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalLinkNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('LinkNode.constructor', async () => {
       const {editor} = testEnv;
 
@@ -613,7 +613,7 @@ describe('LexicalLinkNode tests', () => {
           expect(linkNode.getURL()).toBe('https://example.com/foo');
           expect(linkNode.getRel()).toBe('noreferrer');
           expect(
-            linkNode.getChildren().map((node) => node.getTextContent()),
+            linkNode.getChildren().map(node => node.getTextContent()),
           ).toEqual(['text', '\n']);
           expect($getSelection()).toMatchObject({
             anchor: {
@@ -635,7 +635,7 @@ describe('LexicalLinkNode tests', () => {
       editor.read(() => {
         const paragraph = $getRoot().getFirstChild() as ParagraphNode;
         const children = paragraph.getChildren();
-        expect(children.map((node) => node.getTextContent())).toEqual([
+        expect(children.map(node => node.getTextContent())).toEqual([
           'some text',
           '\n',
         ]);
@@ -850,7 +850,7 @@ describe('LexicalLinkNode tests', () => {
 
         const children = p.getChildren();
         expect(children.length).toBe(3);
-        children.forEach((child) => expect($isTextNode(child)).toBe(true));
+        children.forEach(child => expect($isTextNode(child)).toBe(true));
       });
     });
   });

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -333,7 +333,7 @@ export class ListItemNode extends ElementNode {
     if (siblings.length !== 0) {
       const newListNode = $copyNode(listNode);
 
-      siblings.forEach((sibling) => newListNode.append(sibling));
+      siblings.forEach(sibling => newListNode.append(sibling));
 
       node.insertAfter(newListNode, restoreSelection);
     }
@@ -378,7 +378,7 @@ export class ListItemNode extends ElementNode {
   collapseAtStart(selection: RangeSelection): true {
     const paragraph = $createParagraphNode();
     const children = this.getChildren();
-    children.forEach((child) => paragraph.append(child));
+    children.forEach(child => paragraph.append(child));
     const listNode = this.getParentOrThrow();
     const listNodeParent = listNode.getParentOrThrow();
     const isIndented = $isListItemNode(listNodeParent);
@@ -570,7 +570,7 @@ function $setListItemThemeClassNames(
   if (nestedListItemClassName !== undefined) {
     const nestedListItemClasses = normalizeClassNames(nestedListItemClassName);
 
-    if (node.getChildren().some((child) => $isListNode(child))) {
+    if (node.getChildren().some(child => $isListNode(child))) {
       classesToAdd.push(...nestedListItemClasses);
     } else {
       classesToRemove.push(...nestedListItemClasses);

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -300,7 +300,7 @@ function $normalizeChildren(nodes: Array<LexicalNode>): Array<ListItemNode> {
       normalizedListItems.push(node);
       const children = node.getChildren();
       if (children.length > 1) {
-        children.forEach((child) => {
+        children.forEach(child => {
           if ($isListNode(child)) {
             normalizedListItems.push($wrapInListItem(child));
           }

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -54,7 +54,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalListItemNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('ListItemNode.constructor', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
@@ -52,7 +52,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalListNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('ListNode.constructor', async () => {
       const {editor} = testEnv;
 
@@ -478,7 +478,7 @@ describe('LexicalListNode subclassing tests ($config)', () => {
   function $getListItemValues() {
     return $getRoot()
       .getAllTextNodes()
-      .map((node) => {
+      .map(node => {
         const parent = node.getParent();
         return parent && $isListItemNode(parent) ? parent.getValue() : null;
       });
@@ -493,7 +493,7 @@ describe('LexicalListNode subclassing tests ($config)', () => {
   }
   describe('ListNode as-is', () =>
     initializeUnitTest(
-      (testEnv) => {
+      testEnv => {
         test('applies transform', () => {
           const {editor} = testEnv;
           editor.update(
@@ -512,7 +512,7 @@ describe('LexicalListNode subclassing tests ($config)', () => {
     ));
   describe('ListNodeConfig (no replacement)', () =>
     initializeUnitTest(
-      (testEnv) => {
+      testEnv => {
         test('applies transform', () => {
           const {editor} = testEnv;
           editor.update(
@@ -531,7 +531,7 @@ describe('LexicalListNode subclassing tests ($config)', () => {
     ));
   describe('ListNodeSubclass (no replacement)', () =>
     initializeUnitTest(
-      (testEnv) => {
+      testEnv => {
         test('applies transform', () => {
           const {editor} = testEnv;
           editor.update(

--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -80,7 +80,7 @@ const initOptions = {
 };
 
 describe('insertList', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('inserting with empty root selection', async () => {
       const {editor} = testEnv;
 
@@ -178,7 +178,7 @@ describe('insertList', () => {
 
       editor.read(() => {
         const lists = $nodesOfType(ListNode).filter(
-          (node) => node.getListType() === 'number',
+          node => node.getListType() === 'number',
         );
         expect(lists.length).toBe(2);
       });
@@ -231,7 +231,7 @@ describe('insertList', () => {
 });
 
 describe('$handleListInsertParagraph', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('exits list when list item is completely empty', async () => {
       const {editor} = testEnv;
       registerList(editor);
@@ -385,7 +385,7 @@ describe('$handleListInsertParagraph', () => {
 
 describe('$handleIndent', () => {
   initializeUnitTest(
-    (testEnv) => {
+    testEnv => {
       test('creates a new nested sublist', async () => {
         const {editor} = testEnv;
 
@@ -420,7 +420,7 @@ describe('$handleIndent', () => {
 });
 
 describe('$handleOutdent', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('removes the nested list and replaces list item', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
@@ -17,7 +17,7 @@ import {beforeEach, describe, test} from 'vitest';
 import {registerListStrictIndentTransform} from '../../index';
 
 describe('Lexical List StrictIndentTransform tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     beforeEach(() => {
       const {editor} = testEnv;
       registerListStrictIndentTransform(editor);

--- a/packages/lexical-list/src/__tests__/unit/utils.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/utils.test.ts
@@ -13,7 +13,7 @@ import {$createListItemNode, $createListNode} from '../..';
 import {$getListDepth, $getTopListNode, $isLastItemInList} from '../../utils';
 
 describe('Lexical List Utils tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('getListDepth should return the 1-based depth of a list with one levels', async () => {
       const editor = testEnv.editor;
 

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -122,14 +122,14 @@ export function registerCheckList(
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_DOWN_COMMAND,
-      (event) => {
+      event => {
         return handleArrowUpOrDown(event, editor, false);
       },
       COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_UP_COMMAND,
-      (event) => {
+      event => {
         return handleArrowUpOrDown(event, editor, true);
       },
       COMMAND_PRIORITY_LOW,
@@ -155,7 +155,7 @@ export function registerCheckList(
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_SPACE_COMMAND,
-      (event) => {
+      event => {
         const activeItem = getActiveCheckListItem();
 
         if (activeItem != null && editor.isEditable()) {
@@ -176,7 +176,7 @@ export function registerCheckList(
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_LEFT_COMMAND,
-      (event) => {
+      event => {
         return editor.getEditorState().read(() => {
           const selection = $getSelection();
 
@@ -188,7 +188,7 @@ export function registerCheckList(
               const anchorNode = anchor.getNode();
               const elementNode = $findMatchingParent(
                 anchorNode,
-                (node) => $isElementNode(node) && !node.isInline(),
+                node => $isElementNode(node) && !node.isInline(),
               );
               if ($isListItemNode(elementNode)) {
                 const parent = elementNode.getParent();
@@ -215,7 +215,7 @@ export function registerCheckList(
       COMMAND_PRIORITY_LOW,
     ),
 
-    editor.registerRootListener((rootElement) => {
+    editor.registerRootListener(rootElement => {
       if (rootElement !== null) {
         rootElement.addEventListener('click', configHandleClick);
         rootElement.addEventListener('pointerup', configHandlePointerUp);

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -482,7 +482,7 @@ export function $handleOutdent(listItemNode: ListItemNode): void {
       previousSiblingsListItem.append(previousSiblingsList);
       listItemNode
         .getPreviousSiblings()
-        .forEach((sibling) => previousSiblingsList.append(sibling));
+        .forEach(sibling => previousSiblingsList.append(sibling));
       const nextSiblingsListItem = $copyNode(listItemNode);
       const nextSiblingsList = $copyNode(parentList);
       nextSiblingsListItem.append(nextSiblingsList);
@@ -528,9 +528,7 @@ export function $handleListInsertParagraph(
       $isListItemNode(parentListItem) &&
       parentListItem
         .getChildren()
-        .every(
-          (node) => $isTextNode(node) && node.getTextContent().trim() === '',
-        )
+        .every(node => $isTextNode(node) && node.getTextContent().trim() === '')
     ) {
       listItem = parentListItem;
     }

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -95,7 +95,7 @@ export function registerList(
     ),
     editor.registerCommand(
       UPDATE_LIST_START_COMMAND,
-      (payload) => {
+      payload => {
         const {listNodeKey, newStart} = payload;
         const listNode = $getNodeByKey(listNodeKey);
         if (!$isListNode(listNode)) {
@@ -133,7 +133,7 @@ export function registerList(
       },
       COMMAND_PRIORITY_LOW,
     ),
-    editor.registerNodeTransform(ListItemNode, (node) => {
+    editor.registerNodeTransform(ListItemNode, node => {
       const firstChild = node.getFirstChild();
       if (firstChild) {
         if ($isTextNode(firstChild)) {
@@ -160,7 +160,7 @@ export function registerList(
         }
       }
     }),
-    editor.registerNodeTransform(TextNode, (node) => {
+    editor.registerNodeTransform(TextNode, node => {
       const listItemParentNode = node.getParent();
       if (
         $isListItemNode(listItemParentNode) &&
@@ -191,7 +191,7 @@ export function registerListStrictIndentTransform(
 
     const startingListItemNode = $findMatchingParent(
       listItemNode,
-      (node) =>
+      node =>
         $isListItemNode(node) &&
         $isListNode(node.getParent()) &&
         $isListItemNode(node.getPreviousSibling()),

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -151,7 +151,7 @@ export function isNestedListNode(
 export function $findNearestListItemNode(
   node: LexicalNode,
 ): ListItemNode | null {
-  const matchingParent = $findMatchingParent(node, (parent) =>
+  const matchingParent = $findMatchingParent(node, parent =>
     $isListItemNode(parent),
   );
   return matchingParent as ListItemNode | null;

--- a/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
+++ b/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
@@ -28,7 +28,7 @@ import {
 import {assert, beforeEach, describe, expect, test} from 'vitest';
 
 describe('LexicalMarkNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('$wrapSelectionInMarkNode', () => {
       beforeEach(() => {
         testEnv.editor.update(
@@ -90,13 +90,13 @@ describe('LexicalMarkNode tests', () => {
           expect(paragraphNode.getTextContent()).toEqual(
             'unmarked marked unmarked',
           );
-          expect(paragraphNode.getChildren().map((c) => c.getType())).toEqual([
+          expect(paragraphNode.getChildren().map(c => c.getType())).toEqual([
             'text',
             'mark',
             'text',
           ]);
           expect(
-            paragraphNode.getChildren().map((c) => c.getTextContent()),
+            paragraphNode.getChildren().map(c => c.getTextContent()),
           ).toEqual(['unmarked ', 'marked', ' unmarked']);
         });
       });
@@ -122,7 +122,7 @@ describe('LexicalMarkNode tests', () => {
           expect(paragraphNode.getChildren()).toHaveLength(1);
           const markNode = paragraphNode.getFirstChildOrThrow<MarkNode>();
           expect(markNode.getType()).toEqual('mark');
-          expect(markNode.getChildren().map((c) => c.getKey())).toEqual([
+          expect(markNode.getChildren().map(c => c.getKey())).toEqual([
             decoratorNode.getKey(),
             textNode.getKey(),
           ]);
@@ -153,7 +153,7 @@ describe('LexicalMarkNode tests', () => {
 
           $insertNodeIntoLeaf($createTestDecoratorNode());
 
-          expect(paragraphNode.getChildren().map((c) => c.getType())).toEqual([
+          expect(paragraphNode.getChildren().map(c => c.getType())).toEqual([
             'mark',
           ]);
           const updatedMarkNode = paragraphNode.getFirstChildOrThrow();
@@ -188,7 +188,7 @@ describe('LexicalMarkNode tests', () => {
           expect(paragraphNode.getChildren()).toHaveLength(1);
           const markNode = paragraphNode.getFirstChildOrThrow<MarkNode>();
           expect(markNode.getType()).toEqual('mark');
-          expect(markNode.getChildren().map((c) => c.getKey())).toEqual([
+          expect(markNode.getChildren().map(c => c.getKey())).toEqual([
             elementNode.getKey(),
             textNode.getKey(),
           ]);

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -39,7 +39,7 @@ export function createMarkdownExport(
   // Export only uses text formats that are responsible for single format
   // e.g. it will filter out *** (bold, italic) and instead use separate ** and *
   const textFormatTransformers = byType.textFormat
-    .filter((transformer) => transformer.format.length === 1)
+    .filter(transformer => transformer.format.length === 1)
     // Make sure all text transformers that contain 'code' in their format are at the end of the array. Otherwise, formatted code like
     // <strong><code>code</code></strong> will be exported as `**Bold Code**`, as the code format will be applied first, and the bold format
     // will be applied second and thus skipped entirely, as the code format will prevent any further formatting.
@@ -49,7 +49,7 @@ export function createMarkdownExport(
       );
     });
 
-  return (node) => {
+  return node => {
     const output = [];
     const children = (node || $getRoot()).getChildren();
 
@@ -92,7 +92,7 @@ function exportTopLevelElements(
     if (!transformer.export) {
       continue;
     }
-    const result = transformer.export(node, (_node) =>
+    const result = transformer.export(node, _node =>
       exportChildren(
         _node,
         textTransformersIndex,
@@ -150,7 +150,7 @@ function exportChildren(
 
       const result = transformer.export(
         child,
-        (parentNode) =>
+        parentNode =>
           exportChildren(
             parentNode,
             textTransformersIndex,
@@ -268,7 +268,7 @@ function exportTextFormat(
       // or the nodes before that (which would result in an unclosed tag)
       if (
         !checkHasFormat(prevNode, format) ||
-        !unclosedTags.find((element) => element.tag === tag)
+        !unclosedTags.find(element => element.tag === tag)
       ) {
         unclosedTags.push({format, tag});
         openingTags += tag;
@@ -296,7 +296,7 @@ function exportTextFormat(
       if (
         unclosableTags &&
         unclosedTag &&
-        unclosableTags.find((element) => element.tag === unclosedTag.tag)
+        unclosableTags.find(element => element.tag === unclosedTag.tag)
       ) {
         continue;
       }

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -318,7 +318,7 @@ function $normalizeMarkdownTextNode(textNode: TextNode): void {
 
   // Split node to isolate each tab then replace '\t' into TabNode
   const splitNodes = textNode.splitText(...tabOffsets);
-  splitNodes.forEach((node) => {
+  splitNodes.forEach(node => {
     if (node.getTextContent() === '\t') {
       node.replace($createTabNode());
     }

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -574,7 +574,7 @@ export function registerMarkdownShortcuts(
     ),
     editor.registerCommand(
       KEY_ENTER_COMMAND,
-      (event) => {
+      event => {
         if (event !== null && event.shiftKey) {
           return false;
         }

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -221,12 +221,12 @@ const ENDS_WITH = (regex: RegExp) =>
   new RegExp(`(?:${regex.source})$`, regex.flags);
 
 export const listMarkerState = createState('mdListMarker', {
-  parse: (v) => (typeof v === 'string' && /^[-*+]$/.test(v) ? v : '-'),
+  parse: v => (typeof v === 'string' && /^[-*+]$/.test(v) ? v : '-'),
   resetOnCopyNode: true,
 });
 
 export const codeFenceState = createState('mdCodeFence', {
-  parse: (val) => {
+  parse: val => {
     if (typeof val === 'string' && /^`{3,}$/.test(val)) {
       return val;
     }
@@ -373,7 +373,7 @@ export const HEADING: ElementTransformer = {
     return '#'.repeat(level) + ' ' + exportChildren(node);
   },
   regExp: HEADING_REGEX,
-  replace: createBlockNode((match) => {
+  replace: createBlockNode(match => {
     const tag = ('h' + match[1].length) as HeadingTagType;
     return $createHeadingNode(tag);
   }),
@@ -431,7 +431,7 @@ export const CODE: MultilineElementTransformer = {
     if (textContent.indexOf(fence) > -1) {
       const backticks = textContent.match(/`{3,}/g);
       if (backticks) {
-        const maxLength = Math.max(...backticks.map((b) => b.length));
+        const maxLength = Math.max(...backticks.map(b => b.length));
         fence = '`'.repeat(maxLength + 1);
       }
     }
@@ -569,7 +569,7 @@ export const CODE: MultilineElementTransformer = {
       codeBlockNode.append(textNode);
       rootNode.append(codeBlockNode);
     } else if (children) {
-      createBlockNode((match) => {
+      createBlockNode(match => {
         return $createCodeNode(match ? match[2] : undefined);
       })(rootNode, children, startMatch, isImport);
     }

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -105,7 +105,7 @@ const SIMPLE_INLINE_JSX_MATCHER: TextMatchTransformer = {
 // Matches html within a mdx file
 const MDX_HTML_TRANSFORMER: MultilineElementTransformer = {
   dependencies: [CodeNode],
-  export: (node) => {
+  export: node => {
     if (node.getTextContent().startsWith('From HTML:')) {
       return `<MyComponent>${node
         .getTextContent()

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
@@ -35,7 +35,7 @@ const MarkdownShortcutTestExtension = defineExtension({
     CodeExtension,
   ],
   name: 'MarkdownShortcutTest',
-  register: (editor_) => registerMarkdownShortcuts(editor_),
+  register: editor_ => registerMarkdownShortcuts(editor_),
 });
 
 function typeMarkdown(editor: LexicalEditor, text: string) {
@@ -61,7 +61,7 @@ describe('LINK', () => {
       const paragraph = $getRoot().getFirstChildOrThrow();
       assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
       const children = paragraph.getChildren();
-      expect(children.map((node) => node.getTextContent())).toEqual([
+      expect(children.map(node => node.getTextContent())).toEqual([
         'Start ',
         'test',
       ]);
@@ -78,7 +78,7 @@ describe('LINK', () => {
       assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
       const children = paragraph.getChildren();
 
-      expect(children.map((node) => node.getTextContent())).toEqual([
+      expect(children.map(node => node.getTextContent())).toEqual([
         'Bold',
         ' ',
         'Link',
@@ -112,7 +112,7 @@ describe('LINK', () => {
       assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
       const children = paragraph.getChildren();
 
-      expect(children.map((node) => node.getTextContent())).toEqual([
+      expect(children.map(node => node.getTextContent())).toEqual([
         '[a](https://a.example.com) ',
         'b',
       ]);
@@ -233,9 +233,9 @@ describe('CODE_SPAN_PRECEDENCE', () => {
       assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
       const textNodes = paragraph
         .getChildren()
-        .filter((node) => $isTextNode(node));
+        .filter(node => $isTextNode(node));
       const boldNode = textNodes.find(
-        (node) => $isTextNode(node) && node.hasFormat('bold'),
+        node => $isTextNode(node) && node.hasFormat('bold'),
       );
       expect(boldNode).toBeDefined();
       assert($isTextNode(boldNode!), 'Bold node must be a TextNode');

--- a/packages/lexical-markdown/src/importTextFormatTransformer.ts
+++ b/packages/lexical-markdown/src/importTextFormatTransformer.ts
@@ -130,8 +130,8 @@ function scanDelimiters(
   const delimiters: Delimiter[] = [];
   const delimiterChars = new Set(
     Object.keys(transformersIndex.transformersByTag)
-      .filter((tag) => tag[0] !== '`')
-      .map((tag) => tag[0]),
+      .filter(tag => tag[0] !== '`')
+      .map(tag => tag[0]),
   );
 
   const isEscaped = (index: number): boolean => {
@@ -144,7 +144,7 @@ function scanDelimiters(
 
   const isInExcludedRange = (index: number): boolean => {
     return excludeRanges.some(
-      (range) => index >= range.start && index < range.end,
+      range => index >= range.start && index < range.end,
     );
   };
 
@@ -235,7 +235,7 @@ function processEmphasis(
 
       const maxLen = Math.min(opener.length, closer.length);
       const matchedTag = Object.keys(transformersIndex.transformersByTag)
-        .filter((t) => t[0] === opener.char && t.length <= maxLen)
+        .filter(t => t[0] === opener.char && t.length <= maxLen)
         .sort((a, b) => b.length - a.length)[0];
 
       if (!matchedTag) {

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -432,7 +432,7 @@ export function transformersByType(transformers: Array<Transformer>): Readonly<{
   textFormat: Array<TextFormatTransformer>;
   textMatch: Array<TextMatchTransformer>;
 }> {
-  const byType = indexBy(transformers, (t) => t.type);
+  const byType = indexBy(transformers, t => t.type);
 
   return {
     element: (byType.element || []) as Array<ElementTransformer>,

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -121,7 +121,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
   const removeListener = mergeRegister(
     editor.registerCommand<boolean>(
       DELETE_CHARACTER_COMMAND,
-      (isBackward) => {
+      isBackward => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -135,7 +135,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<boolean>(
       DELETE_WORD_COMMAND,
-      (isBackward) => {
+      isBackward => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -149,7 +149,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<boolean>(
       DELETE_LINE_COMMAND,
-      (isBackward) => {
+      isBackward => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -163,7 +163,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<InputEvent | string>(
       CONTROLLED_TEXT_INSERTION_COMMAND,
-      (eventOrText) => {
+      eventOrText => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -206,7 +206,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<boolean>(
       INSERT_LINE_BREAK_COMMAND,
-      (selectStart) => {
+      selectStart => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -234,7 +234,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_LEFT_COMMAND,
-      (payload) => {
+      payload => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -256,7 +256,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_RIGHT_COMMAND,
-      (payload) => {
+      payload => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -278,7 +278,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_BACKSPACE_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -298,7 +298,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_DELETE_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -312,7 +312,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent | null>(
       KEY_ENTER_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -352,7 +352,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       COPY_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -366,7 +366,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       CUT_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -380,7 +380,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       PASTE_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -394,12 +394,12 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<DragEvent>(
       DROP_COMMAND,
-      (event) => $handlePlainTextDrop(event, editor),
+      event => $handlePlainTextDrop(event, editor),
       COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand<DragEvent>(
       DRAGSTART_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;

--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -538,7 +538,7 @@ test.describe.parallel('Auto Links', () => {
       // Edge Cases
       'http://foo.bar', // Minimal URL with uncommon TLD
       'https://foo.bar', // HTTPS minimal URL with uncommon TLD
-    ].forEach((testUrl) =>
+    ].forEach(testUrl =>
       test(testUrl, async ({page, isPlainText}) => {
         test.skip(isPlainText);
         await focusEditor(page);
@@ -579,7 +579,7 @@ test.describe.parallel('Auto Links', () => {
       'email@domain.name',
       'email@domain.co.uk',
       'firstname-lastname@domain.com',
-    ].forEach((testUrl) =>
+    ].forEach(testUrl =>
       test(testUrl, async ({page, isPlainText}) => {
         test.skip(isPlainText);
         await focusEditor(page);

--- a/packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs
@@ -19,7 +19,7 @@ test.describe('Auto scroll while typing', () => {
   async function addScroll(page, selector_) {
     await evaluate(
       page,
-      (selector) => {
+      selector => {
         const element = document.querySelector(selector);
         element.style.overflow = 'auto';
         element.style.maxHeight = '200px';
@@ -31,7 +31,7 @@ test.describe('Auto scroll while typing', () => {
   async function isCaretVisible(page, selector_) {
     return await evaluate(
       page,
-      (selector) => {
+      selector => {
         const selection = document.getSelection();
         const range = selection.getRangeAt(0);
         const element = document.createElement('span');
@@ -61,8 +61,8 @@ test.describe('Auto scroll while typing', () => {
       name: 'Can auto scroll if parent element is scrollable',
       selector: '.editor-container',
     },
-  ].forEach((testCase) => {
-    [true, false].forEach((isSoftLineBreak) => {
+  ].forEach(testCase => {
+    [true, false].forEach(isSoftLineBreak => {
       test(`${testCase.name}${
         isSoftLineBreak ? ' (soft line break)' : ''
       }`, async ({page, isPlainText, browserName}) => {

--- a/packages/lexical-playground/__tests__/e2e/DateTime.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/DateTime.spec.mjs
@@ -49,7 +49,7 @@ test.describe('DateTime', () => {
       undefined,
       {ignoreClasses: true, ignoreInlineStyles: true},
       // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
-      (actualHtml) =>
+      actualHtml =>
         actualHtml
           .replace(/(<div[^>]*>)(.*?)(<\/div>)/, '$1*$3')
           .replace(
@@ -101,7 +101,7 @@ test.describe('DateTime', () => {
       undefined,
       {ignoreClasses: true, ignoreInlineStyles: true},
       // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
-      (actualHtml) =>
+      actualHtml =>
         actualHtml
           .replace(/(<div[^>]*>)(.*?)(<\/div>)/, '$1*$3')
           .replace(
@@ -139,7 +139,7 @@ test.describe('DateTime', () => {
       undefined,
       {ignoreClasses: true, ignoreInlineStyles: true},
       // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
-      (actualHtml) =>
+      actualHtml =>
         actualHtml
           .replace(/(<div[^>]*>)(.*?)(<\/div>)/, '$1*$3')
           .replace(

--- a/packages/lexical-playground/__tests__/e2e/Extensions.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Extensions.spec.mjs
@@ -208,7 +208,7 @@ test.describe('Extensions', () => {
         3,
       );
 
-      await new Promise((resolve) => {
+      await new Promise(resolve => {
         setTimeout(() => {
           document.execCommand('insertText', false, 'and');
           resolve();

--- a/packages/lexical-playground/__tests__/e2e/File.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/File.spec.mjs
@@ -96,7 +96,7 @@ test.describe('File', () => {
       `,
     );
 
-    page.on('filechooser', (fileChooser) => {
+    page.on('filechooser', fileChooser => {
       fileChooser.setFiles([filePath]);
     });
     await click(page, '.action-button.import');

--- a/packages/lexical-playground/__tests__/e2e/HTML.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HTML.spec.mjs
@@ -92,7 +92,7 @@ test.describe('HTML', () => {
       undefined,
       {ignoreInlineStyles: true},
       // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
-      (actualHtml) =>
+      actualHtml =>
         actualHtml
           .replace(/data-gutter="[^"]*"/g, 'data-gutter="*"')
           .replace(/(<div[^>]*>)(.*?)(<\/div>)/, '$1*$3')
@@ -119,7 +119,7 @@ test.describe('HTML', () => {
       `,
       undefined,
       {ignoreInlineStyles: true},
-      (actualHtml) =>
+      actualHtml =>
         actualHtml
           .replace(/data-gutter="[^"]*"/g, 'data-gutter="*"')
           .replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, '$1\n  *\n$3'),
@@ -133,7 +133,7 @@ test.describe('HTML', () => {
       undefined,
       {ignoreInlineStyles: true},
       // Custom modification: replace the date text and data-lexical-datetime value with wildcards for matching
-      (actualHtml) =>
+      actualHtml =>
         actualHtml
           .replace(/data-gutter="[^"]*"/g, 'data-gutter="*"')
           .replace(/(<div[^>]*>)(.*?)(<\/div>)/g, '$1*$3')
@@ -165,7 +165,7 @@ test.describe('HTML', () => {
       `,
       undefined,
       {ignoreInlineStyles: true},
-      (actualHtml) =>
+      actualHtml =>
         actualHtml
           .replace(/data-gutter="[^"]*"/g, 'data-gutter="*"')
           .replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, '$1\n  *\n$3'),
@@ -229,7 +229,7 @@ test.describe('HTML', () => {
       `,
       undefined,
       {ignoreInlineStyles: true},
-      (actualHtml) =>
+      actualHtml =>
         actualHtml.replace(/data-gutter="[^"]*"/g, 'data-gutter="*"'),
     );
   });

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -605,7 +605,7 @@ test.describe('Images', () => {
       positionStart: 'start',
     });
 
-    const lexicalSelection = await evaluate(page, (editor) => {
+    const lexicalSelection = await evaluate(page, editor => {
       return window.lexicalEditor._editorState._selection;
     });
     expect(lexicalSelection.anchor).toBeTruthy();

--- a/packages/lexical-playground/__tests__/e2e/KeyboardShortcuts.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/KeyboardShortcuts.spec.mjs
@@ -49,47 +49,47 @@ import {
 
 const formatTestCases = [
   {
-    applyShortcut: (page) => applyNormalFormat(page),
+    applyShortcut: page => applyNormalFormat(page),
     canToggle: false,
     format: 'Normal',
   },
   {
-    applyShortcut: (page) => applyHeading(page, 1),
+    applyShortcut: page => applyHeading(page, 1),
     canToggle: false,
     format: 'Heading 1',
   },
   {
-    applyShortcut: (page) => applyHeading(page, 2),
+    applyShortcut: page => applyHeading(page, 2),
     canToggle: false,
     format: 'Heading 2',
   },
   {
-    applyShortcut: (page) => applyHeading(page, 3),
+    applyShortcut: page => applyHeading(page, 3),
     canToggle: false,
     format: 'Heading 3',
   },
   {
-    applyShortcut: (page) => toggleBulletList(page),
+    applyShortcut: page => toggleBulletList(page),
     canToggle: true,
     format: 'Bulleted List',
   },
   {
-    applyShortcut: (page) => toggleNumberedList(page),
+    applyShortcut: page => toggleNumberedList(page),
     canToggle: true,
     format: 'Numbered List',
   },
   {
-    applyShortcut: (page) => toggleChecklist(page),
+    applyShortcut: page => toggleChecklist(page),
     canToggle: true,
     format: 'Check List',
   },
   {
-    applyShortcut: (page) => applyQuoteBlock(page),
+    applyShortcut: page => applyQuoteBlock(page),
     canToggle: false,
     format: 'Quote',
   },
   {
-    applyShortcut: (page) => applyCodeBlock(page),
+    applyShortcut: page => applyCodeBlock(page),
     canToggle: false,
     format: 'Code Block',
   },
@@ -98,52 +98,52 @@ const formatTestCases = [
 const alignmentTestCases = [
   {
     alignment: 'Left Align',
-    applyShortcut: (page) => leftAlign(page),
+    applyShortcut: page => leftAlign(page),
   },
   {
     alignment: 'Center Align',
-    applyShortcut: (page) => centerAlign(page),
+    applyShortcut: page => centerAlign(page),
   },
   {
     alignment: 'Right Align',
-    applyShortcut: (page) => rightAlign(page),
+    applyShortcut: page => rightAlign(page),
   },
   {
     alignment: 'Justify Align',
-    applyShortcut: (page) => justifyAlign(page),
+    applyShortcut: page => justifyAlign(page),
   },
 ];
 
 const additionalStylesTestCases = [
   {
-    applyShortcut: (page) => toggleLowercase(page),
+    applyShortcut: page => toggleLowercase(page),
     style: 'Lowercase',
   },
   {
-    applyShortcut: (page) => toggleUppercase(page),
+    applyShortcut: page => toggleUppercase(page),
     style: 'Uppercase',
   },
   {
-    applyShortcut: (page) => toggleCapitalize(page),
+    applyShortcut: page => toggleCapitalize(page),
     style: 'Capitalize',
   },
   {
-    applyShortcut: (page) => toggleStrikethrough(page),
+    applyShortcut: page => toggleStrikethrough(page),
     style: 'Strikethrough',
   },
   {
-    applyShortcut: (page) => toggleSubscript(page),
+    applyShortcut: page => toggleSubscript(page),
     style: 'Subscript',
   },
   {
-    applyShortcut: (page) => toggleSuperscript(page),
+    applyShortcut: page => toggleSuperscript(page),
     style: 'Superscript',
   },
 ];
 
 const DEFAULT_FORMAT = 'Normal';
 
-const getSelectedFormat = async (page) => {
+const getSelectedFormat = async page => {
   return await textContent(
     page,
     '.toolbar-item.block-controls > .text.dropdown-button-text',
@@ -153,7 +153,7 @@ const getSelectedFormat = async (page) => {
 const isDropdownItemActive = async (page, dropdownItemIndex) => {
   return await evaluate(
     page,
-    async (_dropdownItemIndex) => {
+    async _dropdownItemIndex => {
       await document
         .querySelector(
           'button[aria-label="Formatting options for additional text styles"]',

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -650,7 +650,7 @@ test.describe.parallel('Markdown', () => {
     },
   ];
 
-  BASE_BLOCK_SHORTCUTS.forEach((testCase) => {
+  BASE_BLOCK_SHORTCUTS.forEach(testCase => {
     test(`can convert "${testCase.text}" shortcut`, async ({
       page,
       isCollab,
@@ -674,7 +674,7 @@ test.describe.parallel('Markdown', () => {
     });
   });
 
-  SIMPLE_TEXT_FORMAT_SHORTCUTS.forEach((testCase) => {
+  SIMPLE_TEXT_FORMAT_SHORTCUTS.forEach(testCase => {
     test(`can convert "${testCase.text}" shortcut`, async ({
       page,
       isCollab,
@@ -686,7 +686,7 @@ test.describe.parallel('Markdown', () => {
     });
   });
 
-  NESTED_TEXT_FORMAT_SHORTCUTS.forEach((testCase) => {
+  NESTED_TEXT_FORMAT_SHORTCUTS.forEach(testCase => {
     test(`can convert "${testCase.text}" shortcut`, async ({page}) => {
       await focusEditor(page);
       await page.keyboard.type(testCase.text);

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -88,10 +88,10 @@ test.describe.parallel('Selection', () => {
   }) => {
     // TODO(collab-v2): nested editors are not supported yet
     test.skip(isPlainText || IS_COLLAB_V2);
-    const hasSelection = async (parentSelector) =>
+    const hasSelection = async parentSelector =>
       await evaluate(
         page,
-        (_parentSelector) => {
+        _parentSelector => {
           return (
             document
               .querySelector(`${_parentSelector} > .tree-view-output pre`)
@@ -181,7 +181,7 @@ test.describe.parallel('Selection', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.type('Three');
 
-    const p = (text) =>
+    const p = text =>
       text
         ? html`
             <p class="PlaygroundEditorTheme__paragraph" dir="auto">
@@ -220,7 +220,7 @@ test.describe.parallel('Selection', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.type('Three');
 
-    const p = (text) =>
+    const p = text =>
       text
         ? html`
             <p class="PlaygroundEditorTheme__paragraph" dir="auto">
@@ -274,7 +274,7 @@ test.describe.parallel('Selection', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.type('Three');
 
-    const p = (text) =>
+    const p = text =>
       text
         ? html`
             <p class="PlaygroundEditorTheme__paragraph" dir="auto">
@@ -353,7 +353,7 @@ test.describe.parallel('Selection', () => {
     isPlainText,
   }) => {
     test.skip(isPlainText || !IS_MAC);
-    const modifyImageHTML = async (originalHtml) =>
+    const modifyImageHTML = async originalHtml =>
       await prettifyHTML(
         originalHtml
           .replace(
@@ -1739,7 +1739,7 @@ test.describe.parallel('Selection', () => {
         throw new Error('Expected selection to be no null');
       }
 
-      return new Promise((resolve) => {
+      return new Promise(resolve => {
         editor.update(
           () => {
             for (const node of editor._editorState._nodeMap) {

--- a/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
@@ -131,7 +131,7 @@ test.describe('Tab', () => {
     await page.keyboard.type('Foo');
     await page.keyboard.press('Tab');
 
-    page.on('pageerror', (error) => {
+    page.on('pageerror', error => {
       throw new Error(`Uncaught exception: ${error.message}`);
     });
 

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -84,7 +84,7 @@ async function fillTablePartiallyWithText(page) {
 }
 
 const WRAPPER = IS_TABLE_HORIZONTAL_SCROLL ? [0] : [];
-const nthTableSelector = (nth) =>
+const nthTableSelector = nth =>
   IS_TABLE_HORIZONTAL_SCROLL
     ? `div.PlaygroundEditorTheme__tableScrollableWrapper:nth-of-type(${nth}) > table`
     : `table:nth-of-type(${nth})`;
@@ -2006,7 +2006,7 @@ test.describe.parallel('Tables', () => {
         ignoreClasses: false,
         ignoreInlineStyles: false,
       },
-      (actualHtml) =>
+      actualHtml =>
         // flaky fix: +- 1px for the height assertion
         actualHtml.replace(
           '<tr style="height: 88px">',
@@ -6612,7 +6612,7 @@ test.describe.parallel('Tables', () => {
         ignoreClasses: false,
         ignoreInlineStyles: false,
       },
-      (actualHtml) =>
+      actualHtml =>
         // flaky fix: handle height differences in the assertion
         actualHtml.replace(
           /<tr style="height: \d+px">/,
@@ -7400,7 +7400,7 @@ test.describe.parallel('Tables', () => {
       return anchorMatches && focusMatches;
     };
 
-    const waitForTableSelectionCoordinates = async (expected) => {
+    const waitForTableSelectionCoordinates = async expected => {
       for (let i = 0; i < 20; i++) {
         const coords = await readTableSelectionCoordinates();
         if (matchesExpected(coords, expected)) {

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -112,7 +112,7 @@ test.describe('Toolbar', () => {
           ignoreClasses: true,
           ignoreInlineStyles: true,
         },
-        (actualHtml) =>
+        actualHtml =>
           // flaky fix: remove the extra <p dir="auto"><br /></p> that appears occasionally in CI runs
           actualHtml.replace(
             html`

--- a/packages/lexical-playground/__tests__/regression/5583-select-list-followed-by-element-node.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/5583-select-list-followed-by-element-node.spec.mjs
@@ -31,7 +31,7 @@ test.describe('Regression test #5251', () => {
     test.skip(isPlainText);
     await focusEditor(page);
 
-    page.on('console', (msg) => {
+    page.on('console', msg => {
       if (msg.type() === 'error') {
         if (
           msg.text().includes('error #68') ||

--- a/packages/lexical-playground/__tests__/unit/LayoutContainerNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/LayoutContainerNode.test.ts
@@ -23,7 +23,7 @@ import {LayoutItemNode} from '../../src/nodes/LayoutItemNode';
 
 describe('LayoutContainerNode HTML serialization', () => {
   initializeUnitTest(
-    (testEnv) => {
+    testEnv => {
       describe('exportDOM', () => {
         it('exports with inline grid-template-columns style', async () => {
           const {editor} = testEnv;
@@ -85,7 +85,7 @@ describe('LayoutContainerNode HTML serialization', () => {
             const root = $getRoot();
             const children = root.getChildren();
             const hasLayoutContainer = children.some(
-              (child) => child instanceof LayoutContainerNode,
+              child => child instanceof LayoutContainerNode,
             );
             expect(hasLayoutContainer).toBe(false);
           });

--- a/packages/lexical-playground/__tests__/unit/docSerialization.test.ts
+++ b/packages/lexical-playground/__tests__/unit/docSerialization.test.ts
@@ -20,7 +20,7 @@ import {describe, expect, it} from 'vitest';
 import {docFromHash, docToHash} from '../../src/utils/docSerialization';
 
 describe('docSerialization', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('docToHash/docFromHash round-trips', () => {
       it('with empty state', async () => {
         const {editor} = testEnv;

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -58,7 +58,7 @@ export function wrapTableHtml(
     ${expected
       .replace(/<table(\s[^>]*)?>/g, (match, rawAttrs = '') => {
         const attrs = [...rawAttrs.matchAll(/(\w+)=["']([^"']*)["']/g)].map(
-          (m) => [m[1], m[2]],
+          m => [m[1], m[2]],
         );
         const dirAttr = attrs.find(([k]) => k === 'dir');
         const divAttrs = [
@@ -152,7 +152,7 @@ export async function initialize({
 async function exposeLexicalEditor(page) {
   if (IS_COLLAB) {
     await Promise.all(
-      ['left', 'right'].map(async (name) => {
+      ['left', 'right'].map(async name => {
         const frameLocator = page.frameLocator(`[name="${name}"]`);
         await expect(
           frameLocator.locator('.action-button.connect'),
@@ -238,7 +238,7 @@ async function assertHTMLOnPageOrFrame(
   ignoreInlineStyles,
   ignoreDir,
   frameName,
-  actualHtmlModificationsCallback = (actualHtml) => actualHtml,
+  actualHtmlModificationsCallback = actualHtml => actualHtml,
 ) {
   const expected = await prettifyHTML(expectedHtml.replace(/\n/gm, ''), {
     ignoreClasses,
@@ -409,7 +409,7 @@ async function assertSelectionOnPageOrFrame(page, expected) {
   const selection = await page.evaluate(() => {
     const rootElement = document.querySelector('div[contenteditable="true"]');
 
-    const getPathFromNode = (node) => {
+    const getPathFromNode = node => {
       const path = [];
       if (node === rootElement) {
         return [];
@@ -640,7 +640,7 @@ export async function pasteFromClipboard(
 }
 
 export async function sleep(delay) {
-  await new Promise((resolve) => setTimeout(resolve, delay));
+  await new Promise(resolve => setTimeout(resolve, delay));
 }
 
 // Fair time for the browser to process a newly inserted image
@@ -795,7 +795,7 @@ export function getExpectedDateTimeHtml({selected = false, formats = []} = {}) {
       data-lexical-decorator="true">
       <div
         class="dateTimePill ${selected ? 'selected' : ''} ${formats
-          .map((f) => formatToClassname[f] || '')
+          .map(f => formatToClassname[f] || '')
           .join(' ')}">
         ${date.toDateString()}
       </div>
@@ -1198,8 +1198,8 @@ export async function pressInsertLinkButton(page) {
 export function createHumanReadableSelection(_overview, dto) {
   return {
     anchorOffset: dto.anchorOffset.value,
-    anchorPath: dto.anchorPath.map((p) => p.value),
+    anchorPath: dto.anchorPath.map(p => p.value),
     focusOffset: dto.focusOffset.value,
-    focusPath: dto.focusPath.map((p) => p.value),
+    focusPath: dto.focusPath.map(p => p.value),
   };
 }

--- a/packages/lexical-playground/esm/index.mjs
+++ b/packages/lexical-playground/esm/index.mjs
@@ -21,7 +21,7 @@ const initialConfig = {
   namespace: 'Vanilla JS Demo',
   // Register nodes specific for @lexical/rich-text
   nodes: [HeadingNode, QuoteNode],
-  onError: (error) => {
+  onError: error => {
     throw error;
   },
   theme: {

--- a/packages/lexical-playground/src/buildHTMLConfig.tsx
+++ b/packages/lexical-playground/src/buildHTMLConfig.tsx
@@ -44,14 +44,14 @@ function buildImportMap(): DOMConversionMap {
   // Wrap all TextNode importers with a function that also imports
   // the custom styles implemented by the playground
   for (const [tag, fn] of Object.entries(TextNode.importDOM() || {})) {
-    importMap[tag] = (importNode) => {
+    importMap[tag] = importNode => {
       const importer = fn(importNode);
       if (!importer) {
         return null;
       }
       return {
         ...importer,
-        conversion: (element) => {
+        conversion: element => {
           const output = importer.conversion(element);
           if (
             output === null ||
@@ -93,7 +93,7 @@ function buildExportMap(): DOMExportOutputMap {
           const after = output.after;
           return {
             ...output,
-            after: (generatedElement) => {
+            after: generatedElement => {
               if (after) {
                 generatedElement = after(generatedElement);
               }

--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -303,7 +303,7 @@ export class CommentStore {
 
     const unsubscribe = this._editor.registerCommand(
       TOGGLE_CONNECT_COMMAND,
-      (payload) => {
+      payload => {
         if (connect !== undefined && disconnect !== undefined) {
           const shouldConnect = payload;
 
@@ -348,7 +348,7 @@ export class CommentStore {
                 target === sharedCommentsArray
                   ? undefined
                   : parent instanceof YMap &&
-                    (this._comments.find((t) => t.id === parent.get('id')) as
+                    (this._comments.find(t => t.id === parent.get('id')) as
                       | Thread
                       | undefined);
 

--- a/packages/lexical-playground/src/context/SettingsContext.tsx
+++ b/packages/lexical-playground/src/context/SettingsContext.tsx
@@ -41,7 +41,7 @@ export const SettingsContext = ({
   const [settings, setSettings] = useState(INITIAL_SETTINGS);
 
   const setOption = useCallback((setting: SettingName, value: boolean) => {
-    setSettings((options) => ({
+    setSettings(options => ({
       ...options,
       [setting]: value,
     }));

--- a/packages/lexical-playground/src/context/ToolbarContext.tsx
+++ b/packages/lexical-playground/src/context/ToolbarContext.tsx
@@ -104,7 +104,7 @@ export const ToolbarContext = ({
 
   const updateToolbarState = useCallback(
     <Key extends ToolbarStateKey>(key: Key, value: ToolbarStateValue<Key>) => {
-      setToolbarState((prev) => ({
+      setToolbarState(prev => ({
         ...prev,
         [key]: value,
       }));

--- a/packages/lexical-playground/src/hooks/useReport.ts
+++ b/packages/lexical-playground/src/hooks/useReport.ts
@@ -51,7 +51,7 @@ export default function useReport(): (
   }, [cleanup]);
 
   return useCallback(
-    (content) => {
+    content => {
       // eslint-disable-next-line no-console
       console.log(content);
       const element = getElement();

--- a/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeComponent.tsx
+++ b/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeComponent.tsx
@@ -147,7 +147,7 @@ export default function DateTimeComponent({
   };
 
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    withDateTimeNode((node) => {
+    withDateTimeNode(node => {
       if (e.target.checked) {
         setIncludeTime(true);
       } else {
@@ -162,7 +162,7 @@ export default function DateTimeComponent({
   };
 
   const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    withDateTimeNode((node) => {
+    withDateTimeNode(node => {
       const time = e.target.value;
       if (!selected) {
         setTimeValue(time);
@@ -179,14 +179,14 @@ export default function DateTimeComponent({
   };
 
   const handleDaySelect = (date: Date | undefined) => {
-    withDateTimeNode((node) => {
+    withDateTimeNode(node => {
       if (!timeValue || !date) {
         setSelected(date);
         return;
       }
       const [hours, minutes] = timeValue
         .split(':')
-        .map((str) => parseInt(str, 10));
+        .map(str => parseInt(str, 10));
       const newDate = new Date(
         date.getFullYear(),
         date.getMonth(),

--- a/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeNode.tsx
+++ b/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeNode.tsx
@@ -69,7 +69,7 @@ function $convertDateTimeElement(
   if (dateTimeValue) {
     const node = $createDateTimeNode(new Date(Date.parse(dateTimeValue)));
     return {
-      after: (childLexicalNodes) => {
+      after: childLexicalNodes => {
         // exportDOM returns only one child text, so only the first node of the array is taken
         const firstChild = childLexicalNodes[0];
         if ($isTextNode(firstChild)) {
@@ -96,8 +96,8 @@ function $convertDateTimeElement(
 }
 
 const dateTimeState = createState('dateTime', {
-  parse: (v) => new Date(v as string),
-  unparse: (v) => v.toISOString(),
+  parse: v => new Date(v as string),
+  unparse: v => v.toISOString(),
 });
 
 export class DateTimeNode extends DecoratorTextNode {
@@ -105,7 +105,7 @@ export class DateTimeNode extends DecoratorTextNode {
     return this.config('datetime', {
       extends: DecoratorTextNode,
       importDOM: buildImportMap({
-        span: (domNode) =>
+        span: domNode =>
           domNode.getAttribute('data-lexical-datetime') !== null ||
           // GDocs Support
           (domNode.getAttribute('data-rich-links') !== null &&

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -76,7 +76,7 @@ export default function EquationComponent({
       return mergeRegister(
         editor.registerCommand(
           SELECTION_CHANGE_COMMAND,
-          (payload) => {
+          payload => {
             const activeElement = document.activeElement;
             const inputElem = inputRef.current;
             if (inputElem !== activeElement) {
@@ -88,7 +88,7 @@ export default function EquationComponent({
         ),
         editor.registerCommand(
           KEY_ESCAPE_COMMAND,
-          (payload) => {
+          payload => {
             const activeElement = document.activeElement;
             const inputElem = inputRef.current;
             if (inputElem === activeElement) {
@@ -127,7 +127,7 @@ export default function EquationComponent({
           ref={inputRef}
         />
       ) : (
-        <ErrorBoundary onError={(e) => editor._onError(e)} fallback={null}>
+        <ErrorBoundary onError={e => editor._onError(e)} fallback={null}>
           <KatexRenderer
             equation={equationValue}
             inline={inline}

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -205,7 +205,7 @@ export default function ExcalidrawComponent({
               className="image-edit-button"
               role="button"
               tabIndex={0}
-              onMouseDown={(event) => event.preventDefault()}
+              onMouseDown={event => event.preventDefault()}
               onClick={openModal}
             />
           )}

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -122,7 +122,7 @@ export default function ExcalidrawImage({
 
   return (
     <div
-      ref={(node) => {
+      ref={node => {
         if (node) {
           if (imageContainerRef) {
             imageContainerRef.current = node;

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -92,7 +92,7 @@ function useSuspenseImage(src: string): ImageStatus {
   if (cached && 'error' in cached && typeof cached.error === 'boolean') {
     return cached;
   } else if (!cached) {
-    cached = new Promise<ImageStatus>((resolve) => {
+    cached = new Promise<ImageStatus>(resolve => {
       const img = new Image();
       img.src = src;
       img.onload = () =>
@@ -102,7 +102,7 @@ function useSuspenseImage(src: string): ImageStatus {
           width: img.naturalWidth,
         });
       img.onerror = () => resolve({error: true});
-    }).then((rval) => {
+    }).then(rval => {
       imageCache.set(src, rval);
       return rval;
     });
@@ -376,7 +376,7 @@ export default function ImageComponent({
       ),
       editor.registerCommand(
         DRAGSTART_COMMAND,
-        (event) => {
+        event => {
           if (event.target === imageRef.current) {
             // TODO This is just a temporary workaround for FF to behave like other browsers.
             // Ideally, this handles drag & drop too (and all browsers).
@@ -407,7 +407,7 @@ export default function ImageComponent({
         $onEscape,
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerRootListener((rootElement) => {
+      editor.registerRootListener(rootElement => {
         if (rootElement) {
           rootElement.addEventListener('contextmenu', onRightClick);
           return () =>

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -249,9 +249,9 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
         priority: 0,
       }),
       figure: () => ({
-        conversion: (node) => {
+        conversion: node => {
           return {
-            after: (childNodes) => {
+            after: childNodes => {
               const imageNodes = childNodes.filter($isImageNode);
               const figcaption = node.querySelector('figcaption');
               if (figcaption) {

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -71,8 +71,8 @@ function PollOptionComponent({
           ref={checkboxRef}
           className="PollNode__optionCheckbox"
           type="checkbox"
-          onChange={(e) => {
-            withPollNode((node) => {
+          onChange={e => {
+            withPollNode(node => {
               node.toggleVote(option, username);
             });
           }}
@@ -91,13 +91,13 @@ function PollOptionComponent({
           className="PollNode__optionInput"
           type="text"
           value={text}
-          onChange={(e) => {
+          onChange={e => {
             const target = e.target;
             const value = target.value;
             const selectionStart = target.selectionStart;
             const selectionEnd = target.selectionEnd;
             withPollNode(
-              (node) => {
+              node => {
                 node.setOptionText(option, value);
               },
               () => {
@@ -117,7 +117,7 @@ function PollOptionComponent({
         )}
         aria-label="Remove"
         onClick={() => {
-          withPollNode((node) => {
+          withPollNode(node => {
             node.deleteOption(option);
           });
         }}
@@ -149,7 +149,7 @@ export default function PollComponent({
       }),
       editor.registerCommand<MouseEvent>(
         CLICK_COMMAND,
-        (payload) => {
+        payload => {
           const event = payload;
 
           if (event.target === ref.current) {
@@ -183,7 +183,7 @@ export default function PollComponent({
   };
 
   const addOption = () => {
-    withPollNode((node) => {
+    withPollNode(node => {
       node.addOption(createPollOption());
     });
   };

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -100,7 +100,7 @@ function parseOptions(json: unknown): Options {
 }
 
 const questionState = createState('question', {
-  parse: (v) => (typeof v === 'string' ? v : ''),
+  parse: v => (typeof v === 'string' ? v : ''),
 });
 const optionsState = createState('options', {
   isEqual: (a, b) =>
@@ -113,7 +113,7 @@ export class PollNode extends DecoratorNode<JSX.Element> {
     return this.config('poll', {
       extends: DecoratorNode,
       importDOM: buildImportMap({
-        span: (domNode) =>
+        span: domNode =>
           domNode.getAttribute('data-lexical-poll-question') !== null
             ? {
                 conversion: $convertPollElement,
@@ -142,11 +142,11 @@ export class PollNode extends DecoratorNode<JSX.Element> {
   }
 
   addOption(option: Option): this {
-    return this.setOptions((options) => [...options, option]);
+    return this.setOptions(options => [...options, option]);
   }
 
   deleteOption(option: Option): this {
-    return this.setOptions((prevOptions) => {
+    return this.setOptions(prevOptions => {
       const index = prevOptions.indexOf(option);
       if (index === -1) {
         return prevOptions;
@@ -158,7 +158,7 @@ export class PollNode extends DecoratorNode<JSX.Element> {
   }
 
   setOptionText(option: Option, text: string): this {
-    return this.setOptions((prevOptions) => {
+    return this.setOptions(prevOptions => {
       const clonedOption = cloneOption(option, text);
       const options = Array.from(prevOptions);
       const index = options.indexOf(option);
@@ -168,7 +168,7 @@ export class PollNode extends DecoratorNode<JSX.Element> {
   }
 
   toggleVote(option: Option, username: string): this {
-    return this.setOptions((prevOptions) => {
+    return this.setOptions(prevOptions => {
       const index = prevOptions.indexOf(option);
       if (index === -1) {
         return prevOptions;

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -82,7 +82,7 @@ export default function StickyComponent({
 
   useLayoutEffect(() => {
     const position = positioningRef.current;
-    const resizeObserver = new ResizeObserver((entries) => {
+    const resizeObserver = new ResizeObserver(entries => {
       for (let i = 0; i < entries.length; i++) {
         const entry = entries[i];
         const {target} = entry;
@@ -94,7 +94,7 @@ export default function StickyComponent({
       }
     });
 
-    const removeRootListener = editor.registerRootListener((nextRootElem) => {
+    const removeRootListener = editor.registerRootListener(nextRootElem => {
       if (nextRootElem !== null) {
         resizeObserver.observe(nextRootElem);
         return () => resizeObserver.unobserve(nextRootElem);
@@ -189,7 +189,7 @@ export default function StickyComponent({
     <div ref={stickyContainerRef} className="sticky-note-container">
       <div
         className={`sticky-note ${color}`}
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           const stickyContainer = stickyContainerRef.current;
           if (
             stickyContainer == null ||

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -219,7 +219,7 @@ export default function ActionsPlugin({
 
   useEffect(() => {
     if (mode !== 'wysiwyg') {
-      const unregister = editor.registerNodeTransform(RootNode, (rootNode) => {
+      const unregister = editor.registerNodeTransform(RootNode, rootNode => {
         let codeNode = rootNode.getChildren().find($isCodeNode);
         if (!codeNode) {
           codeNode = $createCodeNode(mode);
@@ -240,7 +240,7 @@ export default function ActionsPlugin({
     if (INITIAL_SETTINGS.isCollab) {
       return;
     }
-    docFromHash(window.location.hash).then((doc) => {
+    docFromHash(window.location.hash).then(doc => {
       if (doc && doc.source === 'Playground') {
         editor.setEditorState(editorStateFromSerializedDocument(editor, doc));
         editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
@@ -249,12 +249,12 @@ export default function ActionsPlugin({
   }, [editor]);
   useEffect(() => {
     return mergeRegister(
-      editor.registerEditableListener((editable) => {
+      editor.registerEditableListener(editable => {
         setIsEditable(editable);
       }),
       editor.registerCommand<boolean>(
         CONNECTED_COMMAND,
-        (payload) => {
+        payload => {
           const isConnected = payload;
           setConnected(isConnected);
           return false;
@@ -372,7 +372,7 @@ export default function ActionsPlugin({
         className="action-button clear"
         disabled={isEditorEmpty}
         onClick={() => {
-          showModal('Clear editor', (onClose) => (
+          showModal('Clear editor', onClose => (
             <ShowClearDialog editor={editor} onClose={onClose} />
           ));
         }}

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -179,11 +179,9 @@ export function AutoEmbedDialog({
       debounce((inputText: string) => {
         const urlMatch = URL_MATCHER.exec(inputText);
         if (embedConfig != null && inputText != null && urlMatch != null) {
-          Promise.resolve(embedConfig.parseUrl(inputText)).then(
-            (parseResult) => {
-              setEmbedResult(parseResult);
-            },
-          );
+          Promise.resolve(embedConfig.parseUrl(inputText)).then(parseResult => {
+            setEmbedResult(parseResult);
+          });
         } else if (embedResult != null) {
           setEmbedResult(null);
         }
@@ -207,7 +205,7 @@ export function AutoEmbedDialog({
           placeholder={embedConfig.exampleUrl}
           value={text}
           data-test-id={`${embedConfig.type}-embed-modal-url`}
-          onChange={(e) => {
+          onChange={e => {
             const {value} = e.target;
             setText(value);
             validateText(value);
@@ -230,7 +228,7 @@ export default function AutoEmbedPlugin(): JSX.Element {
   const [modal, showModal] = useModal();
 
   const openEmbedModal = (embedConfig: PlaygroundEmbedConfig) => {
-    showModal(`Embed ${embedConfig.contentName}`, (onClose) => (
+    showModal(`Embed ${embedConfig.contentName}`, onClose => (
       <AutoEmbedDialog embedConfig={embedConfig} onClose={onClose} />
     ));
   };

--- a/packages/lexical-playground/src/plugins/AutoLinkExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/AutoLinkExtension/index.ts
@@ -19,10 +19,10 @@ const EMAIL_REGEX =
 export const PlaygroundAutoLinkExtension = configExtension(AutoLinkExtension, {
   excludeParents: [$isCodeNode],
   matchers: [
-    createLinkMatcherWithRegExp(URL_REGEX, (text) => {
+    createLinkMatcherWithRegExp(URL_REGEX, text => {
       return text.startsWith('http') ? text : `https://${text}`;
     }),
-    createLinkMatcherWithRegExp(EMAIL_REGEX, (text) => {
+    createLinkMatcherWithRegExp(EMAIL_REGEX, text => {
       return `mailto:${text}`;
     }),
   ],

--- a/packages/lexical-playground/src/plugins/AutocompletePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompletePlugin/index.tsx
@@ -179,12 +179,12 @@ export default function AutocompletePlugin(): JSX.Element | null {
         $clearSuggestion();
         searchPromise = query(match);
         searchPromise.promise
-          .then((newSuggestion) => {
+          .then(newSuggestion => {
             if (searchPromise !== null) {
               updateAsyncSuggestion(searchPromise, newSuggestion);
             }
           })
-          .catch((e) => {
+          .catch(e => {
             if (e !== 'Dismissed') {
               console.error(e);
             }
@@ -288,7 +288,7 @@ class AutocompleteServer {
           ? String.fromCharCode(char0 + 32) + searchText.substring(1)
           : searchText;
         const match = this.DATABASE.find(
-          (dictionaryWord) =>
+          dictionaryWord =>
             dictionaryWord.startsWith(caseInsensitiveSearchText) ?? null,
         );
         if (match === undefined) {

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/formatCodeWithPrettier.ts
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/formatCodeWithPrettier.ts
@@ -27,7 +27,7 @@ type LanguagesType = keyof typeof PRETTIER_PARSER_MODULES;
 async function loadPrettierParserByLang(lang: string) {
   const dynamicImports = PRETTIER_PARSER_MODULES[lang as LanguagesType];
   const modules = await Promise.all(
-    dynamicImports.map((dynamicImport) => dynamicImport()),
+    dynamicImports.map(dynamicImport => dynamicImport()),
   );
   return modules;
 }
@@ -66,7 +66,7 @@ export async function formatCodeWithPrettier(content: string, lang: string) {
   const format = await loadPrettierFormat();
   const options = getPrettierOptions(lang);
   const prettierParsers = await loadPrettierParserByLang(lang);
-  options.plugins = prettierParsers.map((parser) => parser.default || parser);
+  options.plugins = prettierParsers.map(parser => parser.default || parser);
   if (lang === 'html') {
     content = content.replace(
       /(<[a-z][^>]*\bstyle\s*=\s*["'][^"']*white-space\s*:\s*pre[^"']*["'][^>]*>)/gi,

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
@@ -114,7 +114,7 @@ function CodeActionMenuContainer({
   useEffect(() => {
     return editor.registerMutationListener(
       CodeNode,
-      (mutations) => {
+      mutations => {
         editor.getEditorState().read(() => {
           for (const [key, type] of mutations) {
             switch (type) {

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/index.ts
@@ -113,12 +113,12 @@ export const CollapsibleExtension = defineExtension({
     CollapsibleTitleNode,
     CollapsibleContentNode,
   ],
-  register: (editor) =>
+  register: editor =>
     mergeRegister(
       // Structure enforcing transformers for each node type. In case nesting structure is not
       // "Container > Title + Content" it'll unwrap nodes and convert it back
       // to regular content.
-      editor.registerNodeTransform(CollapsibleContentNode, (node) => {
+      editor.registerNodeTransform(CollapsibleContentNode, node => {
         const parent = node.getParent();
         if (!$isCollapsibleContainerNode(parent)) {
           const children = node.getChildren();
@@ -129,7 +129,7 @@ export const CollapsibleExtension = defineExtension({
         }
       }),
 
-      editor.registerNodeTransform(CollapsibleTitleNode, (node) => {
+      editor.registerNodeTransform(CollapsibleTitleNode, node => {
         const parent = node.getParent();
         if (!$isCollapsibleContainerNode(parent)) {
           node.replace($createParagraphNode().append(...node.getChildren()));
@@ -137,7 +137,7 @@ export const CollapsibleExtension = defineExtension({
         }
       }),
 
-      editor.registerNodeTransform(CollapsibleContainerNode, (node) => {
+      editor.registerNodeTransform(CollapsibleContainerNode, node => {
         const children = node.getChildren();
         if (
           children.length !== 2 ||
@@ -191,7 +191,7 @@ export const CollapsibleExtension = defineExtension({
           if ($isRangeSelection(selection)) {
             const titleNode = $findMatchingParent(
               selection.anchor.getNode(),
-              (node) => $isCollapsibleTitleNode(node),
+              node => $isCollapsibleTitleNode(node),
             );
 
             if ($isCollapsibleTitleNode(titleNode)) {

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -505,7 +505,7 @@ function CommentsPanelListComment({
         <>
           <Button
             onClick={() => {
-              showModal('Delete Comment', (onClose) => (
+              showModal('Delete Comment', onClose => (
                 <ShowDeleteCommentOrThreadDialog
                   commentOrThread={comment}
                   deleteCommentOrThread={deleteComment}
@@ -572,7 +572,7 @@ function CommentsPanelList({
 
   return (
     <ul className="CommentPlugin_CommentsPanel_List" ref={listRef}>
-      {comments.map((commentOrThread) => {
+      {comments.map(commentOrThread => {
         const id = commentOrThread.id;
         if (commentOrThread.type === 'thread') {
           const handleClickThread = () => {
@@ -620,7 +620,7 @@ function CommentsPanelList({
                 {/* INTRODUCE DELETE THREAD HERE*/}
                 <Button
                   onClick={() => {
-                    showModal('Delete Thread', (onClose) => (
+                    showModal('Delete Thread', onClose => (
                       <ShowDeleteCommentOrThreadDialog
                         commentOrThread={commentOrThread}
                         deleteCommentOrThread={deleteCommentOrThread}
@@ -634,7 +634,7 @@ function CommentsPanelList({
                 {modal}
               </div>
               <ul className="CommentPlugin_CommentsPanel_List_Thread_Comments">
-                {commentOrThread.comments.map((comment) => (
+                {commentOrThread.comments.map(comment => (
                   <CommentsPanelListComment
                     key={comment.id}
                     comment={comment}
@@ -851,14 +851,14 @@ export default function CommentPlugin({
         (from: MarkNode, to: MarkNode) => {
           // Merge the IDs
           const ids = from.getIDs();
-          ids.forEach((id) => {
+          ids.forEach(id => {
             to.addID(id);
           });
         },
       ),
       editor.registerMutationListener(
         MarkNode,
-        (mutations) => {
+        mutations => {
           editor.getEditorState().read(() => {
             for (const [key, mutation] of mutations) {
               const node: null | MarkNode = $getNodeByKey(key);
@@ -922,7 +922,7 @@ export default function CommentPlugin({
             }
           }
           if (!hasActiveIds) {
-            setActiveIDs((_activeIds) =>
+            setActiveIDs(_activeIds =>
               _activeIds.length === 0 ? _activeIds : [],
             );
           }

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -129,7 +129,7 @@ export function getDynamicOptions(editor: LexicalEditor, queryString: string) {
 
     options.push(
       ...colOptions.map(
-        (columns) =>
+        columns =>
           new ComponentPickerOption(`${rows}x${columns} Table`, {
             icon: <i className="icon table" />,
             keywords: ['table'],
@@ -159,7 +159,7 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
         }),
     }),
     ...([1, 2, 3] as const).map(
-      (n) =>
+      n =>
         new ComponentPickerOption(`Heading ${n}`, {
           icon: <i className={`icon h${n}`} />,
           keywords: ['heading', 'header', `h${n}`],
@@ -176,7 +176,7 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
       icon: <i className="icon table" />,
       keywords: ['table', 'grid', 'spreadsheet', 'rows', 'columns'],
       onSelect: () =>
-        showModal('Insert Table', (onClose) => (
+        showModal('Insert Table', onClose => (
           <InsertTableDialog activeEditor={editor} onClose={onClose} />
         )),
     }),
@@ -250,12 +250,12 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
       icon: <i className="icon poll" />,
       keywords: ['poll', 'vote'],
       onSelect: () =>
-        showModal('Insert Poll', (onClose) => (
+        showModal('Insert Poll', onClose => (
           <InsertPollDialog activeEditor={editor} onClose={onClose} />
         )),
     }),
     ...EmbedConfigs.map(
-      (embedConfig) =>
+      embedConfig =>
         new ComponentPickerOption(`Embed ${embedConfig.contentName}`, {
           icon: embedConfig.icon,
           keywords: [...embedConfig.keywords, 'embed'],
@@ -305,7 +305,7 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
       icon: <i className="icon equation" />,
       keywords: ['equation', 'latex', 'math'],
       onSelect: () =>
-        showModal('Insert Equation', (onClose) => (
+        showModal('Insert Equation', onClose => (
           <InsertEquationDialog activeEditor={editor} onClose={onClose} />
         )),
     }),
@@ -322,7 +322,7 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
       icon: <i className="icon image" />,
       keywords: ['image', 'photo', 'picture', 'file'],
       onSelect: () =>
-        showModal('Insert Image', (onClose) => (
+        showModal('Insert Image', onClose => (
           <InsertImageDialog activeEditor={editor} onClose={onClose} />
         )),
     }),
@@ -336,12 +336,12 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
       icon: <i className="icon columns" />,
       keywords: ['columns', 'layout', 'grid'],
       onSelect: () =>
-        showModal('Insert Columns Layout', (onClose) => (
+        showModal('Insert Columns Layout', onClose => (
           <InsertLayoutDialog activeEditor={editor} onClose={onClose} />
         )),
     }),
     ...(['left', 'center', 'right', 'justify'] as const).map(
-      (alignment) =>
+      alignment =>
         new ComponentPickerOption(`Align ${alignment}`, {
           icon: <i className={`icon ${alignment}-align`} />,
           keywords: ['align', 'justify', alignment],
@@ -374,9 +374,9 @@ export default function ComponentPickerMenuPlugin(): JSX.Element {
     return [
       ...getDynamicOptions(editor, queryString),
       ...baseOptions.filter(
-        (option) =>
+        option =>
           regex.test(option.title) ||
-          option.keywords.some((keyword) => regex.test(keyword)),
+          option.keywords.some(keyword => regex.test(keyword)),
       ),
     ];
   }, [editor, queryString, showModal]);

--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -132,7 +132,7 @@ export default function ContextMenuPlugin(): JSX.Element {
             ancestorNodeWithRootAsParent?.remove();
           } else if ($isNodeSelection(selection)) {
             const selectedNodes = selection.getNodes();
-            selectedNodes.forEach((node) => {
+            selectedNodes.forEach(node => {
               if ($isDecoratorNode(node)) {
                 node.remove();
               }

--- a/packages/lexical-playground/src/plugins/DateTimeExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/DateTimeExtension/index.tsx
@@ -33,10 +33,10 @@ export const INSERT_DATETIME_COMMAND: LexicalCommand<CommandPayload> =
 export const DateTimeExtension = defineExtension({
   name: '@lexical/playground/DateTime',
   nodes: [DateTimeNode],
-  register: (editor) =>
+  register: editor =>
     editor.registerCommand<CommandPayload>(
       INSERT_DATETIME_COMMAND,
-      (payload) => {
+      payload => {
         const {dateTime} = payload;
         const dateTimeNode = $createDateTimeNode(dateTime);
 

--- a/packages/lexical-playground/src/plugins/DragDropPasteExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/DragDropPasteExtension/index.ts
@@ -22,14 +22,14 @@ const ACCEPTABLE_IMAGE_TYPES = [
 
 export const DragDropPasteExtension = defineExtension({
   name: '@lexical/playground/DragDropPaste',
-  register: (editor) =>
+  register: editor =>
     editor.registerCommand(
       DRAG_DROP_PASTE,
-      (files) => {
+      files => {
         (async () => {
           const filesResult = await mediaFileReader(
             files,
-            [ACCEPTABLE_IMAGE_TYPES].flatMap((x) => x),
+            [ACCEPTABLE_IMAGE_TYPES].flatMap(x => x),
           );
           for (const {file, result} of filesResult) {
             if (isMimeType(file, ACCEPTABLE_IMAGE_TYPES)) {

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -76,9 +76,9 @@ export default function DraggableBlockPlugin({
     return [
       ...getDynamicOptions(editor, queryString),
       ...baseOptions.filter(
-        (option) =>
+        option =>
           regex.test(option.title) ||
-          option.keywords.some((keyword) => regex.test(keyword)),
+          option.keywords.some(keyword => regex.test(keyword)),
       ),
     ];
   }, [editor, queryString, showModal]);
@@ -94,7 +94,7 @@ export default function DraggableBlockPlugin({
       return;
     }
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setHighlightedIndex((current) =>
+    setHighlightedIndex(current =>
       Math.min(current, Math.max(options.length - 1, 0)),
     );
   }, [isPickerOpen, options.length]);
@@ -168,12 +168,12 @@ export default function DraggableBlockPlugin({
       }
       if (event.key === 'ArrowDown') {
         event.preventDefault();
-        setHighlightedIndex((index) =>
+        setHighlightedIndex(index =>
           index + 1 >= options.length ? 0 : index + 1,
         );
       } else if (event.key === 'ArrowUp') {
         event.preventDefault();
-        setHighlightedIndex((index) =>
+        setHighlightedIndex(index =>
           index - 1 < 0 ? options.length - 1 : index - 1,
         );
       } else if (event.key === 'Enter') {
@@ -246,7 +246,7 @@ export default function DraggableBlockPlugin({
                 placeholder="Filter blocks..."
                 value={queryString}
                 ref={searchInputRef}
-                onChange={(event) => setQueryString(event.target.value)}
+                onChange={event => setQueryString(event.target.value)}
               />
               <ul>
                 {options.map((option, i: number) => (

--- a/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
@@ -58,7 +58,7 @@ export default function EmojiPickerPlugin() {
   const [emojis, setEmojis] = useState<Array<Emoji>>([]);
 
   useEffect(() => {
-    import('../../utils/emoji-list').then((file) => setEmojis(file.default));
+    import('../../utils/emoji-list').then(file => setEmojis(file.default));
   }, []);
 
   const emojiOptions = useMemo(

--- a/packages/lexical-playground/src/plugins/EmojisExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/EmojisExtension/index.ts
@@ -56,6 +56,6 @@ function $textNodeTransform(node: TextNode): void {
 
 export const EmojisExtension = defineExtension({
   name: '@lexical/playground/Emojis',
-  register: (editor) =>
+  register: editor =>
     editor.registerNodeTransform(TextNode, $textNodeTransform),
 });

--- a/packages/lexical-playground/src/plugins/EquationsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EquationsPlugin/index.tsx
@@ -68,7 +68,7 @@ export default function EquationsPlugin(): JSX.Element | null {
 
     return editor.registerCommand<CommandPayload>(
       INSERT_EQUATION_COMMAND,
-      (payload) => {
+      payload => {
         const {equation, inline} = payload;
         const equationNode = $createEquationNode(equation, inline);
 

--- a/packages/lexical-playground/src/plugins/FigmaExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/FigmaExtension/index.ts
@@ -23,10 +23,10 @@ export const INSERT_FIGMA_COMMAND: LexicalCommand<string> = createCommand(
 export const FigmaExtension = defineExtension({
   name: '@lexical/playground/Figma',
   nodes: [FigmaNode],
-  register: (editor) =>
+  register: editor =>
     editor.registerCommand<string>(
       INSERT_FIGMA_COMMAND,
-      (payload) => {
+      payload => {
         const figmaNode = $createFigmaNode(payload);
         $insertNodeToNearestRoot(figmaNode);
         return true;

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -291,7 +291,7 @@ function FloatingLinkEditor({
 
   return (
     <div
-      ref={(el) => {
+      ref={el => {
         editorRef.current = el;
         refs.setFloating(el);
       }}
@@ -307,10 +307,10 @@ function FloatingLinkEditor({
             ref={inputRef}
             className="link-input"
             value={editedLinkUrl}
-            onChange={(event) => {
+            onChange={event => {
               setEditedLinkUrl(event.target.value);
             }}
-            onKeyDown={(event) => {
+            onKeyDown={event => {
               monitorInputInteraction(event);
             }}
           />
@@ -347,7 +347,7 @@ function FloatingLinkEditor({
             role="button"
             tabIndex={0}
             onMouseDown={preventDefault}
-            onClick={(event) => {
+            onClick={event => {
               event.preventDefault();
               setEditedLinkUrl(linkUrl);
               setIsLinkEditMode(true);
@@ -393,8 +393,8 @@ function useFloatingLinkEditorToolbar(
         }
         const badNode = selection
           .getNodes()
-          .filter((node) => !$isLineBreakNode(node))
-          .find((node) => {
+          .filter(node => !$isLineBreakNode(node))
+          .find(node => {
             const linkNode = $findMatchingParent(node, $isLinkNode);
             const autoLinkNode = $findMatchingParent(node, $isAutoLinkNode);
             return (
@@ -443,7 +443,7 @@ function useFloatingLinkEditorToolbar(
       ),
       editor.registerCommand(
         CLICK_COMMAND,
-        (payload) => {
+        payload => {
           const selection = $getSelection();
           if ($isRangeSelection(selection)) {
             const node = getSelectedNode(selection);

--- a/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
@@ -217,11 +217,11 @@ export function InsertImageDialog({
 export const ImagesExtension = defineExtension({
   name: '@lexical/playground/Images',
   nodes: [ImageNode],
-  register: (editor) =>
+  register: editor =>
     mergeRegister(
       editor.registerCommand<InsertImagePayload>(
         INSERT_IMAGE_COMMAND,
-        (payload) => {
+        payload => {
           const imageNode = $createImageNode(payload);
           $insertNodes([imageNode]);
           if ($isRootOrShadowRoot(imageNode.getParentOrThrow())) {
@@ -234,17 +234,17 @@ export const ImagesExtension = defineExtension({
       ),
       editor.registerCommand<DragEvent>(
         DRAGSTART_COMMAND,
-        (event) => $onDragStart(event),
+        event => $onDragStart(event),
         COMMAND_PRIORITY_HIGH,
       ),
       editor.registerCommand<DragEvent>(
         DRAGOVER_COMMAND,
-        (event) => $onDragover(event),
+        event => $onDragover(event),
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand<DragEvent>(
         DROP_COMMAND,
-        (event) => $onDrop(event, editor),
+        event => $onDrop(event, editor),
         COMMAND_PRIORITY_HIGH,
       ),
     ),

--- a/packages/lexical-playground/src/plugins/LayoutPlugin/InsertLayoutDialog.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutPlugin/InsertLayoutDialog.tsx
@@ -32,7 +32,7 @@ export default function InsertLayoutDialog({
   onClose: () => void;
 }): JSX.Element {
   const [layout, setLayout] = useState(LAYOUTS[0].value);
-  const buttonLabel = LAYOUTS.find((item) => item.value === layout)?.label;
+  const buttonLabel = LAYOUTS.find(item => item.value === layout)?.label;
 
   const onClick = () => {
     activeEditor.dispatchCommand(INSERT_LAYOUT_COMMAND, layout);

--- a/packages/lexical-playground/src/plugins/LayoutPlugin/LayoutPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutPlugin/LayoutPlugin.tsx
@@ -147,7 +147,7 @@ export function LayoutPlugin(): null {
       ),
       editor.registerCommand(
         INSERT_LAYOUT_COMMAND,
-        (template) => {
+        template => {
           editor.update(() => {
             const container = $createLayoutContainerNode(template);
             const itemsCount = getItemsCountFromTemplate(template);
@@ -206,7 +206,7 @@ export function LayoutPlugin(): null {
         COMMAND_PRIORITY_EDITOR,
       ),
 
-      editor.registerNodeTransform(LayoutItemNode, (node) => {
+      editor.registerNodeTransform(LayoutItemNode, node => {
         // Structure enforcing transformers for each node type. In case nesting structure is not
         // "Container > Item" it'll unwrap nodes and convert it back
         // to regular content.
@@ -218,7 +218,7 @@ export function LayoutPlugin(): null {
           $fillLayoutItemIfEmpty(node);
         }
       }),
-      editor.registerNodeTransform(LayoutContainerNode, (node) => {
+      editor.registerNodeTransform(LayoutContainerNode, node => {
         const children = node.getChildren<LexicalNode>();
         if (!children.every($isLayoutItemNode)) {
           for (const child of children) {

--- a/packages/lexical-playground/src/plugins/MarkdownShortcutsExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownShortcutsExtension/index.ts
@@ -15,6 +15,6 @@ import {PLAYGROUND_TRANSFORMERS} from '../MarkdownTransformers';
 // should get a refactor to require less manual configuration
 export const PlaygroundMarkdownShortcutsExtension = defineExtension({
   name: '@lexical/playground/MarkdownShortcuts',
-  register: (editor) =>
+  register: editor =>
     registerMarkdownShortcuts(editor, PLAYGROUND_TRANSFORMERS),
 });

--- a/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
@@ -74,7 +74,7 @@ export const HR: ElementTransformer = {
 
 export const IMAGE: TextMatchTransformer = {
   dependencies: [ImageNode],
-  export: (node) => {
+  export: node => {
     if (!$isImageNode(node)) {
       return null;
     }
@@ -102,7 +102,7 @@ export const EMOJI: TextMatchTransformer = {
   importRegExp: /:([a-z0-9_]+):/,
   regExp: /:([a-z0-9_]+):$/,
   replace: (textNode, [, name]) => {
-    const emoji = emojiList.find((e) => e.aliases.includes(name))?.emoji;
+    const emoji = emojiList.find(e => e.aliases.includes(name))?.emoji;
     if (emoji) {
       textNode.replace($createTextNode(emoji));
     }
@@ -113,7 +113,7 @@ export const EMOJI: TextMatchTransformer = {
 
 export const EQUATION: TextMatchTransformer = {
   dependencies: [EquationNode],
-  export: (node) => {
+  export: node => {
     if (!$isEquationNode(node)) {
       return null;
     }
@@ -133,7 +133,7 @@ export const EQUATION: TextMatchTransformer = {
 
 export const TWEET: ElementTransformer = {
   dependencies: [TweetNode],
-  export: (node) => {
+  export: node => {
     if (!$isTweetNode(node)) {
       return null;
     }
@@ -185,7 +185,7 @@ export const TABLE: ElementTransformer = {
 
       output.push(`| ${rowOutput.join(' | ')} |`);
       if (isHeaderRow) {
-        output.push(`| ${rowOutput.map((_) => '---').join(' | ')} |`);
+        output.push(`| ${rowOutput.map(_ => '---').join(' | ')} |`);
       }
     }
 
@@ -207,7 +207,7 @@ export const TABLE: ElementTransformer = {
       }
 
       // Add header state to row cells
-      lastRow.getChildren().forEach((cell) => {
+      lastRow.getChildren().forEach(cell => {
         if (!$isTableCellNode(cell)) {
           return;
         }
@@ -304,7 +304,7 @@ const mapToTableCells = (textContent: string): Array<TableCellNode> | null => {
   if (!match || !match[1]) {
     return null;
   }
-  return match[1].split('|').map((text) => $createTableCell(text));
+  return match[1].split('|').map(text => $createTableCell(text));
 };
 
 export const PLAYGROUND_TRANSFORMERS: Array<Transformer> = [

--- a/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
@@ -494,7 +494,7 @@ const dummyMentionsData = [
 const dummyLookupService = {
   search(string: string, callback: (results: Array<string>) => void): void {
     setTimeout(() => {
-      const results = dummyMentionsData.filter((mention) =>
+      const results = dummyMentionsData.filter(mention =>
         mention.toLowerCase().includes(string.toLowerCase()),
       );
       callback(results);
@@ -522,7 +522,7 @@ function useMentionLookupService(mentionString: string | null) {
     }
 
     mentionsCache.set(mentionString, null);
-    dummyLookupService.search(mentionString, (newResults) => {
+    dummyLookupService.search(mentionString, newResults => {
       mentionsCache.set(mentionString, newResults);
       setResults(newResults);
     });
@@ -592,7 +592,7 @@ export default function NewMentionsPlugin(): JSX.Element | null {
     () =>
       results
         .map(
-          (result) =>
+          result =>
             new MentionTypeaheadOption(result, <i className="icon user" />),
         )
         .slice(0, SUGGESTION_LIST_LENGTH_LIMIT),

--- a/packages/lexical-playground/src/plugins/PageBreakExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/PageBreakExtension/index.ts
@@ -23,7 +23,7 @@ export const INSERT_PAGE_BREAK: LexicalCommand<undefined> = createCommand();
 export const PageBreakExtension = defineExtension({
   name: '@lexical/playground/PageBreak',
   nodes: [PageBreakNode],
-  register: (editor) =>
+  register: editor =>
     editor.registerCommand(
       INSERT_PAGE_BREAK,
       () => {

--- a/packages/lexical-playground/src/plugins/PageBreakExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/PageBreakExtension/index.tsx
@@ -25,7 +25,7 @@ export const PageBreakExtension = defineExtension({
   dependencies: [ReactExtension],
   name: '@lexical/playground/PageBreak',
   nodes: () => [PageBreakNode],
-  register: (editor) =>
+  register: editor =>
     editor.registerCommand(
       INSERT_PAGE_BREAK,
       () => {

--- a/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
@@ -47,11 +47,11 @@ export interface PagesConfig {
 }
 
 export const PagesExtension = defineExtension({
-  build: (editor) => {
+  build: editor => {
     const getPageSetup = () => editor.getEditorState().read($getPageSetup);
 
     return {
-      pageSetup: watchedSignal(getPageSetup, (pageSetupSignal) =>
+      pageSetup: watchedSignal(getPageSetup, pageSetupSignal =>
         editor.registerMutationListener(RootNode, () => {
           pageSetupSignal.value = getPageSetup();
         }),
@@ -65,7 +65,7 @@ export const PagesExtension = defineExtension({
   dependencies: [PageBreakExtension],
   name: '@lexical/playground/Pages',
   nodes: () => [PageNode, PageContentNode],
-  register: (editor) => {
+  register: editor => {
     let rafId: number | null = null;
     let previousPageKey: NodeKey | null = null;
     const fixedPageHeights = new Map<NodeKey, number>();
@@ -164,7 +164,7 @@ export const PagesExtension = defineExtension({
       const children = contentNode.getChildren();
       const childNodes = Array.from(contentElement.childNodes);
       if (children.length !== childNodes.length) {
-        childNodes.forEach((childNode) => childNode.remove());
+        childNodes.forEach(childNode => childNode.remove());
         contentNode.reconcileObservedMutation(contentElement, editor);
         return $getOverflowingChildren(node);
       }
@@ -222,7 +222,7 @@ export const PagesExtension = defineExtension({
         const nextContent = nextSibling.getContentNode();
         const nextPageFirstChild = nextContent.getFirstChild();
         if (!nextPageFirstChild) return;
-        overflowingChildren.forEach((child) => {
+        overflowingChildren.forEach(child => {
           nextPageFirstChild.insertBefore(child);
         });
       } else {
@@ -441,7 +441,7 @@ export const PagesExtension = defineExtension({
           for (const child of children) {
             if ($isPageNode(child)) {
               const contentNode = child.getContentNode();
-              contentNode.getChildren().forEach((c) => {
+              contentNode.getChildren().forEach(c => {
                 child.insertBefore(c);
               });
               child.remove();
@@ -452,7 +452,7 @@ export const PagesExtension = defineExtension({
       );
     };
 
-    return editor.registerRootListener((rootElement) => {
+    return editor.registerRootListener(rootElement => {
       if (!rootElement) {
         return;
       }
@@ -461,7 +461,7 @@ export const PagesExtension = defineExtension({
 
         // Watches the focused page's content element for size changes
         // and marks the affected page (and its predecessor) for re-measurement.
-        const pageObserver = new ResizeObserver((entries) => {
+        const pageObserver = new ResizeObserver(entries => {
           const pageContent = entries[0].target as HTMLElement;
           editor.read(() => {
             const pageContentNode = $getNearestNodeFromDOMNode(pageContent);
@@ -491,10 +491,10 @@ export const PagesExtension = defineExtension({
           const isInvalid =
             !children.some($isPageNode) ||
             children.some(
-              (child) => !$isPageNode(child) && !$isPageBreakNode(child),
+              child => !$isPageNode(child) && !$isPageBreakNode(child),
             ) ||
             children.some(
-              (child) =>
+              child =>
                 $isPageNode(child) &&
                 child.getContentNode().getChildren().some($isPageBreakNode),
             );
@@ -536,7 +536,7 @@ export const PagesExtension = defineExtension({
         // schedule measurement to fix overflow/underflow before next paint.
         const removePageTransform = editor.registerNodeTransform(
           PageNode,
-          (pageNode) => {
+          pageNode => {
             $ensurePageNodeChildren(pageNode);
             if (isMarkedForMeasurement(pageNode)) return;
             markForMeasurement(pageNode);
@@ -553,7 +553,7 @@ export const PagesExtension = defineExtension({
         // re-measurement so overflow/underflow is corrected.
         const removePageContentTransform = editor.registerNodeTransform(
           PageContentNode,
-          (node) => {
+          node => {
             const pageNode = node.getPageNode();
             if (isMarkedForMeasurement(pageNode)) return;
             markForMeasurement(pageNode);

--- a/packages/lexical-playground/src/plugins/PagesExtension/pageSetup.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/pageSetup.ts
@@ -61,7 +61,7 @@ export const pageSetupState = createState('pageSetup', {
       a.orientation === b.orientation &&
       a.pageSize === b.pageSize &&
       (a.margins === b.margins || marginsIsEqual(a.margins, b.margins))),
-  parse: (v) => {
+  parse: v => {
     if (v && typeof v === 'object' && !Array.isArray(v)) {
       const obj: {[k in string]?: unknown} = v;
       return {

--- a/packages/lexical-playground/src/plugins/PagesReactExtension/PageSetupDropdown.tsx
+++ b/packages/lexical-playground/src/plugins/PagesReactExtension/PageSetupDropdown.tsx
@@ -86,7 +86,7 @@ export function PageSetupDropdownComponent({
     (v: null | Partial<PageSetup>) => {
       editor.update(() => {
         $setPageSetup(
-          v ? (prev) => ({...(prev || DEFAULT_PAGE_SETUP), ...v}) : v,
+          v ? prev => ({...(prev || DEFAULT_PAGE_SETUP), ...v}) : v,
         );
       });
     },
@@ -101,9 +101,9 @@ export function PageSetupDropdownComponent({
       buttonAriaLabel="Page setup: size, orientation, and layout">
       <DropDownItem
         className={`item wide dropdown-submenu-trigger ${pageSizeMenuOpen ? 'expanded' : ''}`}
-        onClick={(event) => {
+        onClick={event => {
           event.stopPropagation();
-          setPageSizeMenuOpen((open) => !open);
+          setPageSizeMenuOpen(open => !open);
         }}>
         <span className="text">Page size</span>
         <i className="chevron-down dropdown-submenu-chevron" />
@@ -112,19 +112,19 @@ export function PageSetupDropdownComponent({
         <>
           <DropDownItem
             className={`item wide dropdown-submenu-item ${dropDownActiveClass(pageSetup === null)}`}
-            onClick={(event) => {
+            onClick={event => {
               event.stopPropagation();
               applyUpdate(null);
             }}>
             <span className="text">Pageless</span>
           </DropDownItem>
-          {PAGE_SIZE_ORDER.map((size) => (
+          {PAGE_SIZE_ORDER.map(size => (
             <DropDownItem
               key={size}
               className={`item wide dropdown-submenu-item ${dropDownActiveClass(
                 pageSetup?.pageSize === size,
               )}`}
-              onClick={(event) => {
+              onClick={event => {
                 event.stopPropagation();
                 applyUpdate({pageSize: size});
               }}>
@@ -137,9 +137,9 @@ export function PageSetupDropdownComponent({
         className={`item wide dropdown-submenu-trigger ${
           orientationMenuOpen ? 'expanded' : ''
         }`}
-        onClick={(event) => {
+        onClick={event => {
           event.stopPropagation();
-          setOrientationMenuOpen((open) => !open);
+          setOrientationMenuOpen(open => !open);
         }}>
         <span className="text">Orientation</span>
         <i className="chevron-down dropdown-submenu-chevron" />
@@ -150,7 +150,7 @@ export function PageSetupDropdownComponent({
             className={`item wide dropdown-submenu-item ${dropDownActiveClass(
               pageSetup?.orientation === 'portrait',
             )}`}
-            onClick={(event) => {
+            onClick={event => {
               event.stopPropagation();
               applyUpdate({orientation: 'portrait'});
             }}>
@@ -160,7 +160,7 @@ export function PageSetupDropdownComponent({
             className={`item wide dropdown-submenu-item ${dropDownActiveClass(
               pageSetup?.orientation === 'landscape',
             )}`}
-            onClick={(event) => {
+            onClick={event => {
               event.stopPropagation();
               applyUpdate({orientation: 'landscape'});
             }}>
@@ -172,16 +172,16 @@ export function PageSetupDropdownComponent({
         className={`item wide dropdown-submenu-trigger ${
           marginsMenuOpen ? 'expanded' : ''
         }`}
-        onClick={(event) => {
+        onClick={event => {
           event.stopPropagation();
-          setMarginsMenuOpen((open) => !open);
+          setMarginsMenuOpen(open => !open);
         }}
         title="Page margins (all sides)">
         <span className="text">Margins</span>
         <i className="chevron-down dropdown-submenu-chevron" />
       </DropDownItem>
       {marginsMenuOpen
-        ? MARGIN_PRESETS.map((preset) => (
+        ? MARGIN_PRESETS.map(preset => (
             <DropDownItem
               key={preset.label}
               className={`item wide dropdown-submenu-item ${dropDownActiveClass(
@@ -190,7 +190,7 @@ export function PageSetupDropdownComponent({
                   preset.margins,
                 ),
               )}`}
-              onClick={(event) => {
+              onClick={event => {
                 event.stopPropagation();
                 applyUpdate({margins: preset.margins});
               }}>

--- a/packages/lexical-playground/src/plugins/PasteLogPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/PasteLogPlugin/index.tsx
@@ -27,7 +27,7 @@ export default function PasteLogPlugin(): JSX.Element {
           const {clipboardData} = e;
           const allData: string[] = [];
           if (clipboardData && clipboardData.types) {
-            clipboardData.types.forEach((type) => {
+            clipboardData.types.forEach(type => {
               allData.push(type.toUpperCase(), clipboardData.getData(type));
             });
           }

--- a/packages/lexical-playground/src/plugins/PollPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/PollPlugin/index.tsx
@@ -70,7 +70,7 @@ export default function PollPlugin(): JSX.Element | null {
 
     return editor.registerCommand<string>(
       INSERT_POLL_COMMAND,
-      (payload) => {
+      payload => {
         const pollNode = $createPollNode(payload, [
           createPollOption(),
           createPollOption(),

--- a/packages/lexical-playground/src/plugins/TabFocusExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/TabFocusExtension/index.ts
@@ -35,7 +35,7 @@ function registerKeyTimeStampTracker() {
 
 export const TabFocusExtension = defineExtension({
   name: '@lexical/playground/TabFocus',
-  register: (editor) => {
+  register: editor => {
     if (!hasRegisteredKeyDownListener) {
       registerKeyTimeStampTracker();
       hasRegisteredKeyDownListener = true;

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -137,7 +137,7 @@ function TableActionMenu({
   useEffect(() => {
     return editor.registerMutationListener(
       TableCellNode,
-      (nodeMutations) => {
+      nodeMutations => {
         const nodeUpdated =
           nodeMutations.get(tableCellNode.getKey()) === 'updated';
 
@@ -504,7 +504,7 @@ function TableActionMenu({
     <div
       className="dropdown"
       ref={dropDownRef}
-      onClick={(e) => {
+      onClick={e => {
         e.stopPropagation();
       }}>
       {mergeCellButton}
@@ -898,7 +898,7 @@ function TableCellActionMenuContainer({
           <button
             type="button"
             className="table-cell-action-button chevron-down"
-            onClick={(e) => {
+            onClick={e => {
               e.stopPropagation();
               setIsMenuOpen(!isMenuOpen);
             }}

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -81,7 +81,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
   useEffect(() => {
     const tableKeys = new Set<NodeKey>();
     return mergeRegister(
-      editor.registerMutationListener(TableNode, (nodeMutations) => {
+      editor.registerMutationListener(TableNode, nodeMutations => {
         for (const [nodeKey, mutation] of nodeMutations) {
           if (mutation === 'destroyed') {
             tableKeys.delete(nodeKey);
@@ -91,7 +91,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
         }
         setHasTable(tableKeys.size > 0);
       }),
-      editor.registerNodeTransform(TableNode, (tableNode) => {
+      editor.registerNodeTransform(TableNode, tableNode => {
         if (tableNode.getColWidths()) {
           return tableNode;
         }
@@ -176,7 +176,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
       capture: true,
     });
 
-    const removeRootListener = editor.registerRootListener((rootElement) => {
+    const removeRootListener = editor.registerRootListener(rootElement => {
       if (rootElement) {
         rootElement.addEventListener('pointermove', onPointerMove);
         rootElement.addEventListener('pointerdown', onPointerDown);
@@ -243,7 +243,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
             height = Math.min(
               ...rowCells.map(
                 // eslint-disable-next-line react-hooks/immutability
-                (cell) => getCellNodeHeight(cell, editor) ?? Infinity,
+                cell => getCellNodeHeight(cell, editor) ?? Infinity,
               ),
             );
           }
@@ -359,7 +359,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
     (
       direction: PointerDraggingDirection,
     ): PointerEventHandler<HTMLDivElement> =>
-      (event) => {
+      event => {
         event.preventDefault();
         event.stopPropagation();
 

--- a/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
@@ -57,7 +57,7 @@ function $calculateResizeRootTables(
   const roots: TableNode[] = [];
   for (const table of tables) {
     if (
-      $findMatchingParent(table, (n) => n !== table && inputTables.has(n)) ===
+      $findMatchingParent(table, n => n !== table && inputTables.has(n)) ===
       null
     ) {
       roots.push(table);
@@ -75,7 +75,7 @@ function $resizeDOMColWidthsToFit(
     return;
   }
   const allNestedTables = $dfs(node)
-    .map((n) => n.node)
+    .map(n => n.node)
     .filter($isTableNode);
   for (const table of allNestedTables) {
     const element = editor.getElementByKey(table.getKey());
@@ -125,7 +125,7 @@ export default function TableFitNestedTablePlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return editor.registerMutationListener(TableNode, (nodeMutations) => {
+    return editor.registerMutationListener(TableNode, nodeMutations => {
       editor.getEditorState().read(() => {
         const modifiedTables = new Set<TableNode>();
         for (const [nodeKey, mutation] of nodeMutations) {
@@ -137,7 +137,7 @@ export default function TableFitNestedTablePlugin(): null {
           }
         }
         const resizeRoots = $calculateResizeRootTables(modifiedTables);
-        resizeRoots.forEach((root) => {
+        resizeRoots.forEach(root => {
           $resizeDOMColWidthsToFit(editor, root);
         });
       });

--- a/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
@@ -359,7 +359,7 @@ function TableHoverActionsV2({
       setIsLeftVisible(false);
     };
 
-    return editor.registerRootListener((rootElement) => {
+    return editor.registerRootListener(rootElement => {
       if (rootElement) {
         rootElement.addEventListener('mouseleave', handleMouseLeave);
         return () =>
@@ -410,7 +410,7 @@ function TableHoverActionsV2({
   }, [canReorder, hoveredColumnIndex, hoveredTable]);
 
   useEffect(() => {
-    dropIndicatorCleanupRef.current.forEach((cleanup) => cleanup());
+    dropIndicatorCleanupRef.current.forEach(cleanup => cleanup());
     dropIndicatorCleanupRef.current = [];
     if (!hoveredTable || !canReorder) {
       return;
@@ -499,12 +499,12 @@ function TableHoverActionsV2({
         },
       });
 
-    dropIndicatorCleanupRef.current = Array.from(headerRow.cells).map((cell) =>
+    dropIndicatorCleanupRef.current = Array.from(headerRow.cells).map(cell =>
       registerDropTarget(cell),
     );
 
     return () => {
-      dropIndicatorCleanupRef.current.forEach((cleanup) => cleanup());
+      dropIndicatorCleanupRef.current.forEach(cleanup => cleanup());
       dropIndicatorCleanupRef.current = [];
       setDropIndicatorState(null);
     };
@@ -609,7 +609,7 @@ function TableHoverActionsV2({
   return (
     <>
       <div
-        ref={(node) => {
+        ref={node => {
           floatingElemRef.current = node;
           refs.setFloating(node);
         }}
@@ -647,7 +647,7 @@ function TableHoverActionsV2({
         />
       </div>
       <button
-        ref={(node) => {
+        ref={node => {
           leftFloatingElemRef.current = node;
           leftRefs.setFloating(node);
         }}

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -189,7 +189,7 @@ function TableOfContentsList({
 export default function TableOfContentsPlugin() {
   return (
     <LexicalTableOfContentsPlugin>
-      {(tableOfContents) => {
+      {tableOfContents => {
         return <TableOfContentsList tableOfContents={tableOfContents} />;
       }}
     </LexicalTableOfContentsPlugin>

--- a/packages/lexical-playground/src/plugins/TableScrollShadowPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableScrollShadowPlugin/index.tsx
@@ -94,15 +94,15 @@ export default function TableScrollShadowPlugin(): null {
     const wrappers = editorElement.querySelectorAll<HTMLElement>(
       `.${SCROLLABLE_WRAPPER_CLASS}`,
     );
-    wrappers.forEach((wrapper) => {
+    wrappers.forEach(wrapper => {
       resizeObserver.observe(wrapper);
       addScrollListener(wrapper);
     });
 
     // Watch for new wrappers to observe
-    const wrapperObserver = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        mutation.addedNodes.forEach((node) => {
+    const wrapperObserver = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        mutation.addedNodes.forEach(node => {
           if (isHTMLElement(node)) {
             if (node.classList.contains(SCROLLABLE_WRAPPER_CLASS)) {
               resizeObserver.observe(node);
@@ -113,7 +113,7 @@ export default function TableScrollShadowPlugin(): null {
             const childWrappers = node.querySelectorAll<HTMLElement>(
               `.${SCROLLABLE_WRAPPER_CLASS}`,
             );
-            childWrappers.forEach((wrapper) => {
+            childWrappers.forEach(wrapper => {
               resizeObserver.observe(wrapper);
               addScrollListener(wrapper);
               updateTableScrollState(wrapper);

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
@@ -220,7 +220,7 @@ ${steps.map(formatStep).join(`\n`)}
   // coalesce some actions like insertText/moveNativeSelection
   const pushStep = useCallback(
     (name: string, value: Step['value']) => {
-      setSteps((currentSteps) => {
+      setSteps(currentSteps => {
         // trying to group steps
         const currentIndex = steps.length - 1;
         const lastStep = steps[currentIndex];
@@ -277,7 +277,7 @@ ${steps.map(formatStep).join(`\n`)}
       }
     };
 
-    return editor.registerRootListener((rootElement) => {
+    return editor.registerRootListener(rootElement => {
       if (rootElement) {
         rootElement.addEventListener('keydown', onKeyDown);
         rootElement.addEventListener('keyup', onKeyUp);
@@ -371,7 +371,7 @@ ${steps.map(formatStep).join(`\n`)}
         });
         setSteps([]);
       }
-      setIsRecording((currentIsRecording) => !currentIsRecording);
+      setIsRecording(currentIsRecording => !currentIsRecording);
     },
     [isRecording],
   );

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -139,7 +139,7 @@ export default function FontSize({
           (selectionFontSize !== '' &&
             Number(inputValue) <= MIN_ALLOWED_FONT_SIZE)
         }
-        onClick={(e) => {
+        onClick={e => {
           updateFontSize(
             editor,
             UpdateFontSizeType.decrement,
@@ -161,7 +161,7 @@ export default function FontSize({
         className="toolbar-item font-size-input"
         min={MIN_ALLOWED_FONT_SIZE}
         max={MAX_ALLOWED_FONT_SIZE}
-        onChange={(e) => setInputValue(e.target.value)}
+        onChange={e => setInputValue(e.target.value)}
         onClick={handleClick}
         onKeyDown={handleKeyPress}
         onBlur={handleInputBlur}
@@ -174,7 +174,7 @@ export default function FontSize({
           (selectionFontSize !== '' &&
             Number(inputValue) >= MAX_ALLOWED_FONT_SIZE)
         }
-        onClick={(e) => {
+        onClick={e => {
           updateFontSize(
             editor,
             UpdateFontSizeType.increment,

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -117,7 +117,7 @@ const rootTypeToRootName = {
 };
 
 const CODE_LANGUAGE_OPTIONS_PRISM: [string, string][] =
-  getCodeLanguageOptionsPrism().filter((option) =>
+  getCodeLanguageOptionsPrism().filter(option =>
     [
       'c',
       'clike',
@@ -143,7 +143,7 @@ const CODE_LANGUAGE_OPTIONS_PRISM: [string, string][] =
   );
 
 const CODE_LANGUAGE_OPTIONS_SHIKI: [string, string][] =
-  getCodeLanguageOptionsShiki().filter((option) =>
+  getCodeLanguageOptionsShiki().filter(option =>
     [
       'c',
       'clike',
@@ -168,7 +168,7 @@ const CODE_LANGUAGE_OPTIONS_SHIKI: [string, string][] =
   );
 
 const CODE_THEME_OPTIONS_SHIKI: [string, string][] =
-  getCodeThemeOptionsShiki().filter((option) =>
+  getCodeThemeOptionsShiki().filter(option =>
     [
       'catppuccin-latte',
       'everforest-light',
@@ -548,7 +548,7 @@ function $findTopLevelElement(node: LexicalNode) {
   let topLevelElement =
     node.getKey() === 'root'
       ? node
-      : $findMatchingParent(node, (e) => {
+      : $findMatchingParent(node, e => {
           const parent = e.getParent();
           return parent !== null && $isRootOrShadowRoot(parent);
         });
@@ -714,7 +714,7 @@ export default function ToolbarPlugin({
         // If node is a link, we need to fetch the parent paragraph node to set format
         matchingParent = $findMatchingParent(
           node,
-          (parentNode) => $isElementNode(parentNode) && !parentNode.isInline(),
+          parentNode => $isElementNode(parentNode) && !parentNode.isInline(),
         );
       }
 
@@ -804,7 +804,7 @@ export default function ToolbarPlugin({
 
   useEffect(() => {
     return mergeRegister(
-      editor.registerEditableListener((editable) => {
+      editor.registerEditableListener(editable => {
         setIsEditable(editable);
       }),
       activeEditor.registerUpdateListener(({editorState}) => {
@@ -817,7 +817,7 @@ export default function ToolbarPlugin({
       }),
       activeEditor.registerCommand<boolean>(
         CAN_UNDO_COMMAND,
-        (payload) => {
+        payload => {
           updateToolbarState('canUndo', payload);
           return false;
         },
@@ -825,7 +825,7 @@ export default function ToolbarPlugin({
       ),
       activeEditor.registerCommand<boolean>(
         CAN_REDO_COMMAND,
-        (payload) => {
+        payload => {
           updateToolbarState('canRedo', payload);
           return false;
         },
@@ -925,7 +925,7 @@ export default function ToolbarPlugin({
     <div className="toolbar">
       <button
         disabled={!toolbarState.canUndo || !isEditable}
-        onClick={(e) =>
+        onClick={e =>
           dispatchToolbarCommand(UNDO_COMMAND, undefined, isKeyboardInput(e))
         }
         title={IS_APPLE ? 'Undo (⌘Z)' : 'Undo (Ctrl+Z)'}
@@ -936,7 +936,7 @@ export default function ToolbarPlugin({
       </button>
       <button
         disabled={!toolbarState.canRedo || !isEditable}
-        onClick={(e) =>
+        onClick={e =>
           dispatchToolbarCommand(REDO_COMMAND, undefined, isKeyboardInput(e))
         }
         title={IS_APPLE ? 'Redo (⇧⌘Z)' : 'Redo (Ctrl+Y)'}
@@ -966,7 +966,7 @@ export default function ToolbarPlugin({
               buttonClassName="toolbar-item code-language"
               buttonLabel={
                 (CODE_LANGUAGE_OPTIONS_PRISM.find(
-                  (opt) =>
+                  opt =>
                     opt[0] ===
                     normalizeCodeLanguagePrism(toolbarState.codeLanguage),
                 ) || ['', ''])[1]
@@ -993,7 +993,7 @@ export default function ToolbarPlugin({
                 buttonClassName="toolbar-item code-language"
                 buttonLabel={
                   (CODE_LANGUAGE_OPTIONS_SHIKI.find(
-                    (opt) =>
+                    opt =>
                       opt[0] ===
                       normalizeCodeLanguageShiki(toolbarState.codeLanguage),
                   ) || ['', ''])[1]
@@ -1017,7 +1017,7 @@ export default function ToolbarPlugin({
                 buttonClassName="toolbar-item code-language"
                 buttonLabel={
                   (CODE_THEME_OPTIONS_SHIKI.find(
-                    (opt) => opt[0] === toolbarState.codeTheme,
+                    opt => opt[0] === toolbarState.codeTheme,
                   ) || ['', ''])[1]
                 }
                 buttonAriaLabel="Select theme">
@@ -1056,9 +1056,7 @@ export default function ToolbarPlugin({
           <Divider />
           <button
             disabled={!isEditable}
-            onClick={(e) =>
-              dispatchFormatTextCommand('bold', isKeyboardInput(e))
-            }
+            onClick={e => dispatchFormatTextCommand('bold', isKeyboardInput(e))}
             className={
               'toolbar-item spaced ' + (toolbarState.isBold ? 'active' : '')
             }
@@ -1069,7 +1067,7 @@ export default function ToolbarPlugin({
           </button>
           <button
             disabled={!isEditable}
-            onClick={(e) =>
+            onClick={e =>
               dispatchFormatTextCommand('italic', isKeyboardInput(e))
             }
             className={
@@ -1082,7 +1080,7 @@ export default function ToolbarPlugin({
           </button>
           <button
             disabled={!isEditable}
-            onClick={(e) =>
+            onClick={e =>
               dispatchFormatTextCommand('underline', isKeyboardInput(e))
             }
             className={
@@ -1097,7 +1095,7 @@ export default function ToolbarPlugin({
           {canViewerSeeInsertCodeButton && (
             <button
               disabled={!isEditable}
-              onClick={(e) =>
+              onClick={e =>
                 dispatchFormatTextCommand('code', isKeyboardInput(e))
               }
               className={
@@ -1145,7 +1143,7 @@ export default function ToolbarPlugin({
             buttonAriaLabel="Formatting options for additional text styles"
             buttonIconClassName="icon dropdown-more">
             <DropDownItem
-              onClick={(e) =>
+              onClick={e =>
                 dispatchFormatTextCommand('lowercase', isKeyboardInput(e))
               }
               className={
@@ -1160,7 +1158,7 @@ export default function ToolbarPlugin({
               <span className="shortcut">{SHORTCUTS.LOWERCASE}</span>
             </DropDownItem>
             <DropDownItem
-              onClick={(e) =>
+              onClick={e =>
                 dispatchFormatTextCommand('uppercase', isKeyboardInput(e))
               }
               className={
@@ -1175,7 +1173,7 @@ export default function ToolbarPlugin({
               <span className="shortcut">{SHORTCUTS.UPPERCASE}</span>
             </DropDownItem>
             <DropDownItem
-              onClick={(e) =>
+              onClick={e =>
                 dispatchFormatTextCommand('capitalize', isKeyboardInput(e))
               }
               className={
@@ -1190,7 +1188,7 @@ export default function ToolbarPlugin({
               <span className="shortcut">{SHORTCUTS.CAPITALIZE}</span>
             </DropDownItem>
             <DropDownItem
-              onClick={(e) =>
+              onClick={e =>
                 dispatchFormatTextCommand('strikethrough', isKeyboardInput(e))
               }
               className={
@@ -1205,7 +1203,7 @@ export default function ToolbarPlugin({
               <span className="shortcut">{SHORTCUTS.STRIKETHROUGH}</span>
             </DropDownItem>
             <DropDownItem
-              onClick={(e) =>
+              onClick={e =>
                 dispatchFormatTextCommand('subscript', isKeyboardInput(e))
               }
               className={
@@ -1220,7 +1218,7 @@ export default function ToolbarPlugin({
               <span className="shortcut">{SHORTCUTS.SUBSCRIPT}</span>
             </DropDownItem>
             <DropDownItem
-              onClick={(e) =>
+              onClick={e =>
                 dispatchFormatTextCommand('superscript', isKeyboardInput(e))
               }
               className={
@@ -1235,7 +1233,7 @@ export default function ToolbarPlugin({
               <span className="shortcut">{SHORTCUTS.SUPERSCRIPT}</span>
             </DropDownItem>
             <DropDownItem
-              onClick={(e) =>
+              onClick={e =>
                 dispatchFormatTextCommand('highlight', isKeyboardInput(e))
               }
               className={
@@ -1249,7 +1247,7 @@ export default function ToolbarPlugin({
               </div>
             </DropDownItem>
             <DropDownItem
-              onClick={(e) => clearFormatting(activeEditor, isKeyboardInput(e))}
+              onClick={e => clearFormatting(activeEditor, isKeyboardInput(e))}
               className="item wide"
               title="Clear text formatting"
               aria-label="Clear all text formatting">
@@ -1286,7 +1284,7 @@ export default function ToolbarPlugin({
                 </DropDownItem>
                 <DropDownItem
                   onClick={() => {
-                    showModal('Insert Image', (onClose) => (
+                    showModal('Insert Image', onClose => (
                       <InsertImageDialog
                         activeEditor={activeEditor}
                         onClose={onClose}
@@ -1318,7 +1316,7 @@ export default function ToolbarPlugin({
                 </DropDownItem>
                 <DropDownItem
                   onClick={() => {
-                    showModal('Insert Table', (onClose) => (
+                    showModal('Insert Table', onClose => (
                       <InsertTableDialog
                         activeEditor={activeEditor}
                         onClose={onClose}
@@ -1331,7 +1329,7 @@ export default function ToolbarPlugin({
                 </DropDownItem>
                 <DropDownItem
                   onClick={() => {
-                    showModal('Insert Poll', (onClose) => (
+                    showModal('Insert Poll', onClose => (
                       <InsertPollDialog
                         activeEditor={activeEditor}
                         onClose={onClose}
@@ -1344,7 +1342,7 @@ export default function ToolbarPlugin({
                 </DropDownItem>
                 <DropDownItem
                   onClick={() => {
-                    showModal('Insert Columns Layout', (onClose) => (
+                    showModal('Insert Columns Layout', onClose => (
                       <InsertLayoutDialog
                         activeEditor={activeEditor}
                         onClose={onClose}
@@ -1358,7 +1356,7 @@ export default function ToolbarPlugin({
 
                 <DropDownItem
                   onClick={() => {
-                    showModal('Insert Equation', (onClose) => (
+                    showModal('Insert Equation', onClose => (
                       <InsertEquationDialog
                         activeEditor={activeEditor}
                         onClose={onClose}
@@ -1400,7 +1398,7 @@ export default function ToolbarPlugin({
                   <i className="icon calendar" />
                   <span className="text">Date</span>
                 </DropDownItem>
-                {EmbedConfigs.map((embedConfig) => (
+                {EmbedConfigs.map(embedConfig => (
                   <DropDownItem
                     key={embedConfig.type}
                     onClick={() =>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -346,7 +346,7 @@ export const clearFormatting = (
         return;
       }
 
-      extractedNodes.forEach((node) => {
+      extractedNodes.forEach(node => {
         if ($isTextNode(node)) {
           if (node.getStyle() !== '') {
             node.setStyle('');

--- a/packages/lexical-playground/src/plugins/TwitterExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/TwitterExtension/index.ts
@@ -23,10 +23,10 @@ export const INSERT_TWEET_COMMAND: LexicalCommand<string> = createCommand(
 export const TwitterExtension = defineExtension({
   name: '@lexical/playground/Twitter',
   nodes: [TweetNode],
-  register: (editor) =>
+  register: editor =>
     editor.registerCommand<string>(
       INSERT_TWEET_COMMAND,
-      (payload) => {
+      payload => {
         const tweetNode = $createTweetNode(payload);
         $insertNodeToNearestRoot(tweetNode);
 

--- a/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
@@ -96,7 +96,7 @@ export function VersionsPlugin({id}: {id: string}) {
           },
           COMMAND_PRIORITY_CRITICAL,
         ),
-        editor.registerEditableListener((isEditable) => {
+        editor.registerEditableListener(isEditable => {
           if (isEditable && isDiffMode) {
             editor.dispatchCommand(
               CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL,
@@ -136,7 +136,7 @@ export function VersionsPlugin({id}: {id: string}) {
     }
     return editor.registerMutationListener(
       TextNode,
-      (nodes) => {
+      nodes => {
         const userToColor = new Map<User, string>();
         const getUserColor = (user: User): string => {
           if (userToColor.has(user)) {
@@ -186,7 +186,7 @@ export function VersionsPlugin({id}: {id: string}) {
     }
 
     const now = Date.now();
-    setVersions((prevVersions) => [
+    setVersions(prevVersions => [
       ...prevVersions,
       {
         name: `Snapshot ${new Date(now).toLocaleString()}`,

--- a/packages/lexical-playground/src/plugins/YouTubeExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/YouTubeExtension/index.ts
@@ -23,10 +23,10 @@ export const INSERT_YOUTUBE_COMMAND: LexicalCommand<string> = createCommand(
 export const YouTubeExtension = defineExtension({
   name: '@lexical/playground/YouTube',
   nodes: [YouTubeNode],
-  register: (editor) =>
+  register: editor =>
     editor.registerCommand<string>(
       INSERT_YOUTUBE_COMMAND,
-      (payload) => {
+      payload => {
         const youTubeNode = $createYouTubeNode(payload);
         $insertNodeToNearestRoot(youTubeNode);
 

--- a/packages/lexical-playground/src/server/validation.ts
+++ b/packages/lexical-playground/src/server/validation.ts
@@ -24,14 +24,14 @@ global.__DEV__ = true;
 const editor = createHeadlessEditor({
   namespace: 'validation',
   nodes: [...PlaygroundNodes],
-  onError: (error) => {
+  onError: error => {
     console.error(error);
   },
 });
 
 const getJSONData = (req: http.IncomingMessage): Promise<string> => {
   const body: Array<Uint8Array> = [];
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     req
       .on('data', (chunk: Uint8Array) => {
         body.push(chunk);

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -130,12 +130,12 @@ export default function ColorPicker({
       ref={innerDivRef}>
       <TextInput label="Hex" onChange={onSetHex} value={inputColor} />
       <div className="color-picker-basic-color">
-        {basicColors.map((basicColor) => (
+        {basicColors.map(basicColor => (
           <button
             className={basicColor === selfColor.hex ? 'active' : ''}
             key={basicColor}
             style={{backgroundColor: basicColor}}
-            onClick={(e) => onBasicColorClick(e, basicColor)}
+            onClick={e => onBasicColorClick(e, basicColor)}
           />
         ))}
       </div>
@@ -291,7 +291,7 @@ function hex2rgb(hex: string): RGB {
       )
       .substring(1)
       .match(/.{2}/g) || []
-  ).map((x) => parseInt(x, 16));
+  ).map(x => parseInt(x, 16));
 
   return {
     b: rbgArr[2],
@@ -340,7 +340,7 @@ function hsv2rgb({h, s, v}: HSV): RGB {
 }
 
 function rgb2hex({b, g, r}: RGB): string {
-  return '#' + [r, g, b].map((x) => x.toString(16).padStart(2, '0')).join('');
+  return '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
 }
 
 function transformColor<M extends keyof Color, C extends Color[M]>(

--- a/packages/lexical-playground/src/ui/DropDown.tsx
+++ b/packages/lexical-playground/src/ui/DropDown.tsx
@@ -88,7 +88,7 @@ function DropDownItems({
 
   const registerItem = useCallback(
     (itemRef: React.RefObject<null | HTMLButtonElement>) => {
-      setItems((prev) => (prev ? [...prev, itemRef] : [itemRef]));
+      setItems(prev => (prev ? [...prev, itemRef] : [itemRef]));
     },
     [setItems],
   );
@@ -109,7 +109,7 @@ function DropDownItems({
     if (key === 'Escape' || key === 'Tab') {
       onClose();
     } else if (key === 'ArrowUp') {
-      setHighlightedItem((prev) => {
+      setHighlightedItem(prev => {
         if (!prev) {
           return items[0];
         }
@@ -117,7 +117,7 @@ function DropDownItems({
         return items[index === -1 ? items.length - 1 : index];
       });
     } else if (key === 'ArrowDown') {
-      setHighlightedItem((prev) => {
+      setHighlightedItem(prev => {
         if (!prev) {
           return items[0];
         }

--- a/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
@@ -132,7 +132,7 @@ export default function ExcalidrawModal({
   }, [elements, files, onDelete]);
 
   const save = () => {
-    if (elements?.some((el) => !el.isDeleted)) {
+    if (elements?.some(el => !el.isDeleted)) {
       const appState = excalidrawAPI?.getAppState();
       // We only need a subset of the state
       const partialState: Partial<AppState> = {

--- a/packages/lexical-playground/src/ui/FileInput.tsx
+++ b/packages/lexical-playground/src/ui/FileInput.tsx
@@ -32,7 +32,7 @@ export default function FileInput({
         type="file"
         accept={accept}
         className="Input__input"
-        onChange={(e) => onChange(e.target.files)}
+        onChange={e => onChange(e.target.files)}
         data-test-id={dataTestId}
       />
     </div>

--- a/packages/lexical-playground/src/ui/ImageResizer.tsx
+++ b/packages/lexical-playground/src/ui/ImageResizer.tsx
@@ -266,49 +266,49 @@ export default function ImageResizer({
       )}
       <div
         className="image-resizer image-resizer-n"
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           handlePointerDown(event, Direction.north);
         }}
       />
       <div
         className="image-resizer image-resizer-ne"
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           handlePointerDown(event, Direction.north | Direction.east);
         }}
       />
       <div
         className="image-resizer image-resizer-e"
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           handlePointerDown(event, Direction.east);
         }}
       />
       <div
         className="image-resizer image-resizer-se"
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           handlePointerDown(event, Direction.south | Direction.east);
         }}
       />
       <div
         className="image-resizer image-resizer-s"
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           handlePointerDown(event, Direction.south);
         }}
       />
       <div
         className="image-resizer image-resizer-sw"
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           handlePointerDown(event, Direction.south | Direction.west);
         }}
       />
       <div
         className="image-resizer image-resizer-w"
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           handlePointerDown(event, Direction.west);
         }}
       />
       <div
         className="image-resizer image-resizer-nw"
-        onPointerDown={(event) => {
+        onPointerDown={event => {
           handlePointerDown(event, Direction.north | Direction.west);
         }}
       />

--- a/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
+++ b/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
@@ -54,7 +54,7 @@ export default function KatexEquationAlterer({
       <div className="KatexEquationAlterer_centerRow">
         {inline ? (
           <input
-            onChange={(event) => {
+            onChange={event => {
               setEquation(event.target.value);
             }}
             value={equation}
@@ -63,7 +63,7 @@ export default function KatexEquationAlterer({
           />
         ) : (
           <textarea
-            onChange={(event) => {
+            onChange={event => {
               setEquation(event.target.value);
             }}
             value={equation}
@@ -74,7 +74,7 @@ export default function KatexEquationAlterer({
       </div>
       <div className="KatexEquationAlterer_defaultRow">Visualization </div>
       <div className="KatexEquationAlterer_centerRow">
-        <ErrorBoundary onError={(e) => editor._onError(e)} fallback={null}>
+        <ErrorBoundary onError={e => editor._onError(e)} fallback={null}>
           <KatexRenderer
             equation={equation}
             inline={false}

--- a/packages/lexical-playground/src/ui/TextInput.tsx
+++ b/packages/lexical-playground/src/ui/TextInput.tsx
@@ -38,7 +38,7 @@ export default function TextInput({
         className="Input__input"
         placeholder={placeholder}
         value={value}
-        onChange={(e) => {
+        onChange={e => {
           onChange(e.target.value);
         }}
         data-test-id={dataTestId}

--- a/packages/lexical-playground/src/utils/getThemeSelector.ts
+++ b/packages/lexical-playground/src/utils/getThemeSelector.ts
@@ -20,6 +20,6 @@ export function getThemeSelector(
   }
   return className
     .split(/\s+/g)
-    .map((cls) => `.${cls}`)
+    .map(cls => `.${cls}`)
     .join();
 }

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -145,7 +145,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
       }
     };
     return mergeRegister(
-      ...[LinkNode, AutoLinkNode].map((Klass) =>
+      ...[LinkNode, AutoLinkNode].map(Klass =>
         editor.registerMutationListener(Klass, (...args) => listener(...args), {
           skipInitialization: true,
         }),

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -54,7 +54,7 @@ export function BlockWithAlignableContents({
     return mergeRegister(
       editor.registerCommand<ElementFormatType>(
         FORMAT_ELEMENT_COMMAND,
-        (formatType) => {
+        formatType => {
           if (isSelected) {
             const selection = $getSelection();
 
@@ -86,7 +86,7 @@ export function BlockWithAlignableContents({
       ),
       editor.registerCommand<MouseEvent>(
         CLICK_COMMAND,
-        (event) => {
+        event => {
           if (event.target === ref.current) {
             event.preventDefault();
             if (!event.shiftKey) {

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -76,7 +76,7 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
         html,
         namespace,
         nodes,
-        onError: (error) => onError(error, editor),
+        onError: error => onError(error, editor),
         theme,
       });
       initializeEditor(editor, initialEditorState);

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -75,7 +75,7 @@ function Placeholder({
   useLayoutEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setEditable(editor.isEditable());
-    return editor.registerEditableListener((currentIsEditable) => {
+    return editor.registerEditableListener(currentIsEditable => {
       setEditable(currentIsEditable);
     });
   }, [editor]);

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -432,14 +432,14 @@ function useDraggableBlockMenu(
     return mergeRegister(
       editor.registerCommand(
         DRAGOVER_COMMAND,
-        (event) => {
+        event => {
           return onDragover(event);
         },
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         DROP_COMMAND,
-        (event) => {
+        event => {
           return $onDrop(event);
         },
         COMMAND_PRIORITY_HIGH,
@@ -456,7 +456,7 @@ function useDraggableBlockMenu(
     }
 
     return mergeRegister(
-      editor.registerRootListener((rootElement) => {
+      editor.registerRootListener(rootElement => {
         function onBlur(event: FocusEvent) {
           const relatedTarget = event.relatedTarget;
           if (isHTMLElement(relatedTarget) && isOnMenu(relatedTarget)) {

--- a/packages/lexical-react/src/LexicalHorizontalRulePlugin.ts
+++ b/packages/lexical-react/src/LexicalHorizontalRulePlugin.ts
@@ -28,7 +28,7 @@ export function HorizontalRulePlugin(): null {
   useEffect(() => {
     return editor.registerCommand(
       INSERT_HORIZONTAL_RULE_COMMAND,
-      (type) => {
+      type => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -200,7 +200,7 @@ export function LexicalNestedComposer({
   // Update `isEditable` state of nested editor in response to the same change on parent editor.
   useEffect(() => {
     if (!skipEditableListener) {
-      const editableListener: EditableListener = (editable) =>
+      const editableListener: EditableListener = editable =>
         initialEditor.setEditable(editable);
       editableListener(parentEditor.isEditable());
       return parentEditor.registerEditableListener(editableListener);

--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -211,7 +211,7 @@ const NodeContextMenuPlugin = forwardRef<
           const node =
             $getNearestNodeFromDOMNode(e.target as Element) ?? $getRoot();
           if (node) {
-            visibleItems = items!.filter((option) =>
+            visibleItems = items!.filter(option =>
               option.$showOn ? option.$showOn(node) : true,
             );
           }
@@ -242,14 +242,14 @@ const NodeContextMenuPlugin = forwardRef<
         }
       }) as MenuType[];
 
-      listContentRef.current = renderableItems.map((item) => item.key);
+      listContentRef.current = renderableItems.map(item => item.key);
 
       setRenderItems(renderableItems);
 
       setIsOpen(true);
     }
 
-    return editor.registerRootListener((rootElement) => {
+    return editor.registerRootListener(rootElement => {
       if (rootElement !== null) {
         rootElement.addEventListener('contextmenu', onContextMenu);
         return () =>

--- a/packages/lexical-react/src/LexicalNodeEventPlugin.ts
+++ b/packages/lexical-react/src/LexicalNodeEventPlugin.ts
@@ -46,7 +46,7 @@ export function NodeEventPlugin({
               : null
             : $findMatchingParent(
                 nearestNode,
-                (node) => node instanceof nodeType,
+                node => node instanceof nodeType,
               );
           if (targetNode !== null) {
             listenerRef.current(event, editor, targetNode.getKey());
@@ -56,7 +56,7 @@ export function NodeEventPlugin({
       });
     };
 
-    return editor.registerRootListener((rootElement) => {
+    return editor.registerRootListener(rootElement => {
       if (rootElement) {
         rootElement.addEventListener(eventType, onEvent, isCaptured);
         return () =>

--- a/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
@@ -191,7 +191,7 @@ export function TableOfContentsPlugin({children}: Props): JSX.Element {
           // If a node is changes, all child heading positions need to be updated
           $getRoot()
             .getChildren()
-            .forEach((node) => {
+            .forEach(node => {
               if ($isElementNode(node) && dirtyElements.get(node.__key)) {
                 updateChildHeadings(node);
               }

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -96,7 +96,7 @@ export function TablePlugin({
     if (hasCellBackgroundColor) {
       return;
     }
-    return editor.registerNodeTransform(TableCellNode, (node) => {
+    return editor.registerNodeTransform(TableCellNode, node => {
       if (node.getBackgroundColor() !== null) {
         node.setBackgroundColor(null);
       }

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -116,7 +116,7 @@ export function TreeView({
       timeTravelPanelClassName={timeTravelPanelClassName}
       setEditorReadOnly={handleEditorReadOnly}
       editorState={editorCurrentState}
-      setEditorState={(state) => editor.setEditorState(state)}
+      setEditorState={state => editor.setEditorState(state)}
       generateContent={async function (exportDOM) {
         // Generates the content for the tree view, allowing customization with exportDOM and customPrintNode
         return generateContent(editor, commandsLog, exportDOM, customPrintNode);

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -324,7 +324,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
 
   useEffect(
     () =>
-      editor.registerEditableListener((isEditable) => {
+      editor.registerEditableListener(isEditable => {
         if (!isEditable) {
           closeTypeahead();
         }

--- a/packages/lexical-react/src/ReactPluginHostExtension.tsx
+++ b/packages/lexical-react/src/ReactPluginHostExtension.tsx
@@ -199,7 +199,7 @@ export const ReactPluginHostExtension = defineExtension({
       },
       editor.registerCommand(
         REACT_PLUGIN_HOST_MOUNT_PLUGIN_COMMAND,
-        (arg) => {
+        arg => {
           // This runs before the PluginHost version
           untracked(() => {
             const {plugins} = mountedPluginsStore.value;
@@ -212,7 +212,7 @@ export const ReactPluginHostExtension = defineExtension({
       ),
       editor.registerCommand(
         REACT_PLUGIN_HOST_MOUNT_ROOT_COMMAND,
-        (arg) => {
+        arg => {
           invariant(
             root === undefined,
             'ReactPluginHostExtension: Root is already mounted',

--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -523,7 +523,7 @@ describe('Collaboration', () => {
       const editor = client.getEditor();
 
       const state = createState('foo', {
-        parse: (value) => (value as {foo: string}) || {foo: 'foo'},
+        parse: value => (value as {foo: string}) || {foo: 'foo'},
       });
 
       act(() => {

--- a/packages/lexical-react/src/__tests__/unit/CollaborationSnapshot.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationSnapshot.test.ts
@@ -45,7 +45,7 @@ describe('CollaborationSnapshot', () => {
     editor1 = client1.getEditor();
     editor2 = client2.getEditor();
 
-    const mutationListener: MutationListener = (mutations) => {
+    const mutationListener: MutationListener = mutations => {
       editor1.getEditorState().read(() => {
         for (const [nodeKey, mutation] of mutations) {
           if (mutation === 'destroyed') {
@@ -442,7 +442,7 @@ describe('CollaborationSnapshot', () => {
         ),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise(resolve => setTimeout(resolve, 100));
 
       expectHtmlToBeEqual(
         client1.getHTML(),

--- a/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
@@ -31,7 +31,7 @@ import {
 const $insertParagraph = (...children: Array<string | LexicalNode>) => {
   const root = $getRoot();
   const paragraph = $createParagraphNode();
-  const nodes = children.map((child) => {
+  const nodes = children.map(child => {
     return typeof child === 'string' ? $createTextNode(child) : child;
   });
   paragraph.append(...nodes);
@@ -198,7 +198,7 @@ describe('CollaborationWithCollisions', () => {
   describe.each([[false], [true]])(
     'useCollabV2: %s',
     (useCollabV2: boolean) => {
-      SIMPLE_TEXT_COLLISION_TESTS.forEach((testCase) => {
+      SIMPLE_TEXT_COLLISION_TESTS.forEach(testCase => {
         it(testCase.name, async () => {
           const connection = createTestConnection(useCollabV2);
           const clients = createAndStartClients(

--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
@@ -51,7 +51,7 @@ describe('LexicalComposer tests', () => {
           initialConfig={{
             namespace: '',
             nodes: [],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
             theme,
@@ -94,7 +94,7 @@ describe('LexicalComposer tests', () => {
               },
               namespace: '',
               nodes: [],
-              onError: (err) => {
+              onError: err => {
                 throw err;
               },
             }}>

--- a/packages/lexical-react/src/__tests__/unit/LexicalContentEditableElement.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalContentEditableElement.test.tsx
@@ -25,7 +25,7 @@ describe('ContentEditableElement tests', () => {
 
     editor = createEditor({
       namespace: 'ContentEditableElement',
-      onError: (error) => {
+      onError: error => {
         throw error;
       },
     });
@@ -188,7 +188,7 @@ describe('ContentEditableElement tests', () => {
 
   it('registers and cleans up root element properly', async () => {
     let rootElement: HTMLElement | null = null;
-    editor.setRootElement = vi.fn((element) => {
+    editor.setRootElement = vi.fn(element => {
       rootElement = element;
     });
 

--- a/packages/lexical-react/src/__tests__/unit/LexicalExtensionEditorComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalExtensionEditorComposer.test.tsx
@@ -56,7 +56,7 @@ const DecorateState = createState('decorate', {
     (node: ReactDecoratorNode): React.ReactNode =>
       null,
 });
-const InlineState = createState('inline', {parse: (v) => !!v});
+const InlineState = createState('inline', {parse: v => !!v});
 
 class ReactDecoratorNode extends DecoratorNode<React.ReactNode> {
   $config() {
@@ -206,7 +206,7 @@ describe('LexicalExtensionEditorComposer', () => {
     const handled: number[] = [];
     editor.registerCommand(
       TestCommand,
-      (payload) => {
+      payload => {
         handled.push(payload);
         return true;
       },

--- a/packages/lexical-react/src/__tests__/unit/LexicalMenu.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalMenu.test.tsx
@@ -182,7 +182,7 @@ describe('LexicalMenu', () => {
 
       // Verify text content
       const texts = Array.from(items).map(
-        (item) => item.querySelector('.text')?.textContent,
+        item => item.querySelector('.text')?.textContent,
       );
       expect(texts).toEqual(['Option A', 'Option B', 'Option C']);
     });
@@ -374,7 +374,7 @@ describe('LexicalMenu', () => {
       });
 
       expect(capturedOptions).toHaveLength(3);
-      expect(capturedOptions.map((o) => o.title)).toEqual(['X', 'Y', 'Z']);
+      expect(capturedOptions.map(o => o.title)).toEqual(['X', 'Y', 'Z']);
     });
 
     it('should pass empty string as matchingString when no match', async () => {

--- a/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
@@ -154,7 +154,7 @@ describe('LexicalNestedComposer', () => {
             },
             namespace: 'parent',
             nodes: [ReactDecoratorNode],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
           }}>
@@ -246,7 +246,7 @@ describe('LexicalNestedComposer', () => {
             },
             namespace: 'parent',
             nodes: [ReactDecoratorNode],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
           }}>
@@ -349,7 +349,7 @@ describe('LexicalNestedComposer', () => {
             },
             namespace: 'parent',
             nodes: [ReactDecoratorNode],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
           }}>
@@ -449,7 +449,7 @@ describe('LexicalNestedComposer', () => {
             },
             namespace: 'parent',
             nodes: [ReactDecoratorNode],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
           }}>
@@ -473,7 +473,7 @@ describe('LexicalNestedComposer', () => {
     // nodes inherited
     expect([...nestedEditor._nodes.keys()].sort()).toEqual(
       [...editor._nodes.keys()]
-        .filter((k) => k !== ReactDecoratorNode.getType())
+        .filter(k => k !== ReactDecoratorNode.getType())
         .sort(),
     );
     expectHtmlToBeEqual(
@@ -551,7 +551,7 @@ describe('LexicalNestedComposer', () => {
             },
             namespace: 'parent',
             nodes: [ReactDecoratorNode],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
           }}>
@@ -575,7 +575,7 @@ describe('LexicalNestedComposer', () => {
     // nodes inherited
     expect([...nestedEditor._nodes.keys()].sort()).toEqual(
       [...editor._nodes.keys()]
-        .filter((k) => k !== ReactDecoratorNode.getType())
+        .filter(k => k !== ReactDecoratorNode.getType())
         .sort(),
     );
     expect(editor.isEditable()).toBe(true);
@@ -702,7 +702,7 @@ describe('LexicalNestedComposer', () => {
             },
             namespace: 'parent',
             nodes: [ReactDecoratorNode],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
           }}>
@@ -726,7 +726,7 @@ describe('LexicalNestedComposer', () => {
     // nodes not inherited
     expect([...nestedEditor._nodes.keys()].sort()).toEqual(
       [...editor._nodes.keys()]
-        .filter((k) => k !== ReactDecoratorNode.getType())
+        .filter(k => k !== ReactDecoratorNode.getType())
         .sort(),
     );
     expect(editor.isEditable()).toBe(true);
@@ -812,7 +812,7 @@ describe('LexicalNestedComposer', () => {
     let editor: undefined | LexicalEditor;
     let nestedEditor: undefined | LexicalEditor;
     const DELEGATED_COMMAND = createCommand<unknown>('DELEGATED_COMMAND');
-    const $commandListener = vi.fn((_) => false);
+    const $commandListener = vi.fn(_ => false);
     function DelegateListenerPlugin() {
       const [currentEditor] = useLexicalComposerContext();
       useEffect(() => {
@@ -885,7 +885,7 @@ describe('LexicalNestedComposer', () => {
             },
             namespace: 'parent',
             nodes: [ReactDecoratorNode],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
           }}>
@@ -910,7 +910,7 @@ describe('LexicalNestedComposer', () => {
     // nodes not inherited
     expect([...nestedEditor._nodes.keys()].sort()).toEqual(
       [...editor._nodes.keys()]
-        .filter((k) => k !== ReactDecoratorNode.getType())
+        .filter(k => k !== ReactDecoratorNode.getType())
         .sort(),
     );
     expect(warn.mock.calls).toEqual([]);
@@ -975,7 +975,7 @@ describe('LexicalNestedComposer', () => {
       $commandListener.mockClear();
       // Can stop propagation from nested editor
       $commandListener.mockImplementation(
-        (opts) =>
+        opts =>
           opts.dispatchEditor === opts.currentEditor &&
           opts.priority === COMMAND_PRIORITY_EDITOR,
       );
@@ -1012,7 +1012,7 @@ describe('LexicalNestedComposer', () => {
 
       // Can stop propagation from parent editor
       $commandListener.mockImplementation(
-        (opts) => opts.dispatchEditor !== opts.currentEditor,
+        opts => opts.dispatchEditor !== opts.currentEditor,
       );
       expect(nestedEditor?.dispatchCommand(DELEGATED_COMMAND, undefined)).toBe(
         true,
@@ -1101,7 +1101,7 @@ describe('LexicalNestedComposer', () => {
               StaticTransformNode,
               ConfigTransformNode,
             ],
-            onError: (err) => {
+            onError: err => {
               throw err;
             },
           }}>

--- a/packages/lexical-react/src/__tests__/unit/LexicalNodeMenuPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalNodeMenuPlugin.test.tsx
@@ -121,7 +121,7 @@ function createApp(plugin: React.ReactNode): React.FC {
         initialConfig={{
           namespace: 'test-node-menu',
           nodes: [],
-          onError: (err) => {
+          onError: err => {
             throw err;
           },
           theme: {},

--- a/packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx
@@ -134,7 +134,7 @@ function createApp(plugin: React.ReactNode): React.FC {
         initialConfig={{
           namespace: 'test-typeahead',
           nodes: [],
-          onError: (err) => {
+          onError: err => {
             throw err;
           },
           theme: {},

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -85,7 +85,7 @@ describe('LexicalNodeHelpers tests', () => {
               editorState: $initialEditorState,
               namespace: '',
               nodes: plugin === 'PlainTextPlugin' ? [] : RICH_TEXT_NODES,
-              onError: (err) => {
+              onError: err => {
                 throw err;
               },
               theme: {},
@@ -136,7 +136,7 @@ describe('LexicalNodeHelpers tests', () => {
               editorState: initialEditorStateJson,
               namespace: '',
               nodes: plugin === 'PlainTextPlugin' ? [] : RICH_TEXT_NODES,
-              onError: (err) => {
+              onError: err => {
                 throw err;
               },
               theme: {},
@@ -195,7 +195,7 @@ describe('LexicalNodeHelpers tests', () => {
             initialConfig={{
               namespace: '',
               nodes: plugin === 'PlainTextPlugin' ? [] : RICH_TEXT_NODES,
-              onError: (err) => {
+              onError: err => {
                 throw err;
               },
               theme: {},
@@ -204,7 +204,7 @@ describe('LexicalNodeHelpers tests', () => {
             {plugin === 'PlainTextPlugin' ? (
               <PlainTextPlugin
                 contentEditable={<ContentEditable />}
-                placeholder={(isEditable) =>
+                placeholder={isEditable =>
                   isEditable ? (
                     <span className="placeholder">My placeholder</span>
                   ) : null
@@ -214,7 +214,7 @@ describe('LexicalNodeHelpers tests', () => {
             ) : (
               <RichTextPlugin
                 contentEditable={<ContentEditable />}
-                placeholder={(isEditable) =>
+                placeholder={isEditable =>
                   isEditable ? (
                     <span className="placeholder">My placeholder</span>
                   ) : null

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
@@ -30,7 +30,7 @@ import {$mergePrevious} from '../../shared/useCharacterLimit';
 
 describe('LexicalNodeHelpers tests', () => {
   initializeUnitTest(
-    (testEnv) => {
+    testEnv => {
       describe('merge', () => {
         function $initializeEditorWithLeftRightOverflowNodes(): [
           NodeKey,

--- a/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmpty.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmpty.test.tsx
@@ -46,7 +46,7 @@ describe('useLexicalIsTextContentEmpty', () => {
         createEditor({
           namespace: '',
           nodes: [ParagraphNode],
-          onError: (err) => {
+          onError: err => {
             throw err;
           },
         }),

--- a/packages/lexical-react/src/__tests__/utils/index.tsx
+++ b/packages/lexical-react/src/__tests__/utils/index.tsx
@@ -137,7 +137,7 @@ export class Client implements Provider {
   }
 
   _broadcastUpdate(update: Uint8Array) {
-    this._connection._clients.forEach((client) => {
+    this._connection._clients.forEach(client => {
       if (client !== this) {
         if (client._connected) {
           Y.applyUpdate(client._doc, update, this._connection);
@@ -195,14 +195,14 @@ export class Client implements Provider {
             initialConfig={{
               editorState: null,
               namespace: '',
-              onError: (e) => {
+              onError: e => {
                 throw e;
               },
             }}>
             <Editor
               provider={this}
               doc={this._doc}
-              setEditor={(editor) => (this._editor = editor)}
+              setEditor={editor => (this._editor = editor)}
               awarenessData={awarenessData}
               shouldBootstrapEditor={options.shouldBootstrapEditor}
               useCollabV2={this._connection._useCollabV2}
@@ -249,7 +249,7 @@ export class Client implements Provider {
     const listenerSet = this._listeners.get(type);
 
     if (listenerSet !== undefined) {
-      listenerSet.forEach((callback) => callback(data));
+      listenerSet.forEach(callback => callback(data));
     }
   }
 

--- a/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
+++ b/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
@@ -63,7 +63,7 @@ function ContentEditableElementImpl(
   const [isEditable, setEditable] = useState(editor.isEditable());
 
   const handleRef = useCallback<RefCallback<HTMLDivElement>>(
-    (rootElement) => {
+    rootElement => {
       // defaultView is required for a root element.
       // In multi-window setups, the defaultView may not exist at certain points.
       if (
@@ -82,7 +82,7 @@ function ContentEditableElementImpl(
 
   useLayoutEffect(() => {
     setEditable(editor.isEditable());
-    return editor.registerEditableListener((currentIsEditable) => {
+    return editor.registerEditableListener(currentIsEditable => {
       setEditable(currentIsEditable);
     });
   }, [editor]);

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -442,7 +442,7 @@ export function LexicalMenu<TOption extends MenuOption>({
     return mergeRegister(
       editor.registerCommand<KeyboardEvent>(
         KEY_ARROW_DOWN_COMMAND,
-        (payload) => {
+        payload => {
           const event = payload;
           if (options !== null && options.length) {
             const newSelectedIndex =
@@ -480,7 +480,7 @@ export function LexicalMenu<TOption extends MenuOption>({
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ARROW_UP_COMMAND,
-        (payload) => {
+        payload => {
           const event = payload;
           if (options !== null && options.length) {
             const newSelectedIndex =
@@ -512,7 +512,7 @@ export function LexicalMenu<TOption extends MenuOption>({
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ESCAPE_COMMAND,
-        (payload) => {
+        payload => {
           const event = payload;
           event.preventDefault();
           event.stopImmediatePropagation();
@@ -523,7 +523,7 @@ export function LexicalMenu<TOption extends MenuOption>({
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_TAB_COMMAND,
-        (payload) => {
+        payload => {
           const event = payload;
           if (
             options === null ||

--- a/packages/lexical-react/src/shared/buildEditorComponent.tsx
+++ b/packages/lexical-react/src/shared/buildEditorComponent.tsx
@@ -20,7 +20,7 @@ export function buildEditorComponent(
   context: LexicalComposerContextWithEditor,
 ) {
   const [editor] = context;
-  const rawConfigDecorators = config.decorators.map((El) =>
+  const rawConfigDecorators = config.decorators.map(El =>
     // eslint-disable-next-line react/jsx-key -- wrapped later
     typeof El === 'function' ? <El context={context} /> : El,
   );
@@ -36,7 +36,7 @@ export function buildEditorComponent(
       () =>
         rawConfigDecorators.map((decorator, i) => (
           <ErrorBoundary
-            onError={(e) => {
+            onError={e => {
               editor._onError(e);
             }}
             key={i}>

--- a/packages/lexical-react/src/shared/mergeRefs.ts
+++ b/packages/lexical-react/src/shared/mergeRefs.ts
@@ -8,7 +8,7 @@
 import type {Ref} from 'react';
 
 export function mergeRefs<T>(...refs: Ref<T>[]): (value: null | T) => void {
-  return (value) => {
+  return value => {
     for (const ref of refs) {
       if (typeof ref === 'function') {
         ref(value);

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -45,7 +45,7 @@ export function useCharacterLimit(
   optional: OptionalProps = Object.freeze({}),
 ): void {
   const {
-    strlen = (input) => input.length,
+    strlen = input => input.length,
     // UTF-16
     remainingCharacters = () => {
       return;
@@ -103,7 +103,7 @@ export function useCharacterLimit(
       }),
       editor.registerCommand(
         DELETE_CHARACTER_COMMAND,
-        (isBackward) => {
+        isBackward => {
           const selection = $getSelection();
           if (!$isRangeSelection(selection)) {
             return false;

--- a/packages/lexical-react/src/shared/useDecorators.tsx
+++ b/packages/lexical-react/src/shared/useDecorators.tsx
@@ -33,7 +33,7 @@ export function useDecorators(
 
   // Subscribe to changes
   useLayoutEffect(() => {
-    return editor.registerDecoratorListener<JSX.Element>((nextDecorators) => {
+    return editor.registerDecoratorListener<JSX.Element>(nextDecorators => {
       flushSync(() => {
         setDecorators(nextDecorators);
       });
@@ -55,7 +55,7 @@ export function useDecorators(
     for (let i = 0; i < decoratorKeys.length; i++) {
       const nodeKey = decoratorKeys[i];
       const reactDecorator = (
-        <ErrorBoundary onError={(e) => editor._onError(e)}>
+        <ErrorBoundary onError={e => editor._onError(e)}>
           <Suspense fallback={null}>{decorators[nodeKey]}</Suspense>
         </ErrorBoundary>
       );

--- a/packages/lexical-react/src/shared/useReactDecorators.tsx
+++ b/packages/lexical-react/src/shared/useReactDecorators.tsx
@@ -38,7 +38,7 @@ export function useReactDecorators(
       if (element !== null) {
         const reactDecorator = (
           <ErrorBoundary
-            onError={(e) => {
+            onError={e => {
               editor._onError(e);
             }}>
             <Suspense fallback={null}>{decorators[nodeKey]}</Suspense>

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -400,7 +400,7 @@ function useProvider(
   useEffect(() => {
     return editor.registerCommand(
       TOGGLE_CONNECT_COMMAND,
-      (payload) => {
+      payload => {
         const shouldConnect = payload;
 
         if (shouldConnect) {

--- a/packages/lexical-react/src/useLexicalEditable.ts
+++ b/packages/lexical-react/src/useLexicalEditable.ts
@@ -14,7 +14,7 @@ import {useLexicalSubscription} from './useLexicalSubscription';
 function subscription(editor: LexicalEditor): LexicalSubscription<boolean> {
   return {
     initialValueFn: () => editor.isEditable(),
-    subscribe: (callback) => {
+    subscribe: callback => {
       return editor.registerEditableListener(callback);
     },
   };

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
@@ -36,7 +36,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalHeadingNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('HeadingNode.constructor', async () => {
       const {editor} = testEnv;
       await editor.update(() => {

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
@@ -19,7 +19,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalQuoteNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('QuoteNode.constructor', async () => {
       const {editor} = testEnv;
       await editor.update(() => {

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalTabNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalTabNode.test.ts
@@ -21,7 +21,7 @@ import {initializeUnitTest, invariant} from 'lexical/src/__tests__/utils';
 import {describe, expect, test} from 'vitest';
 
 describe('LexicalTabNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('INSERT_TAB_COMMAND applies selection format and style to TabNode', async () => {
       const {editor} = testEnv;
       registerRichText(editor);
@@ -49,7 +49,7 @@ describe('LexicalTabNode tests', () => {
       await editor.read(() => {
         const root = $getRoot();
         const nodes = root.getAllTextNodes();
-        const tabNode = nodes.find((n) => n.getType() === 'tab');
+        const tabNode = nodes.find(n => n.getType() === 'tab');
         invariant(tabNode !== undefined && $isTabNode(tabNode));
         expect(tabNode.getFormat()).toBe(1);
       });
@@ -92,7 +92,7 @@ describe('LexicalTabNode tests', () => {
         const root = $getRoot();
         const tabNodes = root
           .getAllTextNodes()
-          .filter((n) => n.getType() === 'tab');
+          .filter(n => n.getType() === 'tab');
         expect(tabNodes.length).toBe(2);
         tabNodes[1].selectStart();
       });
@@ -106,7 +106,7 @@ describe('LexicalTabNode tests', () => {
       await editor.read(() => {
         const root = $getRoot();
         const nodes = root.getAllTextNodes();
-        const xNode = nodes.find((n) => n.getTextContent() === 'x');
+        const xNode = nodes.find(n => n.getTextContent() === 'x');
         invariant(xNode !== undefined && $isTextNode(xNode));
         expect(xNode.getFormat()).toBe(1);
       });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -199,7 +199,7 @@ export class QuoteNode extends ElementNode {
   collapseAtStart(): true {
     const paragraph = $createParagraphNode();
     const children = this.getChildren();
-    children.forEach((child) => paragraph.append(child));
+    children.forEach(child => paragraph.append(child));
     this.replace(paragraph);
     return true;
   }
@@ -401,7 +401,7 @@ export class HeadingNode extends ElementNode {
       ? $createHeadingNode(this.getTag())
       : $createParagraphNode();
     const children = this.getChildren();
-    children.forEach((child) => newElement.append(child));
+    children.forEach(child => newElement.append(child));
     this.replace(newElement);
     return true;
   }
@@ -495,7 +495,7 @@ async function onCutForRichText(
     if ($isRangeSelection(selection)) {
       selection.removeText();
     } else if ($isNodeSelection(selection)) {
-      selection.getNodes().forEach((node) => node.remove());
+      selection.getNodes().forEach(node => node.remove());
     }
   });
 }
@@ -572,7 +572,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
   const removeListener = mergeRegister(
     editor.registerCommand(
       CLICK_COMMAND,
-      (payload) => {
+      payload => {
         const selection = $getSelection();
         if ($isNodeSelection(selection)) {
           selection.clear();
@@ -584,7 +584,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<boolean>(
       DELETE_CHARACTER_COMMAND,
-      (isBackward) => {
+      isBackward => {
         const selection = $getSelection();
         if ($isRangeSelection(selection)) {
           selection.deleteCharacter(isBackward);
@@ -599,7 +599,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<boolean>(
       DELETE_WORD_COMMAND,
-      (isBackward) => {
+      isBackward => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;
@@ -611,7 +611,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<boolean>(
       DELETE_LINE_COMMAND,
-      (isBackward) => {
+      isBackward => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;
@@ -623,7 +623,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       CONTROLLED_TEXT_INSERTION_COMMAND,
-      (eventOrText) => {
+      eventOrText => {
         const selection = $getSelection();
 
         if (typeof eventOrText === 'string') {
@@ -664,7 +664,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<TextFormatType>(
       FORMAT_TEXT_COMMAND,
-      (format) => {
+      format => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;
@@ -676,7 +676,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<ElementFormatType>(
       FORMAT_ELEMENT_COMMAND,
-      (format) => {
+      format => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection) && !$isNodeSelection(selection)) {
           return false;
@@ -698,7 +698,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<boolean>(
       INSERT_LINE_BREAK_COMMAND,
-      (selectStart) => {
+      selectStart => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;
@@ -737,7 +737,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     editor.registerCommand(
       INDENT_CONTENT_COMMAND,
       () => {
-        return $handleIndentAndOutdent((block) => {
+        return $handleIndentAndOutdent(block => {
           const indent = block.getIndent();
           block.setIndent(indent + 1);
         });
@@ -747,7 +747,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     editor.registerCommand(
       OUTDENT_CONTENT_COMMAND,
       () => {
-        return $handleIndentAndOutdent((block) => {
+        return $handleIndentAndOutdent(block => {
           const indent = block.getIndent();
           if (indent > 0) {
             block.setIndent(Math.max(0, indent - 1));
@@ -758,7 +758,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_UP_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if ($isNodeSelection(selection)) {
           // If selection is on a node, let's try and move selection
@@ -788,7 +788,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_DOWN_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if ($isNodeSelection(selection)) {
           // If selection is on a node, let's try and move selection
@@ -822,7 +822,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_LEFT_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if ($isNodeSelection(selection)) {
           // If selection is on a node, let's try and move selection
@@ -853,7 +853,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_RIGHT_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if ($isNodeSelection(selection)) {
           // If selection is on a node, let's try and move selection
@@ -884,7 +884,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_BACKSPACE_COMMAND,
-      (event) => {
+      event => {
         if ($isTargetWithinDecorator(event.target as HTMLElement)) {
           return false;
         }
@@ -910,7 +910,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent>(
       KEY_DELETE_COMMAND,
-      (event) => {
+      event => {
         if ($isTargetWithinDecorator(event.target as HTMLElement)) {
           return false;
         }
@@ -925,7 +925,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<KeyboardEvent | null>(
       KEY_ENTER_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           return false;
@@ -970,7 +970,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<DragEvent>(
       DROP_COMMAND,
-      (event) => {
+      event => {
         const [, files] = eventFiles(event);
         if (files.length > 0) {
           const x = event.clientX;
@@ -1006,7 +1006,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<DragEvent>(
       DRAGSTART_COMMAND,
-      (event) => {
+      event => {
         const [isFileTransfer] = eventFiles(event);
         const selection = $getSelection();
         if (isFileTransfer && !$isRangeSelection(selection)) {
@@ -1034,7 +1034,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand<DragEvent>(
       DRAGOVER_COMMAND,
-      (event) => {
+      event => {
         const [isFileTransfer] = eventFiles(event);
         const selection = $getSelection();
         if (isFileTransfer && !$isRangeSelection(selection)) {
@@ -1066,7 +1066,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       COPY_COMMAND,
-      (event) => {
+      event => {
         copyToClipboard(
           editor,
           objectKlassEquals(event, ClipboardEvent) ? event : null,
@@ -1077,7 +1077,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       CUT_COMMAND,
-      (event) => {
+      event => {
         onCutForRichText(event, editor);
         return true;
       },
@@ -1085,7 +1085,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       PASTE_COMMAND,
-      (event) => {
+      event => {
         const [, files, hasTextContent] = eventFiles(event);
         if (files.length > 0 && !hasTextContent) {
           editor.dispatchCommand(DRAG_DROP_PASTE, files);
@@ -1112,7 +1112,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       KEY_SPACE_COMMAND,
-      (_) => {
+      _ => {
         const selection = $getSelection();
 
         if ($isRangeSelection(selection)) {
@@ -1125,7 +1125,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       KEY_TAB_COMMAND,
-      (_) => {
+      _ => {
         const selection = $getSelection();
 
         if ($isRangeSelection(selection)) {

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -285,7 +285,7 @@ describe('LexicalSelection tests', () => {
     editor!.getEditorState().read(() => {
       const xNode = $getRoot()
         .getAllTextNodes()
-        .find((node) => node.getTextContent() === 'x');
+        .find(node => node.getTextContent() === 'x');
       expect(xNode).toBeDefined();
       expect(xNode!.hasFormat('bold')).toBe(true);
     });
@@ -1879,7 +1879,7 @@ describe('LexicalSelection tests', () => {
       },
     ];
     baseCases
-      .flatMap((testCase) => {
+      .flatMap(testCase => {
         // Test inverse selection
         const inverse = {
           ...testCase,
@@ -2187,7 +2187,7 @@ describe('LexicalSelection tests', () => {
       },
     ];
     baseCases
-      .flatMap((testCase) => {
+      .flatMap(testCase => {
         const inverse = {
           ...testCase,
           invertSelection: true,
@@ -2424,7 +2424,7 @@ describe('LexicalSelection tests', () => {
         },
         name: 'moves selection to parent if next sibling is not a text node',
       },
-    ].forEach((testCase) => {
+    ].forEach(testCase => {
       test(testCase.name, async () => {
         await testEditor.update(() => {
           const {key, offset} = testCase.fn();

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -140,7 +140,7 @@ describe('LexicalSelectionHelpers tests', () => {
       });
 
       // getTextContent
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         expect(selection.getTextContent()).toEqual('');
       });
 
@@ -189,7 +189,7 @@ describe('LexicalSelectionHelpers tests', () => {
       });
 
       // insertParagraph
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         selection.insertParagraph();
 
         expect(selection.anchor).toEqual(
@@ -735,7 +735,7 @@ describe('LexicalSelectionHelpers tests', () => {
       });
 
       // getTextContent
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         expect(selection.getTextContent()).toEqual('');
       });
 
@@ -888,7 +888,7 @@ describe('LexicalSelectionHelpers tests', () => {
       });
 
       // getTextContent
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         expect(selection.getTextContent()).toEqual('');
       });
 
@@ -1041,7 +1041,7 @@ describe('LexicalSelectionHelpers tests', () => {
       });
 
       // getTextContent
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         expect(selection.getTextContent()).toEqual('');
       });
 
@@ -1344,7 +1344,7 @@ describe('LexicalSelectionHelpers tests', () => {
       });
 
       // getTextContent
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         expect(selection.getTextContent()).toEqual('a');
       });
 
@@ -1393,7 +1393,7 @@ describe('LexicalSelectionHelpers tests', () => {
       });
 
       // insertParagraph
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         selection.insertParagraph();
 
         expect(selection.anchor).toEqual(
@@ -1513,12 +1513,12 @@ describe('LexicalSelectionHelpers tests', () => {
       };
 
       // getNodes
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         expect(selection.getNodes()).toEqual([$getNodeByKey('a')]);
       });
 
       // getTextContent
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         expect(selection.getTextContent()).toEqual('a');
       });
 
@@ -1684,7 +1684,7 @@ describe('LexicalSelectionHelpers tests', () => {
       });
 
       // getTextContent
-      setupTestCase((selection) => {
+      setupTestCase(selection => {
         expect(selection.getTextContent()).toEqual('abc');
       });
 
@@ -3185,7 +3185,7 @@ describe('$patchStyleText', () => {
 
   test.each<TextModeType>(['token', 'segmented'])(
     'can update style of text node that is in %s mode',
-    async (mode) => {
+    async mode => {
       const editor = createTestEditor();
 
       const element = document.createElement('div');

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -323,7 +323,7 @@ export function $patchStyleText(
       $patchStyle(emptyNode, patch);
     }
   }
-  $forEachSelectedTextNode((textNode) => {
+  $forEachSelectedTextNode(textNode => {
     $patchStyle(textNode, patch);
   });
 

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -181,7 +181,7 @@ export function $wrapNodes(
     let element = createElement();
     element.setFormat(target.getFormatType());
     element.setIndent(target.getIndent());
-    children.forEach((child) => element.append(child));
+    children.forEach(child => element.append(child));
 
     if (wrappingElement) {
       element = wrappingElement.append(element);
@@ -326,12 +326,12 @@ export function $wrapNodesImpl(
         elementMapping.set(parentKey, targetElement);
         // Move node and its siblings to the new
         // element.
-        parent.getChildren().forEach((child) => {
+        parent.getChildren().forEach(child => {
           targetElement.append(child);
           movedNodes.add(child.getKey());
           if ($isElementNode(child)) {
             // Skip nested leaf nodes if the parent has already been moved
-            child.getChildrenKeys().forEach((key) => movedNodes.add(key));
+            child.getChildrenKeys().forEach(key => movedNodes.add(key));
           }
         });
         $removeParentEmptyElements(parent);

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -397,7 +397,7 @@ export function $convertTableCellNodeElement(
   const hasUnderlineTextDecoration = textDecoration.includes('underline');
   const color = style.color;
   return {
-    after: (childLexicalNodes) => {
+    after: childLexicalNodes => {
       const result: LexicalNode[] = [];
       let paragraphNode: ParagraphNode | null = null;
 

--- a/packages/lexical-table/src/LexicalTableExtension.ts
+++ b/packages/lexical-table/src/LexicalTableExtension.ts
@@ -91,7 +91,7 @@ export const TableExtension = defineExtension({
       effect(() =>
         stores.hasCellBackgroundColor.value
           ? undefined
-          : editor.registerNodeTransform(TableCellNode, (node) => {
+          : editor.registerNodeTransform(TableCellNode, node => {
               if (node.getBackgroundColor() !== null) {
                 node.setBackgroundColor(null);
               }

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -365,7 +365,7 @@ export class TableNode extends ElementNode {
     updateColgroup(
       tableElement,
       this.getColumnCount(),
-      colWidths.map((width) => width * scale),
+      colWidths.map(width => width * scale),
     );
   }
 
@@ -373,7 +373,7 @@ export class TableNode extends ElementNode {
     const superExport = super.exportDOM(editor);
     const {element} = superExport;
     return {
-      after: (tableElement) => {
+      after: tableElement => {
         if (superExport.after) {
           tableElement = superExport.after(tableElement);
         }
@@ -605,7 +605,7 @@ export class TableNode extends ElementNode {
     }
 
     let columnCount = 0;
-    firstRow.getChildren().forEach((cell) => {
+    firstRow.getChildren().forEach(cell => {
       if ($isTableCellNode(cell)) {
         columnCount += cell.getColSpan();
       }
@@ -660,7 +660,7 @@ export function $convertTableElement(
     }
   }
   return {
-    after: (children) => $descendantsMatching(children, $isTableRowNode),
+    after: children => $descendantsMatching(children, $isTableRowNode),
     node: tableNode,
   };
 }

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -212,7 +212,7 @@ export class TableObserver {
 
   removeListeners() {
     this.abortController.abort('removeListeners');
-    Array.from(this.listenersToRemove).forEach((removeListener) =>
+    Array.from(this.listenersToRemove).forEach(removeListener =>
       removeListener(),
     );
     this.listenersToRemove.clear();
@@ -226,7 +226,7 @@ export class TableObserver {
   }
 
   trackTable() {
-    const observer = new MutationObserver((records) => {
+    const observer = new MutationObserver(records => {
       this.editor.getEditorState().read(
         () => {
           let gridNeedsRedraw = false;
@@ -552,13 +552,13 @@ export class TableObserver {
       return;
     }
 
-    selectedNodes.forEach((cellNode) => {
+    selectedNodes.forEach(cellNode => {
       if ($isElementNode(cellNode)) {
         const paragraphNode = $createParagraphNode();
         const textNode = $createTextNode();
         paragraphNode.append(textNode);
         cellNode.append(paragraphNode);
-        cellNode.getChildren().forEach((child) => {
+        cellNode.getChildren().forEach(child => {
           if (child !== paragraphNode) {
             child.remove();
           }

--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -267,7 +267,7 @@ function $tableSelectAllCommand(): boolean {
 export function registerTableCellUnmergeTransform(
   editor: LexicalEditor,
 ): () => void {
-  return editor.registerNodeTransform(TableCellNode, (node) => {
+  return editor.registerNodeTransform(TableCellNode, node => {
     if (node.getColSpan() > 1 || node.getRowSpan() > 1) {
       // When we have rowSpan we have to map the entire Table to understand where the new Cells
       // fit best; let's analyze all Cells at once to save us from further transform iterations
@@ -352,7 +352,7 @@ export function registerTableSelectionObserver(
     ),
     editor.registerMutationListener(
       TableNode,
-      (nodeMutations) => {
+      nodeMutations => {
         editor.getEditorState().read(
           () => {
             for (const [nodeKey, mutation] of nodeMutations) {
@@ -412,7 +412,7 @@ export function registerTablePlugin(
   return mergeRegister(
     editor.registerCommand(
       INSERT_TABLE_COMMAND,
-      (payload) => {
+      payload => {
         return $insertTable(payload, hasNestedTables.peek());
       },
       COMMAND_PRIORITY_EDITOR,
@@ -455,7 +455,7 @@ function $tableSelectionInsertClipboardNodesCommand(
   const {nodes, selection} = selectionPayload;
 
   const hasTables = nodes.some(
-    (n) => $isTableNode(n) || $dfs(n).some((d) => $isTableNode(d.node)),
+    n => $isTableNode(n) || $dfs(n).some(d => $isTableNode(d.node)),
   );
   if (!hasTables) {
     // Not pasting a table - no special handling required.
@@ -466,10 +466,10 @@ function $tableSelectionInsertClipboardNodesCommand(
   const isRangeSelection = $isRangeSelection(selection);
   const isSelectionInsideOfGrid =
     (isRangeSelection &&
-      $findMatchingParent(selection.anchor.getNode(), (n) =>
+      $findMatchingParent(selection.anchor.getNode(), n =>
         $isTableCellNode(n),
       ) !== null &&
-      $findMatchingParent(selection.focus.getNode(), (n) =>
+      $findMatchingParent(selection.focus.getNode(), n =>
         $isTableCellNode(n),
       ) !== null) ||
     isTableSelection;
@@ -510,7 +510,7 @@ function $insertTableIntoGrid(
 
   const [anchor, focus] = anchorAndFocus;
   const [anchorCellNode, anchorRowNode, gridNode] = $getNodeTriplet(anchor);
-  const focusCellNode = $findMatchingParent(focus.getNode(), (n) =>
+  const focusCellNode = $findMatchingParent(focus.getNode(), n =>
     $isTableCellNode(n),
   );
 
@@ -645,7 +645,7 @@ function $insertTableIntoGrid(
         cell.setBackgroundColor(backgroundColor);
       }
       const originalChildren = cell.getChildren();
-      templateCell.getChildren().forEach((child) => {
+      templateCell.getChildren().forEach(child => {
         if ($isTextNode(child)) {
           const paragraphNode = $createParagraphNode();
           paragraphNode.append(child);
@@ -654,7 +654,7 @@ function $insertTableIntoGrid(
           cell.append(child);
         }
       });
-      originalChildren.forEach((n) => n.remove());
+      originalChildren.forEach(n => n.remove());
     }
   }
 

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -138,7 +138,7 @@ export function $convertTableRowElement(domNode: Node): DOMConversionOutput {
   }
 
   return {
-    after: (children) => $descendantsMatching(children, $isTableCellNode),
+    after: children => $descendantsMatching(children, $isTableCellNode),
     node: $createTableRowNode(height),
   };
 }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -351,7 +351,7 @@ export class TableSelection implements BaseSelection {
           lastRow = currentRow;
         }
         if (!nodeMap.has(cell.getKey())) {
-          $visitRecursively(cell, (childNode) => {
+          $visitRecursively(cell, childNode => {
             nodeMap.set(childNode.getKey(), childNode);
           });
         }
@@ -366,7 +366,7 @@ export class TableSelection implements BaseSelection {
   }
 
   getTextContent(): string {
-    const nodes = this.getNodes().filter((node) => $isTableCellNode(node));
+    const nodes = this.getNodes().filter(node => $isTableCellNode(node));
     let textContent = '';
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -408,7 +408,7 @@ export function applyTableHandlers(
     tableObserver.listenersToRemove.add(
       editor.registerCommand(
         command,
-        (event) =>
+        event =>
           $handleArrowKey(
             editor,
             event,
@@ -425,7 +425,7 @@ export function applyTableHandlers(
   tableObserver.listenersToRemove.add(
     editor.registerCommand(
       KEY_ESCAPE_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if ($isTableSelection(selection)) {
           const focusCellNode = $findParentTableCellNodeInTable(
@@ -482,14 +482,14 @@ export function applyTableHandlers(
 
       const nearestElementNode = $findMatchingParent(
         selection.anchor.getNode(),
-        (n) => $isElementNode(n),
+        n => $isElementNode(n),
       );
 
       const topLevelCellElementNode =
         nearestElementNode &&
         $findMatchingParent(
           nearestElementNode,
-          (n) => $isElementNode(n) && $isTableCellNode(n.getParent()),
+          n => $isElementNode(n) && $isTableCellNode(n.getParent()),
         );
 
       if (
@@ -582,7 +582,7 @@ export function applyTableHandlers(
   tableObserver.listenersToRemove.add(
     editor.registerCommand(
       CUT_COMMAND,
-      (event) => {
+      event => {
         const selection = $getSelection();
         if (selection) {
           if (!($isTableSelection(selection) || $isRangeSelection(selection))) {
@@ -611,7 +611,7 @@ export function applyTableHandlers(
   tableObserver.listenersToRemove.add(
     editor.registerCommand(
       FORMAT_TEXT_COMMAND,
-      (payload) => {
+      payload => {
         const selection = $getSelection();
 
         if (!$isSelectionInTable(selection, tableNode)) {
@@ -625,7 +625,7 @@ export function applyTableHandlers(
         } else if ($isRangeSelection(selection)) {
           const tableCellNode = $findMatchingParent(
             selection.anchor.getNode(),
-            (n) => $isTableCellNode(n),
+            n => $isTableCellNode(n),
           );
 
           if (!$isTableCellNode(tableCellNode)) {
@@ -642,7 +642,7 @@ export function applyTableHandlers(
   tableObserver.listenersToRemove.add(
     editor.registerCommand(
       FORMAT_ELEMENT_COMMAND,
-      (formatType) => {
+      formatType => {
         const selection = $getSelection();
         if (
           !$isTableSelection(selection) ||
@@ -709,7 +709,7 @@ export function applyTableHandlers(
   tableObserver.listenersToRemove.add(
     editor.registerCommand(
       CONTROLLED_TEXT_INSERTION_COMMAND,
-      (payload) => {
+      payload => {
         const selection = $getSelection();
 
         if (!$isSelectionInTable(selection, tableNode)) {
@@ -723,7 +723,7 @@ export function applyTableHandlers(
         } else if ($isRangeSelection(selection)) {
           const tableCellNode = $findMatchingParent(
             selection.anchor.getNode(),
-            (n) => $isTableCellNode(n),
+            n => $isTableCellNode(n),
           );
 
           if (!$isTableCellNode(tableCellNode)) {
@@ -755,7 +755,7 @@ export function applyTableHandlers(
     tableObserver.listenersToRemove.add(
       editor.registerCommand(
         KEY_TAB_COMMAND,
-        (event) => {
+        event => {
           const selection = $getSelection();
           if (
             !$isRangeSelection(selection) ||
@@ -789,7 +789,7 @@ export function applyTableHandlers(
   tableObserver.listenersToRemove.add(
     editor.registerCommand(
       FOCUS_COMMAND,
-      (payload) => {
+      payload => {
         return tableNode.isSelected();
       },
       COMMAND_PRIORITY_HIGH,
@@ -898,7 +898,7 @@ export function $handleTableSelectionChangeCommand(
         tableNode.is(
           $findMatchingParent(
             anchorCell,
-            (node) => node.is(tableNode) || node.is(firstCell),
+            node => node.is(tableNode) || node.is(firstCell),
           ),
         )
       ) {
@@ -1391,7 +1391,7 @@ export function $addHighlightStyleToTable(
   tableSelection: TableObserver,
 ) {
   tableSelection.$disableHighlightStyle();
-  $forEachTableCell(tableSelection.table, (cell) => {
+  $forEachTableCell(tableSelection.table, cell => {
     cell.highlighted = true;
     $addHighlightToDOM(editor, cell);
   });
@@ -1402,7 +1402,7 @@ export function $removeHighlightStyleToTable(
   tableObserver: TableObserver,
 ) {
   tableObserver.$enableHighlightStyle();
-  $forEachTableCell(tableObserver.table, (cell) => {
+  $forEachTableCell(tableObserver.table, cell => {
     const elem = cell.elem;
     cell.highlighted = false;
     $removeHighlightFromDOM(editor, cell);
@@ -1940,7 +1940,7 @@ function $handleArrowKey(
           ((direction === 'up' && !selection.isBackward()) ||
             (direction === 'down' && selection.isBackward()));
         if (isTableUnselect) {
-          let focusParentNode = $findMatchingParent(focusNode, (n) =>
+          let focusParentNode = $findMatchingParent(focusNode, n =>
             $isTableNode(n),
           );
           if ($isTableCellNode(focusParentNode)) {
@@ -2033,7 +2033,7 @@ function $handleArrowKey(
         } else {
           let focusParentNode = $findMatchingParent(
             focusNode,
-            (n) => $isElementNode(n) && !n.isInline(),
+            n => $isElementNode(n) && !n.isInline(),
           );
           if ($isTableCellNode(focusParentNode)) {
             focusParentNode = $findMatchingParent(
@@ -2334,16 +2334,14 @@ function $getTableEdgeCursorPosition(
     return undefined;
   }
 
-  const anchorCellNode = $findMatchingParent(selection.anchor.getNode(), (n) =>
+  const anchorCellNode = $findMatchingParent(selection.anchor.getNode(), n =>
     $isTableCellNode(n),
   ) as TableCellNode | null;
   if (!anchorCellNode) {
     return undefined;
   }
 
-  const parentTable = $findMatchingParent(anchorCellNode, (n) =>
-    $isTableNode(n),
-  );
+  const parentTable = $findMatchingParent(anchorCellNode, n => $isTableNode(n));
   if (!$isTableNode(parentTable) || !parentTable.is(tableNode)) {
     return undefined;
   }

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -82,7 +82,7 @@ export function $createTableNodeWithDimensions(
 export function $getTableCellNodeFromLexicalNode(
   startingNode: LexicalNode,
 ): TableCellNode | null {
-  const node = $findMatchingParent(startingNode, (n) => $isTableCellNode(n));
+  const node = $findMatchingParent(startingNode, n => $isTableCellNode(n));
 
   if ($isTableCellNode(node)) {
     return node;
@@ -94,7 +94,7 @@ export function $getTableCellNodeFromLexicalNode(
 export function $getTableRowNodeFromTableCellNodeOrThrow(
   startingNode: LexicalNode,
 ): TableRowNode {
-  const node = $findMatchingParent(startingNode, (n) => $isTableRowNode(n));
+  const node = $findMatchingParent(startingNode, n => $isTableRowNode(n));
 
   if ($isTableRowNode(node)) {
     return node;
@@ -106,7 +106,7 @@ export function $getTableRowNodeFromTableCellNodeOrThrow(
 export function $getTableNodeFromLexicalNodeOrThrow(
   startingNode: LexicalNode,
 ): TableNode {
-  const node = $findMatchingParent(startingNode, (n) => $isTableNode(n));
+  const node = $findMatchingParent(startingNode, n => $isTableNode(n));
 
   if ($isTableNode(node)) {
     return node;
@@ -120,14 +120,14 @@ export function $getTableRowIndexFromTableCellNode(
 ): number {
   const tableRowNode = $getTableRowNodeFromTableCellNodeOrThrow(tableCellNode);
   const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableRowNode);
-  return tableNode.getChildren().findIndex((n) => n.is(tableRowNode));
+  return tableNode.getChildren().findIndex(n => n.is(tableRowNode));
 }
 
 export function $getTableColumnIndexFromTableCellNode(
   tableCellNode: TableCellNode,
 ): number {
   const tableRowNode = $getTableRowNodeFromTableCellNodeOrThrow(tableCellNode);
-  return tableRowNode.getChildren().findIndex((n) => n.is(tableCellNode));
+  return tableRowNode.getChildren().findIndex(n => n.is(tableCellNode));
 }
 
 export type TableCellSiblings = {
@@ -842,7 +842,7 @@ export function $mergeCells(cellNodes: TableCellNode[]): TableCellNode | null {
         continue;
       }
 
-      if (cellNodes.some((cell) => cell.is(mapCell.cell))) {
+      if (cellNodes.some(cell => cell.is(mapCell.cell))) {
         processedCells.add(cellKey);
         // Get the actual position of this cell in the grid
         const cellStartRow = mapCell.startRow;
@@ -1314,7 +1314,7 @@ export function $moveTableColumn(
     return;
   }
   const rows = tableNode.getChildren().filter($isTableRowNode);
-  rows.forEach((row) => {
+  rows.forEach(row => {
     const cells = row.getChildren();
     const [moved] = cells.splice(originColumn, 1);
     cells.splice(targetColumn, 0, moved);

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -30,7 +30,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalTableCellNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('TableCellNode.constructor', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -78,7 +78,7 @@ describe('TableExtension', () => {
     );
     editor.read(() => {
       const children = $getRoot().getChildren();
-      expect(children.map((node) => node.getType())).toEqual([
+      expect(children.map(node => node.getType())).toEqual([
         'paragraph',
         'table',
         'paragraph',
@@ -87,7 +87,7 @@ describe('TableExtension', () => {
       expect($isTableNode(table)).toBe(true);
       const rows = table.getChildren();
       expect(rows.length).toBe(2);
-      rows.forEach((row) => {
+      rows.forEach(row => {
         expect($isTableRowNode(row)).toBe(true);
         if ($isTableRowNode(row)) {
           const cells = row.getChildren();
@@ -505,7 +505,7 @@ describe('TableExtension', () => {
         const selectedNodes = selection.getNodes().filter($isTableCellNode);
         const totalCells = tableMap.reduce((acc, row) => {
           const uniqueCells = new Set();
-          row.forEach((cellMap) => {
+          row.forEach(cellMap => {
             if (cellMap && cellMap.cell) {
               uniqueCells.add(cellMap.cell.getKey());
             }
@@ -601,11 +601,11 @@ describe('TableExtension', () => {
         // Verify all unique cells are in the selection (merged cells should appear once)
         const selectedNodes = selection.getNodes().filter($isTableCellNode);
         const uniqueCellKeys = new Set(
-          selectedNodes.map((node) => node.getKey()),
+          selectedNodes.map(node => node.getKey()),
         );
         const totalUniqueCells = new Set<NodeKey>();
-        tableMap.forEach((row) => {
-          row.forEach((cellMap) => {
+        tableMap.forEach(row => {
+          row.forEach(cellMap => {
             if (cellMap && cellMap.cell) {
               totalUniqueCells.add(cellMap.cell.getKey());
             }

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableMobileSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableMobileSelection.test.tsx
@@ -51,7 +51,7 @@ interface PointerEventInit extends EventInit {
  * would incorrectly create table selections instead of just moving the cursor.
  */
 describe('LexicalTableMobileSelection', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     /**
      * Helper function to create a 2x2 table for testing
      */

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -103,7 +103,7 @@ function wrapTableHtml(expected: string): string {
 polyfillContentEditable();
 
 describe('LexicalTableNode tests', () => {
-  [false, true].forEach((hasHorizontalScroll) => {
+  [false, true].forEach(hasHorizontalScroll => {
     describe(`hasHorizontalScroll={${hasHorizontalScroll}}`, () => {
       function expectTableHtmlToBeEqual(
         actual: string,
@@ -126,7 +126,7 @@ describe('LexicalTableNode tests', () => {
       }
 
       initializeUnitTest(
-        (testEnv) => {
+        testEnv => {
           beforeEach(async () => {
             const {editor} = testEnv;
             await editor.update(() => {
@@ -1848,7 +1848,7 @@ describe('LexicalTableNode tests', () => {
       return <TablePlugin hasHorizontalScroll={hasHorizontalScroll} />;
     }
     initializeUnitTest(
-      (testEnv) => {
+      testEnv => {
         beforeEach(async () => {
           const {editor} = testEnv;
           await editor.update(() => {

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableRowNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableRowNode.test.ts
@@ -18,7 +18,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalTableRowNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('TableRowNode.constructor', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -32,7 +32,7 @@ import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 import {beforeEach, describe, expect, test} from 'vitest';
 
 describe('table selection', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     let tableNode: TableNode;
     let tableMap: TableMapType;
     let tableSelection: TableSelection;
@@ -75,7 +75,7 @@ describe('table selection', () => {
             expect(
               $getRoot()
                 .getAllTextNodes()
-                .map((node) => node.getStyle()),
+                .map(node => node.getStyle()),
             ).toEqual(Array.from({length}, () => ''));
             expect($isTableSelection($getSelection())).toBe(true);
             $patchStyleText($getSelection()!, {color: 'red'});
@@ -83,7 +83,7 @@ describe('table selection', () => {
             expect(
               $getRoot()
                 .getAllTextNodes()
-                .map((node) => node.getStyle()),
+                .map(node => node.getStyle()),
             ).toEqual(Array.from({length}, () => 'color: red;'));
           },
           {discrete: true},

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -42,11 +42,11 @@ function $createTestTable(rows: number, columns: number): TableNode {
 }
 
 function $getTableCellTexts(tableNode: TableNode): string[][] {
-  return tableNode.getChildren().map((row) => {
+  return tableNode.getChildren().map(row => {
     if (!$isTableRowNode(row)) {
       return [];
     }
-    return row.getChildren().map((cell) => {
+    return row.getChildren().map(cell => {
       if (!$isTableCellNode(cell)) {
         return '';
       }
@@ -483,7 +483,7 @@ describe('$moveTableColumn', () => {
       // Verify row and column count is preserved
       const rows = table.getChildren();
       expect(rows.length).toBe(3);
-      rows.forEach((row) => {
+      rows.forEach(row => {
         if (!$isTableRowNode(row)) {
           throw new Error('Expected row node');
         }

--- a/packages/lexical-tailwind/src/index.ts
+++ b/packages/lexical-tailwind/src/index.ts
@@ -114,7 +114,7 @@ const theme: EditorThemeClasses = {
       'list-[lower-alpha]',
       'list-[upper-roman]',
       'list-[lower-roman]',
-    ].map((cls) => join(listCommonClasses, cls)),
+    ].map(cls => join(listCommonClasses, cls)),
     ul: join(listCommonClasses, 'list-disc'),
   },
   // mark: 'PlaygroundEditorTheme__mark',

--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -39,7 +39,7 @@ interface DFSKeyPair {
 }
 
 describe('LexicalNodeHelpers tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('dfs order', () => {
       let expectedKeys: DFSKeyPair[];
       let reverseExpectedKeys: DFSKeyPair[];
@@ -118,7 +118,7 @@ describe('LexicalNodeHelpers tests', () => {
               text5,
               block3,
               text6,
-            ].map((n) => ({depth: n.getParentKeys().length, node: n.getKey()})),
+            ].map(n => ({depth: n.getParentKeys().length, node: n.getKey()})),
           );
           // R, P2, B3, T6, T5, T4, P1, B2, T3, T2, B1, T1
           expect(reverseExpectedKeys).toEqual(
@@ -135,7 +135,7 @@ describe('LexicalNodeHelpers tests', () => {
               text2,
               block1,
               text1,
-            ].map((n) => ({depth: n.getParentKeys().length, node: n.getKey()})),
+            ].map(n => ({depth: n.getParentKeys().length, node: n.getKey()})),
           );
         });
       });

--- a/packages/lexical-utils/src/__tests__/unit/LexicalRootHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalRootHelpers.test.ts
@@ -16,7 +16,7 @@ import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 import {describe, expect, it} from 'vitest';
 
 describe('LexicalRootHelpers tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     it('textContent', async () => {
       const editor = testEnv.editor;
 

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRootAtCaret.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRootAtCaret.test.ts
@@ -219,9 +219,9 @@ const scenarios: Scenario[] = [
 const optionVariants: {
   options: SplitAtPointCaretNextOptions;
   splits: SplitFlags;
-}[] = [true, false].flatMap((first) =>
-  [true, false].flatMap((last) =>
-    [true, false].flatMap((removeEmptyDestination) => [
+}[] = [true, false].flatMap(first =>
+  [true, false].flatMap(last =>
+    [true, false].flatMap(removeEmptyDestination => [
       {
         options: {
           $shouldSplit: (_node, edge) =>

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
@@ -18,7 +18,7 @@ class MyEvent2 extends Event {}
 const MyEventShadow = (() => class MyEvent extends Event {})();
 
 describe('LexicalUtilsKlassEqual tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     it('objectKlassEquals', async () => {
       const eventInstance = new MyEvent('');
       expect(eventInstance instanceof MyEvent).toBeTruthy();

--- a/packages/lexical-utils/src/__tests__/unit/descendantsMatching.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/descendantsMatching.test.tsx
@@ -50,7 +50,7 @@ describe('$descendantsMatching', () => {
     editor._headless = true;
   });
 
-  [0, 1, 2].forEach((depth) =>
+  [0, 1, 2].forEach(depth =>
     it(`Can un-nest children at depth ${depth}`, () => {
       editor.update(
         () => {

--- a/packages/lexical-utils/src/__tests__/unit/iterators.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/iterators.test.tsx
@@ -37,16 +37,16 @@ describe('$firstToLastIterator', () => {
         );
         // Check initial state
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
         expect(
-          Array.from($firstToLastIterator(parent), (node) => {
+          Array.from($firstToLastIterator(parent), node => {
             return assertClass(node, TextNode).getTextContent();
           }),
         ).toEqual(['0', '1', '2', '3', '4']);
         // Parent was not affected
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
       },
       {discrete: true},
@@ -62,10 +62,10 @@ describe('$firstToLastIterator', () => {
         );
         // Check initial state
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
         expect(
-          Array.from($firstToLastIterator(parent), (node) => {
+          Array.from($firstToLastIterator(parent), node => {
             const rval = assertClass(node, TextNode).getTextContent();
             node.remove();
             return rval;
@@ -86,10 +86,10 @@ describe('$firstToLastIterator', () => {
         );
         // Check initial state
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
         expect(() =>
-          Array.from($firstToLastIterator(parent), (node) => {
+          Array.from($firstToLastIterator(parent), node => {
             const rval = assertClass(node, TextNode).getTextContent();
             parent.append(node);
             return rval;
@@ -109,10 +109,10 @@ describe('$firstToLastIterator', () => {
         );
         // Check initial state
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
         expect(
-          Array.from($firstToLastIterator(parent), (node) => {
+          Array.from($firstToLastIterator(parent), node => {
             const rval = assertClass(node, TextNode).getTextContent();
             if (node.getPreviousSibling() !== null) {
               parent.splice(0, 0, [node]);
@@ -122,7 +122,7 @@ describe('$firstToLastIterator', () => {
         ).toEqual(['0', '1', '2', '3', '4']);
         // This mutation reversed the nodes while traversing
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['4', '3', '2', '1', '0']);
       },
       {discrete: true},
@@ -148,16 +148,16 @@ describe('$lastToFirstIterator', () => {
         );
         // Check initial state
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
         expect(
-          Array.from($lastToFirstIterator(parent), (node) => {
+          Array.from($lastToFirstIterator(parent), node => {
             return assertClass(node, TextNode).getTextContent();
           }),
         ).toEqual(['4', '3', '2', '1', '0']);
         // Parent was not affected
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
       },
       {discrete: true},
@@ -173,10 +173,10 @@ describe('$lastToFirstIterator', () => {
         );
         // Check initial state
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
         expect(
-          Array.from($lastToFirstIterator(parent), (node) => {
+          Array.from($lastToFirstIterator(parent), node => {
             const rval = assertClass(node, TextNode).getTextContent();
             node.remove();
             return rval;
@@ -197,10 +197,10 @@ describe('$lastToFirstIterator', () => {
         );
         // Check initial state
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['0', '1', '2', '3', '4']);
         expect(
-          Array.from($lastToFirstIterator(parent), (node) => {
+          Array.from($lastToFirstIterator(parent), node => {
             const rval = assertClass(node, TextNode).getTextContent();
             parent.append(node);
             return rval;
@@ -208,7 +208,7 @@ describe('$lastToFirstIterator', () => {
         ).toEqual(['4', '3', '2', '1', '0']);
         // This mutation reversed the nodes while traversing
         expect(
-          parent.getAllTextNodes().map((node) => node.getTextContent()),
+          parent.getAllTextNodes().map(node => node.getTextContent()),
         ).toEqual(['4', '3', '2', '1', '0']);
       },
       {discrete: true},

--- a/packages/lexical-utils/src/__tests__/unit/unwrapAndFilterDescendants.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/unwrapAndFilterDescendants.test.tsx
@@ -69,7 +69,7 @@ describe('$unwrapAndFilterDescendants', () => {
       {discrete: true},
     );
   });
-  [0, 1, 2].forEach((depth) =>
+  [0, 1, 2].forEach(depth =>
     it(`Can un-nest children at depth ${depth}`, () => {
       editor.update(
         () => {

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -251,7 +251,7 @@ function $dfsCaretIterator<D extends CaretDirection>(
   return makeStepwiseIterator({
     hasNext: (state): state is NodeCaret<'next'> => state !== null,
     initial: startCaret,
-    map: (state) => ({depth, node: state.origin}),
+    map: state => ({depth, node: state.origin}),
     step: (state: NodeCaret<'next'>) => {
       if (state.isSameNodeCaret(endCaret)) {
         return null;
@@ -363,7 +363,7 @@ export function $getNearestBlockElementAncestorOrThrow(
 ): ElementNode {
   const blockNode = $findMatchingParent(
     startNode,
-    (node) => $isElementNode(node) && !node.isInline(),
+    node => $isElementNode(node) && !node.isInline(),
   );
   if (!$isElementNode(blockNode)) {
     invariant(
@@ -812,7 +812,7 @@ function $unwrapAndFilterDescendantsImpl(
       $unwrapAndFilterDescendantsImpl(
         node,
         $predicate,
-        $onSuccess || ((child) => node.insertAfter(child)),
+        $onSuccess || (child => node.insertAfter(child)),
       );
     }
     node.remove();
@@ -890,7 +890,7 @@ function $childIterator<D extends CaretDirection>(
   return makeStepwiseIterator({
     hasNext: $isSiblingCaret,
     initial: startCaret.getAdjacentCaret(),
-    map: (caret) => {
+    map: caret => {
       const origin = caret.origin.getLatest();
       if (__DEV__ && seen !== null) {
         const key = origin.getKey();
@@ -982,7 +982,7 @@ export interface StateConfigWrapper<K extends string, V> {
 export function makeStateWrapper<K extends string, V>(
   stateConfig: StateConfig<K, V>,
 ): StateConfigWrapper<K, V> {
-  const $get: StateConfigWrapper<K, V>['$get'] = (node) =>
+  const $get: StateConfigWrapper<K, V>['$get'] = node =>
     $getState(node, stateConfig);
   const $set: StateConfigWrapper<K, V>['$set'] = (node, valueOrUpdater) =>
     $setState(node, stateConfig, valueOrUpdater);

--- a/packages/lexical-utils/src/positionNodeOnRange.ts
+++ b/packages/lexical-utils/src/positionNodeOnRange.ts
@@ -127,7 +127,7 @@ export default function mlcPositionNodeOnRange(
     stop();
     rootDOMNode = currentRootDOMNode;
     parentDOMNode = currentParentDOMNode;
-    observer = new MutationObserver((mutations) => {
+    observer = new MutationObserver(mutations => {
       const nextRootDOMNode = editor.getRootElement();
       const nextParentDOMNode =
         nextRootDOMNode && nextRootDOMNode.parentElement;

--- a/packages/lexical-utils/src/selectionAlwaysOnDisplay.ts
+++ b/packages/lexical-utils/src/selectionAlwaysOnDisplay.ts
@@ -38,7 +38,7 @@ export default function selectionAlwaysOnDisplay(
     }
   };
 
-  return editor.registerRootListener((rootElement) => {
+  return editor.registerRootListener(rootElement => {
     if (rootElement) {
       const document = rootElement.ownerDocument;
       document.addEventListener('selectionchange', onSelectionChange);

--- a/packages/lexical-website/docs/concepts/nodes.mdx
+++ b/packages/lexical-website/docs/concepts/nodes.mdx
@@ -512,7 +512,7 @@ const DEFAULT_COLOR = 'inherit';
 // highlight-start
 // This defines how the color property is parsed along with a default value
 const colorState = createState('color', {
-  parse: (value) => (typeof value === 'string' ? value : DEFAULT_COLOR),
+  parse: value => (typeof value === 'string' ? value : DEFAULT_COLOR),
 });
 // highlight-end
 

--- a/packages/lexical-website/docusaurus.config.ts
+++ b/packages/lexical-website/docusaurus.config.ts
@@ -55,14 +55,14 @@ function buildLexicalWebpackAliases() {
         moduleExports.import.default,
         moduleExports.require.development,
         moduleExports.require.default,
-      ].flatMap((fn) => {
+      ].flatMap(fn => {
         if (!fn) {
           return [];
         }
         const rel = fn.replace(/^\.\//, '');
         return [pkg.resolve('dist', rel), pkg.resolve(rel)];
       });
-      const resolved = candidates.find((f) => fs.existsSync(f));
+      const resolved = candidates.find(f => fs.existsSync(f));
       if (!resolved) {
         throw new Error(
           `Missing dist file for ${name}. Run \`pnpm run build\` first.\n` +
@@ -153,7 +153,7 @@ const sidebarItemsGenerator: SidebarItemsGenerator = async ({
   const items = await defaultSidebarItemsGenerator(args);
   if (args.item.dirName === 'api') {
     return items
-      .map((sidebarItem) => {
+      .map(sidebarItem => {
         if (sidebarItem.type === 'doc' && sidebarItem.id in docLabels) {
           return {...sidebarItem, label: docLabels[sidebarItem.id]};
         } else if (sidebarItem.type !== 'category') {
@@ -221,7 +221,7 @@ const sidebarItemsGenerator: SidebarItemsGenerator = async ({
 
 const parseFrontMatter: NonNullable<
   Config['markdown']
->['parseFrontMatter'] = async (params) => {
+>['parseFrontMatter'] = async params => {
   const result = await params.defaultParseFrontMatter(params);
   if (params.filePath.endsWith('/docs/api/modules.md')) {
     Object.assign(result.frontMatter, {
@@ -247,10 +247,10 @@ const docusaurusPluginTypedocConfig = {
     ? []
     : packagesManager
         .getPublicPackages()
-        .flatMap((pkg) =>
+        .flatMap(pkg =>
           pkg
             .getExportedNpmModuleEntries()
-            .map((entry) =>
+            .map(entry =>
               path.relative(
                 __dirname,
                 pkg.resolve('src', entry.sourceFileName),
@@ -402,7 +402,7 @@ const config: Config = {
         ],
       },
     ],
-  ].filter((plugin) => plugin != null),
+  ].filter(plugin => plugin != null),
   presets: [
     [
       require.resolve('docusaurus-plugin-internaldocs-fb/docusaurus-preset'),
@@ -482,7 +482,7 @@ const config: Config = {
           position: 'right',
           to: DISCORD_URL,
         },
-      ].filter((item) => item != null),
+      ].filter(item => item != null),
       logo: {
         alt: 'Lexical',
         height: 12,

--- a/packages/lexical-website/plugins/package-docs/index.mjs
+++ b/packages/lexical-website/plugins/package-docs/index.mjs
@@ -61,7 +61,7 @@ const packageDocsPlugin = async function (context, options) {
           `custom_edit_url: ${editUrl.replace(/\/$/, '')}/${folderName}/README.md`,
         ]
           .filter(Boolean)
-          .map((s) => s.trim())
+          .map(s => s.trim())
           .join('\n');
         fs.writeFileSync(
           targetPath,

--- a/packages/lexical-website/src/components/CommunityTeam.tsx
+++ b/packages/lexical-website/src/components/CommunityTeam.tsx
@@ -122,7 +122,7 @@ function TeamSection({title, description, members}: TeamSectionProps) {
         </p>
       </div>
       <div className="flex flex-1 flex-col gap-3">
-        {members.map((member) => (
+        {members.map(member => (
           <TeamMemberCard key={member.username} member={member} />
         ))}
       </div>

--- a/packages/lexical-website/src/components/ErrorCodePage.tsx
+++ b/packages/lexical-website/src/components/ErrorCodePage.tsx
@@ -43,7 +43,7 @@ function ErrorFinder() {
 
   useEffect(() => {
     if (!process.env.FB_INTERNAL) {
-      import('../../../../scripts/error-codes/codes.json').then((module) =>
+      import('../../../../scripts/error-codes/codes.json').then(module =>
         setCodes(module as unknown as ErrorCodes),
       );
     }

--- a/packages/lexical-website/src/components/Gallery/Card.tsx
+++ b/packages/lexical-website/src/components/Gallery/Card.tsx
@@ -27,7 +27,7 @@ function getCardImage(item: Example) {
 function CardTagChips({tags}: {tags: Array<string>}) {
   return (
     <ul className={clsx('clean-list', styles.cardTags)}>
-      {tags.map((tagKey) => {
+      {tags.map(tagKey => {
         const tag = TagList[tagKey];
         if (!tag) {
           return null;

--- a/packages/lexical-website/src/components/Gallery/components/Filters.tsx
+++ b/packages/lexical-website/src/components/Gallery/components/Filters.tsx
@@ -71,7 +71,7 @@ function TagList({
 }) {
   return (
     <ul className={clsx('clean-list', styles.tagList)}>
-      {Object.keys(allTags).map((tag) => {
+      {Object.keys(allTags).map(tag => {
         return (
           <TagListItem
             key={tag}

--- a/packages/lexical-website/src/components/Gallery/components/SearchBar.tsx
+++ b/packages/lexical-website/src/components/Gallery/components/SearchBar.tsx
@@ -18,7 +18,7 @@ export default function SearchBar() {
       <input
         placeholder={'Search for plugin...'}
         value={searchName}
-        onInput={(e) => {
+        onInput={e => {
           setSearchName(e.currentTarget.value);
         }}
       />

--- a/packages/lexical-website/src/components/Gallery/components/TagSelect.tsx
+++ b/packages/lexical-website/src/components/Gallery/components/TagSelect.tsx
@@ -21,10 +21,8 @@ function useTagState(tag: string) {
   const [tags, setTags] = useTags();
   const isSelected = tags.includes(tag);
   const toggle = useCallback(() => {
-    setTags((list) => {
-      return list.includes(tag)
-        ? list.filter((t) => t !== tag)
-        : [...list, tag];
+    setTags(list => {
+      return list.includes(tag) ? list.filter(t => t !== tag) : [...list, tag];
     });
   }, [tag, setTags]);
 
@@ -57,7 +55,7 @@ export default function TagSelect({
         checked={isSelected}
         onChange={toggle}
         className={styles.screenReaderOnly}
-        onKeyDown={(e) => {
+        onKeyDown={e => {
           if (e.key === 'Enter') {
             toggle();
           }

--- a/packages/lexical-website/src/components/Gallery/pluginList.tsx
+++ b/packages/lexical-website/src/components/Gallery/pluginList.tsx
@@ -26,7 +26,7 @@ export type Example = {
 export const plugins = (customFields: {
   [key: string]: unknown;
 }): Array<Example> =>
-  galleryExamples.map((example) => ({
+  galleryExamples.map(example => ({
     description: example.description,
     preview: getScreenshotPreview(example),
     tags: example.tags,

--- a/packages/lexical-website/src/components/Gallery/utils.tsx
+++ b/packages/lexical-website/src/components/Gallery/utils.tsx
@@ -29,13 +29,13 @@ function filterExamples({
   tags: Array<string>;
 }) {
   if (searchName) {
-    examples = examples.filter((example) =>
+    examples = examples.filter(example =>
       example.title.toLowerCase().includes(searchName.toLowerCase()),
     );
   }
   if (tags.length !== 0) {
-    examples = examples.filter((example) =>
-      example.tags.some((tag) => tags.includes(tag)),
+    examples = examples.filter(example =>
+      example.tags.some(tag => tags.includes(tag)),
     );
   }
   return examples;

--- a/packages/lexical-website/src/components/HomepageExamples.tsx
+++ b/packages/lexical-website/src/components/HomepageExamples.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import StackBlitzButton from './StackBlitzButton';
 
 const AgentEditor = React.lazy(() =>
-  import('@examples/agent-example/Editor').then((m) => ({default: m.Editor})),
+  import('@examples/agent-example/Editor').then(m => ({default: m.Editor})),
 );
 
 interface Section {

--- a/packages/lexical-website/src/plugins/lexical-remark-slugify-anchors/index.js
+++ b/packages/lexical-website/src/plugins/lexical-remark-slugify-anchors/index.js
@@ -16,7 +16,7 @@ const {visit} = require('unist-util-visit');
  */
 module.exports = function lexicalRemarkSlugifyAnchors() {
   return (/** @type import('mdast').Root */ tree) => {
-    visit(tree, (node) => {
+    visit(tree, node => {
       if (node.type === 'link') {
         // Fix url anchors with a preceding $, e.g. #$getroot to #getroot
         node.url = node.url.replace(/#\$/, '#');

--- a/packages/lexical-website/src/plugins/lexical-typedoc-plugin-legacy-router/index.mjs
+++ b/packages/lexical-website/src/plugins/lexical-typedoc-plugin-legacy-router/index.mjs
@@ -28,7 +28,7 @@ export function load(app) {
         comment &&
         comment.summary.length === 1 &&
         comment.summary.some(
-          (part) =>
+          part =>
             part.kind === 'text' &&
             part.text.startsWith(
               'Copyright (c) Meta Platforms, Inc. and affiliates.',
@@ -47,7 +47,7 @@ class LegacyRouter extends ModuleRouter {
     const original = super.getIdealBaseName(reflection);
     const modified = original.replace(
       /(?:@lexical\/(?:react\/)?[^/]+|lexical)/,
-      (s) => `modules/${s.replace(/^@/, '').replace(/[/]/g, '_')}`,
+      s => `modules/${s.replace(/^@/, '').replace(/[/]/g, '_')}`,
     );
     return modified;
   }

--- a/packages/lexical-website/src/plugins/lexical-typedoc-plugin-module-name/index.mjs
+++ b/packages/lexical-website/src/plugins/lexical-typedoc-plugin-module-name/index.mjs
@@ -14,7 +14,7 @@ export function load(/** @type {import('typedoc').Application} */ app) {
     (/** @type {import('typedoc').Context} */ context) => {
       context.project
         .getReflectionsByKind(typedoc.ReflectionKind.Module)
-        .forEach((reflection) => {
+        .forEach(reflection => {
           // Replace "lexical-react/src/foo" with "@lexical/react/foo"
           reflection.name = reflection.name
             .replace(/^lexical-/, '@lexical/')

--- a/packages/lexical-yjs/src/CollabV2Mapping.ts
+++ b/packages/lexical-yjs/src/CollabV2Mapping.ts
@@ -49,7 +49,7 @@ export class CollabV2Mapping {
       }
       this._sharedTypeToNodeKeys.set(
         sharedType,
-        node.map((n) => n.getKey()),
+        node.map(n => n.getKey()),
       );
       for (const n of node) {
         this._nodeMap.set(n.getKey(), n);
@@ -74,7 +74,7 @@ export class CollabV2Mapping {
     }
     if (sharedType instanceof XmlText) {
       const arr = Array.from(
-        nodes.map((nodeKey) => this._nodeMap.get(nodeKey)!),
+        nodes.map(nodeKey => this._nodeMap.get(nodeKey)!),
       ) as Array<TextNode>;
       return arr.length > 0 ? arr : undefined;
     }

--- a/packages/lexical-yjs/src/RenderSnapshot.ts
+++ b/packages/lexical-yjs/src/RenderSnapshot.ts
@@ -30,7 +30,7 @@ export type YChange<UserT = any> = {
 
 const ychangeState = createState<typeof STATE_KEY, YChange | null>(STATE_KEY, {
   isEqual: (a, b) => a === b,
-  parse: (value) => (value as YChange) ?? null,
+  parse: value => (value as YChange) ?? null,
 });
 
 export function $getYChangeState<UserT = unknown>(
@@ -58,13 +58,13 @@ export const renderSnapshot__EXPERIMENTAL = (
   const {doc} = binding;
   invariant(!doc.gc, 'GC must be disabled to render snapshot');
 
-  doc.transact((transaction) => {
+  doc.transact(transaction => {
     // Before rendering, we are going to sanitize ops and split deleted ops
     // if they were deleted by seperate users.
     const pud = new PermanentUserData(doc);
     if (pud) {
-      pud.dss.forEach((ds) => {
-        iterateDeletedStructs(transaction, ds, (_item) => {});
+      pud.dss.forEach(ds => {
+        iterateDeletedStructs(transaction, ds, _item => {});
       });
     }
 

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -146,7 +146,7 @@ export function syncYjsChangesToLexical(
   // safely computed during the event call. If it is accessed after event
   // call it might result in unexpected behavior.
   // https://github.com/yjs/yjs/blob/00ef472d68545cb260abd35c2de4b3b78719c9e4/src/utils/YEvent.js#L132
-  events.forEach((event) => event.delta);
+  events.forEach(event => event.delta);
 
   editor.update(
     () => {
@@ -357,7 +357,7 @@ export function syncYjsChangesToLexicalV2__EXPERIMENTAL(
   const editorState = editor._editorState;
 
   // Remove deleted nodes from the mapping
-  iterateDeletedStructs(transaction, transaction.deleteSet, (struct) => {
+  iterateDeletedStructs(transaction, transaction.deleteSet, struct => {
     if (struct.constructor === Item) {
       const content = struct.content as ContentType;
       const type = content.type;
@@ -372,7 +372,7 @@ export function syncYjsChangesToLexicalV2__EXPERIMENTAL(
   // safely computed during the event call. If it is accessed after event
   // call it might result in unexpected behavior.
   // https://github.com/yjs/yjs/blob/00ef472d68545cb260abd35c2de4b3b78719c9e4/src/utils/YEvent.js#L132
-  events.forEach((event) => event.delta);
+  events.forEach(event => event.delta);
 
   editor.update(
     () => {
@@ -445,7 +445,7 @@ export function syncLexicalUpdateToYjsV2__EXPERIMENTAL(
 
   // Nodes are normalized synchronously (`discrete: true` above), so the mapping may now be
   // incorrect for these nodes, as they point to `getLatest` which is mutable within an update.
-  normalizedNodes.forEach((nodeKey) => {
+  normalizedNodes.forEach(nodeKey => {
     binding.mapping.deleteNode(nodeKey);
   });
 

--- a/packages/lexical-yjs/src/SyncV2.ts
+++ b/packages/lexical-yjs/src/SyncV2.ts
@@ -126,7 +126,7 @@ export const $createOrUpdateNodeFromYElement = (
           computeYChange,
         );
         if (ns !== null) {
-          ns.forEach((textchild) => {
+          ns.forEach(textchild => {
             if (textchild !== null) {
               children.push(textchild);
             }
@@ -142,7 +142,7 @@ export const $createOrUpdateNodeFromYElement = (
     } else {
       typeListToArraySnapshot(el, new Snapshot(prevSnapshot.ds, snapshot.sv))
         .filter(
-          (childType) =>
+          childType =>
             !childType._item.deleted ||
             isItemVisible(childType._item, snapshot) ||
             isItemVisible(childType._item, prevSnapshot),
@@ -182,7 +182,7 @@ export const $createOrUpdateNodeFromYElement = (
   if (!keysChanged) {
     $getWritableNodeState(node).updateFromJSON(state);
   } else {
-    const stateKeysChanged = Object.keys(state).filter((k) =>
+    const stateKeysChanged = Object.keys(state).filter(k =>
       keysChanged.has(stateKeyToAttrKey(k)),
     );
     if (stateKeysChanged.length > 0) {
@@ -200,12 +200,8 @@ export const $createOrUpdateNodeFromYElement = (
 
 const $spliceChildren = (node: ElementNode, nextChildren: LexicalNode[]) => {
   const prevChildren = node.getChildren();
-  const prevChildrenKeySet = new Set(
-    prevChildren.map((child) => child.getKey()),
-  );
-  const nextChildrenKeySet = new Set(
-    nextChildren.map((child) => child.getKey()),
-  );
+  const prevChildrenKeySet = new Set(prevChildren.map(child => child.getKey()));
+  const nextChildrenKeySet = new Set(nextChildren.map(child => child.getKey()));
 
   const prevEndIndex = prevChildren.length - 1;
   const nextEndIndex = nextChildren.length - 1;
@@ -285,14 +281,14 @@ const $createOrUpdateTextNodesFromYText = (
   let nodes: TextNode[] = binding.mapping.get(text) ?? [];
 
   const nodeTypes: string[] = deltas.map(
-    (delta) => delta.attributes.t ?? TextNode.getType(),
+    delta => delta.attributes.t ?? TextNode.getType(),
   );
   const canReuseNodes =
     nodes.length === nodeTypes.length &&
     nodes.every((node, i) => node.getType() === nodeTypes[i]);
   if (!canReuseNodes) {
     const registeredNodes = binding.editor._nodes;
-    nodes = nodeTypes.map((type) => {
+    nodes = nodeTypes.map(type => {
       const nodeInfo = registeredNodes.get(type);
       if (nodeInfo === undefined) {
         throw new Error(
@@ -330,7 +326,7 @@ const $createOrUpdateTextNodesFromYText = (
     $getWritableNodeState(node).updateFromJSON(state);
   }
 
-  const latestNodes = nodes.map((node) => node.getLatest());
+  const latestNodes = nodes.map(node => node.getLatest());
   binding.mapping.set(text, latestNodes);
   return latestNodes;
 };
@@ -366,7 +362,7 @@ const createTypeFromElementNode = (
   }
   type.insert(
     0,
-    normalizeNodeContent(node).map((n) =>
+    normalizeNodeContent(node).map(n =>
       $createTypeFromTextOrElementNode(n, binding),
     ),
   );
@@ -391,13 +387,13 @@ const equalAttrs = (
   pattrs: Record<string | number | symbol, unknown>,
   yattrs: Record<string | number | symbol, unknown> | null,
 ) => {
-  const keys = Object.keys(pattrs).filter((key) => pattrs[key] !== null);
+  const keys = Object.keys(pattrs).filter(key => pattrs[key] !== null);
   if (yattrs == null) {
     return keys.length === 0;
   }
   let eq =
     keys.length ===
-    Object.keys(yattrs).filter((key) => yattrs[key] !== null).length;
+    Object.keys(yattrs).filter(key => yattrs[key] !== null).length;
   for (let i = 0; i < keys.length && eq; i++) {
     const key = keys[i];
     const l = pattrs[key];
@@ -599,7 +595,7 @@ const $updateYText = (
     };
   });
 
-  const nextText = content.map((c) => c.insert).join('');
+  const nextText = content.map(c => c.insert).join('');
   const selection = $getSelection();
   let cursorOffset: number;
   if ($isRangeSelection(selection) && selection.isCollapsed()) {
@@ -623,7 +619,7 @@ const $updateYText = (
   ytext.delete(index, remove);
   ytext.insert(index, insert);
   ytext.applyDelta(
-    content.map((c) => ({attributes: c.attributes, retain: c.insert.length})),
+    content.map(c => ({attributes: c.attributes, retain: c.insert.length})),
   );
 };
 
@@ -861,7 +857,7 @@ export const $updateYFragment = (
   } else if (yDelLen > 0) {
     yDomFragment
       .slice(left, left + yDelLen)
-      .forEach((type) => binding.mapping.delete(type));
+      .forEach(type => binding.mapping.delete(type));
     yDomFragment.delete(left, yDelLen);
   }
   if (left + right < lChildCnt) {

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -89,7 +89,7 @@ function isExcludedProperty(
 export function initializeNodeProperties(binding: BaseBinding): void {
   const {editor, nodeProperties} = binding;
   editor.update(() => {
-    editor._nodes.forEach((nodeInfo) => {
+    editor._nodes.forEach(nodeInfo => {
       const node = new nodeInfo.klass();
       const defaultProperties: {[property: string]: unknown} = {};
       for (const [property, value] of Object.entries(node)) {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -607,7 +607,7 @@ function initializeConversionCache(
   const conversionCache = new Map();
   const handledConversions = new Set();
   const addConversionsToCache = (map: DOMConversionMap) => {
-    Object.keys(map).forEach((key) => {
+    Object.keys(map).forEach(key => {
       let currentCache = conversionCache.get(key);
 
       if (currentCache === undefined) {
@@ -618,7 +618,7 @@ function initializeConversionCache(
       currentCache.push(map[key]);
     });
   };
-  nodes.forEach((node) => {
+  nodes.forEach(node => {
     const importDOM = node.klass.importDOM;
 
     if (importDOM == null || handledConversions.has(importDOM)) {
@@ -781,7 +781,7 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
           // by mocking its static getType
           klass !== LexicalNode
         ) {
-          (['getType', 'clone'] as const).forEach((method) => {
+          (['getType', 'clone'] as const).forEach(method => {
             if (!hasOwnStaticMethod(klass, method)) {
               console.warn(`${name} must implement static "${method}" method`);
             }
@@ -1149,9 +1149,7 @@ export class LexicalEditor {
       listeners.delete(listener);
 
       if (
-        listenersInPriorityOrder.every(
-          (listenersSet) => listenersSet.size === 0,
-        )
+        listenersInPriorityOrder.every(listenersSet => listenersSet.size === 0)
       ) {
         commandsMap.delete(command);
       }
@@ -1297,10 +1295,10 @@ export class LexicalEditor {
 
     markNodesWithTypesAsDirty(
       this,
-      registeredNodes.map((node) => node.klass.getType()),
+      registeredNodes.map(node => node.klass.getType()),
     );
     return () => {
-      registeredNodes.forEach((node) =>
+      registeredNodes.forEach(node =>
         node.transforms.delete(listener as Transform<LexicalNode>),
       );
     };

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -525,7 +525,7 @@ function onClick(event: PointerEvent, editor: LexicalEditor): void {
           if (anchorNode !== focusNode) {
             const parentNode = $findMatchingParent(
               anchorNode,
-              (node) => $isElementNode(node) && !node.isInline(),
+              node => $isElementNode(node) && !node.isInline(),
             );
             if ($isElementNode(parentNode)) {
               parentNode.select(0);

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -664,7 +664,7 @@ export class LexicalNode {
 
     const isSelected = targetSelection
       .getNodes()
-      .some((n) => n.__key === this.__key);
+      .some(n => n.__key === this.__key);
 
     if ($isTextNode(this)) {
       return isSelected;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -344,7 +344,7 @@ export class NodeSelection implements BaseSelection {
     }
     const a: Set<NodeKey> = this._nodes;
     const b: Set<NodeKey> = selection._nodes;
-    return a.size === b.size && Array.from(a).every((key) => b.has(key));
+    return a.size === b.size && Array.from(a).every(key => b.has(key));
   }
 
   isCollapsed(): boolean {
@@ -1201,7 +1201,7 @@ export class RangeSelection implements BaseSelection {
       }
     }
     const applyFormatToElements = (alignWith: number | null) => {
-      selectedNodes.forEach((node) => {
+      selectedNodes.forEach(node => {
         if ($isElementNode(node)) {
           const newFormat = node.getFormatFlags(formatType, alignWith);
           node.setTextFormat(newFormat);
@@ -1755,7 +1755,7 @@ export class RangeSelection implements BaseSelection {
       if (
         initialRange
           .getTextSlices()
-          .every((slice) => slice === null || slice.distance === 0)
+          .every(slice => slice === null || slice.distance === 0)
       ) {
         // There's no text in the direction of the deletion so we can explore our options
         let state:

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -142,7 +142,7 @@ export const isArray = Array.isArray;
 export const scheduleMicroTask: (fn: () => void) => void =
   typeof queueMicrotask === 'function'
     ? queueMicrotask
-    : (fn) => {
+    : fn => {
         // No window prefix intended (#1400)
         Promise.resolve().then(fn);
       };
@@ -2211,7 +2211,7 @@ export function getStaticNodeConfig(klass: Klass<LexicalNode>): {
       }
       klass.importJSON =
         (ownNodeConfig && ownNodeConfig.$importJSON) ||
-        ((serializedNode) => new klass().updateFromJSON(serializedNode));
+        (serializedNode => new klass().updateFromJSON(serializedNode));
     }
     if (!hasOwnStaticMethod(klass, 'importDOM') && ownNodeConfig) {
       const {importDOM} = ownNodeConfig;

--- a/packages/lexical/src/__tests__/unit/CodeBlock.test.ts
+++ b/packages/lexical/src/__tests__/unit/CodeBlock.test.ts
@@ -22,7 +22,7 @@ import {beforeEach, describe, expect, test} from 'vitest';
 
 describe('CodeBlock tests', () => {
   initializeUnitTest(
-    (testEnv) => {
+    testEnv => {
       beforeEach(async () => {
         const {editor} = testEnv;
         await editor.update(() => {

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -23,7 +23,7 @@ import {beforeEach, describe, expect, test} from 'vitest';
 
 describe('HTMLCopyAndPaste tests', () => {
   initializeUnitTest(
-    (testEnv) => {
+    testEnv => {
       beforeEach(async () => {
         const {editor} = testEnv;
         await editor.update(() => {

--- a/packages/lexical/src/__tests__/unit/HandleTextDrop.test.ts
+++ b/packages/lexical/src/__tests__/unit/HandleTextDrop.test.ts
@@ -87,7 +87,7 @@ function $markActiveSelectionAsDragSource(
 }
 
 describe('$handleTextDrop', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     beforeEach(() => {
       caretFromPointState.current = () => null;
     });
@@ -361,7 +361,7 @@ describe('$handleTextDrop', () => {
         expect(topLevelChildren.length).toBe(2);
 
         const allDecorators = topLevelChildren
-          .flatMap((c) =>
+          .flatMap(c =>
             'getChildren' in c && typeof c.getChildren === 'function'
               ? c.getChildren()
               : [],
@@ -519,7 +519,7 @@ describe('$handleRichTextDrop across editors', () => {
     const observedDispatches: InputEvent[] = [];
     sourceContainer.addEventListener(
       'beforeinput',
-      (e) => observedDispatches.push(e as InputEvent),
+      e => observedDispatches.push(e as InputEvent),
       true,
     );
 

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -258,7 +258,7 @@ describe('LexicalEditor tests', () => {
       editor.registerNodeTransform(RootNode, $transform);
       editor.registerNodeTransform(ParagraphNode, $transform);
       editor.registerNodeTransform(TextNode, $transform);
-      editor.registerNodeTransform(ParagraphNode, (node) => {
+      editor.registerNodeTransform(ParagraphNode, node => {
         const lastChild = node.getLastChild();
         if (
           $isTextNode(lastChild) &&
@@ -294,7 +294,7 @@ describe('LexicalEditor tests', () => {
       ]);
       events.length = 0;
       // Add a transform that mutates the text
-      await editor.registerNodeTransform(TextNode, (node) => {
+      await editor.registerNodeTransform(TextNode, node => {
         const textContent = node.getTextContent();
         if (textContent.startsWith('[')) {
           return;
@@ -316,14 +316,14 @@ describe('LexicalEditor tests', () => {
         editor.read(() =>
           $getRoot()
             .getAllTextNodes()
-            .map((node) => node.getTextContent()),
+            .map(node => node.getTextContent()),
         ),
       ).toEqual(['[first]', '[second]']);
       events.length = 0;
       await editor.update(() => {
         $getRoot()
           .getAllTextNodes()
-          .forEach((node) =>
+          .forEach(node =>
             node.setTextContent(`:${node.getTextContent().slice(1, -1)}:`),
           );
         paragraphNode.append($createTextNode('third').setMode('token'));
@@ -355,7 +355,7 @@ describe('LexicalEditor tests', () => {
         editor.read(() =>
           $getRoot()
             .getAllTextNodes()
-            .map((node) => node.getTextContent()),
+            .map(node => node.getTextContent()),
         ),
       ).toEqual(['[:first:]', '[:second:]', '[third]', '[fourth]']);
     });
@@ -418,7 +418,7 @@ describe('LexicalEditor tests', () => {
       });
       expect(editor.read(() => $getRoot().getTextContent())).toEqual('');
       expect(editor.read(() => $getEditor())).toBe(editor);
-      editor.registerNodeTransform(TextNode, (node) => {
+      editor.registerNodeTransform(TextNode, node => {
         if (node.getTextContent() === 'This works!') {
           node.replace($createTextNode('Transforms work!'));
         }
@@ -735,7 +735,7 @@ describe('LexicalEditor tests', () => {
     init();
 
     // 2. Add italics
-    const italicsListener = editor.registerNodeTransform(TextNode, (node) => {
+    const italicsListener = editor.registerNodeTransform(TextNode, node => {
       if (
         node.getTextContent() === 'foo' &&
         node.hasFormat('bold') &&
@@ -746,14 +746,14 @@ describe('LexicalEditor tests', () => {
     });
 
     // 1. Add bold
-    const boldListener = editor.registerNodeTransform(TextNode, (node) => {
+    const boldListener = editor.registerNodeTransform(TextNode, node => {
       if (node.getTextContent() === 'foo' && !node.hasFormat('bold')) {
         node.toggleFormat('bold');
       }
     });
 
     // 2. Add underline
-    const underlineListener = editor.registerNodeTransform(TextNode, (node) => {
+    const underlineListener = editor.registerNodeTransform(TextNode, node => {
       if (
         node.getTextContent() === 'foo' &&
         node.hasFormat('bold') &&
@@ -787,7 +787,7 @@ describe('LexicalEditor tests', () => {
     // 2. (Block transform) Add text
     const testParagraphListener = editor.registerNodeTransform(
       ParagraphNode,
-      (paragraph) => {
+      paragraph => {
         if (skipFirst[0]) {
           skipFirst[0] = false;
 
@@ -801,7 +801,7 @@ describe('LexicalEditor tests', () => {
     );
 
     // 2. (Text transform) Add bold to text
-    const boldListener = editor.registerNodeTransform(TextNode, (node) => {
+    const boldListener = editor.registerNodeTransform(TextNode, node => {
       if (node.getTextContent() === 'foo' && !node.hasFormat('bold')) {
         node.toggleFormat('bold');
       }
@@ -810,7 +810,7 @@ describe('LexicalEditor tests', () => {
     // 3. (Block transform) Add italics to bold text
     const italicsListener = editor.registerNodeTransform(
       ParagraphNode,
-      (paragraph) => {
+      paragraph => {
         const child = paragraph.getLastDescendant();
 
         if (
@@ -849,7 +849,7 @@ describe('LexicalEditor tests', () => {
     init();
 
     // 1. [Foo] into [<empty>,Fo,o,<empty>,!,<empty>]
-    const fooListener = editor.registerNodeTransform(TextNode, (node) => {
+    const fooListener = editor.registerNodeTransform(TextNode, node => {
       if (node.getTextContent() === 'Foo' && !hasRun[0]) {
         const [before, after] = node.splitText(2);
 
@@ -865,7 +865,7 @@ describe('LexicalEditor tests', () => {
     // 2. [Foo!] into [<empty>,Fo,o!,<empty>,!,<empty>]
     const megaFooListener = editor.registerNodeTransform(
       ParagraphNode,
-      (paragraph) => {
+      paragraph => {
         const child = paragraph.getFirstChild();
 
         if (
@@ -886,7 +886,7 @@ describe('LexicalEditor tests', () => {
     );
 
     // 3. [Foo!!] into formatted bold [<empty>,Fo,o!!,<empty>]
-    const boldFooListener = editor.registerNodeTransform(TextNode, (node) => {
+    const boldFooListener = editor.registerNodeTransform(TextNode, node => {
       if (node.getTextContent() === 'Foo!!' && !hasRun[2]) {
         node.toggleFormat('bold');
 
@@ -920,7 +920,7 @@ describe('LexicalEditor tests', () => {
 
     const executeTransform = vi.fn();
     let hasBeenRemoved = false;
-    const removeListener = editor.registerNodeTransform(TextNode, (node) => {
+    const removeListener = editor.registerNodeTransform(TextNode, node => {
       if (hasBeenRemoved) {
         executeTransform();
       }
@@ -959,13 +959,13 @@ describe('LexicalEditor tests', () => {
 
     const removeParagraphTransform = editor.registerNodeTransform(
       ParagraphNode,
-      (node) => {
+      node => {
         executeParagraphNodeTransform();
       },
     );
     const removeTextNodeTransform = editor.registerNodeTransform(
       TextNode,
-      (node) => {
+      node => {
         executeTextNodeTransform();
       },
     );
@@ -1051,7 +1051,7 @@ describe('LexicalEditor tests', () => {
         $getRoot()
           .getChildren()
           .filter($isParagraphNode)
-          .forEach((node) => node.remove());
+          .forEach(node => node.remove());
       },
       {discrete: true},
     );
@@ -1104,7 +1104,7 @@ describe('LexicalEditor tests', () => {
         paragraph1.append(...textNodes.slice(3));
       });
 
-      removeTransform = editor.registerNodeTransform(TextNode, (node) => {
+      removeTransform = editor.registerNodeTransform(TextNode, node => {
         textTransformCount[Number(node.__text)]++;
       });
     });
@@ -1172,7 +1172,7 @@ describe('LexicalEditor tests', () => {
     const errorListener = vi.fn();
     init(errorListener);
 
-    const boldListener = editor.registerNodeTransform(TextNode, (node) => {
+    const boldListener = editor.registerNodeTransform(TextNode, node => {
       node.toggleFormat('bold');
     });
 
@@ -1360,14 +1360,14 @@ describe('LexicalEditor tests', () => {
 
       // Subscribe to changes
       useEffect(() => {
-        return editor.registerDecoratorListener<ReactNode>((nextDecorators) => {
+        return editor.registerDecoratorListener<ReactNode>(nextDecorators => {
           setDecorators(nextDecorators);
         });
       }, []);
 
       const decoratedPortals = useMemo(
         () =>
-          Object.keys(decorators).map((nodeKey) => {
+          Object.keys(decorators).map(nodeKey => {
             const reactDecorator = decorators[nodeKey];
             const element = editor.getElementByKey(nodeKey)!;
 
@@ -1942,7 +1942,7 @@ describe('LexicalEditor tests', () => {
     );
 
     expect(editor._commands.has(command)).toEqual(true);
-    expect(editor._commands.get(command)?.map((v) => [...v])).toEqual([
+    expect(editor._commands.get(command)?.map(v => [...v])).toEqual([
       [commandListener, commandListenerTwo],
       [],
       [],
@@ -1952,7 +1952,7 @@ describe('LexicalEditor tests', () => {
 
     removeCommandListener();
 
-    expect(editor._commands.get(command)?.map((v) => [...v])).toEqual([
+    expect(editor._commands.get(command)?.map(v => [...v])).toEqual([
       [commandListenerTwo],
       [],
       [],
@@ -2002,7 +2002,7 @@ describe('LexicalEditor tests', () => {
       root.append(paragraph);
       paragraph.append(textNode);
     });
-    editor.registerTextContentListener((text) => {
+    editor.registerTextContentListener(text => {
       fn(text);
     });
 
@@ -2627,7 +2627,7 @@ describe('LexicalEditor tests', () => {
 
     editor.registerMutationListener(
       TextNode,
-      (map) => {
+      map => {
         mutationListener();
         editor.registerMutationListener(
           TextNode,
@@ -2905,7 +2905,7 @@ describe('LexicalEditor tests', () => {
     expect(mutationListenerA).toHaveBeenCalledTimes(2);
     expect(mutationListenerB).toHaveBeenCalledTimes(2);
     expect(mutationListenerC).toHaveBeenCalledTimes(1);
-    [mutationListenerA, mutationListenerB, mutationListenerC].forEach((fn) => {
+    [mutationListenerA, mutationListenerB, mutationListenerC].forEach(fn => {
       expect(fn).toHaveBeenLastCalledWith(
         expect.anything(),
         expect.objectContaining({

--- a/packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts
@@ -127,7 +127,7 @@ describe('LexicalEditor listeners', () => {
       const editableListenerCallback = vi.fn();
       const editableListener = vi
         .fn()
-        .mockImplementation((editable) =>
+        .mockImplementation(editable =>
           editableListenerCallback.bind(null, editable),
         );
       const unregister = editor.registerEditableListener(editableListener);

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
@@ -21,7 +21,7 @@ import {$createRootNode, RootNode} from '../../nodes/LexicalRootNode';
 import {initializeUnitTest} from '../utils';
 
 describe('LexicalEditorState tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('constructor', async () => {
       const root = $createRootNode();
       const nodeMap = new Map([['root', root]]);

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -103,7 +103,7 @@ describe('LexicalNode tests', () => {
     vi.restoreAllMocks();
   });
   initializeUnitTest(
-    (testEnv) => {
+    testEnv => {
       let paragraphNode: ParagraphNode;
       let textNode: TextNode;
 
@@ -495,13 +495,12 @@ describe('LexicalNode tests', () => {
               expect($isRangeSelection(selection)).toBe(true);
               const dbg = [selection.anchor, selection.focus]
                 .map(
-                  (point) =>
-                    `(${names[point.key] || point.key}:${point.offset})`,
+                  point => `(${names[point.key] || point.key}:${point.offset})`,
                 )
                 .join(' ');
               const nodes = `[${selection
                 .getNodes()
-                .map((k) => names[k.__key] || k.__key)
+                .map(k => names[k.__key] || k.__key)
                 .join(',')}]`;
               expect([dbg, nodes, inlineDecoratorNode.isSelected()]).toEqual([
                 dbg,

--- a/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
@@ -37,7 +37,7 @@ type Equal<X, Y> =
     : false;
 
 const numberState = createState('numberState', {
-  parse: (v) => (typeof v === 'number' ? v : 0),
+  parse: v => (typeof v === 'number' ? v : 0),
 });
 const boolState = createState('boolState', {parse: Boolean});
 class StateNode extends TestNode {
@@ -116,7 +116,7 @@ function $createStateNode() {
 
 describe('LexicalNode state', () => {
   initializeUnitTest(
-    (testEnv) => {
+    testEnv => {
       let root: RootNode;
 
       beforeEach(async () => {
@@ -128,7 +128,7 @@ describe('LexicalNode state', () => {
 
       test(`state.$set() and state.$get() need to be inside an update`, async () => {
         const stringState = createState('stringState', {
-          parse: (value) => (typeof value === 'string' ? value : ''),
+          parse: value => (typeof value === 'string' ? value : ''),
         });
         const $fn = () => {
           $setState(root, stringState, 'hello');
@@ -157,7 +157,7 @@ describe('LexicalNode state', () => {
 
       test(`getState and setState`, async () => {
         const stringState = createState('stringState', {
-          parse: (value) => (typeof value === 'string' ? value : ''),
+          parse: value => (typeof value === 'string' ? value : ''),
         });
         const {editor} = testEnv;
         editor.update(() => {
@@ -168,7 +168,7 @@ describe('LexicalNode state', () => {
           expect($getState(root, stringState)).toBe('hello');
 
           const maybeStringState = createState('maybeStringState', {
-            parse: (value) => (typeof value === 'string' ? value : undefined),
+            parse: value => (typeof value === 'string' ? value : undefined),
           });
           const maybeStringValue = $getState(root, maybeStringState);
           type _Test2 = Expect<
@@ -202,7 +202,7 @@ describe('LexicalNode state', () => {
         const {editor} = testEnv;
         editor.update(
           () => {
-            const k0 = createState('foo', {parse: (v) => !!v});
+            const k0 = createState('foo', {parse: v => !!v});
             const k1 = createState('foo', {parse: () => 'foo'});
             expect($getState(root, k0)).toBe(false);
             $setState(root, k0, true);
@@ -226,7 +226,7 @@ describe('LexicalNode state', () => {
           expect(stateNode.getNumber()).toBe(0);
           stateNode.setNumber(1);
           expect(stateNode.getNumber()).toBe(1);
-          stateNode.setNumber((n) => n + 1);
+          stateNode.setNumber(n => n + 1);
           expect(stateNode.getNumber()).toBe(2);
           $setState(stateNode, boolState, true);
           expect(stateNode.exportJSON()).toMatchObject({
@@ -270,7 +270,7 @@ describe('LexicalNode state', () => {
         const {editor} = testEnv;
         editor.update(() => {
           const indentState = createState('indent', {
-            parse: (value) => (typeof value === 'number' ? value : 0),
+            parse: value => (typeof value === 'number' ? value : 0),
           });
           const paragraph = $createParagraphNode();
           expect($getState(paragraph, indentState)).toBe(0);
@@ -287,7 +287,7 @@ describe('LexicalNode state', () => {
           expect(json3).not.toHaveProperty(NODE_STATE_KEY);
 
           const foo = createState('foo', {
-            parse: (value) => (typeof value === 'string' ? value : ''),
+            parse: value => (typeof value === 'string' ? value : ''),
           });
           $setState(paragraph, foo, 'fooValue');
           const json4 = paragraph.exportJSON();
@@ -306,7 +306,7 @@ describe('LexicalNode state', () => {
         editor.update(() => {
           const paragraph = $createParagraphNode();
           const objectState = createState('object', {
-            parse: (value) =>
+            parse: value =>
               (value as TestObject) || {
                 bar: 0,
                 foo: '',
@@ -339,7 +339,7 @@ describe('LexicalNode state', () => {
         let v0: RootNode;
         let v1: RootNode;
         const vk = createState('vk', {
-          parse: (v) => (typeof v === 'number' ? v : null),
+          parse: v => (typeof v === 'number' ? v : null),
         });
         editor.update(
           () => {
@@ -430,7 +430,7 @@ describe('LexicalNode state', () => {
         test('TextNode merging only with equivalent state', () => {
           const {editor} = testEnv;
           const classNameState = createState('className', {
-            parse: (v) => (typeof v === 'string' ? v : ''),
+            parse: v => (typeof v === 'string' ? v : ''),
           });
           const $createTextWithClassName = (className: string) =>
             $setState($createTextNode(className), classNameState, className);
@@ -456,9 +456,9 @@ describe('LexicalNode state', () => {
             const textNodes = $getRoot().getAllTextNodes();
             expect(textNodes).toHaveLength(6);
             expect(
-              textNodes.map((node) => $getState(node, classNameState)),
+              textNodes.map(node => $getState(node, classNameState)),
             ).toEqual(['red', '', 'red', 'blue', 'red', 'blue']);
-            expect(textNodes.map((node) => node.getTextContent())).toEqual([
+            expect(textNodes.map(node => node.getTextContent())).toEqual([
               'red',
               'none!',
               'red',
@@ -480,9 +480,9 @@ describe('LexicalNode state', () => {
             const textNodes = $getRoot().getAllTextNodes();
             expect(textNodes).toHaveLength(4);
             expect(
-              textNodes.map((node) => $getState(node, classNameState)),
+              textNodes.map(node => $getState(node, classNameState)),
             ).toEqual(['red', 'blue', 'red', 'blue']);
-            expect(textNodes.map((node) => node.getTextContent())).toEqual([
+            expect(textNodes.map(node => node.getTextContent())).toEqual([
               'rednone!red',
               'blueblue',
               'red',
@@ -500,7 +500,7 @@ describe('LexicalNode state', () => {
           let v4!: RootNode;
           let v5!: RootNode;
           const vk = createState('vk', {
-            parse: (v) => (typeof v === 'number' ? v : null),
+            parse: v => (typeof v === 'number' ? v : null),
           });
           editor.update(
             () => {
@@ -590,7 +590,7 @@ describe('LexicalNode state', () => {
         test('state with resetOnCopyNode: true is reset when using $copyNode', () => {
           const {editor} = testEnv;
           const resetState = createState('resetState', {
-            parse: (v) => (typeof v === 'number' ? v : 0),
+            parse: v => (typeof v === 'number' ? v : 0),
             resetOnCopyNode: true,
           });
           editor.update(
@@ -610,7 +610,7 @@ describe('LexicalNode state', () => {
         test('state with resetOnCopyNode: false is preserved when using $copyNode', () => {
           const {editor} = testEnv;
           const persistState = createState('persistState', {
-            parse: (v) => (typeof v === 'number' ? v : 0),
+            parse: v => (typeof v === 'number' ? v : 0),
             resetOnCopyNode: false,
           });
           editor.update(
@@ -630,7 +630,7 @@ describe('LexicalNode state', () => {
         test('state without resetOnCopyNode option is preserved when using $copyNode', () => {
           const {editor} = testEnv;
           const defaultState = createState('defaultState', {
-            parse: (v) => (typeof v === 'number' ? v : 0),
+            parse: v => (typeof v === 'number' ? v : 0),
           });
           editor.update(
             () => {
@@ -649,15 +649,15 @@ describe('LexicalNode state', () => {
         test('multiple states with different resetOnCopyNode configurations', () => {
           const {editor} = testEnv;
           const resetState = createState('resetState', {
-            parse: (v) => (typeof v === 'number' ? v : 0),
+            parse: v => (typeof v === 'number' ? v : 0),
             resetOnCopyNode: true,
           });
           const persistState = createState('persistState', {
-            parse: (v) => (typeof v === 'string' ? v : ''),
+            parse: v => (typeof v === 'string' ? v : ''),
             resetOnCopyNode: false,
           });
           const defaultState = createState('defaultState', {
-            parse: (v) => (typeof v === 'boolean' ? v : false),
+            parse: v => (typeof v === 'boolean' ? v : false),
           });
 
           editor.update(

--- a/packages/lexical/src/__tests__/unit/LexicalNormalization.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalNormalization.test.tsx
@@ -22,7 +22,7 @@ import {
 } from '../utils';
 
 describe('LexicalNormalization tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('$normalizeSelection', () => {
       for (const reversed of [false, true]) {
         const getAnchor = (x: RangeSelection) =>

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -19,7 +19,7 @@ import {$getReconciledDirection} from '../../LexicalReconciler';
 import {initializeUnitTest} from '../utils';
 
 describe('LexicalReconciler', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('Should set direction of root node children to auto if root node has no direction', async () => {
       const {editor} = testEnv;
 
@@ -35,7 +35,7 @@ describe('LexicalReconciler', () => {
       const directions = editor.read(() => {
         return $getRoot()
           .getChildren<ParagraphNode>()
-          .map((child) => $getReconciledDirection(child));
+          .map(child => $getReconciledDirection(child));
       });
       expect(directions).toEqual(['auto', 'auto', 'auto']);
     });
@@ -56,7 +56,7 @@ describe('LexicalReconciler', () => {
       const directions = editor.read(() => {
         return $getRoot()
           .getChildren<ParagraphNode>()
-          .map((child) => $getReconciledDirection(child));
+          .map(child => $getReconciledDirection(child));
       });
       expect(directions).toEqual([null, null, null]);
     });
@@ -88,7 +88,7 @@ describe('LexicalReconciler', () => {
       const directions = editor.read(() => {
         return $getRoot()
           .getChildren<ParagraphNode>()
-          .map((child) => $getReconciledDirection(child));
+          .map(child => $getReconciledDirection(child));
       });
       expect(directions).toEqual(['rtl', 'ltr', 'ltr', 'rtl', 'auto']);
     });
@@ -111,7 +111,7 @@ describe('LexicalReconciler', () => {
       const directions = editor.read(() => {
         return $getRoot()
           .getChildren<ParagraphNode>()
-          .map((child) => $getReconciledDirection(child));
+          .map(child => $getReconciledDirection(child));
       });
       expect(directions).toEqual(['ltr', null, null]);
     });
@@ -132,7 +132,7 @@ describe('LexicalReconciler', () => {
       let directions = editor.read(() => {
         return $getRoot()
           .getChildren<ParagraphNode>()
-          .map((child) => $getReconciledDirection(child));
+          .map(child => $getReconciledDirection(child));
       });
       expect(directions).toEqual(['auto', 'ltr']);
 
@@ -144,7 +144,7 @@ describe('LexicalReconciler', () => {
       directions = editor.read(() => {
         return $getRoot()
           .getChildren<ParagraphNode>()
-          .map((child) => $getReconciledDirection(child));
+          .map(child => $getReconciledDirection(child));
       });
       expect(directions).toEqual([null, 'ltr']);
 
@@ -156,7 +156,7 @@ describe('LexicalReconciler', () => {
       directions = editor.read(() => {
         return $getRoot()
           .getChildren<ParagraphNode>()
-          .map((child) => $getReconciledDirection(child));
+          .map(child => $getReconciledDirection(child));
       });
       expect(directions).toEqual(['auto', 'ltr']);
     });

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -49,11 +49,11 @@ import {
 } from '../utils';
 
 function mapLatest<T extends LexicalNode>(nodes: T[]): T[] {
-  return nodes.map((node) => node.getLatest());
+  return nodes.map(node => node.getLatest());
 }
 
 describe('LexicalSelection tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('Inserting text either side of inline elements', () => {
       const setup = async (
         mode: 'start-of-paragraph' | 'mid-paragraph' | 'end-of-paragraph',
@@ -524,9 +524,9 @@ describe('LexicalSelection tests', () => {
               expect(trailingTokenText.isAttached()).toBe(false);
               const allTextNodes = $getRoot().getAllTextNodes();
               // The token node will be completely removed
-              expect(allTextNodes.map((node) => node.getTextContent())).toEqual(
-                ['lead'],
-              );
+              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+                'lead',
+              ]);
               const selection = $assertRangeSelection($getSelection());
               expect(selection.isCollapsed()).toBe(true);
               expect(selection.anchor.key).toBe(leadingText.getKey());
@@ -670,9 +670,9 @@ describe('LexicalSelection tests', () => {
               expect(trailingText.isAttached()).toBe(true);
               const allTextNodes = $getRoot().getAllTextNodes();
               // The token node will be completely removed
-              expect(allTextNodes.map((node) => node.getTextContent())).toEqual(
-                ['ing text'],
-              );
+              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+                'ing text',
+              ]);
               const selection = $assertRangeSelection($getSelection());
               expect(selection.isCollapsed()).toBe(true);
               expect(selection.anchor.key).toBe(trailingText.getKey());
@@ -788,9 +788,9 @@ describe('LexicalSelection tests', () => {
               // expecting a new node since it was segmented
               expect(trailingSegmentedText.isAttached()).toBe(false);
               const allTextNodes = $getRoot().getAllTextNodes();
-              expect(allTextNodes.map((node) => node.getTextContent())).toEqual(
-                ['text'],
-              );
+              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+                'text',
+              ]);
               const selection = $assertRangeSelection($getSelection());
               expect(selection.isCollapsed()).toBe(true);
               expect(selection.anchor.key).toBe(allTextNodes[0].getKey());
@@ -817,9 +817,10 @@ describe('LexicalSelection tests', () => {
               expect(trailingSegmentedText.isAttached()).toBe(false);
               const allTextNodes = $getRoot().getAllTextNodes();
               // These should get merged in reconciliation
-              expect(allTextNodes.map((node) => node.getTextContent())).toEqual(
-                ['lead', 'text'],
-              );
+              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+                'lead',
+                'text',
+              ]);
               const selection = $assertRangeSelection($getSelection());
               expect(selection.isCollapsed()).toBe(true);
               expect(selection.anchor.key).toBe(leadingText.getKey());
@@ -830,7 +831,7 @@ describe('LexicalSelection tests', () => {
           testEnv.editor.getEditorState().read(() => {
             const allTextNodes = $getRoot().getAllTextNodes();
             // These should get merged in reconciliation
-            expect(allTextNodes.map((node) => node.getTextContent())).toEqual([
+            expect(allTextNodes.map(node => node.getTextContent())).toEqual([
               'leadtext',
             ]);
             expect(leadingText.isAttached()).toBe(true);
@@ -865,7 +866,7 @@ describe('Regression tests for #6701', () => {
     }
     const editor = createEditor({
       nodes: [InlineElementNode],
-      onError: (err) => {
+      onError: err => {
         throw err;
       },
     });
@@ -885,7 +886,7 @@ describe('Regression tests for #6701', () => {
 });
 
 describe('getNodes()', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     let paragraphNode: ParagraphNode;
     let paragraphText: TextNode;
     let linkNode: LinkNode;
@@ -975,7 +976,7 @@ describe('getNodes()', () => {
                 listItem2,
                 listItemText2,
                 emptyParagraph,
-              ].map((node) => node.getLatest()),
+              ].map(node => node.getLatest()),
             );
           },
           {discrete: true},
@@ -1008,7 +1009,7 @@ describe('getNodes()', () => {
                 listItemText2,
                 noLongerEmptyParagraph,
                 inlineDecoratorTrailing,
-              ].map((node) => node.getLatest()),
+              ].map(node => node.getLatest()),
             );
           },
           {discrete: true},
@@ -1044,7 +1045,7 @@ describe('getNodes()', () => {
                 listItem2,
                 listItemText2,
                 emptyParagraph,
-              ].map((node) => node.getLatest()),
+              ].map(node => node.getLatest()),
             );
           },
           {discrete: true},
@@ -1081,7 +1082,7 @@ describe('getNodes()', () => {
                 listItemText2,
                 noLongerEmptyParagraph,
                 inlineElementTrailing,
-              ].map((node) => node.getLatest()),
+              ].map(node => node.getLatest()),
             );
           },
           {discrete: true},
@@ -1114,7 +1115,7 @@ describe('getNodes()', () => {
                 listItemText1,
                 listItem2,
                 listItemText2,
-              ].map((n) => n.getLatest()),
+              ].map(n => n.getLatest()),
             );
           },
           {discrete: true},
@@ -1200,7 +1201,7 @@ describe('getNodes()', () => {
           });
           expect(selection.getNodes()).toEqual(
             // The bias is towards the right
-            [inlineDecoratorTrailing].map((node) => node.getLatest()),
+            [inlineDecoratorTrailing].map(node => node.getLatest()),
           );
         },
         {discrete: true},
@@ -1236,7 +1237,7 @@ describe('getNodes()', () => {
           expect(selection.getNodes()).toEqual(
             // The bias is towards the last descendant since no
             // nodes exist to the right
-            [inlineDecoratorTrailing].map((node) => node.getLatest()),
+            [inlineDecoratorTrailing].map(node => node.getLatest()),
           );
         },
         {discrete: true},
@@ -1278,7 +1279,7 @@ describe('getNodes()', () => {
               listItemText2,
               noLongerEmptyParagraph,
               inlineDecoratorLeading,
-            ].map((node) => node.getLatest()),
+            ].map(node => node.getLatest()),
           );
         },
         {discrete: true},
@@ -1371,7 +1372,7 @@ describe('getNodes()', () => {
 });
 
 describe('extract()', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     let paragraphNode: ParagraphNode;
     let paragraphText: TextNode;
     let linkNode: LinkNode;
@@ -1556,7 +1557,7 @@ describe('extract()', () => {
 });
 
 describe('Regression #7081', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('Firefox selection & paste before linebreak', () => {
       testEnv.editor.update(
         () => {
@@ -1590,7 +1591,7 @@ describe('Regression #7081', () => {
 });
 
 describe('Regression #7173', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('Can insertNodes of multiple blocks with a target of an initial empty block and the entire next block', () => {
       testEnv.editor.update(
         () => {
@@ -1616,7 +1617,7 @@ describe('Regression #7173', () => {
 });
 
 describe('Regression #3181', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('Point.isBefore edge case with mixed TextNode & ElementNode and matching descendants', () => {
       testEnv.editor.update(
         () => {
@@ -1655,7 +1656,7 @@ describe('Regression #3181', () => {
 });
 
 describe('Regression #8067', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('Formatting issue when replacing text with format', () => {
       testEnv.editor.update(
         () => {
@@ -1679,7 +1680,7 @@ describe('Regression #8067', () => {
 });
 
 describe('Regression #8098', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('Do not apply format and style when moving to different node', async () => {
       const {editor} = testEnv;
       let normalTextKey: string;

--- a/packages/lexical/src/__tests__/unit/LexicalSerialization.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSerialization.test.ts
@@ -102,7 +102,7 @@ function $createEditorContent() {
 }
 
 describe('LexicalSerialization tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('serializes and deserializes from JSON', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -42,7 +42,7 @@ import {
 import {initializeUnitTest} from '../utils';
 
 describe('LexicalUtils tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('scheduleMicroTask(): native', async () => {
       vi.resetModules();
 
@@ -363,7 +363,7 @@ describe('LexicalUtils tests', () => {
       const paragraphKeys: string[] = [];
 
       const $paragraphKeys = () =>
-        $nodesOfType(ParagraphNode).map((node) => node.getKey());
+        $nodesOfType(ParagraphNode).map(node => node.getKey());
 
       await editor.update(() => {
         const root = $getRoot();
@@ -503,7 +503,7 @@ describe('LexicalUtils tests', () => {
       const textMap = typeToNodeMap.get('text')!;
       expect(textMap.size).toEqual(2);
       expect(
-        [...textMap.values()].map((node) => (node as TextNode).__text),
+        [...textMap.values()].map(node => (node as TextNode).__text),
       ).toEqual(expect.arrayContaining(['a', 'b']));
     });
 
@@ -591,7 +591,7 @@ describe('$applyNodeReplacement', () => {
       nodes: [
         {
           replace: TextNode,
-          with: (node) => $createExtendedTextNode().initWithTextNode(node),
+          with: node => $createExtendedTextNode().initWithTextNode(node),
           withKlass: ExtendedExtendedTextNode,
         },
       ],
@@ -617,7 +617,7 @@ describe('$applyNodeReplacement', () => {
       nodes: [
         {
           replace: TextNode,
-          with: (node) => node,
+          with: node => node,
           withKlass: ExtendedTextNode,
         },
       ],
@@ -702,7 +702,7 @@ describe('$applyNodeReplacement', () => {
       nodes: [
         {
           replace: TextNode,
-          with: (node) => $createExtendedTextNode().initWithTextNode(node),
+          with: node => $createExtendedTextNode().initWithTextNode(node),
           withKlass: ExtendedTextNode,
         },
       ],
@@ -729,7 +729,7 @@ describe('$applyNodeReplacement', () => {
         ExtendedTextNode,
         {
           replace: ExtendedTextNode,
-          with: (node) =>
+          with: node =>
             $createExtendedExtendedTextNode().initWithExtendedTextNode(node),
           withKlass: ExtendedExtendedTextNode,
         },
@@ -759,12 +759,12 @@ describe('$applyNodeReplacement', () => {
         ExtendedTextNode,
         {
           replace: TextNode,
-          with: (node) => $createExtendedTextNode().initWithTextNode(node),
+          with: node => $createExtendedTextNode().initWithTextNode(node),
           withKlass: ExtendedTextNode,
         },
         {
           replace: ExtendedTextNode,
-          with: (node) =>
+          with: node =>
             $createExtendedExtendedTextNode().initWithExtendedTextNode(node),
           withKlass: ExtendedExtendedTextNode,
         },
@@ -793,12 +793,12 @@ describe('$applyNodeReplacement', () => {
         ExtendedExtendedTextNode,
         {
           replace: TextNode,
-          with: (node) => $createExtendedTextNode().initWithTextNode(node),
+          with: node => $createExtendedTextNode().initWithTextNode(node),
           withKlass: ExtendedTextNode,
         },
         {
           replace: ExtendedTextNode,
-          with: (node) =>
+          with: node =>
             $createExtendedExtendedTextNode().initWithExtendedTextNode(node),
           withKlass: ExtendedExtendedTextNode,
         },
@@ -825,7 +825,7 @@ describe('$applyNodeReplacement', () => {
 });
 describe('$copyNode', () => {
   const STRING_STATE = createState('string-state', {
-    parse: (v) => (typeof v === 'string' ? v : ''),
+    parse: v => (typeof v === 'string' ? v : ''),
   });
   class ExtendedParagraphNode extends ParagraphNode {
     __string: string = 'default';

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -465,7 +465,7 @@ export function TestComposer({
   return (
     <LexicalComposer
       initialConfig={{
-        onError: (e) => {
+        onError: e => {
           throw e;
         },
         ...config,
@@ -493,7 +493,7 @@ export function createTestEditor(
   const customNodes = config.nodes || [];
   const editor = createEditor({
     namespace: config.namespace,
-    onError: (e) => {
+    onError: e => {
       throw e;
     },
     ...config,
@@ -507,7 +507,7 @@ export function createTestHeadlessEditor(
 ): LexicalEditor {
   return createHeadlessEditor({
     editorState,
-    onError: (error) => {
+    onError: error => {
       throw error;
     },
   });

--- a/packages/lexical/src/caret/LexicalCaret.ts
+++ b/packages/lexical/src/caret/LexicalCaret.ts
@@ -392,7 +392,7 @@ abstract class AbstractCaret<
     return makeStepwiseIterator({
       hasNext: $isSiblingCaret,
       initial: this.getAdjacentCaret(),
-      map: (caret) => caret,
+      map: caret => caret,
       step: (caret: SiblingCaret<LexicalNode, D>) => caret.getAdjacentCaret(),
     });
   }
@@ -1038,7 +1038,7 @@ class CaretRangeImpl<D extends CaretDirection> implements CaretRange<D> {
       hasNext: (state: null | NodeCaret<D>): state is NodeCaret<D> =>
         state !== null && !(isTextFocus && focus.isSameNodeCaret(state)),
       initial: anchor.isSameNodeCaret(focus) ? null : step(anchor),
-      map: (state) => state,
+      map: state => state,
       step,
     });
   }

--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -371,7 +371,7 @@ export function $removeTextFromCaretRange<D extends CaretDirection>(
   invariant(
     false,
     '$removeTextFromCaretRange: selection was lost, could not find a new anchor given candidates with keys: %s',
-    JSON.stringify(anchorCandidates.map((n) => n.origin.__key)),
+    JSON.stringify(anchorCandidates.map(n => n.origin.__key)),
   );
 }
 
@@ -433,7 +433,7 @@ function $getBlockMergeTargets(
     anchorBlock &&
     $getBlock(
       focusElements,
-      (node) => seenStart.has(node.getKey()) && INTERNAL_$isBlock(node),
+      node => seenStart.has(node.getKey()) && INTERNAL_$isBlock(node),
     );
   return anchorBlock && focusBlock ? [anchorBlock, focusBlock] : null;
 }

--- a/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
+++ b/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
@@ -86,7 +86,7 @@ function insideNode(size: number) {
 }
 
 describe('LexicalCaret', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('$getChildCaret', () => {
       for (const direction of DIRECTIONS) {
         test(`direction ${direction}`, async () => {
@@ -183,7 +183,7 @@ describe('LexicalCaret', () => {
               );
 
               expect(
-                Array.from(caret, (nextCaret) => nextCaret.origin.getKey()),
+                Array.from(caret, nextCaret => nextCaret.origin.getKey()),
               ).toEqual(
                 direction === 'next'
                   ? root.getChildrenKeys()
@@ -201,7 +201,7 @@ describe('LexicalCaret', () => {
           await testEnv.editor.update(
             () => {
               const paragraph = $createParagraphNode();
-              const tokens = ['-2', '-1', '0', '1', '2'].map((text) =>
+              const tokens = ['-2', '-1', '0', '1', '2'].map(text =>
                 $createTextNode(text).setMode('token'),
               );
               const root = $getRoot();
@@ -226,7 +226,7 @@ describe('LexicalCaret', () => {
               expect(
                 Array.from(
                   caret,
-                  (nextCaret) =>
+                  nextCaret =>
                     (direction === 'next' ? 1 : -1) *
                     +nextCaret.origin.getTextContent(),
                 ),
@@ -289,7 +289,7 @@ describe('LexicalCaret', () => {
               expect(
                 Array.from(
                   caret,
-                  (nextCaret) =>
+                  nextCaret =>
                     (direction === 'next' ? 1 : -1) *
                     +nextCaret.origin.getTextContent(),
                 ),
@@ -298,33 +298,33 @@ describe('LexicalCaret', () => {
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(
                 tokens
-                  .map((n) => n.getTextContent())
-                  .filter((t) => t !== String(offset)),
+                  .map(n => n.getTextContent())
+                  .filter(t => t !== String(offset)),
               );
               caret.insert(tokens[ZERO_INDEX + offset]);
               expect(
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
-              ).toEqual(tokens.map((n) => n.getTextContent()));
+                  .map(node => node.getTextContent()),
+              ).toEqual(tokens.map(n => n.getTextContent()));
               caret.replaceOrInsert(tokens[ZERO_INDEX + offset]);
               expect(
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
-              ).toEqual(tokens.map((n) => n.getTextContent()));
+                  .map(node => node.getTextContent()),
+              ).toEqual(tokens.map(n => n.getTextContent()));
 
               caret.replaceOrInsert($createTextNode('replaced!'));
               expect(
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(
                 tokens.map((n, i) =>
                   i === ZERO_INDEX + offset ? 'replaced!' : n.getTextContent(),
@@ -332,13 +332,13 @@ describe('LexicalCaret', () => {
               );
               caret.replaceOrInsert(tokens[ZERO_INDEX + offset]);
 
-              const abNodes = ['a', 'b'].map((t) => $createTextNode(t));
+              const abNodes = ['a', 'b'].map(t => $createTextNode(t));
               caret.splice(0, abNodes);
               expect(
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(
                 tokens.flatMap((n, i) => {
                   if (i !== ZERO_INDEX) {
@@ -350,14 +350,14 @@ describe('LexicalCaret', () => {
                   }
                 }),
               );
-              abNodes.forEach((n) => n.remove());
+              abNodes.forEach(n => n.remove());
 
               caret.splice(0, abNodes, 'previous');
               expect(
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(
                 tokens.flatMap((n, i) => {
                   if (i !== ZERO_INDEX) {
@@ -369,14 +369,14 @@ describe('LexicalCaret', () => {
                   }
                 }),
               );
-              abNodes.forEach((n) => n.remove());
+              abNodes.forEach(n => n.remove());
 
               caret.splice(1, abNodes);
               expect(
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(
                 tokens.flatMap((n, i) => {
                   if (i === ZERO_INDEX + offset) {
@@ -397,7 +397,7 @@ describe('LexicalCaret', () => {
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(
                 tokens.map((n, i) =>
                   i === ZERO_INDEX + offset ? 'a' : n.getTextContent(),
@@ -410,7 +410,7 @@ describe('LexicalCaret', () => {
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(
                 direction === 'next'
                   ? ['-2', '-1', '0', 'a']
@@ -423,7 +423,7 @@ describe('LexicalCaret', () => {
                 paragraph
                   .getLatest()
                   .getChildren()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(
                 direction === 'next'
                   ? ['-2', '-1', '0', 'a', 'b']
@@ -439,7 +439,7 @@ describe('LexicalCaret', () => {
     describe('$caretRangeFromSelection', () => {
       test('collapsed text point selection', async () => {
         await testEnv.editor.update(() => {
-          const textNodes = ['first', 'second', 'third'].map((text) =>
+          const textNodes = ['first', 'second', 'third'].map(text =>
             $createTextNode(text).setMode('token'),
           );
           $getRoot()
@@ -498,7 +498,7 @@ describe('LexicalCaret', () => {
       for (const direction of DIRECTIONS) {
         test(`full text node selection (${direction})`, async () => {
           await testEnv.editor.update(() => {
-            const textNodes = ['first', 'second', 'third'].map((text) =>
+            const textNodes = ['first', 'second', 'third'].map(text =>
               $createTextNode(text).setMode('token'),
             );
             $getRoot()
@@ -548,7 +548,7 @@ describe('LexicalCaret', () => {
       }
       test('single text node non-empty selection', async () => {
         await testEnv.editor.update(() => {
-          const textNodes = ['first', 'second', 'third'].map((text) =>
+          const textNodes = ['first', 'second', 'third'].map(text =>
             $createTextNode(text).setMode('token'),
           );
           $getRoot()
@@ -597,7 +597,7 @@ describe('LexicalCaret', () => {
       for (const direction of DIRECTIONS) {
         test(`multiple text node non-empty selection (${direction})`, async () => {
           await testEnv.editor.update(() => {
-            const textNodes = ['first', 'second', 'third'].map((text) =>
+            const textNodes = ['first', 'second', 'third'].map(text =>
               $createTextNode(text).setMode('token'),
             );
             $getRoot()
@@ -677,7 +677,7 @@ describe('LexicalCaret', () => {
                     expect([...range.iterNodeCarets('root')]).toMatchObject(
                       textNodes
                         .slice(indexNodeStart + 1, indexNodeEnd)
-                        .map((origin) => ({
+                        .map(origin => ({
                           direction,
                           origin,
                           type: 'sibling',
@@ -706,7 +706,7 @@ describe('LexicalCaret', () => {
               expect(
                 $getRoot()
                   .getAllTextNodes()
-                  .map((n) => n.getTextContent()),
+                  .map(n => n.getTextContent()),
               ).toEqual(['[before]', '[after]']);
               invariant($isHeadingNode(newHeadingNode), 'paragraph inserted');
               expect($getRoot().getChildren()).toEqual([
@@ -832,9 +832,10 @@ describe('LexicalCaret', () => {
               expect(trailingSegmentedText.isAttached()).toBe(false);
               const allTextNodes = $getRoot().getAllTextNodes();
               // These should get merged in reconciliation
-              expect(allTextNodes.map((node) => node.getTextContent())).toEqual(
-                ['lead', 'text'],
-              );
+              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+                'lead',
+                'text',
+              ]);
               const selection = $assertRangeSelection($getSelection());
               expect(selection.isCollapsed()).toBe(true);
               expect(selection.anchor.key).toBe(leadingText.getKey());
@@ -846,7 +847,7 @@ describe('LexicalCaret', () => {
           testEnv.editor.getEditorState().read(() => {
             const allTextNodes = $getRoot().getAllTextNodes();
             // These should get merged in reconciliation
-            expect(allTextNodes.map((node) => node.getTextContent())).toEqual([
+            expect(allTextNodes.map(node => node.getTextContent())).toEqual([
               'leadtext',
             ]);
             expect(leadingText.isAttached()).toBe(true);
@@ -858,7 +859,7 @@ describe('LexicalCaret', () => {
         beforeEach(() => {
           testEnv.editor.update(() => {
             // Ensure that the separate texts don't get merged
-            const textNodes = texts.map((text) =>
+            const textNodes = texts.map(text =>
               $createTextNode(text).setStyle(`color: --color-${text}`),
             );
             $getRoot()
@@ -1068,9 +1069,9 @@ describe('LexicalCaret', () => {
                   $setSelection(null);
                   const remainingNodes = $getRoot().getAllTextNodes();
                   expect(remainingNodes).toEqual(
-                    originalNodes.map((n) => n.getLatest()),
+                    originalNodes.map(n => n.getLatest()),
                   );
-                  expect(remainingNodes.map((n) => n.getTextContent())).toEqual(
+                  expect(remainingNodes.map(n => n.getTextContent())).toEqual(
                     texts.filter((_v, j) => j !== i),
                   );
                   expect(resultRange.isCollapsed()).toBe(true);
@@ -1201,7 +1202,7 @@ describe('LexicalCaret', () => {
                   expect(
                     range
                       .getTextSlices()
-                      .filter((slice) => slice && slice.distance !== 0),
+                      .filter(slice => slice && slice.distance !== 0),
                   ).toMatchObject(
                     anchorBias === 'outside' && focusBias === 'outside'
                       ? []
@@ -1212,11 +1213,11 @@ describe('LexicalCaret', () => {
                   const resultRange = $removeTextFromCaretRange(range);
                   $setSelection(null);
                   const remainingNodes = $getRoot().getAllTextNodes();
-                  expect(remainingNodes.map((n) => n.getTextContent())).toEqual(
+                  expect(remainingNodes.map(n => n.getTextContent())).toEqual(
                     texts.filter((_v, j) => j !== i),
                   );
                   expect(remainingNodes).toEqual(
-                    originalNodes.map((n) => n.getLatest()),
+                    originalNodes.map(n => n.getLatest()),
                   );
                   expect(resultRange.isCollapsed()).toBe(true);
                   // bias towards the start
@@ -1285,7 +1286,7 @@ describe('LexicalCaret', () => {
                 const slices = range
                   .getTextSlices()
                   .filter($isTextPointCaretSlice)
-                  .filter((slice) => slice.distance !== 0);
+                  .filter(slice => slice.distance !== 0);
                 expect([...range.iterNodeCarets('root')]).toEqual([]);
                 expect(slices.length).toBe(1);
                 const [slice] = slices;
@@ -1306,7 +1307,7 @@ describe('LexicalCaret', () => {
                 });
                 const remainingNodes = $getRoot().getAllTextNodes();
                 expect(remainingNodes).toHaveLength(texts.length);
-                expect(remainingNodes.map((n) => n.getTextContent())).toEqual(
+                expect(remainingNodes.map(n => n.getTextContent())).toEqual(
                   texts.map((v, j) =>
                     i === j ? v.slice(0, offsetStart) + v.slice(offsetEnd) : v,
                   ),
@@ -1361,7 +1362,7 @@ describe('LexicalCaret', () => {
                   .getTextSlices()
                   .filter($isTextPointCaretSlice);
                 expect(slices).toHaveLength(2);
-                expect(slices.map((slice) => slice.getTextContent())).toEqual(
+                expect(slices.map(slice => slice.getTextContent())).toEqual(
                   direction === 'next'
                     ? [
                         startCaret.origin
@@ -1482,13 +1483,13 @@ describe('LexicalCaret', () => {
         beforeEach(async () => {
           await testEnv.editor.update(() => {
             // Ensure that the separate texts don't get merged
-            const textNodes = texts.map((text) =>
+            const textNodes = texts.map(text =>
               $createTextNode(text).setStyle(`color: --color-${text}`),
             );
             $getRoot()
               .clear()
               .append(
-                ...textNodes.map((node) => $createParagraphNode().append(node)),
+                ...textNodes.map(node => $createParagraphNode().append(node)),
               );
           });
         });
@@ -1535,7 +1536,7 @@ describe('LexicalCaret', () => {
                   .getTextSlices()
                   .filter($isTextPointCaretSlice);
                 expect(slices).toHaveLength(2);
-                expect(slices.map((slice) => slice.getTextContent())).toEqual(
+                expect(slices.map(slice => slice.getTextContent())).toEqual(
                   direction === 'next'
                     ? [
                         startCaret.origin
@@ -1675,7 +1676,7 @@ describe('LexicalCaret', () => {
               expect(
                 $getRoot()
                   .getAllTextNodes()
-                  .map((node) => node.getTextContent()),
+                  .map(node => node.getTextContent()),
               ).toEqual(['list', 'nested']);
               expect(listNode.getLatest().getChildren().length).toEqual(1);
             },
@@ -1684,7 +1685,7 @@ describe('LexicalCaret', () => {
           testEnv.editor.getEditorState().read(() => {
             const allTextNodes = $getRoot().getAllTextNodes();
             // These should get merged in reconciliation
-            expect(allTextNodes.map((node) => node.getTextContent())).toEqual([
+            expect(allTextNodes.map(node => node.getTextContent())).toEqual([
               'listnested',
             ]);
           });
@@ -1896,8 +1897,8 @@ describe('LexicalCaret', () => {
           test(title, () => {
             testEnv.editor.update(
               () => {
-                const nodes = $getTestNodes().map((n) => n.getLatest());
-                const ancestors = $getTestAncestors().map((n) => n.getLatest());
+                const nodes = $getTestNodes().map(n => n.getLatest());
+                const ancestors = $getTestAncestors().map(n => n.getLatest());
                 const commonAncestor = $getTestCommonAncestor().getLatest();
                 expect($getCommonAncestor(nodes[0], nodes[1])).toEqual({
                   a: ancestors[0],
@@ -1952,7 +1953,7 @@ describe('LexicalCaret', () => {
 });
 
 describe('LexicalSelectionHelpers', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('with a fully-selected text node preceded by an inline element', () => {
       test('a single text node', async () => {
         await testEnv.editor.update(() => {
@@ -1992,7 +1993,7 @@ describe('LexicalSelectionHelpers', () => {
 });
 
 describe('$splitAtPointCaretNext', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('Does not split a TextNode at the beginning', () => {
       testEnv.editor.update(
         () => {

--- a/packages/lexical/src/caret/__tests__/unit/docs-traversals.test.ts
+++ b/packages/lexical/src/caret/__tests__/unit/docs-traversals.test.ts
@@ -30,7 +30,7 @@ import {initializeUnitTest} from '../../../__tests__/utils';
 
 // The tests below here are intended to be basically copied from packages/lexical-website/docs/concepts/traversals.md
 describe('traversals.md', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     describe('Traversal Strategies', () => {
       let paragraphA: ParagraphNode;
       let textA1: TextNode;

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -648,7 +648,7 @@ export class ElementNode extends LexicalNode {
   clear(): this {
     const writableSelf = this.getWritable();
     const children = this.getChildren();
-    children.forEach((child) => child.remove());
+    children.forEach(child => child.remove());
     return writableSelf;
   }
   append(...nodesToAppend: LexicalNode[]): this {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -447,7 +447,7 @@ describe('LexicalElementNode tests', () => {
       },
     ];
 
-    BASE_INSERTIONS.forEach((testCase) => {
+    BASE_INSERTIONS.forEach(testCase => {
       it(`Plain text: ${testCase.name}`, async () => {
         await update(() => {
           block.splice(
@@ -590,7 +590,7 @@ describe('LexicalElementNode tests', () => {
       },
     ];
 
-    NESTED_ELEMENTS_TESTS.forEach((testCase) => {
+    NESTED_ELEMENTS_TESTS.forEach(testCase => {
       it(`Nested elements: ${testCase.name}`, async () => {
         await update(() => {
           const text1 = $createTextNode('Foo');
@@ -658,7 +658,7 @@ describe('LexicalElementNode tests', () => {
       const transforms = new Set();
       const expectedTransforms: string[] = [];
 
-      const removeTransform = editor.registerNodeTransform(TextNode, (node) => {
+      const removeTransform = editor.registerNodeTransform(TextNode, node => {
         transforms.add(node.__key);
       });
 
@@ -693,7 +693,7 @@ describe('LexicalElementNode tests', () => {
 
       await update(() => {
         expect(block.getTextContent()).toEqual('Foo2BarBaz');
-        expectedTransforms.forEach((key) => {
+        expectedTransforms.forEach(key => {
           expect(transforms).toContain(key);
         });
       });
@@ -710,7 +710,7 @@ describe('getDOMSlot tests', () => {
     document.body.appendChild(container);
     editor = createEditor({
       nodes: [WrapperElementNode],
-      onError: (error) => {
+      onError: error => {
         throw error;
       },
     });

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../../__tests__/utils';
 
 describe('LexicalGC tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('RootNode.clear() with a child and subchild', async () => {
       const {editor} = testEnv;
       await editor.update(() => {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalLineBreakNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalLineBreakNode.test.ts
@@ -12,7 +12,7 @@ import {describe, expect, test} from 'vitest';
 import {initializeUnitTest} from '../../../__tests__/utils';
 
 describe('LexicalLineBreakNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('LineBreakNode.constructor', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
@@ -25,7 +25,7 @@ const editorConfig = Object.freeze({
 });
 
 describe('LexicalParagraphNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     test('ParagraphNode.constructor', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
@@ -28,7 +28,7 @@ import {
 import {$createRootNode} from '../../LexicalRootNode';
 
 describe('LexicalRootNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     let rootNode: RootNode;
 
     function expectRootTextContentToBe(text: string): void {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
@@ -42,7 +42,7 @@ import {
 } from '../../../__tests__/utils';
 
 describe('LexicalTabNode tests', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     beforeEach(async () => {
       const {editor} = testEnv;
       await editor.update(() => {
@@ -290,7 +290,7 @@ describe('LexicalTabNode tests', () => {
 
     describe('TabNode at selection boundaries with normal TextNode sibling (#7602)', () => {
       const input = 'x\tx';
-      (['next', 'previous'] as const).forEach((direction) => {
+      (['next', 'previous'] as const).forEach(direction => {
         [
           {output: 'yx', start: 0},
           {output: 'xy', start: 1},
@@ -318,7 +318,7 @@ describe('LexicalTabNode tests', () => {
             // Using read here because we want to see the post-normalization merged state
             editor.read(() => {
               const expectNodes = $getRoot().getAllTextNodes();
-              expect(expectNodes.map((node) => node.getTextContent())).toEqual([
+              expect(expectNodes.map(node => node.getTextContent())).toEqual([
                 output,
               ]);
               expect(expectNodes.map($isTabNode)).toEqual([false]);

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -347,12 +347,12 @@ describe('LexicalTextNode tests', () => {
       $getRoot().append(paragraphNode);
 
       // Set each format and ensure that the other formats are cleared
-      capitalizationFormats.forEach((formatToSet) => {
+      capitalizationFormats.forEach(formatToSet => {
         textNode.toggleFormat(formatToSet);
 
         capitalizationFormats
-          .filter((format) => format !== formatToSet)
-          .forEach((format) => expect(textNode.hasFormat(format)).toBe(false));
+          .filter(format => format !== formatToSet)
+          .forEach(format => expect(textNode.hasFormat(format)).toBe(false));
 
         expect(textNode.hasFormat(formatToSet)).toBe(true);
       });
@@ -489,7 +489,7 @@ describe('LexicalTextNode tests', () => {
           const splitNodes = textNode.splitText(...splitOffsets);
 
           expect(paragraphNode.getChildren()).toHaveLength(splitStrings.length);
-          expect(splitNodes.map((node) => node.getTextContent())).toEqual(
+          expect(splitNodes.map(node => node.getTextContent())).toEqual(
             splitStrings,
           );
         });
@@ -628,7 +628,7 @@ describe('LexicalTextNode tests', () => {
       await update(() => {
         const textNode = $createTextNode('foo');
         const splits = textNode.splitText(1, 2);
-        expect(splits.map((split) => split.getTextContent())).toEqual([
+        expect(splits.map(split => split.getTextContent())).toEqual([
           'f',
           'o',
           'o',
@@ -640,15 +640,13 @@ describe('LexicalTextNode tests', () => {
       await update(() => {
         const textNode = $createTextNode('hello world');
         const state = createState('state', {
-          parse: (v) => v,
-          unparse: (v) => v,
+          parse: v => v,
+          unparse: v => v,
         });
         $setState(textNode, state, 'foo');
         const splits = textNode.splitText(3, 5);
         expect(
-          splits
-            .map((split) => $getState(split, state))
-            .every((v) => v === 'foo'),
+          splits.map(split => $getState(split, state)).every(v => v === 'foo'),
         ).toEqual(true);
 
         // Check that the state value is not aliased to the original node.
@@ -663,15 +661,13 @@ describe('LexicalTextNode tests', () => {
       await update(() => {
         const textNode = $createTestSegmentedNode('hello world');
         const state = createState('state', {
-          parse: (v) => v,
-          unparse: (v) => v,
+          parse: v => v,
+          unparse: v => v,
         });
         $setState(textNode, state, 'foo');
         const splits = textNode.splitText(3, 5);
         expect(
-          splits
-            .map((split) => $getState(split, state))
-            .every((v) => v === 'foo'),
+          splits.map(split => $getState(split, state)).every(v => v === 'foo'),
         ).toEqual(true);
       });
     });

--- a/packages/shared/viteModuleResolution.ts
+++ b/packages/shared/viteModuleResolution.ts
@@ -58,12 +58,12 @@ const sourceModuleResolution = (isSsrBuild = false) => {
   return [
     ...packagesManager
       .getPublicPackages()
-      .flatMap((pkg) =>
+      .flatMap(pkg =>
         pkg.getExportedNpmModuleEntries().map(toAlias.bind(null, pkg)),
       ),
     ...['shared']
-      .map((name) => packagesManager.getPackageByDirectoryName(name))
-      .flatMap((pkg) =>
+      .map(name => packagesManager.getPackageByDirectoryName(name))
+      .flatMap(pkg =>
         pkg.getPrivateModuleEntries().map(toAlias.bind(null, pkg)),
       ),
   ];
@@ -74,19 +74,19 @@ const distModuleResolution = (
   isSsrBuild = false,
 ) => {
   return [
-    ...packagesManager.getPublicPackages().flatMap((pkg) =>
+    ...packagesManager.getPublicPackages().flatMap(pkg =>
       pkg
         .getNormalizedNpmModuleExportEntries()
         .map((entry: NpmModuleExportEntry) => {
           const [name, moduleExports] = entry;
           const replacements = ([environment, 'default'] as const).flatMap(
-            (condition) =>
+            condition =>
               [
                 !isSsrBuild &&
                   moduleExports.browser &&
                   moduleExports.browser[condition],
                 moduleExports.import[condition],
-              ].flatMap((fn) => (fn ? [pkg.resolve('dist', fn)] : [])),
+              ].flatMap(fn => (fn ? [pkg.resolve('dist', fn)] : [])),
           );
           const replacement = replacements.find(fs.existsSync.bind(fs));
           if (!replacement) {

--- a/scripts/__tests__/integration/ascii-only.test.mjs
+++ b/scripts/__tests__/integration/ascii-only.test.mjs
@@ -20,7 +20,7 @@ describe('prod ascii-only check', () => {
       });
       expect(files).not.toHaveLength(0);
       expect(
-        files.filter((fn) =>
+        files.filter(fn =>
           // eslint-disable-next-line no-control-regex
           /[^\x00-\x7f]/.test(fs.readFileSync(fn, {encoding: 'utf8'})),
         ),

--- a/scripts/__tests__/integration/prepare-release.test.mjs
+++ b/scripts/__tests__/integration/prepare-release.test.mjs
@@ -27,12 +27,12 @@ describe('prepare-release tests', () => {
   }
 });
 ['examples', 'scripts/__tests__/integration/fixtures']
-  .flatMap((packagesDir) =>
+  .flatMap(packagesDir =>
     glob.sync(`${packagesDir}/*/package.json`, {windowsPathsNoEscape: true}),
   )
-  .forEach((exampleJsonPath) => describeExample(exampleJsonPath));
+  .forEach(exampleJsonPath => describeExample(exampleJsonPath));
 // dev-examples use workspace:* deps and are tested with pnpm workspace
 // linking rather than published tarballs
 glob
   .sync('dev-examples/*/package.json', {windowsPathsNoEscape: true})
-  .forEach((exampleJsonPath) => describeDevExample(exampleJsonPath));
+  .forEach(exampleJsonPath => describeDevExample(exampleJsonPath));

--- a/scripts/__tests__/integration/setup.mjs
+++ b/scripts/__tests__/integration/setup.mjs
@@ -22,7 +22,7 @@ export default async function () {
   const needsBuild = packagesManager
     .getPublicPackages()
     .some(
-      (pkg) =>
+      pkg =>
         !fs.existsSync(
           path.resolve(`./npm/${pkg.getDirectoryName()}-${version}.tgz`),
         ),

--- a/scripts/__tests__/integration/utils.mjs
+++ b/scripts/__tests__/integration/utils.mjs
@@ -44,10 +44,10 @@ function expectSuccessfulExec(cmd) {
   const env = Object.fromEntries(
     Object.entries(process.env).filter(([k]) => k !== 'VITEST_WORKER_ID'),
   );
-  return exec(cmd, {env}).catch((err) => {
+  return exec(cmd, {env}).catch(err => {
     expect(
       Object.fromEntries(
-        ['code', 'stdout', 'stderr'].map((prop) => [prop, err[prop]]),
+        ['code', 'stdout', 'stderr'].map(prop => [prop, err[prop]]),
       ),
     ).toBe(null);
     throw err;
@@ -90,13 +90,13 @@ async function buildExample({packageJson, exampleDir}) {
   const installDeps = Array.from(depsMap.entries(), ([dep, pkg]) =>
     path.resolve('npm', `${pkg.getDirectoryName()}-${monorepoVersion}.tgz`),
   );
-  ['node_modules', 'dist', 'build', '.next', '.svelte-kit'].forEach(
-    (cleanDir) => fs.removeSync(path.resolve(exampleDir, cleanDir)),
+  ['node_modules', 'dist', 'build', '.next', '.svelte-kit'].forEach(cleanDir =>
+    fs.removeSync(path.resolve(exampleDir, cleanDir)),
   );
 
   await withCwd(exampleDir, async () => {
     await expectSuccessfulExec(
-      `npm install --no-save ${installDeps.map((fn) => `'${fn}'`).join(' ')}`,
+      `npm install --no-save ${installDeps.map(fn => `'${fn}'`).join(' ')}`,
     );
     await expectSuccessfulExec('npm run build');
     if (hasPlaywright) {
@@ -127,7 +127,7 @@ function describeExample(packageJsonPath, bodyFun = undefined) {
       expect(true).toBe(true);
     });
     test(`installed lexical ${monorepoVersion}`, () => {
-      const packageNames = deps.map((pkg) => pkg.getNpmName());
+      const packageNames = deps.map(pkg => pkg.getNpmName());
       expect(packageNames).toContain('lexical');
       for (const pkg of deps) {
         const installedPath = path.join(

--- a/scripts/__tests__/unit/build.test.ts
+++ b/scripts/__tests__/unit/build.test.ts
@@ -19,18 +19,18 @@ const monorepoPackageJson = (
 ).default();
 
 const publicNpmNames = new Set(
-  packagesManager.getPublicPackages().map((pkg) => pkg.getNpmName()),
+  packagesManager.getPublicPackages().map(pkg => pkg.getNpmName()),
 );
 
 describe('public package.json audits (`pnpm run update-packages` to fix most issues)', () => {
-  packagesManager.getPublicPackages().forEach((pkg) => {
+  packagesManager.getPublicPackages().forEach(pkg => {
     const npmName = pkg.getNpmName();
     const packageJson = pkg.packageJson;
     describe(npmName, () => {
       const sourceFiles = fs
         .readdirSync(pkg.resolve('src'))
-        .filter((str) => /\.tsx?/.test(str))
-        .map((str) => str.replace(/\.tsx?$/, ''))
+        .filter(str => /\.tsx?/.test(str))
+        .map(str => str.replace(/\.tsx?$/, ''))
         .sort();
       const exportedModules = pkg.getExportedNpmModuleNames().sort();
       const {dependencies = {}, peerDependencies = {}} = packageJson;
@@ -60,9 +60,7 @@ describe('public package.json audits (`pnpm run update-packages` to fix most iss
       });
       it('must not have monorepo peerDependencies', () => {
         expect(
-          Object.keys(peerDependencies).filter((dep) =>
-            publicNpmNames.has(dep),
-          ),
+          Object.keys(peerDependencies).filter(dep => publicNpmNames.has(dep)),
         ).toEqual([]);
       });
       it('monorepo dependencies must use workspace:* as the version', () => {
@@ -77,7 +75,7 @@ describe('public package.json audits (`pnpm run update-packages` to fix most iss
       });
       test.each(exportedModules)(
         `should have a source file for exported module %s`,
-        (exportedModule) => {
+        exportedModule => {
           expect(sourceFiles).toContain(
             exportedModule.slice(npmName.length + 1) || 'index',
           );
@@ -89,7 +87,7 @@ describe('public package.json audits (`pnpm run update-packages` to fix most iss
         });
         test.each(sourceFiles)(
           `%s.tsx? must have an exported module`,
-          (sourceFile) => {
+          sourceFile => {
             expect(exportedModules).toContain(`${npmName}/${sourceFile}`);
           },
         );
@@ -99,7 +97,7 @@ describe('public package.json audits (`pnpm run update-packages` to fix most iss
 });
 
 describe('documentation audits (`pnpm run update-packages` to fix most issues)', () => {
-  packagesManager.getPublicPackages().forEach((pkg) => {
+  packagesManager.getPublicPackages().forEach(pkg => {
     const npmName = pkg.getNpmName();
     describe(npmName, () => {
       const root = pkg.resolve('..', '..');
@@ -119,7 +117,7 @@ describe('documentation audits (`pnpm run update-packages` to fix most issues)',
 });
 
 describe('www public package audits (`pnpm run update-packages` to fix most issues)', () => {
-  packagesManager.getPublicPackages().forEach((pkg) => {
+  packagesManager.getPublicPackages().forEach(pkg => {
     const npmName = pkg.getNpmName();
     const wwwEntrypoint = `${npmToWwwName(npmName)}.js`;
     describe(npmName, () => {
@@ -131,7 +129,7 @@ describe('www public package audits (`pnpm run update-packages` to fix most issu
         ).not.toEqual([]);
       });
       // Only worry about the entrypoint stub if it has a single module export
-      if (pkg.getExportedNpmModuleNames().every((name) => name === npmName)) {
+      if (pkg.getExportedNpmModuleNames().every(name => name === npmName)) {
         it(`has a packages/${pkg.getDirectoryName()}/${wwwEntrypoint}`, () => {
           expect(fs.existsSync(pkg.resolve(wwwEntrypoint))).toBe(true);
         });

--- a/scripts/__tests__/unit/stackblitz.test.ts
+++ b/scripts/__tests__/unit/stackblitz.test.ts
@@ -17,7 +17,7 @@ describe('stackblitz doc url audits', () => {
     .sync(['packages/*/README.md', 'packages/lexical-website/docs/**/*.md'], {
       ignore: 'packages/lexical-website/docs/api/**',
     })
-    .forEach((fn) =>
+    .forEach(fn =>
       describe(fn, () =>
         it('Does not have incorrect stackblitz URLs', () => {
           const contents = fs.readFileSync(fn, 'utf8');

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -41,9 +41,9 @@ const isWWW = argv.www;
 const extractCodes = argv.codes;
 
 const modulePackageMappings = Object.fromEntries(
-  packagesManager.getPublicPackages().flatMap((pkg) => {
+  packagesManager.getPublicPackages().flatMap(pkg => {
     const pkgName = pkg.getNpmName();
-    return pkg.getExportedNpmModuleNames().map((npm) => [npm, pkgName]);
+    return pkg.getExportedNpmModuleNames().map(npm => [npm, pkgName]);
   }),
 );
 
@@ -56,21 +56,21 @@ function getShikiAssets(assetType) {
       ),
       {windowsPathsNoEscape: true},
     )
-    .map((p) => path.basename(p.replaceAll('\\', '/'), '.mjs'));
+    .map(p => path.basename(p.replaceAll('\\', '/'), '.mjs'));
 }
 
 const wwwMappings = {
   ...Object.fromEntries(
-    Object.keys(modulePackageMappings).map((npm) => [npm, npmToWwwName(npm)]),
+    Object.keys(modulePackageMappings).map(npm => [npm, npmToWwwName(npm)]),
   ),
   ...Object.fromEntries(
-    getShikiAssets('langs').map((name) => [
+    getShikiAssets('langs').map(name => [
       `@shikijs/langs/${name}`,
       `shikijs-langs-${name}`,
     ]),
   ),
   ...Object.fromEntries(
-    getShikiAssets('themes').map((name) => [
+    getShikiAssets('themes').map(name => [
       `@shikijs/themes/${name}`,
       `shikijs-themes-${name}`,
     ]),
@@ -137,7 +137,7 @@ const thirdPartyExternalsRegExp = new RegExp(
 const strictWWWMappings = {};
 
 // Add quotes around mappings to make them more strict.
-Object.keys(wwwMappings).forEach((mapping) => {
+Object.keys(wwwMappings).forEach(mapping => {
   strictWWWMappings[`'${mapping}'`] = `'${wwwMappings[mapping]}'`;
 });
 

--- a/scripts/capture-gallery-screenshots.ts
+++ b/scripts/capture-gallery-screenshots.ts
@@ -48,7 +48,7 @@ const PORT = 5180;
 const IS_WINDOWS = process.platform === 'win32';
 
 function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+  return new Promise(r => setTimeout(r, ms));
 }
 
 function waitForServer(port: number, timeoutMs = 60000): Promise<void> {
@@ -226,7 +226,7 @@ async function main(): Promise<void> {
   console.warn('\nDone!');
 }
 
-main().catch((err) => {
+main().catch(err => {
   console.error('Fatal error:', err);
   process.exit(1);
 });

--- a/scripts/check-flow-types.mjs
+++ b/scripts/check-flow-types.mjs
@@ -9,7 +9,7 @@
 import {spawn} from 'node:child_process';
 
 async function runFlow(renderer, args) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     let cmd = import.meta.dirname + '/../node_modules/.bin/flow';
     if (process.platform === 'win32') {
       cmd = cmd.replace(/\//g, '\\') + '.cmd';

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -15,6 +15,6 @@ fs.removeSync(path.resolve(`./npm`));
 fs.removeSync(path.resolve(`./.ts-temp`));
 packagesManager
   .getPublicPackages()
-  .forEach((pkg) =>
-    ['dist', 'npm'].forEach((subdir) => fs.removeSync(pkg.resolve(subdir))),
+  .forEach(pkg =>
+    ['dist', 'npm'].forEach(subdir => fs.removeSync(pkg.resolve(subdir))),
   );

--- a/scripts/create-docs.mjs
+++ b/scripts/create-docs.mjs
@@ -26,7 +26,7 @@ ${description}
 }
 
 function createDocs() {
-  packagesManager.getPublicPackages().forEach((pkg) => {
+  packagesManager.getPublicPackages().forEach(pkg => {
     const npmName = pkg.getNpmName();
     const directoryName = pkg.getDirectoryName();
     const root = pkg.resolve('..', '..');

--- a/scripts/create-www-stubs.mjs
+++ b/scripts/create-www-stubs.mjs
@@ -40,10 +40,10 @@ module.exports = require('./dist/${filename}');
 }
 
 function updateWwwStubs() {
-  packagesManager.getPublicPackages().forEach((pkg) => {
+  packagesManager.getPublicPackages().forEach(pkg => {
     const npmName = pkg.getNpmName();
     // Only worry about the entrypoint stub if it has a single module export
-    if (pkg.getExportedNpmModuleNames().some((name) => name !== npmName)) {
+    if (pkg.getExportedNpmModuleNames().some(name => name !== npmName)) {
       return;
     }
 

--- a/scripts/error-codes/__tests__/unit/ErrorMap.test.ts
+++ b/scripts/error-codes/__tests__/unit/ErrorMap.test.ts
@@ -11,7 +11,7 @@ import {describe, expect, test, vi} from 'vitest';
 import ErrorMap from '../../ErrorMap';
 
 function waitTick(): Promise<void> {
-  return new Promise((resolve) => queueMicrotask(resolve));
+  return new Promise(resolve => queueMicrotask(resolve));
 }
 
 describe('ErrorMap', () => {

--- a/scripts/error-codes/__tests__/unit/transform-error-messages.test.ts
+++ b/scripts/error-codes/__tests__/unit/transform-error-messages.test.ts
@@ -16,7 +16,7 @@ import transformErrorMessages from '../../transform-error-messages.mjs';
 const prettierConfig = prettier.resolveConfig(__filename) || {};
 
 function waitTick(): Promise<void> {
-  return new Promise((resolve) => queueMicrotask(resolve));
+  return new Promise(resolve => queueMicrotask(resolve));
 }
 
 async function withCodes(
@@ -85,7 +85,7 @@ async function expectTransform(opts: ExpectTransformOptions) {
   return await withCodes(
     opts.messageMapBefore,
     opts.messageMapExpect,
-    async (errorCodesPath) => {
+    async errorCodesPath => {
       const {code} = babel.transformSync(fmt`${opts.codeBefore}`, {
         configFile: false,
         plugins: [[transformErrorMessages, {errorCodesPath, ...opts.opts}]],

--- a/scripts/error-codes/transform-error-messages.mjs
+++ b/scripts/error-codes/transform-error-messages.mjs
@@ -30,7 +30,7 @@ function getErrorMap(filepath) {
       ...(prettier.resolveConfig(import.meta.filename) || {}),
       filepath,
     };
-    errorMap = new ErrorMap(fs.readJsonSync(filepath), (newErrorMap) =>
+    errorMap = new ErrorMap(fs.readJsonSync(filepath), newErrorMap =>
       fs.writeFileSync(
         filepath,
         prettier.format(JSON.stringify(newErrorMap), prettierConfig),
@@ -103,9 +103,7 @@ export default function transformErrorMessages(babel, opts) {
             const errorMsgExpressions = Array.from(node.arguments.slice(2));
             const errorMsgQuasis = errorMsgLiteral
               .split('%s')
-              .map((raw) =>
-                t.templateElement({cooked: String.raw({raw}), raw}),
-              );
+              .map(raw => t.templateElement({cooked: String.raw({raw}), raw}));
 
             // Outputs:
             //   `A ${adj} message that contains ${noun}`;

--- a/scripts/find-all-pr-reviewers.mjs
+++ b/scripts/find-all-pr-reviewers.mjs
@@ -102,7 +102,7 @@ async function findAllPRReviewers() {
 
       // Add a small delay to avoid rate limiting
       if (hasNextPage) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise(resolve => setTimeout(resolve, 100));
       }
     } catch (error) {
       console.error('Error parsing response:', error.message);
@@ -120,7 +120,7 @@ async function findAllPRReviewers() {
   );
 
   console.log('=== All PR Reviewers (Alphabetical) ===\n');
-  reviewerList.forEach((reviewer) => {
+  reviewerList.forEach(reviewer => {
     console.log(reviewer);
   });
 
@@ -131,7 +131,7 @@ async function findAllPRReviewers() {
 }
 
 // Run the script
-findAllPRReviewers().catch((error) => {
+findAllPRReviewers().catch(error => {
   console.error('Error finding PR reviewers:', error);
   process.exit(1);
 });

--- a/scripts/format-reviewers-markdown.mjs
+++ b/scripts/format-reviewers-markdown.mjs
@@ -65,9 +65,9 @@ const teamDataPath = join(
 );
 const teamData = JSON.parse(fs.readFileSync(teamDataPath, 'utf8'));
 
-const coreUsernames = teamData.core.map((m) => m.username);
-const emeritiUsernames = teamData.emeriti.map((m) => m.username);
-const distinguishedUsernames = teamData.distinguished.map((m) => m.username);
+const coreUsernames = teamData.core.map(m => m.username);
+const emeritiUsernames = teamData.emeriti.map(m => m.username);
+const distinguishedUsernames = teamData.distinguished.map(m => m.username);
 
 // Create a map of username -> display name
 // Priority: team.json data, then hardcoded historical data
@@ -80,7 +80,7 @@ allHistoricalReviewers.forEach(({name, username}) => {
 
 // Then override with team.json data (which is more authoritative)
 [...teamData.core, ...teamData.emeriti, ...teamData.distinguished].forEach(
-  (member) => {
+  member => {
     usernameToName.set(member.username, member.name);
   },
 );
@@ -93,23 +93,23 @@ function formatReviewer(username) {
 
 // Categorize all historical reviewers
 const core = allHistoricalReviewers
-  .filter((r) => coreUsernames.includes(r.username))
+  .filter(r => coreUsernames.includes(r.username))
   .sort((a, b) =>
     a.username.toLowerCase().localeCompare(b.username.toLowerCase()),
   );
 const emeriti = allHistoricalReviewers
-  .filter((r) => emeritiUsernames.includes(r.username))
+  .filter(r => emeritiUsernames.includes(r.username))
   .sort((a, b) =>
     a.username.toLowerCase().localeCompare(b.username.toLowerCase()),
   );
 const distinguished = allHistoricalReviewers
-  .filter((r) => distinguishedUsernames.includes(r.username))
+  .filter(r => distinguishedUsernames.includes(r.username))
   .sort((a, b) =>
     a.username.toLowerCase().localeCompare(b.username.toLowerCase()),
   );
 const notInTeamData = allHistoricalReviewers
   .filter(
-    (r) =>
+    r =>
       !coreUsernames.includes(r.username) &&
       !emeritiUsernames.includes(r.username) &&
       !distinguishedUsernames.includes(r.username),

--- a/scripts/generate-team-data.mjs
+++ b/scripts/generate-team-data.mjs
@@ -72,8 +72,8 @@ function fetchContributors() {
   if (!result) {
     throw new Error('Failed to fetch contributors');
   }
-  const lines = result.split('\n').filter((line) => line.trim());
-  return lines.map((line) => JSON.parse(line));
+  const lines = result.split('\n').filter(line => line.trim());
+  return lines.map(line => JSON.parse(line));
 }
 
 /**
@@ -336,7 +336,7 @@ async function generateTeamData() {
 }
 
 // Run the script
-generateTeamData().catch((error) => {
+generateTeamData().catch(error => {
   console.error('Error generating team data:', error);
   process.exit(1);
 });

--- a/scripts/lint-flow-types.mjs
+++ b/scripts/lint-flow-types.mjs
@@ -18,7 +18,7 @@ const pretty = process.env.CI !== 'true';
 
 /** @type {ts.FormatDiagnosticsHost} */
 const diagnosticsHost = {
-  getCanonicalFileName: (fn) => fn,
+  getCanonicalFileName: fn => fn,
   getCurrentDirectory: () => './',
   getNewLine: () => '\n',
 };
@@ -42,7 +42,7 @@ function lintFlowTypes() {
 
 function collectFlowExports(flowAst) {
   const exportNames = new Map();
-  const exportId = (node) => {
+  const exportId = node => {
     const identifier =
       node.type === 'Identifier'
         ? node
@@ -99,7 +99,7 @@ function compareFlowDts(
   });
   const flowMap = collectFlowExports(flowAst);
   const symbols = entrypoint.getExportSymbols();
-  const tsMap = new Map(symbols.map((sym) => [sym.getName(), sym]));
+  const tsMap = new Map(symbols.map(sym => [sym.getName(), sym]));
   for (const [name, symbol] of tsMap) {
     if (flowMap.has(name)) {
       continue;
@@ -159,7 +159,7 @@ function lintFlowTypesForPackage(
     }
     const flowMsg = flowDiagnostics
       .map(
-        (ident) =>
+        ident =>
           `${ident.loc.source}:${ident.loc.start.line}:${ident.loc.start.column} - warning: Flow export '${ident.name}' does not have a TypeScript declaration`,
       )
       .join('\n');

--- a/scripts/npm/postversion.mjs
+++ b/scripts/npm/postversion.mjs
@@ -76,7 +76,7 @@ async function main() {
     'push',
     ...(process.env.DRY_RUN === '1' ? ['--dry-run'] : []),
     'origin',
-    ...refs.map((ref) => `+${ref}`),
+    ...refs.map(ref => `+${ref}`),
   ]);
   if (GITHUB_OUTPUT) {
     commands.push(

--- a/scripts/npm/prepare-release.mjs
+++ b/scripts/npm/prepare-release.mjs
@@ -43,10 +43,10 @@ function preparePackage(pkg) {
       `Missing Flow type definitions for package ${pkg.getDirectoryName()}`,
     );
   }
-  flowSources.forEach((flowSource) =>
+  flowSources.forEach(flowSource =>
     fs.copySync(flowSource, pkg.resolve('npm', path.basename(flowSource))),
   );
-  ['package.json', 'README.md'].forEach((fn) =>
+  ['package.json', 'README.md'].forEach(fn =>
     fs.copySync(pkg.resolve(fn), pkg.resolve('npm', fn)),
   );
 
@@ -55,9 +55,9 @@ function preparePackage(pkg) {
   const npmPackageJson = fs.readJsonSync(npmPackageJsonPath);
 
   // Replace workspace:* in dependencies and devDependencies
-  ['dependencies', 'devDependencies'].forEach((depType) => {
+  ['dependencies', 'devDependencies'].forEach(depType => {
     if (npmPackageJson[depType]) {
-      Object.keys(npmPackageJson[depType]).forEach((dep) => {
+      Object.keys(npmPackageJson[depType]).forEach(dep => {
         if (npmPackageJson[depType][dep] === 'workspace:*') {
           npmPackageJson[depType][dep] = version;
         }

--- a/scripts/npm/release.mjs
+++ b/scripts/npm/release.mjs
@@ -31,7 +31,7 @@ async function publish() {
   if (!nonInteractive) {
     console.info(
       `You're about to publish:
-    ${pkgs.map((pkg) => pkg.getNpmName()).join('\n')}
+    ${pkgs.map(pkg => pkg.getNpmName()).join('\n')}
 
     Type "publish" to confirm.`,
     );
@@ -43,7 +43,7 @@ async function publish() {
     if (dryRun === undefined || dryRun === 0) {
       await exec(
         `cd ./packages/${pkg.getDirectoryName()}/npm && pnpm publish --access public --tag ${channel} --no-git-checks`,
-      ).catch((err) => {
+      ).catch(err => {
         if (
           ignorePreviouslyPublished &&
           err &&
@@ -67,7 +67,7 @@ async function publish() {
 }
 
 async function waitForInput() {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,

--- a/scripts/override-react.mjs
+++ b/scripts/override-react.mjs
@@ -24,7 +24,7 @@ async function main() {
   [
     'package.json',
     ...glob.sync('./packages/*/package.json', {windowsPathsNoEscape: true}),
-  ].forEach((fn) => {
+  ].forEach(fn => {
     const json = fs.readJsonSync(fn);
     const isRoot = fn === 'package.json';
     let didUpdate = isRoot;
@@ -32,7 +32,7 @@ async function main() {
       json.overrides ||= {};
       Object.assign(
         json.overrides,
-        Object.fromEntries(packages.map((pkg) => [pkg, '$' + pkg])),
+        Object.fromEntries(packages.map(pkg => [pkg, '$' + pkg])),
       );
     } else if (json.dependencies) {
       for (const k of packages) {
@@ -46,7 +46,7 @@ async function main() {
       fs.writeJsonSync(fn, json, {spaces: 2});
     }
   });
-  const cmd = `pnpm add -w ${packages.map((pkg) => `${pkg}@${version}`).join(' ')}`;
+  const cmd = `pnpm add -w ${packages.map(pkg => `${pkg}@${version}`).join(' ')}`;
   console.log(cmd);
   await exec(cmd);
   await exec(

--- a/scripts/shared/PackageMetadata.mjs
+++ b/scripts/shared/PackageMetadata.mjs
@@ -143,16 +143,16 @@ export class PackageMetadata {
    */
   getExportedNpmModuleEntries() {
     const npmName = this.getNpmName();
-    return this.getExportedNpmModuleNames().map((name) => {
+    return this.getExportedNpmModuleNames().map(name => {
       const outputFileName = npmToWwwName(name);
       const sourceBaseNames =
         name === npmName
           ? ['index']
           : [name.replace(/^.*\//, ''), outputFileName];
-      const sourceCandidates = sourceBaseNames.flatMap((sourceBaseName) =>
-        ['.ts', '.tsx'].map((ext) => sourceBaseName + ext),
+      const sourceCandidates = sourceBaseNames.flatMap(sourceBaseName =>
+        ['.ts', '.tsx'].map(ext => sourceBaseName + ext),
       );
-      const sourceFileName = sourceCandidates.find((fn) =>
+      const sourceFileName = sourceCandidates.find(fn =>
         fs.existsSync(this.resolve('src', fn)),
       );
       if (!sourceFileName) {
@@ -164,7 +164,7 @@ export class PackageMetadata {
       }
       const browserSourceFileName = [
         sourceFileName.replace(/(\.tsx?)$/, '.browser$1'),
-      ].find((fn) => fs.existsSync(this.resolve('src', fn)));
+      ].find(fn => fs.existsSync(this.resolve('src', fn)));
       return {browserSourceFileName, name, sourceFileName};
     });
   }

--- a/scripts/shared/childProcess.mjs
+++ b/scripts/shared/childProcess.mjs
@@ -20,7 +20,7 @@ export const exec = promisify(execCb);
 export function spawn(command, args, options) {
   return new Promise((resolve, reject) => {
     const child = spawnCb(command, args, options);
-    child.on('close', (code) => {
+    child.on('close', code => {
       if (code === 0) {
         resolve();
       } else {

--- a/scripts/shared/packagesManager.mjs
+++ b/scripts/shared/packagesManager.mjs
@@ -40,7 +40,7 @@ class PackagesManager {
    */
   constructor(packagePaths) {
     this.packages = packagePaths
-      .map((packagePath) => new PackageMetadata(packagePath))
+      .map(packagePath => new PackageMetadata(packagePath))
       .sort(packageSort);
     for (const pkg of this.packages) {
       this.packagesByNpmName.set(pkg.getNpmName(), pkg);
@@ -90,7 +90,7 @@ class PackagesManager {
    * @returns {Array<PackageMetadata>}
    */
   getPublicPackages() {
-    return this.packages.filter((pkg) => !pkg.isPrivate());
+    return this.packages.filter(pkg => !pkg.isPrivate());
   }
 
   /**
@@ -106,7 +106,7 @@ class PackagesManager {
     const depsMap = new Map();
     const visited = new Set();
     /** @param {string[]} deps */
-    const traverse = (deps) => {
+    const traverse = deps => {
       for (const dep of deps) {
         if (visited.has(dep)) {
           continue;

--- a/scripts/update-examples.mjs
+++ b/scripts/update-examples.mjs
@@ -24,7 +24,7 @@ async function main() {
     argv._.length > 0
       ? argv._
       : ['examples/*', 'scripts/__tests__/integration/fixtures/*'];
-  for (const fn of paths.flatMap((dir) =>
+  for (const fn of paths.flatMap(dir =>
     globSync(path.join(dir, 'package.json'), {windowsPathsNoEscape: true}),
   )) {
     const pkg = new PackageMetadata(fn);
@@ -70,7 +70,7 @@ async function main() {
       );
       for (const dir of [
         pkg.resolve('node_modules', '{lexical,@lexical}'),
-      ].flatMap((v) => globSync(v))) {
+      ].flatMap(v => globSync(v))) {
         console.log(`> rm -rf ${dir}`);
         fs.rmSync(dir, {force: true, recursive: true});
       }

--- a/scripts/updateVersion.mjs
+++ b/scripts/updateVersion.mjs
@@ -20,7 +20,7 @@ const monorepoPackageJson = readMonorepoPackageJson();
 const version = monorepoPackageJson.version;
 
 const publicNpmNames = new Set(
-  packagesManager.getPublicPackages().map((pkg) => pkg.getNpmName()),
+  packagesManager.getPublicPackages().map(pkg => pkg.getNpmName()),
 );
 
 /**
@@ -57,7 +57,7 @@ function updateVersion() {
       './examples/*/package.json',
       './scripts/__tests__/integration/fixtures/*/package.json',
     ])
-    .forEach((packageJsonPath) =>
+    .forEach(packageJsonPath =>
       updatePackage(new PackageMetadata(packageJsonPath)),
     );
 }
@@ -213,8 +213,8 @@ function updateDependencies(pkg) {
     peerDependencies = {},
     devDependencies = {},
   } = packageJson;
-  [dependencies, devDependencies].forEach((deps) => {
-    Object.keys(deps).forEach((dep) => {
+  [dependencies, devDependencies].forEach(deps => {
+    Object.keys(deps).forEach(dep => {
       if (publicNpmNames.has(dep)) {
         deps[dep] = depVersion;
       }
@@ -222,7 +222,7 @@ function updateDependencies(pkg) {
   });
   // Move peerDependencies on lexical monorepo packages to dependencies
   // per #5783
-  Object.keys(peerDependencies).forEach((peerDep) => {
+  Object.keys(peerDependencies).forEach(peerDep => {
     if (publicNpmNames.has(peerDep)) {
       delete peerDependencies[peerDep];
       dependencies[peerDep] = depVersion;

--- a/scripts/validate-tsc-types.mjs
+++ b/scripts/validate-tsc-types.mjs
@@ -15,7 +15,7 @@ const pretty = process.env.CI !== 'true';
 
 /** @type {ts.FormatDiagnosticsHost} */
 const diagnosticsHost = {
-  getCanonicalFileName: (fn) => fn,
+  getCanonicalFileName: fn => fn,
   getCurrentDirectory: () => './',
   getNewLine: () => '\n',
 };
@@ -63,7 +63,7 @@ function validateTscTypes() {
         });
       }
     };
-    ast.forEachChild((node) => {
+    ast.forEachChild(node => {
       if (node.kind === ts.SyntaxKind.ExportDeclaration) {
         const exportNode =
           /** @type {import('typescript').ExportDeclaration} */ (node);

--- a/scripts/www/npmToWwwName.mjs
+++ b/scripts/www/npmToWwwName.mjs
@@ -32,8 +32,8 @@ export default function npmToWwwName(name) {
     }
   }
   return parts
-    .flatMap((part) => part.split('-'))
-    .map((part) =>
+    .flatMap(part => part.split('-'))
+    .map(part =>
       /^use[A-Z]/.test(part)
         ? part
         : part.charAt(0).toUpperCase() + part.slice(1),

--- a/scripts/www/transformFlowFileContents.mjs
+++ b/scripts/www/transformFlowFileContents.mjs
@@ -15,14 +15,14 @@ import npmToWwwName from './npmToWwwName.mjs';
 const wwwMappings = Object.fromEntries(
   packagesManager
     .getPublicPackages()
-    .flatMap((pkg) =>
-      pkg.getExportedNpmModuleNames().map((npm) => [npm, npmToWwwName(npm)]),
+    .flatMap(pkg =>
+      pkg.getExportedNpmModuleNames().map(npm => [npm, npmToWwwName(npm)]),
     ),
 );
 
 const prettierConfig = prettier
   .resolveConfig(import.meta.filename)
-  .then((cfg) => cfg || {});
+  .then(cfg => cfg || {});
 
 /**
  * Add a statement to the end of the code so the comments don't
@@ -59,7 +59,7 @@ export default async function transformFlowFileContents(source) {
   return unwrapCode(
     await transform(
       wrapCode(source),
-      (context) => ({
+      context => ({
         ExportNamedDeclaration(node) {
           const exportSource = node.source;
           if (!exportSource) {


### PR DESCRIPTION
## Summary
- Update `.prettierrc` to set `arrowParens: "avoid"`, removing unnecessary parentheses from single-parameter arrow functions
- Apply formatting repo-wide (355 files, mechanical parens removal)        
- why: fix prettier failure on www sync diff

## Test plan
- [x] Prettier pre-commit hook passes with the new config