### PR TITLE
[lexical-extension] Bug Fix: Use maybeFromEditor in getPeerDependencyFromEditor

### DIFF
--- a/packages/lexical-extension/src/getPeerDependencyFromEditor.ts
+++ b/packages/lexical-extension/src/getPeerDependencyFromEditor.ts
@@ -43,7 +43,8 @@ export function getPeerDependencyFromEditor<
   editor: LexicalEditor,
   extensionName: Extension['name'],
 ): LexicalExtensionDependency<Extension> | undefined {
-  const builder = LexicalBuilder.fromEditor(editor);
+  const builder = LexicalBuilder.maybeFromEditor(editor);
+  if (!builder) return undefined;
   const peer = builder.extensionNameMap.get(extensionName);
   return peer
     ? (peer.getExtensionDependency() as LexicalExtensionDependency<Extension>)


### PR DESCRIPTION
## Summary

Fixes a crash introduced by #8360, which moved code block escape logic into `CodeNode.insertNewAfter()` with a backward-compat fallback that calls `getPeerDependencyFromEditor()`. The fallback was intended to gracefully handle editors not built with `buildEditorFromExtensions()`, but `getPeerDependencyFromEditor` itself called `LexicalBuilder.fromEditor(editor)` — which **throws** when no builder is attached to the editor. This means the fallback path could never be reached, and pressing Enter inside a code block crashed the editor.

This affects every editor created with `createEditor()` directly, which includes all editors on www today.

### Call chain before this fix

1. User presses Enter in a code block
2. Lexical calls `CodeNode.insertNewAfter()`
3. `insertNewAfter` calls `getPeerDependencyFromEditor(editor, 'LexicalCode')` to check if `CodeExtension` is registered
4. `getPeerDependencyFromEditor` calls `LexicalBuilder.fromEditor(editor)`
5. `fromEditor` internally calls `maybeFromEditor(editor)` which returns `undefined` (no builder attached)
6. `fromEditor` sees `undefined` and throws: *"The given editor was not created with LexicalBuilder"*
7. `insertNewAfter` never gets to evaluate the `!` check or run the fallback — it has already crashed

### With this fix

- Step 4 now calls `LexicalBuilder.maybeFromEditor(editor)` directly, which returns `undefined` instead of throwing
- The new `if (!builder) return undefined` early-returns gracefully
- Back in `insertNewAfter`, `!undefined` is truthy, so it enters the fallback branch and runs the old code block exit logic
- No crash

This aligns with the function's own JSDoc, which documents the editor parameter as one that "*may* have been built using extension" and the return type as `| undefined`.

## Test plan

- [x] Verified on www: the `MLCShortcuts-e2e.js` test that was failing now passes
- [x] TypeScript type check passes (`pnpm run tsc`)