### PR TITLE
[lexical] Chore: Fix path-to-regexp dependency vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,8 @@
       "postcss": ">=8.5.10",
       "astro": ">=6.1.6",
       "eslint": ">=9.26.0",
-      "immutable": ">=4.3.8"
+      "immutable": ">=4.3.8",
+      "path-to-regexp": ">=0.1.13"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   astro: '>=6.1.6'
   eslint: '>=9.26.0'
   immutable: '>=4.3.8'
+  path-to-regexp: '>=0.1.13'
 
 importers:
 
@@ -9912,9 +9913,6 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
-
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@1.9.0:
     resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
@@ -20382,7 +20380,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 3.3.0
       proxy-addr: 2.0.7
       qs: 6.15.0
       range-parser: 1.2.1
@@ -23547,8 +23545,6 @@ snapshots:
     dependencies:
       lru-cache: 11.3.3
       minipass: 7.1.3
-
-  path-to-regexp@0.1.12: {}
 
   path-to-regexp@1.9.0:
     dependencies:


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
Updated package.json to manually override the version of the dependency path-to-regexp to >=0.1.13 to address the security vulnerability.

Repository: [facebook/lexical](https://github.com/facebook/lexical)
Manifest file: [pnpm-lock.yaml](https://github.com/facebook/lexical/blob/main/pnpm-lock.yaml)
Package name: path-to-regexp
Affected versions: < 0.1.13
Fixed in version: 0.1.13

## Test plan

### Before

N/A

### After

N/A