### PR TITLE
fix(lexical): treat elements with display:inline as non-block in isBlockDomNode

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1912,7 +1912,16 @@ export function isBlockDomNode(
     /^(address|article|aside|blockquote|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hr|li|main|nav|noscript|ol|p|pre|section|table|td|tfoot|ul|video)$/,
     'i',
   );
-  return node.nodeName.match(blockNodes) !== null;
+  if (!node.nodeName.match(blockNodes)) {
+    return false;
+  }
+  if (isHTMLElement(node)) {
+    const display = node.style.display;
+    if (display !== '' && display.startsWith('inline')) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
Closes #8418

When pasting HTML from Ghostty terminal (and other sources that use `display: inline` on block-level elements like `<div>`), the importDOM pipeline incorrectly treats them as block elements, inserting unintended linebreaks.

The fix extends `isBlockDomNode` in LexicalUtils.ts to check the element's inline style `display` property. If it starts with "inline" (e.g. `display: inline`, `display: inline-block`), the element is treated as non-block, matching the existing logic in `LexicalTextNode.ts:1335`.