### PR TITLE
[lexical-markdown] Bug Fix: Preserve hard line breaks in default markdown import

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -475,12 +475,7 @@ function $exportChildren(
 }
 
 function $exportLineBreak(node: LineBreakNode): string {
-  const hardLineBreak = $getState(node, hardLineBreakState);
-
-  if (hardLineBreak !== null) {
-    return hardLineBreak + '\n';
-  }
-  return '\n';
+  return $getState(node, hardLineBreakState) + '\n';
 }
 
 function exportTextFormat(

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -10,6 +10,7 @@ import type {
   BaseSelection,
   ElementNode,
   LexicalNode,
+  LineBreakNode,
   TextFormatType,
   TextNode,
 } from 'lexical';
@@ -17,6 +18,7 @@ import type {
 import {$sliceSelectedTextNodeContent} from '@lexical/selection';
 import {
   $getRoot,
+  $getState,
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
@@ -25,6 +27,7 @@ import {
 
 import {
   ElementTransformer,
+  hardLineBreakState,
   MultilineElementTransformer,
   TextFormatTransformer,
   TextMatchTransformer,
@@ -62,7 +65,7 @@ export function createMarkdownExport(
 
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
-      const result = exportTopLevelElements(
+      const result = $exportTopLevelElements(
         child,
         elementTransformers,
         textFormatTransformers,
@@ -285,7 +288,7 @@ function $exportChildrenForSelection(
 
     if ($isLineBreakNode(child)) {
       if (childIncluded) {
-        output.push('\n');
+        output.push($exportLineBreak(child));
         anyChildIncluded = true;
       }
     } else if ($isTextNode(child)) {
@@ -338,7 +341,7 @@ function $exportChildrenForSelection(
   return {markdown: output.join(''), shouldInclude: anyChildIncluded};
 }
 
-function exportTopLevelElements(
+function $exportTopLevelElements(
   node: LexicalNode,
   elementTransformers: Array<ElementTransformer | MultilineElementTransformer>,
   textTransformersIndex: Array<TextFormatTransformer>,
@@ -350,7 +353,7 @@ function exportTopLevelElements(
       continue;
     }
     const result = transformer.export(node, _node =>
-      exportChildren(
+      $exportChildren(
         _node,
         textTransformersIndex,
         textMatchTransformers,
@@ -366,7 +369,7 @@ function exportTopLevelElements(
   }
 
   if ($isElementNode(node)) {
-    return exportChildren(
+    return $exportChildren(
       node,
       textTransformersIndex,
       textMatchTransformers,
@@ -381,7 +384,7 @@ function exportTopLevelElements(
   }
 }
 
-function exportChildren(
+function $exportChildren(
   node: ElementNode,
   textTransformersIndex: Array<TextFormatTransformer>,
   textMatchTransformers: Array<TextMatchTransformer>,
@@ -408,7 +411,7 @@ function exportChildren(
       const result = transformer.export(
         child,
         parentNode =>
-          exportChildren(
+          $exportChildren(
             parentNode,
             textTransformersIndex,
             textMatchTransformers,
@@ -439,7 +442,7 @@ function exportChildren(
     }
 
     if ($isLineBreakNode(child)) {
-      output.push('\n');
+      output.push($exportLineBreak(child));
     } else if ($isTextNode(child)) {
       output.push(
         exportTextFormat(
@@ -454,7 +457,7 @@ function exportChildren(
     } else if ($isElementNode(child)) {
       // empty paragraph returns ""
       output.push(
-        exportChildren(
+        $exportChildren(
           child,
           textTransformersIndex,
           textMatchTransformers,
@@ -469,6 +472,18 @@ function exportChildren(
   }
 
   return output.join('');
+}
+
+function $exportLineBreak(node: LineBreakNode): string {
+  const hardLineBreak = $getState(node, hardLineBreakState);
+
+  if (hardLineBreak === 'backslash') {
+    return '\\\n';
+  }
+  if (hardLineBreak === 'spaces') {
+    return '  \n';
+  }
+  return '\n';
 }
 
 function exportTextFormat(

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -477,11 +477,8 @@ function $exportChildren(
 function $exportLineBreak(node: LineBreakNode): string {
   const hardLineBreak = $getState(node, hardLineBreakState);
 
-  if (hardLineBreak === 'backslash') {
-    return '\\\n';
-  }
-  if (hardLineBreak === 'spaces') {
-    return '  \n';
+  if (hardLineBreak !== null) {
+    return hardLineBreak + '\n';
   }
   return '\n';
 }

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -18,7 +18,6 @@ import {$isListItemNode, $isListNode, ListItemNode} from '@lexical/list';
 import {$isQuoteNode} from '@lexical/rich-text';
 import {$findMatchingParent} from '@lexical/utils';
 import {
-  $createLineBreakNode,
   $createParagraphNode,
   $createTabNode,
   $createTextNode,
@@ -26,12 +25,12 @@ import {
   $getSelection,
   $isElementNode,
   $isParagraphNode,
-  $isTextNode,
   ElementNode,
   TextNode,
 } from 'lexical';
 
 import {importTextTransformers} from './importTextTransformers';
+import {$createMarkdownLineBreakNode} from './MarkdownTransformers';
 import {isEmptyParagraph, transformersByType} from './utils';
 
 export type TextFormatTransformersIndex = Readonly<{
@@ -283,18 +282,8 @@ function $importBlocks(
       }
 
       if (targetNode != null && targetNode.getTextContentSize() > 0) {
-        const lastChild = targetNode.getLastChild();
-        if ($isTextNode(lastChild)) {
-          const lastText = lastChild.getTextContent();
-          if (lastText.endsWith('\\')) {
-            lastChild.setTextContent(lastText.slice(0, -1));
-          } else if (/ {2,}$/.test(lastText)) {
-            lastChild.setTextContent(lastText.replace(/ {2,}$/, ''));
-          }
-        }
-
         targetNode.splice(targetNode.getChildrenSize(), 0, [
-          $createLineBreakNode(),
+          $createMarkdownLineBreakNode(targetNode),
           ...elementNode.getChildren(),
         ]);
         elementNode.remove();

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -37,12 +37,14 @@ import {
   $createTextNode,
   $findMatchingParent,
   $getState,
+  $isTextNode,
   $setState,
   BaseSelection,
   createState,
   ElementNode,
   Klass,
   LexicalNode,
+  LineBreakNode,
   TextFormatType,
   TextNode,
 } from 'lexical';
@@ -240,6 +242,55 @@ export const codeFenceState = createState('mdCodeFence', {
   resetOnCopyNode: true,
 });
 
+export type MarkdownHardLineBreak = 'backslash' | 'spaces';
+
+export const hardLineBreakState = createState('mdHardLineBreak', {
+  parse: (val): MarkdownHardLineBreak | null =>
+    val === 'backslash' || val === 'spaces' ? val : null,
+});
+
+export function getMarkdownHardLineBreak(
+  line: string,
+): MarkdownHardLineBreak | null {
+  if (line.endsWith('\\')) {
+    return 'backslash';
+  }
+  if (/\S {2,}$/.test(line)) {
+    return 'spaces';
+  }
+  return null;
+}
+
+function removeMarkdownHardLineBreak(
+  line: string,
+  hardLineBreak: MarkdownHardLineBreak,
+): string {
+  return hardLineBreak === 'backslash'
+    ? line.slice(0, -1)
+    : line.replace(/ {2,}$/, '');
+}
+
+export function $createMarkdownLineBreakNode(
+  previousNode: ElementNode,
+): LineBreakNode {
+  const lineBreakNode = $createLineBreakNode();
+  const lastChild = previousNode.getLastChild();
+
+  if ($isTextNode(lastChild)) {
+    const lastText = lastChild.getTextContent();
+    const hardLineBreak = getMarkdownHardLineBreak(lastText);
+
+    if (hardLineBreak !== null) {
+      lastChild.setTextContent(
+        removeMarkdownHardLineBreak(lastText, hardLineBreak),
+      );
+      $setState(lineBreakNode, hardLineBreakState, hardLineBreak);
+    }
+  }
+
+  return lineBreakNode;
+}
+
 const createBlockNode = (
   createNode: (match: Array<string>) => ElementNode,
 ): ElementTransformer['replace'] => {
@@ -421,7 +472,7 @@ export const QUOTE: ElementTransformer = {
       const previousNode = parentNode.getPreviousSibling();
       if ($isQuoteNode(previousNode)) {
         previousNode.splice(previousNode.getChildrenSize(), 0, [
-          $createLineBreakNode(),
+          $createMarkdownLineBreakNode(previousNode),
           ...children,
         ]);
         parentNode.remove();
@@ -801,6 +852,10 @@ export function normalizeMarkdown(
     const rawLine = lines[i];
     const line = rawLine.trimEnd();
     const lastLine = sanitizedLines[sanitizedLines.length - 1];
+    const hardLineBreak =
+      i < lines.length - 1 ? getMarkdownHardLineBreak(rawLine) : null;
+    const lastLineHasHardLineBreak =
+      lastLine !== undefined && getMarkdownHardLineBreak(lastLine) !== null;
 
     // Code blocks of ```single line``` don't toggle the inCodeBlock flag
     if (CODE_SINGLE_LINE_REGEX.test(line)) {
@@ -835,6 +890,7 @@ export function normalizeMarkdown(
       CHECK_LIST_REGEX.test(line) ||
       TABLE_ROW_REG_EXP.test(line) ||
       TABLE_ROW_DIVIDER_REG_EXP.test(line) ||
+      lastLineHasHardLineBreak ||
       !shouldMergeAdjacentLines ||
       TAG_START_REGEX.test(line) ||
       TAG_END_REGEX.test(line) ||
@@ -847,11 +903,13 @@ export function normalizeMarkdown(
       // collapse to '' because trimEnd() already reduced them, so they
       // continue to act as paragraph separators.
       sanitizedLines.push(
-        !shouldMergeAdjacentLines && line !== '' ? rawLine : line,
+        (!shouldMergeAdjacentLines && line !== '') || hardLineBreak !== null
+          ? rawLine
+          : line,
       );
     } else {
       sanitizedLines[sanitizedLines.length - 1] =
-        lastLine + ' ' + line.trimStart();
+        lastLine + ' ' + (hardLineBreak === null ? line : rawLine).trimStart();
     }
   }
 

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -242,32 +242,38 @@ export const codeFenceState = createState('mdCodeFence', {
   resetOnCopyNode: true,
 });
 
-export type MarkdownHardLineBreak = 'backslash' | 'spaces';
+export type MarkdownHardLineBreak = string;
 
 export const hardLineBreakState = createState('mdHardLineBreak', {
-  parse: (val): MarkdownHardLineBreak | null =>
-    val === 'backslash' || val === 'spaces' ? val : null,
+  parse: (val): MarkdownHardLineBreak | null => {
+    if (val === '\\') {
+      return val;
+    }
+    if (typeof val === 'string' && /^ {2,}$/.test(val)) {
+      return val;
+    }
+    return null;
+  },
+  resetOnCopyNode: true,
 });
 
-export function getMarkdownHardLineBreak(
+export function parseMarkdownHardLineBreak(
   line: string,
-): MarkdownHardLineBreak | null {
+): [string, MarkdownHardLineBreak] | null {
   if (line.endsWith('\\')) {
-    return 'backslash';
+    return [line.slice(0, -1), '\\'];
   }
-  if (/\S {2,}$/.test(line)) {
-    return 'spaces';
-  }
-  return null;
-}
 
-function removeMarkdownHardLineBreak(
-  line: string,
-  hardLineBreak: MarkdownHardLineBreak,
-): string {
-  return hardLineBreak === 'backslash'
-    ? line.slice(0, -1)
-    : line.replace(/ {2,}$/, '');
+  const spaces = line.match(/ {2,}$/);
+  if (spaces !== null) {
+    const marker = spaces[0];
+    const text = line.slice(0, -marker.length);
+    if (text !== '' && /\S$/.test(text)) {
+      return [text, marker];
+    }
+  }
+
+  return null;
 }
 
 export function $createMarkdownLineBreakNode(
@@ -278,13 +284,12 @@ export function $createMarkdownLineBreakNode(
 
   if ($isTextNode(lastChild)) {
     const lastText = lastChild.getTextContent();
-    const hardLineBreak = getMarkdownHardLineBreak(lastText);
+    const hardLineBreak = parseMarkdownHardLineBreak(lastText);
 
     if (hardLineBreak !== null) {
-      lastChild.setTextContent(
-        removeMarkdownHardLineBreak(lastText, hardLineBreak),
-      );
-      $setState(lineBreakNode, hardLineBreakState, hardLineBreak);
+      const [text, marker] = hardLineBreak;
+      lastChild.setTextContent(text);
+      $setState(lineBreakNode, hardLineBreakState, marker);
     }
   }
 
@@ -853,9 +858,9 @@ export function normalizeMarkdown(
     const line = rawLine.trimEnd();
     const lastLine = sanitizedLines[sanitizedLines.length - 1];
     const hardLineBreak =
-      i < lines.length - 1 ? getMarkdownHardLineBreak(rawLine) : null;
+      i < lines.length - 1 ? parseMarkdownHardLineBreak(rawLine) : null;
     const lastLineHasHardLineBreak =
-      lastLine !== undefined && getMarkdownHardLineBreak(lastLine) !== null;
+      lastLine !== undefined && parseMarkdownHardLineBreak(lastLine) !== null;
 
     // Code blocks of ```single line``` don't toggle the inCodeBlock flag
     if (CODE_SINGLE_LINE_REGEX.test(line)) {

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -245,14 +245,11 @@ export const codeFenceState = createState('mdCodeFence', {
 export type MarkdownHardLineBreak = string;
 
 export const hardLineBreakState = createState('mdHardLineBreak', {
-  parse: (val): MarkdownHardLineBreak | null => {
-    if (val === '\\') {
+  parse: (val): MarkdownHardLineBreak => {
+    if (typeof val === 'string' && /^(\\| {2,})$/.test(val)) {
       return val;
     }
-    if (typeof val === 'string' && /^ {2,}$/.test(val)) {
-      return val;
-    }
-    return null;
+    return '';
   },
   resetOnCopyNode: true,
 });
@@ -264,16 +261,8 @@ export function parseMarkdownHardLineBreak(
     return [line.slice(0, -1), '\\'];
   }
 
-  const spaces = line.match(/ {2,}$/);
-  if (spaces !== null) {
-    const marker = spaces[0];
-    const text = line.slice(0, -marker.length);
-    if (text !== '' && /\S$/.test(text)) {
-      return [text, marker];
-    }
-  }
-
-  return null;
+  const spaces = line.match(/^(.*?\S)( {2,})$/);
+  return spaces ? [spaces[1], spaces[2]] : null;
 }
 
 export function $createMarkdownLineBreakNode(

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -37,6 +37,7 @@ import {
   $createTextNode,
   $findMatchingParent,
   $getState,
+  $isLineBreakNode,
   $isTextNode,
   $setState,
   BaseSelection,
@@ -265,21 +266,60 @@ export function parseMarkdownHardLineBreak(
   return spaces ? [spaces[1], spaces[2]] : null;
 }
 
+function hasNonWhitespaceContentOnLine(
+  children: Array<LexicalNode>,
+  endIndex: number,
+): boolean {
+  for (let i = endIndex - 1; i >= 0; i--) {
+    if ($isLineBreakNode(children[i])) {
+      return false;
+    }
+    if (/\S/.test(children[i].getTextContent())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function $extractMarkdownHardLineBreakMarker(
+  previousNode: ElementNode,
+): MarkdownHardLineBreak | null {
+  const children = previousNode.getChildren();
+  const lastChildIndex = children.length - 1;
+  const lastChild = children[lastChildIndex];
+
+  if (!$isTextNode(lastChild)) {
+    return null;
+  }
+
+  const lastText = lastChild.getTextContent();
+  const hardLineBreak = parseMarkdownHardLineBreak(lastText);
+
+  if (hardLineBreak !== null) {
+    const [text, marker] = hardLineBreak;
+    lastChild.setTextContent(text);
+    return marker;
+  }
+
+  if (
+    /^ {2,}$/.test(lastText) &&
+    hasNonWhitespaceContentOnLine(children, lastChildIndex)
+  ) {
+    lastChild.setTextContent('');
+    return lastText;
+  }
+
+  return null;
+}
+
 export function $createMarkdownLineBreakNode(
   previousNode: ElementNode,
 ): LineBreakNode {
   const lineBreakNode = $createLineBreakNode();
-  const lastChild = previousNode.getLastChild();
+  const hardLineBreak = $extractMarkdownHardLineBreakMarker(previousNode);
 
-  if ($isTextNode(lastChild)) {
-    const lastText = lastChild.getTextContent();
-    const hardLineBreak = parseMarkdownHardLineBreak(lastText);
-
-    if (hardLineBreak !== null) {
-      const [text, marker] = hardLineBreak;
-      lastChild.setTextContent(text);
-      $setState(lineBreakNode, hardLineBreakState, marker);
-    }
+  if (hardLineBreak !== null) {
+    $setState(lineBreakNode, hardLineBreakState, hardLineBreak);
   }
 
   return lineBreakNode;

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -28,7 +28,10 @@ import {
   $getState,
   $getTextPointCaret,
   $insertNodes,
+  $isElementNode,
+  $isLineBreakNode,
   $isRangeSelection,
+  $isTextNode,
   $setSelectionFromCaretRange,
   $setState,
   KEY_ENTER_COMMAND,
@@ -1754,6 +1757,48 @@ describe('markdown whitespace import (default mode)', () => {
     return parsed[1];
   }
 
+  function expectImportedHardLineBreakMarker(md: string, marker: string): void {
+    const editor = createTestEditor();
+
+    editor.update(
+      () =>
+        $convertFromMarkdownString(md, [
+          ...TRANSFORMERS,
+          HIGHLIGHT_TEXT_MATCH_IMPORT,
+        ]),
+      {discrete: true},
+    );
+
+    editor.getEditorState().read(() => {
+      const block = $getRoot().getFirstChildOrThrow();
+      assert($isElementNode(block), 'Expected an element block');
+      const lineBreakNode = block
+        .getChildren()
+        .find(child => $isLineBreakNode(child));
+
+      assert(lineBreakNode !== undefined, 'Expected a line break node');
+      expect(
+        block
+          .getChildren()
+          .filter($isTextNode)
+          .map(child => child.getTextContent()),
+      ).not.toContain(marker);
+      expect(block.getTextContent()).toBe('foo\nbar');
+      expect($getState(lineBreakNode, hardLineBreakState)).toBe(marker);
+    });
+
+    expect(
+      editor
+        .getEditorState()
+        .read(() =>
+          $convertToMarkdownString([
+            ...TRANSFORMERS,
+            HIGHLIGHT_TEXT_MATCH_IMPORT,
+          ]),
+        ),
+    ).toBe(md);
+  }
+
   it('preserves trailing whitespace on a standalone paragraph line (default mode)', () => {
     // A paragraph with trailing spaces, separated by an empty line from the next.
     const md = 'hello world   \n\nnext paragraph';
@@ -1817,6 +1862,62 @@ describe('markdown whitespace import (default mode)', () => {
 
   it('preserves backslash hard line break in default mode', () => {
     expectRoundTrip('foo\\\nbar');
+  });
+
+  it('stores a two-space hard line break marker after formatted text', () => {
+    expectImportedHardLineBreakMarker('**foo**  \nbar', '  ');
+  });
+
+  it('stores exact hard line break spaces after formatted text', () => {
+    expectImportedHardLineBreakMarker('**foo**   \nbar', '   ');
+  });
+
+  it('stores a two-space hard line break marker after a link', () => {
+    expectImportedHardLineBreakMarker(
+      '[foo](https://lexical.dev)  \nbar',
+      '  ',
+    );
+  });
+
+  it('does not infer a hard line break marker from spaces inside a link', () => {
+    const md = '[foo  ](https://lexical.dev)\nbar';
+    const editor = createTestEditor();
+
+    editor.update(
+      () =>
+        $convertFromMarkdownString(md, [
+          ...TRANSFORMERS,
+          HIGHLIGHT_TEXT_MATCH_IMPORT,
+        ]),
+      {discrete: true},
+    );
+
+    editor.getEditorState().read(() => {
+      const block = $getRoot().getFirstChildOrThrow();
+      assert($isElementNode(block), 'Expected an element block');
+      const lineBreakNode = block
+        .getChildren()
+        .find(child => $isLineBreakNode(child));
+
+      assert(lineBreakNode !== undefined, 'Expected a line break node');
+      expect(block.getTextContent()).toBe('foo  \nbar');
+      expect($getState(lineBreakNode, hardLineBreakState)).toBe('');
+    });
+
+    expect(
+      editor
+        .getEditorState()
+        .read(() =>
+          $convertToMarkdownString([
+            ...TRANSFORMERS,
+            HIGHLIGHT_TEXT_MATCH_IMPORT,
+          ]),
+        ),
+    ).toBe(md);
+  });
+
+  it('stores a two-space hard line break marker after formatted blockquote text', () => {
+    expectImportedHardLineBreakMarker('> **foo**  \n> bar', '  ');
   });
 
   it('preserves two-space hard line break in merge-adjacent mode', () => {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -33,7 +33,7 @@ import {
   $setState,
   KEY_ENTER_COMMAND,
 } from 'lexical';
-import {describe, expect, it} from 'vitest';
+import {assert, describe, expect, it} from 'vitest';
 
 import {
   $convertFromMarkdownString,
@@ -1750,9 +1750,7 @@ describe('markdown whitespace import (default mode)', () => {
 
   function getHardLineBreakMarker(line: string): string {
     const parsed = parseMarkdownHardLineBreak(line);
-    if (parsed === null) {
-      throw new Error('Expected a hard line break marker');
-    }
+    assert(parsed !== null, 'Expected a hard line break marker');
     return parsed[1];
   }
 
@@ -1889,7 +1887,7 @@ describe('markdown whitespace import (default mode)', () => {
 
         expect($getState(lineBreakNode, hardLineBreakState)).toBe('   ');
         const copy = $copyNode(lineBreakNode);
-        expect($getState(copy, hardLineBreakState)).toBe(null);
+        expect($getState(copy, hardLineBreakState)).toBe('');
         expect($getState(lineBreakNode, hardLineBreakState)).toBe('   ');
       },
       {discrete: true},

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -1494,6 +1494,11 @@ after`;
     expect(normalizeMarkdown(md, true)).toBe(md);
   });
 
+  it('preserves exact hard-break trailing spaces when merging adjacent lines', () => {
+    const md = ['foo   ', 'bar'].join('\n');
+    expect(normalizeMarkdown(md, true)).toBe(md);
+  });
+
   it('preserves backslash hard-breaks when merging adjacent lines', () => {
     const md = `foo\\
 bar`;
@@ -1797,12 +1802,20 @@ describe('markdown whitespace import (default mode)', () => {
     expectRoundTrip('foo  \nbar');
   });
 
+  it('preserves exact hard line break spaces in default mode', () => {
+    expectRoundTrip('foo   \nbar');
+  });
+
   it('preserves backslash hard line break in default mode', () => {
     expectRoundTrip('foo\\\nbar');
   });
 
   it('preserves two-space hard line break in merge-adjacent mode', () => {
     expectRoundTrip('foo  \nbar', true);
+  });
+
+  it('preserves exact hard line break spaces in merge-adjacent mode', () => {
+    expectRoundTrip('foo   \nbar', true);
   });
 
   it('preserves backslash hard line break in merge-adjacent mode', () => {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -1489,10 +1489,20 @@ after`;
     expect(normalizeMarkdown(md, true)).toBe('```\ncode\n```\nNext line');
   });
 
-  it('trims hard-break trailing spaces when merging adjacent lines', () => {
-    const md = `foo  
+  it('preserves hard-break trailing spaces when merging adjacent lines', () => {
+    const md = ['foo  ', 'bar'].join('\n');
+    expect(normalizeMarkdown(md, true)).toBe(md);
+  });
+
+  it('preserves backslash hard-breaks when merging adjacent lines', () => {
+    const md = `foo\\
 bar`;
-    expect(normalizeMarkdown(md, true)).toBe(`foo bar`);
+    expect(normalizeMarkdown(md, true)).toBe(md);
+  });
+
+  it('merges a soft break before a hard-breaking line', () => {
+    const md = ['foo', 'bar  ', 'baz'].join('\n');
+    expect(normalizeMarkdown(md, true)).toBe(['foo bar  ', 'baz'].join('\n'));
   });
 
   it('treats whitespace-only lines as empty separators (no merge across them)', () => {
@@ -1703,6 +1713,33 @@ describe('markdown whitespace import (default mode)', () => {
     });
   }
 
+  function expectRoundTrip(md: string, shouldMergeAdjacentLines = false): void {
+    const editor = createTestEditor();
+
+    editor.update(
+      () =>
+        $convertFromMarkdownString(
+          md,
+          [...TRANSFORMERS, HIGHLIGHT_TEXT_MATCH_IMPORT],
+          undefined,
+          false,
+          shouldMergeAdjacentLines,
+        ),
+      {discrete: true},
+    );
+
+    expect(
+      editor
+        .getEditorState()
+        .read(() =>
+          $convertToMarkdownString([
+            ...TRANSFORMERS,
+            HIGHLIGHT_TEXT_MATCH_IMPORT,
+          ]),
+        ),
+    ).toBe(md);
+  }
+
   it('preserves trailing whitespace on a standalone paragraph line (default mode)', () => {
     // A paragraph with trailing spaces, separated by an empty line from the next.
     const md = 'hello world   \n\nnext paragraph';
@@ -1754,34 +1791,30 @@ describe('markdown whitespace import (default mode)', () => {
     ).toBe(md);
   });
 
-  it('handles two-space hard line break in default mode (adjacent lines merged into LineBreak)', () => {
+  it('preserves two-space hard line break in default mode', () => {
     // In default mode, "foo  \nbar" has two adjacent non-empty lines → normalizeMarkdown
     // preserves the trailing "  " which $importBlocks then converts to a LineBreakNode.
-    const md = 'foo  \nbar';
-    const editor = createTestEditor();
+    expectRoundTrip('foo  \nbar');
+  });
 
-    editor.update(
-      () =>
-        $convertFromMarkdownString(md, [
-          ...TRANSFORMERS,
-          HIGHLIGHT_TEXT_MATCH_IMPORT,
-        ]),
-      {discrete: true},
-    );
+  it('preserves backslash hard line break in default mode', () => {
+    expectRoundTrip('foo\\\nbar');
+  });
 
-    const exported = editor
-      .getEditorState()
-      .read(() =>
-        $convertToMarkdownString([
-          ...TRANSFORMERS,
-          HIGHLIGHT_TEXT_MATCH_IMPORT,
-        ]),
-      );
+  it('preserves two-space hard line break in merge-adjacent mode', () => {
+    expectRoundTrip('foo  \nbar', true);
+  });
 
-    // The hard-break + next line are within the same paragraph; after import and
-    // re-export, the paragraph containing a LineBreakNode exports as "foo\nbar"
-    // (a single newline without the trailing spaces, since the break is now structural).
-    expect(exported).toBe('foo\nbar');
+  it('preserves backslash hard line break in merge-adjacent mode', () => {
+    expectRoundTrip('foo\\\nbar', true);
+  });
+
+  it('preserves two-space hard line break between blockquote lines', () => {
+    expectRoundTrip('> foo  \n> bar');
+  });
+
+  it('preserves backslash hard line break between blockquote lines', () => {
+    expectRoundTrip('> foo\\\n> bar');
   });
 });
 

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -18,6 +18,7 @@ import {
 } from '@lexical/list';
 import {$createQuoteNode, HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {
+  $copyNode,
   $createLineBreakNode,
   $createParagraphNode,
   $createTextNode,
@@ -47,10 +48,12 @@ import {
   CHECK_LIST,
   CODE,
   ElementTransformer,
+  hardLineBreakState,
   HEADING,
   listMarkerState,
   MultilineElementTransformer,
   normalizeMarkdown,
+  parseMarkdownHardLineBreak,
   TRANSFORMERS,
 } from '../../MarkdownTransformers';
 
@@ -1745,6 +1748,14 @@ describe('markdown whitespace import (default mode)', () => {
     ).toBe(md);
   }
 
+  function getHardLineBreakMarker(line: string): string {
+    const parsed = parseMarkdownHardLineBreak(line);
+    if (parsed === null) {
+      throw new Error('Expected a hard line break marker');
+    }
+    return parsed[1];
+  }
+
   it('preserves trailing whitespace on a standalone paragraph line (default mode)', () => {
     // A paragraph with trailing spaces, separated by an empty line from the next.
     const md = 'hello world   \n\nnext paragraph';
@@ -1826,8 +1837,63 @@ describe('markdown whitespace import (default mode)', () => {
     expectRoundTrip('> foo  \n> bar');
   });
 
+  it('preserves exact hard line break spaces between blockquote lines', () => {
+    expectRoundTrip('> foo   \n> bar');
+  });
+
   it('preserves backslash hard line break between blockquote lines', () => {
     expectRoundTrip('> foo\\\n> bar');
+  });
+
+  it('exports exact hard line break markers from line break state', () => {
+    const editor = createTestEditor();
+    const marker = getHardLineBreakMarker('foo   ');
+
+    editor.update(
+      () => {
+        const lineBreakNode = $createLineBreakNode();
+        $setState(lineBreakNode, hardLineBreakState, marker);
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append(
+              $createTextNode('foo'),
+              lineBreakNode,
+              $createTextNode('bar'),
+            ),
+          );
+      },
+      {discrete: true},
+    );
+
+    expect(
+      editor
+        .getEditorState()
+        .read(() =>
+          $convertToMarkdownString([
+            ...TRANSFORMERS,
+            HIGHLIGHT_TEXT_MATCH_IMPORT,
+          ]),
+        ),
+    ).toBe('foo   \nbar');
+  });
+
+  it('does not copy markdown hard line break markers when line breaks are copied', () => {
+    const editor = createTestEditor();
+    const marker = getHardLineBreakMarker('foo   ');
+
+    editor.update(
+      () => {
+        const lineBreakNode = $createLineBreakNode();
+        $setState(lineBreakNode, hardLineBreakState, marker);
+
+        expect($getState(lineBreakNode, hardLineBreakState)).toBe('   ');
+        const copy = $copyNode(lineBreakNode);
+        expect($getState(copy, hardLineBreakState)).toBe(null);
+        expect($getState(lineBreakNode, hardLineBreakState)).toBe('   ');
+      },
+      {discrete: true},
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Preserve CommonMark hard line break markers when default markdown import joins adjacent lines into a `LineBreakNode`.

The preserve-newlines path already keeps hard-break spelling because it preserves source lines directly. In default import, the hard-break marker was stripped before export could distinguish it from a soft line break. In merge-adjacent mode, hard breaks could also be folded into spaces.

This adds markdown provenance to generated `LineBreakNode`s with NodeState, reuses that path for paragraph/list/quote line joins, and exports tagged line breaks with their original marker style.

## Test plan

- `pnpm vitest --project unit packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts --run`
- `pnpm run test-unit`
- `pnpm run ci-check`
- `pnpm run build`
