### PR TITLE
[lexical-website][lexical-react] Documentation Update: Clarify editorState null vs undefined and empty-state pitfall

### DIFF
--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -34,6 +34,29 @@ import useLayoutEffect from 'shared/useLayoutEffect';
 
 const HISTORY_MERGE_OPTIONS = {tag: HISTORY_MERGE_TAG};
 
+/**
+ * The initial editor state accepted by {@link LexicalComposer} via
+ * `initialConfig.editorState`. Each variant is handled differently:
+ *
+ * - `null` — skip default initialization entirely. The root is left with no
+ *   children for an external owner (typically the
+ *   [collaboration plugin](/docs/collaboration/react) and its Yjs document)
+ *   to populate.
+ * - `string` — a JSON string produced by serializing an `EditorState`. Parsed
+ *   with {@link LexicalEditor.parseEditorState} and applied via
+ *   {@link LexicalEditor.setEditorState}.
+ * - `EditorState` — applied directly via {@link LexicalEditor.setEditorState}.
+ * - `(editor) => void` — an updater run inside `editor.update(...)`. Invoked
+ *   only when the root is still empty, so it will not overwrite content
+ *   bootstrapped by another mechanism, and is silently skipped if the root
+ *   already has children.
+ *
+ * Note that `string` and `EditorState` inputs go through `setEditorState`,
+ * which throws when the parsed state satisfies `EditorState.isEmpty()` (root
+ * with no children and no selection). The empty serialization produced by
+ * initializing with `null` and never modifying the editor falls into this
+ * category, so it cannot be re-applied via `setEditorState` after a round-trip.
+ */
 export type InitialEditorStateType =
   | null
   | string
@@ -46,6 +69,16 @@ export type InitialConfigType = Readonly<{
   onError: (error: Error, editor: LexicalEditor) => void;
   editable?: boolean;
   theme?: EditorThemeClasses;
+  /**
+   * The initial state of the editor. Read once on mount; changes after the
+   * first render are ignored.
+   *
+   * Omitting the field (or passing `undefined`) seeds the root with a default
+   * empty `ParagraphNode`. Pass `null` to skip that default — required when
+   * pairing with the collaboration plugin so that the Yjs document, not
+   * Lexical, owns the initial content. See {@link InitialEditorStateType}
+   * for the full set of accepted shapes.
+   */
   editorState?: InitialEditorStateType;
   html?: HTMLConfig;
 }>;

--- a/packages/lexical-website/docs/concepts/editor-state.md
+++ b/packages/lexical-website/docs/concepts/editor-state.md
@@ -108,8 +108,26 @@ const editorStateRef = useRef(undefined);
 </LexicalComposer>
 ```
 
-Note that Lexical uses `initialConfig.editorState` only once (when it's being initialized) and passing different value later
-won't be reflected in editor. See "Update state" below for proper ways of updating editor state.
+Lexical reads `initialConfig.editorState` only once (when the editor is created); passing
+a different value later won't be reflected. See "Updating state" below for the proper way
+to change editor state after initialization.
+
+The `editorState` field accepts:
+
+- a JSON string, parsed with `editor.parseEditorState()` (as in the example above);
+- an `EditorState` instance, applied directly with `editor.setEditorState()`;
+- a function `(editor) => void`, run inside `editor.update(...)` and invoked only if the
+  root is still empty (so a populated root is left untouched);
+- `null`, which skips default initialization entirely. Use this with the
+  [collaboration plugin](/docs/collaboration/react) so that the Yjs document, not
+  Lexical, owns the initial state.
+
+Omitting the field (or passing `undefined`) seeds the root with a default empty
+`ParagraphNode`. The two are not interchangeable: `null` leaves the root with no children,
+while `undefined` produces a single empty line. If your `loadContent` may yield `null` or
+`undefined` for new documents, coalesce to `undefined` (e.g. `(await loadContent()) ?? undefined`)
+so the editor still gets the default paragraph rather than the collab-style uninitialized
+state.
 
 ## Updating state
 
@@ -172,6 +190,20 @@ Here's an example of how you can set editor state from a stringified JSON:
 const editorState = editor.parseEditorState(editorStateJSONString);
 editor.setEditorState(editorState);
 ```
+
+:::warning
+
+`setEditorState` throws when called with an `EditorState` that satisfies
+`editorState.isEmpty()` — i.e. the root is the only node and there is no selection. The
+message is `"setEditorState: the editor state is empty. Ensure the editor state's root
+node never becomes empty."`. The `EditorState` produced by initializing with
+`editorState: null` and never appending content (typical for a collaboration document
+before peers connect) has exactly this shape, so persisting and reloading such a state
+will fail at the `setEditorState` call. Note that `parseEditorState` itself succeeds — the
+throw lands on the apply step. Either guard with `editorState.isEmpty()` before calling
+`setEditorState`, or seed the document with a `ParagraphNode` before serializing.
+
+:::
 
 ## State update listener
 


### PR DESCRIPTION
## Description

Closes #5079.

`LexicalComposer`'s `initialConfig.editorState` accepts `null` and `undefined` with intentionally different semantics — `null` skips default initialization (used by the collaboration plugin), while `undefined` seeds the root with an empty paragraph. The distinction wasn't documented anywhere, and the related failure mode (`setEditorState` throws on a state whose root is the only node and there is no selection) wasn't mentioned either, so users hit the cryptic `"the editor state is empty..."` error after persisting and reloading a never-modified editor.

This PR:

- Adds TSDoc to `InitialEditorStateType` and the `editorState` field of `InitialConfigType`. These flow into the generated TypeDoc API page and IDE hover tips.
- Expands the existing `initialConfig.editorState` note in the editor-state concept doc to enumerate the accepted shapes and call out the `null` vs `undefined` distinction, including the recommended `?? undefined` coalesce pattern when a loader can return `null` for new documents.
- Adds a \`:::warning\` admonition next to the \`setEditorState\` example explaining when it throws (referencing \`EditorState.isEmpty()\` directly) and how to avoid the empty-state pitfall.

## Test plan

### Before
The bug at #5079 (and the maintainer reply: *"null means to not initialize the editor at all, whereas an undefined value gives the default. The former is used for collaborative editing scenarios."*) — none of this was reflected in the docs or the type definition.

### After
- \`pnpm run prettier\`, \`pnpm run lint\`, \`pnpm run tsc\` all pass.
- \`pnpm -C packages/lexical-website run build\` succeeds; the new TSDoc renders correctly on the generated \`@lexical/react/LexicalComposer\` API page.