### PR TITLE
fix(lexical-react): prevent false onChange event on initial autofocus with code highlighting

### DIFF
--- a/packages/lexical-react/src/LexicalOnChangePlugin.ts
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.ts
@@ -10,6 +10,7 @@ import type {EditorState, LexicalEditor} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {HISTORY_MERGE_TAG} from 'lexical';
+import {useRef} from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 export function OnChangePlugin({
@@ -26,9 +27,11 @@ export function OnChangePlugin({
   ) => void;
 }): null {
   const [editor] = useLexicalComposerContext();
+  const initialPrevEditorStateRef = useRef<EditorState | null>(null);
 
   useLayoutEffect(() => {
     if (onChange) {
+      initialPrevEditorStateRef.current = editor.getEditorState();
       return editor.registerUpdateListener(
         ({editorState, dirtyElements, dirtyLeaves, prevEditorState, tags}) => {
           if (
@@ -36,7 +39,8 @@ export function OnChangePlugin({
               dirtyElements.size === 0 &&
               dirtyLeaves.size === 0) ||
             (ignoreHistoryMergeTagChange && tags.has(HISTORY_MERGE_TAG)) ||
-            prevEditorState.isEmpty()
+            prevEditorState.isEmpty() ||
+            prevEditorState === initialPrevEditorStateRef.current
           ) {
             return;
           }


### PR DESCRIPTION
Closes #4493

When AutoFocusPlugin, CodeHighlightPlugin, and OnChangePlugin are all used together, an onChange event fires on initial load even though the editor state hasn't changed.

Root cause: LexicalComposer initializes editor state in useMemo (before child useLayoutEffect callbacks). When AutoFocusPlugin later calls editor.focus(), code highlighting transforms can dirty nodes. By this point prevEditorState.isEmpty() returns false because initial content was already loaded.

Fix: Snapshots the editor state at listener registration time. Skips the first update where prevEditorState still matches that snapshot (reference equality). After the auto-focus update creates a new EditorState, subsequent user edits have a different prevEditorState and fire onChange normally.