### PR TITLE
[lexical-utils] Bug Fix: Pass editor context to editorState.read() in markSelection

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/markSelection.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/markSelection.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getRoot,
+  $setSelection,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it, vi} from 'vitest';
+
+import {markSelection} from '../../index';
+
+Range.prototype.getBoundingClientRect = function (): DOMRect {
+  const rect = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+  };
+  return {
+    ...rect,
+    toJSON() {
+      return rect;
+    },
+  };
+};
+
+Range.prototype.getClientRects = function (): DOMRectList {
+  return {
+    item: () => null,
+    length: 0,
+    [Symbol.iterator]: function* () {},
+  } as DOMRectList;
+};
+
+describe('markSelection', () => {
+  initializeUnitTest((testEnv) => {
+    it('does not throw for text-type selection points', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('hello');
+        paragraph.append(text);
+        root.append(paragraph);
+
+        const selection = $createRangeSelection();
+        selection.anchor.set(text.getKey(), 0, 'text');
+        selection.focus.set(text.getKey(), 5, 'text');
+        $setSelection(selection);
+      });
+
+      expect(() => {
+        const cleanup = markSelection(editor, vi.fn());
+        cleanup();
+      }).not.toThrow();
+    });
+
+    it('does not throw for element-type selection points', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+
+        const selection = $createRangeSelection();
+        selection.anchor.set(paragraph.getKey(), 0, 'element');
+        selection.focus.set(paragraph.getKey(), 0, 'element');
+        $setSelection(selection);
+      });
+
+      expect(() => {
+        const cleanup = markSelection(editor, vi.fn());
+        cleanup();
+      }).not.toThrow();
+    });
+
+    it('calls onReposition for a range selection', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('hello world');
+        paragraph.append(text);
+        root.append(paragraph);
+
+        const selection = $createRangeSelection();
+        selection.anchor.set(text.getKey(), 0, 'text');
+        selection.focus.set(text.getKey(), 5, 'text');
+        $setSelection(selection);
+      });
+
+      const onReposition = vi.fn();
+      const cleanup = markSelection(editor, onReposition);
+      cleanup();
+    });
+
+    it('returns a cleanup function that can be called safely', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('test');
+        paragraph.append(text);
+        root.append(paragraph);
+      });
+
+      const cleanup = markSelection(editor, vi.fn());
+      expect(() => cleanup()).not.toThrow();
+    });
+  });
+});

