### PR TITLE
[lexical-playground] Bug Fix: Position FloatingLinkEditor below the entire link for multi-line and decorator-only links

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -9,7 +9,14 @@ import type {JSX} from 'react';
 
 import './index.css';
 
-import {autoUpdate, flip, offset, shift, useFloating} from '@floating-ui/react';
+import {
+  autoUpdate,
+  flip,
+  inline,
+  offset,
+  shift,
+  useFloating,
+} from '@floating-ui/react';
 import {
   $createLinkNode,
   $isAutoLinkNode,
@@ -21,6 +28,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
+  $isDecoratorNode,
   $isLineBreakNode,
   $isNodeSelection,
   $isRangeSelection,
@@ -102,6 +110,7 @@ function FloatingLinkEditor({
 
   const {refs, floatingStyles} = useFloating({
     middleware: [
+      inline(),
       offset(10),
       flip({
         boundary: scrollerElem || undefined,
@@ -154,28 +163,47 @@ function FloatingLinkEditor({
     const rootElement = editor.getRootElement();
 
     if (selection !== null && rootElement !== null && editor.isEditable()) {
-      let domRect: DOMRect | undefined;
+      let referenceElement: Element | null = null;
 
       if ($isNodeSelection(selection)) {
         const nodes = selection.getNodes();
         if (nodes.length > 0) {
-          const element = editor.getElementByKey(nodes[0].getKey());
-          if (element) {
-            domRect = element.getBoundingClientRect();
-          }
+          referenceElement = editor.getElementByKey(nodes[0].getKey());
         }
+      } else if (
+        $isRangeSelection(selection) &&
+        nativeSelection !== null &&
+        nativeSelection.rangeCount > 0 &&
+        rootElement.contains(nativeSelection.anchorNode)
+      ) {
+        const linkNode = $getSelectedLinkNode(selection);
+        if (linkNode) {
+          // For decorator-only links (e.g. linked images), anchor to the
+          // decorator's element since the link's line box may not match
+          // the decorator's visual extent.
+          const onlyChild =
+            linkNode.getChildrenSize() === 1 ? linkNode.getFirstChild() : null;
+          referenceElement =
+            onlyChild && $isDecoratorNode(onlyChild)
+              ? editor.getElementByKey(onlyChild.getKey())
+              : editor.getElementByKey(linkNode.getKey());
+        }
+      }
+
+      if (referenceElement) {
+        // Use a virtual element exposing both rect methods so `inline`
+        // can read client rects reliably.
+        const refEl = referenceElement;
+        refs.setPositionReference({
+          getBoundingClientRect: () => refEl.getBoundingClientRect(),
+          getClientRects: () => refEl.getClientRects(),
+        });
       } else if (
         nativeSelection !== null &&
         nativeSelection.rangeCount > 0 &&
         rootElement.contains(nativeSelection.anchorNode)
       ) {
-        domRect = nativeSelection.getRangeAt(0).getBoundingClientRect();
-      }
-
-      if (domRect) {
-        refs.setPositionReference({
-          getBoundingClientRect: () => domRect,
-        });
+        refs.setPositionReference(nativeSelection.getRangeAt(0));
       }
       setLastSelection(selection);
     } else if (!activeElement || activeElement.className !== 'link-input') {


### PR DESCRIPTION
## Summary

- Fixes #8263. For multi-line links, the floating link toolbar attached to the cursor's range rect (one line tall), so a cursor on line 1 placed the toolbar between line 1 and line 2 — covering line 2 (and the cursor when it sat there).
- The NodeSelection branch already uses the link element's bounding rect; align RangeSelection by looking up the LinkNode and using `getClientRects()[last]` (the last visual line of the link). Falls back to the prior range-rect behavior when the cursor is not inside a link.
- For decorator-only links (e.g. an image wrapped in a link), the link element's line box can be misaligned with the decorator's visual extent (baseline-based positioning makes the `<a>` rect sit on the image's lower half). When the link has a single decorator child, anchor to the decorator's rect directly so the toolbar lands below the image.

### Before
<img width="527" height="456" alt="스크린샷 2026-04-30 오전 1 51 52" src="https://github.com/user-attachments/assets/f889c0ca-732c-45bf-bf24-cf71b5480c5e" />

### After
<img width="551" height="445" alt="스크린샷 2026-04-30 오전 1 52 23" src="https://github.com/user-attachments/assets/9e0141c2-af24-4067-8c56-e254e1a0c356" />

## Test plan
- [x] Single-line link: toolbar appears below the link (no regression)
- [x] Multi-line link, cursor on line 1: toolbar appears below the last line, not covering line 2
- [x] Multi-line link, cursor on line 2: toolbar appears below the last line
- [x] Image link (decorator-only link): toolbar appears below the image
- [x] Single-character link (#8392): still works via `$getSelectedLinkNode`'s right-bias path