### PR TITLE
[lexical] perf: defer DOM Selection property reads in $updateDOMSelection

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3015,10 +3015,6 @@ export function $updateDOMSelection(
   rootElement: HTMLElement,
   nodeCount: number,
 ): void {
-  const anchorDOMNode = domSelection.anchorNode;
-  const focusDOMNode = domSelection.focusNode;
-  const anchorOffset = domSelection.anchorOffset;
-  const focusOffset = domSelection.focusOffset;
   const activeElement = document.activeElement;
 
   // TODO: make this not hard-coded, and add another config option
@@ -3038,13 +3034,23 @@ export function $updateDOMSelection(
     // lose focus.
     if (
       prevSelection !== null &&
-      isSelectionWithinEditor(editor, anchorDOMNode, focusDOMNode)
+      isSelectionWithinEditor(
+        editor,
+        domSelection.anchorNode,
+        domSelection.focusNode,
+      )
     ) {
       domSelection.removeAllRanges();
     }
 
     return;
   }
+
+  // DOM Selection property reads (anchorNode, focusNode, anchorOffset,
+  // focusOffset) are deferred to their single point of use in the diff
+  // check below, and guarded by a cheap domSelection.type check first.
+  // These reads force the browser to resolve the selection against the
+  // current layout, triggering synchronous style/layout recalculation.
 
   const anchor = nextSelection.anchor;
   const focus = nextSelection.focus;
@@ -3111,11 +3117,11 @@ export function $updateDOMSelection(
   // we're moving selection to within an element, as this can
   // sometimes be problematic around scrolling.
   if (
-    anchorOffset === nextAnchorOffset &&
-    focusOffset === nextFocusOffset &&
-    anchorDOMNode === nextAnchorNode &&
-    focusDOMNode === nextFocusNode && // Badly interpreted range selection when collapsed - #1482
-    !(domSelection.type === 'Range' && isCollapsed)
+    !(domSelection.type === 'Range' && isCollapsed) && // Badly interpreted range selection when collapsed - #1482
+    domSelection.anchorOffset === nextAnchorOffset &&
+    domSelection.focusOffset === nextFocusOffset &&
+    domSelection.anchorNode === nextAnchorNode &&
+    domSelection.focusNode === nextFocusNode
   ) {
     // If the root element does not have focus, ensure it has focus
     if (activeElement === null || !rootElement.contains(activeElement)) {


### PR DESCRIPTION
## Summary

Accessing `domSelection.anchorNode`, `.focusNode`, `.anchorOffset`, and `.focusOffset` forces the browser to resolve the selection against the current layout, triggering synchronous style/layout recalculation.

Previously these four properties were read eagerly at the top of `$updateDOMSelection`, even when the function would immediately return via one of two early-exit paths:
1. Collaboration tag / decorator input check
2. `!isRangeSelection(nextSelection)` (the common case on mount)

During initial mount, both `prevSelection` and `nextSelection` are null, so the function hits the `!isRangeSelection` branch and returns — but only after the browser has already paid the layout recalc cost for property reads that are never consumed.

## Performance trace

<img width="2894" height="776" alt="image" src="https://github.com/user-attachments/assets/049d0911-7116-4644-8f9d-5d7e6edf1ea4" />

## Changes

- Keep `document.activeElement` at the top (needed for the first early return)
- Inline `domSelection.anchorNode`/`.focusNode` directly in the `isSelectionWithinEditor` call (only reached when `prevSelection !== null`)
- Defer the four property reads (`anchorNode`, `focusNode`, `anchorOffset`, `focusOffset`) to just after the early returns, right before the diff-check block that actually uses them

## Impact

Zero layout-triggering `Selection` reads on mount and on any code path that exits early. This eliminates unnecessary forced style/layout recalculations during Lexical node mounting.