--- a/packages/lexical-utils/src/__tests__/unit/markSelection.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/markSelection.test.tsx
@@ -46,7 +46,7 @@ Range.prototype.getClientRects = function (): DOMRectList {
 };
 
 describe('markSelection', () => {
-  initializeUnitTest((testEnv) => {
+  initializeUnitTest(testEnv => {
     it('does not throw for text-type selection points', async () => {
       const {editor} = testEnv;
       await editor.update(() => {

--- a/packages/lexical-utils/src/markSelection.ts
+++ b/packages/lexical-utils/src/markSelection.ts
@@ -107,61 +107,68 @@ export default function markSelection(
   let previousFocusOffset: null | number = null;
   let removeRangeListener: () => void = () => {};
   function compute(editorState: EditorState) {
-    editorState.read(() => {
-      const selection = $getSelection();
-      if (!$isRangeSelection(selection)) {
-        // TODO
-        previousAnchorNode = null;
-        previousAnchorOffset = null;
-        previousFocusNode = null;
-        previousFocusOffset = null;
-        removeRangeListener();
-        removeRangeListener = () => {};
-        return;
-      }
-      const [start, end] = $getOrderedSelectionPoints(selection);
-      const currentStartNode = start.getNode() as TextNode | ElementNode;
-      const currentStartNodeKey = currentStartNode.getKey();
-      const currentStartOffset = start.offset;
-      const currentEndNode = end.getNode() as TextNode | ElementNode;
-      const currentEndNodeKey = currentEndNode.getKey();
-      const currentEndOffset = end.offset;
-      const currentStartNodeDOM = editor.getElementByKey(currentStartNodeKey);
-      const currentEndNodeDOM = editor.getElementByKey(currentEndNodeKey);
-      const differentStartDOM =
-        previousAnchorNode === null ||
-        currentStartNodeDOM !== previousAnchorNodeDOM ||
-        currentStartOffset !== previousAnchorOffset ||
-        currentStartNodeKey !== previousAnchorNode.getKey();
-      const differentEndDOM =
-        previousFocusNode === null ||
-        currentEndNodeDOM !== previousFocusNodeDOM ||
-        currentEndOffset !== previousFocusOffset ||
-        currentEndNodeKey !== previousFocusNode.getKey();
-      if (
-        (differentStartDOM || differentEndDOM) &&
-        currentStartNodeDOM !== null &&
-        currentEndNodeDOM !== null
-      ) {
-        const range = $rangeFromPoints(
-          editor,
-          start,
-          currentStartNode,
-          currentStartNodeDOM,
-          end,
-          currentEndNode,
-          currentEndNodeDOM,
-        );
-        removeRangeListener();
-        removeRangeListener = positionNodeOnRange(editor, range, onReposition);
-      }
-      previousAnchorNode = currentStartNode;
-      previousAnchorNodeDOM = currentStartNodeDOM;
-      previousAnchorOffset = currentStartOffset;
-      previousFocusNode = currentEndNode;
-      previousFocusNodeDOM = currentEndNodeDOM;
-      previousFocusOffset = currentEndOffset;
-    });
+    editorState.read(
+      () => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          // TODO
+          previousAnchorNode = null;
+          previousAnchorOffset = null;
+          previousFocusNode = null;
+          previousFocusOffset = null;
+          removeRangeListener();
+          removeRangeListener = () => {};
+          return;
+        }
+        const [start, end] = $getOrderedSelectionPoints(selection);
+        const currentStartNode = start.getNode() as TextNode | ElementNode;
+        const currentStartNodeKey = currentStartNode.getKey();
+        const currentStartOffset = start.offset;
+        const currentEndNode = end.getNode() as TextNode | ElementNode;
+        const currentEndNodeKey = currentEndNode.getKey();
+        const currentEndOffset = end.offset;
+        const currentStartNodeDOM = editor.getElementByKey(currentStartNodeKey);
+        const currentEndNodeDOM = editor.getElementByKey(currentEndNodeKey);
+        const differentStartDOM =
+          previousAnchorNode === null ||
+          currentStartNodeDOM !== previousAnchorNodeDOM ||
+          currentStartOffset !== previousAnchorOffset ||
+          currentStartNodeKey !== previousAnchorNode.getKey();
+        const differentEndDOM =
+          previousFocusNode === null ||
+          currentEndNodeDOM !== previousFocusNodeDOM ||
+          currentEndOffset !== previousFocusOffset ||
+          currentEndNodeKey !== previousFocusNode.getKey();
+        if (
+          (differentStartDOM || differentEndDOM) &&
+          currentStartNodeDOM !== null &&
+          currentEndNodeDOM !== null
+        ) {
+          const range = $rangeFromPoints(
+            editor,
+            start,
+            currentStartNode,
+            currentStartNodeDOM,
+            end,
+            currentEndNode,
+            currentEndNodeDOM,
+          );
+          removeRangeListener();
+          removeRangeListener = positionNodeOnRange(
+            editor,
+            range,
+            onReposition,
+          );
+        }
+        previousAnchorNode = currentStartNode;
+        previousAnchorNodeDOM = currentStartNodeDOM;
+        previousAnchorOffset = currentStartOffset;
+        previousFocusNode = currentEndNode;
+        previousFocusNodeDOM = currentEndNodeDOM;
+        previousFocusOffset = currentEndOffset;
+      },
+      {editor},
+    );
   }
   compute(editor.getEditorState());
   return mergeRegister(

--- a/packages/lexical-utils/src/markSelection.ts
+++ b/packages/lexical-utils/src/markSelection.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  $getEditor,
   $getEditorDOMRenderConfig,
   $getSelection,
   $isElementNode,
@@ -31,6 +30,7 @@ function $getOrderedSelectionPoints(selection: RangeSelection): [Point, Point] {
 }
 
 function $rangeTargetFromPoint(
+  editor: LexicalEditor,
   point: Point,
   node: ElementNode | TextNode,
   dom: HTMLElement,
@@ -39,7 +39,6 @@ function $rangeTargetFromPoint(
     const textDOM = getDOMTextNode(dom) || dom;
     return [textDOM, point.offset];
   } else {
-    const editor = $getEditor();
     const slot = $getEditorDOMRenderConfig(editor).$getDOMSlot(
       node,
       dom,
@@ -60,8 +59,8 @@ function $rangeFromPoints(
 ): Range {
   const editorDocument = editor._window ? editor._window.document : document;
   const range = editorDocument.createRange();
-  range.setStart(...$rangeTargetFromPoint(start, startNode, startDOM));
-  range.setEnd(...$rangeTargetFromPoint(end, endNode, endDOM));
+  range.setStart(...$rangeTargetFromPoint(editor, start, startNode, startDOM));
+  range.setEnd(...$rangeTargetFromPoint(editor, end, endNode, endDOM));
   return range;
 }
 
@@ -107,68 +106,61 @@ export default function markSelection(
   let previousFocusOffset: null | number = null;
   let removeRangeListener: () => void = () => {};
   function compute(editorState: EditorState) {
-    editorState.read(
-      () => {
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection)) {
-          // TODO
-          previousAnchorNode = null;
-          previousAnchorOffset = null;
-          previousFocusNode = null;
-          previousFocusOffset = null;
-          removeRangeListener();
-          removeRangeListener = () => {};
-          return;
-        }
-        const [start, end] = $getOrderedSelectionPoints(selection);
-        const currentStartNode = start.getNode() as TextNode | ElementNode;
-        const currentStartNodeKey = currentStartNode.getKey();
-        const currentStartOffset = start.offset;
-        const currentEndNode = end.getNode() as TextNode | ElementNode;
-        const currentEndNodeKey = currentEndNode.getKey();
-        const currentEndOffset = end.offset;
-        const currentStartNodeDOM = editor.getElementByKey(currentStartNodeKey);
-        const currentEndNodeDOM = editor.getElementByKey(currentEndNodeKey);
-        const differentStartDOM =
-          previousAnchorNode === null ||
-          currentStartNodeDOM !== previousAnchorNodeDOM ||
-          currentStartOffset !== previousAnchorOffset ||
-          currentStartNodeKey !== previousAnchorNode.getKey();
-        const differentEndDOM =
-          previousFocusNode === null ||
-          currentEndNodeDOM !== previousFocusNodeDOM ||
-          currentEndOffset !== previousFocusOffset ||
-          currentEndNodeKey !== previousFocusNode.getKey();
-        if (
-          (differentStartDOM || differentEndDOM) &&
-          currentStartNodeDOM !== null &&
-          currentEndNodeDOM !== null
-        ) {
-          const range = $rangeFromPoints(
-            editor,
-            start,
-            currentStartNode,
-            currentStartNodeDOM,
-            end,
-            currentEndNode,
-            currentEndNodeDOM,
-          );
-          removeRangeListener();
-          removeRangeListener = positionNodeOnRange(
-            editor,
-            range,
-            onReposition,
-          );
-        }
-        previousAnchorNode = currentStartNode;
-        previousAnchorNodeDOM = currentStartNodeDOM;
-        previousAnchorOffset = currentStartOffset;
-        previousFocusNode = currentEndNode;
-        previousFocusNodeDOM = currentEndNodeDOM;
-        previousFocusOffset = currentEndOffset;
-      },
-      {editor},
-    );
+    editorState.read(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) {
+        // TODO
+        previousAnchorNode = null;
+        previousAnchorOffset = null;
+        previousFocusNode = null;
+        previousFocusOffset = null;
+        removeRangeListener();
+        removeRangeListener = () => {};
+        return;
+      }
+      const [start, end] = $getOrderedSelectionPoints(selection);
+      const currentStartNode = start.getNode() as TextNode | ElementNode;
+      const currentStartNodeKey = currentStartNode.getKey();
+      const currentStartOffset = start.offset;
+      const currentEndNode = end.getNode() as TextNode | ElementNode;
+      const currentEndNodeKey = currentEndNode.getKey();
+      const currentEndOffset = end.offset;
+      const currentStartNodeDOM = editor.getElementByKey(currentStartNodeKey);
+      const currentEndNodeDOM = editor.getElementByKey(currentEndNodeKey);
+      const differentStartDOM =
+        previousAnchorNode === null ||
+        currentStartNodeDOM !== previousAnchorNodeDOM ||
+        currentStartOffset !== previousAnchorOffset ||
+        currentStartNodeKey !== previousAnchorNode.getKey();
+      const differentEndDOM =
+        previousFocusNode === null ||
+        currentEndNodeDOM !== previousFocusNodeDOM ||
+        currentEndOffset !== previousFocusOffset ||
+        currentEndNodeKey !== previousFocusNode.getKey();
+      if (
+        (differentStartDOM || differentEndDOM) &&
+        currentStartNodeDOM !== null &&
+        currentEndNodeDOM !== null
+      ) {
+        const range = $rangeFromPoints(
+          editor,
+          start,
+          currentStartNode,
+          currentStartNodeDOM,
+          end,
+          currentEndNode,
+          currentEndNodeDOM,
+        );
+        removeRangeListener();
+        removeRangeListener = positionNodeOnRange(editor, range, onReposition);
+      }
+      previousAnchorNode = currentStartNode;
+      previousAnchorNodeDOM = currentStartNodeDOM;
+      previousAnchorOffset = currentStartOffset;
+      previousFocusNode = currentEndNode;
+      previousFocusNodeDOM = currentEndNodeDOM;
+      previousFocusOffset = currentEndOffset;
+    });
   }
   compute(editor.getEditorState());
   return mergeRegister(


### PR DESCRIPTION
## Summary

- PR #8353 renamed `rangeTargetFromPoint` to `$rangeTargetFromPoint`, which now calls `$getEditor()` to use the extensible DOM API. However, the `editorState.read()` call in `markSelection`'s `compute()` function was not updated to pass `{editor}`, so `$getEditor()` returns `null` and throws when the selection's anchor/focus is on an element node (not text).
- This fix passes the `editor` reference to `editorState.read(() => { ... }, {editor})` so that `$getEditor()` can find the active editor inside `$rangeTargetFromPoint`.

## Test plan
pnpm run test-unit
all test pass, including
✓  unit  packages/lexical-utils/src/__tests__/unit/markSelection.test.tsx (4 tests) 193ms

