### PR TITLE
fix(lexical-playground): add BLOCK_EQUATION markdown transformer for $$...$$ syntax

### DIFF
--- a/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
@@ -114,7 +114,7 @@ export const EMOJI: TextMatchTransformer = {
 export const EQUATION: TextMatchTransformer = {
   dependencies: [EquationNode],
   export: node => {
-    if (!$isEquationNode(node)) {
+    if (!$isEquationNode(node) || !node.__inline) {
       return null;
     }
 
@@ -125,6 +125,26 @@ export const EQUATION: TextMatchTransformer = {
   replace: (textNode, match) => {
     const [, equation] = match;
     const equationNode = $createEquationNode(equation, true);
+    textNode.replace(equationNode);
+  },
+  trigger: '$',
+  type: 'text-match',
+};
+
+export const BLOCK_EQUATION: TextMatchTransformer = {
+  dependencies: [EquationNode],
+  export: node => {
+    if (!$isEquationNode(node) || node.__inline) {
+      return null;
+    }
+
+    return `$$${node.getEquation()}$$`;
+  },
+  importRegExp: /\$\$([^$]+?)\$\$/,
+  regExp: /\$\$([^$]+?)\$\$$/,
+  replace: (textNode, match) => {
+    const [, equation] = match;
+    const equationNode = $createEquationNode(equation, false);
     textNode.replace(equationNode);
   },
   trigger: '$',
@@ -312,6 +332,7 @@ export const PLAYGROUND_TRANSFORMERS: Array<Transformer> = [
   HR,
   IMAGE,
   EMOJI,
+  BLOCK_EQUATION,
   EQUATION,
   TWEET,
   CHECK_LIST,


### PR DESCRIPTION
Closes #6936

Adds a new BLOCK_EQUATION TextMatchTransformer that handles `$$...$$` block math equations. The existing EQUATION transformer only handled inline `$...$` equations, causing block equations to be incorrectly converted to inline when using the markdown shortcut.

Changes:
- Added BLOCK_EQUATION transformer (using $([^$]+?)$$ regex) that creates equations with inline=false
- Updated EQUATION export to only match inline equations (inline=true)
- Placed BLOCK_EQUATION before EQUATION in the transformers array so $$ is matched before $