### PR TITLE
[*] Bug Fix: Fix release workflow's missing rename from release.js to release.mjs

### DIFF
--- a/.github/workflows/call-npm-publish.yml
+++ b/.github/workflows/call-npm-publish.yml
@@ -36,6 +36,6 @@ jobs:
       - uses: pnpm/action-setup@v6
       - run: pnpm install
       - run: pnpm run prepare-release
-      - run: node ./scripts/npm/release.js --non-interactive $DRY_RUN_ARG $IGNORE_PREVIOUSLY_PUBLISHED_ARG --channel='${{ inputs.channel }}'
+      - run: node ./scripts/npm/release.mjs --non-interactive $DRY_RUN_ARG $IGNORE_PREVIOUSLY_PUBLISHED_ARG --channel='${{ inputs.channel }}'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/lexical-website/docs/maintainers-guide.md
+++ b/packages/lexical-website/docs/maintainers-guide.md
@@ -285,7 +285,7 @@ from main in step 4).
 4. After PR is merged to main, publish to NPM with the Github Actions "Publish to NPM" workflow (`pre-release.yml`)
 5. Create a GitHub release from the tag created in step 1, manually editing the release notes
 6. Announce the release in #announcements on Discord
-7. Raise a PR against the post-release-* version branch (created by `call-post-release.yml` via `pre-release.yml`) to update the examples
+7. If a post-release-* version branch was created, raise a PR against it (may be created by `call-post-release.yml` via `pre-release.yml`) to update the examples. Since v0.44.0 this is no longer likely because we do not commit lockfiles for examples.
 
 ## Release Protocol
 


### PR DESCRIPTION
## Description

The ESM refactoring missed a workflow when renaming references from .js to .mjs

## Test plan

Run the release workflow action (it worked to release 0.44.0 when running from this branch)
