### PR TITLE
[lexical-clipboard] Chore: Export GetClipboardDataExtension

### DIFF
--- a/packages/lexical-clipboard/src/__tests__/unit/GetClipboardDataExtension.test.ts
+++ b/packages/lexical-clipboard/src/__tests__/unit/GetClipboardDataExtension.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $exportMimeTypeFromSelection,
+  $getClipboardDataFromSelection,
+  type GetClipboardDataConfig,
+  GetClipboardDataExtension,
+  setLexicalClipboardDataTransfer,
+} from '@lexical/clipboard';
+import {
+  buildEditorFromExtensions,
+  configExtension,
+  defineExtension,
+} from '@lexical/extension';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {DataTransferMock} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
+
+const SEED_TEXT = 'hello world';
+
+function $initialEditorState(): void {
+  const text = $createTextNode(SEED_TEXT);
+  $getRoot().append($createParagraphNode().append(text));
+  text.select(0, SEED_TEXT.length);
+}
+
+function buildSeededEditor(override: Partial<GetClipboardDataConfig> = {}) {
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState,
+      dependencies: [configExtension(GetClipboardDataExtension, override)],
+      name: '[test-root]',
+    }),
+  );
+}
+
+describe('GetClipboardDataExtension', () => {
+  it('produces default text/plain, text/html, and application/x-lexical-editor entries', () => {
+    using editor = buildSeededEditor();
+    editor.read(() => {
+      const data = $getClipboardDataFromSelection();
+      expect(data['text/plain']).toBe(SEED_TEXT);
+      expect(data['text/html']).toContain(SEED_TEXT);
+
+      const lexicalPayload = data['application/x-lexical-editor'];
+      expect(typeof lexicalPayload).toBe('string');
+      const parsed = JSON.parse(lexicalPayload!);
+      expect(parsed.namespace).toBe(editor._config.namespace);
+      expect(Array.isArray(parsed.nodes)).toBe(true);
+      expect(parsed.nodes.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('lets an override replace the default output for an existing MIME type', () => {
+    using editor = buildSeededEditor({
+      $exportMimeType: {
+        'text/plain': [() => 'OVERRIDDEN'],
+      },
+    });
+    editor.read(() => {
+      const data = $getClipboardDataFromSelection();
+      expect(data['text/plain']).toBe('OVERRIDDEN');
+      // Other MIME types still come from the defaults below the override.
+      expect(data['text/html']).toContain(SEED_TEXT);
+    });
+  });
+
+  it('falls through to the default handler when the override calls next()', () => {
+    using editor = buildSeededEditor({
+      $exportMimeType: {
+        'text/plain': [(_selection, next) => `[wrapped] ${next() ?? ''}`],
+      },
+    });
+    editor.read(() => {
+      const data = $getClipboardDataFromSelection();
+      expect(data['text/plain']).toBe(`[wrapped] ${SEED_TEXT}`);
+    });
+  });
+
+  it('omits a MIME type when its top handler returns null without calling next()', () => {
+    using editor = buildSeededEditor({
+      $exportMimeType: {
+        'text/html': [() => null],
+      },
+    });
+    editor.read(() => {
+      const data = $getClipboardDataFromSelection();
+      expect(data['text/html']).toBeUndefined();
+      // Defaults for other MIME types are unaffected.
+      expect(data['text/plain']).toBe(SEED_TEXT);
+      expect(typeof data['application/x-lexical-editor']).toBe('string');
+    });
+  });
+
+  it('registers a brand-new custom MIME type', () => {
+    using editor = buildSeededEditor({
+      $exportMimeType: {
+        'application/x-myformat': [
+          selection =>
+            selection
+              ? JSON.stringify({text: selection.getTextContent(), v: 1})
+              : null,
+        ],
+      },
+    });
+    editor.read(() => {
+      const data = $getClipboardDataFromSelection();
+      expect(data['application/x-myformat']).toBe(
+        JSON.stringify({text: SEED_TEXT, v: 1}),
+      );
+      // Defaults are still produced.
+      expect(data['text/plain']).toBe(SEED_TEXT);
+      expect(data['text/html']).toContain(SEED_TEXT);
+    });
+  });
+
+  it('runs higher-indexed handlers first within a single MIME stack', () => {
+    const calls: string[] = [];
+    using editor = buildSeededEditor({
+      $exportMimeType: {
+        'text/plain': [
+          (_selection, next) => {
+            calls.push('A');
+            return `A(${next() ?? ''})`;
+          },
+          (_selection, next) => {
+            calls.push('B');
+            return `B(${next() ?? ''})`;
+          },
+        ],
+      },
+    });
+    editor.read(() => {
+      const data = $getClipboardDataFromSelection();
+      // Stack after merge: [defaultFn, A, B]; B runs first, calls next() -> A,
+      // A calls next() -> defaultFn (returns SEED_TEXT).
+      expect(data['text/plain']).toBe(`B(A(${SEED_TEXT}))`);
+      expect(calls).toEqual(['B', 'A']);
+    });
+  });
+
+  describe('$exportMimeTypeFromSelection', () => {
+    it('returns the configured stack output for known MIME types', () => {
+      using editor = buildSeededEditor({
+        $exportMimeType: {
+          'application/x-myformat': [() => 'custom-payload'],
+        },
+      });
+      editor.read(() => {
+        expect($exportMimeTypeFromSelection('text/plain')).toBe(SEED_TEXT);
+        expect($exportMimeTypeFromSelection('application/x-myformat')).toBe(
+          'custom-payload',
+        );
+      });
+    });
+
+    it('returns null for MIME types that have no registered handler', () => {
+      using editor = buildSeededEditor();
+      editor.read(() => {
+        expect($exportMimeTypeFromSelection('application/x-unknown')).toBe(
+          null,
+        );
+      });
+    });
+
+    it('uses the default config when GetClipboardDataExtension is not built into the editor', () => {
+      using editor = buildEditorFromExtensions(
+        defineExtension({
+          $initialEditorState,
+          name: '[test-root]',
+        }),
+      );
+      editor.read(() => {
+        expect($exportMimeTypeFromSelection('text/plain')).toBe(SEED_TEXT);
+        expect($exportMimeTypeFromSelection('text/html')).toContain(SEED_TEXT);
+      });
+    });
+  });
+
+  it('setLexicalClipboardDataTransfer wires custom MIME types into the DataTransfer', () => {
+    using editor = buildSeededEditor({
+      $exportMimeType: {
+        'application/x-myformat': [() => 'custom-payload'],
+      },
+    });
+    const dt = new DataTransferMock();
+    editor.read(() => {
+      setLexicalClipboardDataTransfer(
+        dt as unknown as DataTransfer,
+        $getClipboardDataFromSelection(),
+      );
+    });
+    expect(dt.getData('text/plain')).toBe(SEED_TEXT);
+    expect(dt.getData('text/html')).toContain(SEED_TEXT);
+    expect(dt.getData('application/x-myformat')).toBe('custom-payload');
+  });
+});

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -8,12 +8,9 @@
 
 /// <reference types="trusted-types" />
 
-import {
-  getExtensionDependencyFromEditor,
-  LexicalBuilder,
-} from '@lexical/extension';
+import {getPeerDependencyFromEditor} from '@lexical/extension';
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
-import {$addNodeStyle, $sliceSelectedTextNodeContent} from '@lexical/selection';
+import {$sliceSelectedTextNodeContent} from '@lexical/selection';
 import {objectKlassEquals} from '@lexical/utils';
 import {
   $caretFromPoint,
@@ -59,7 +56,7 @@ export interface LexicalClipboardData {
   'text/html'?: string | undefined;
   'application/x-lexical-editor'?: string | undefined;
   'text/plain': string;
-  [mimeType: string]: string | undefined;
+  [mimeType: string & {}]: string | undefined;
 }
 
 /**
@@ -652,13 +649,8 @@ export function $generateNodesFromSerializedNodes(
   serializedNodes: Array<BaseSerializedNode>,
 ): Array<LexicalNode> {
   const nodes = [];
-  for (let i = 0; i < serializedNodes.length; i++) {
-    const serializedNode = serializedNodes[i];
-    const node = $parseSerializedNode(serializedNode);
-    if ($isTextNode(node)) {
-      $addNodeStyle(node);
-    }
-    nodes.push(node);
+  for (const serializedNode of serializedNodes) {
+    nodes.push($parseSerializedNode(serializedNode));
   }
   return nodes;
 }
@@ -825,28 +817,65 @@ export function setLexicalClipboardDataTransfer(
   }
 }
 
+/**
+ * A function that produces the serialized representation of a selection for
+ * a single MIME type. Functions are arranged in a stack per MIME type (see
+ * {@link ExportMimeTypeConfig}); the function at the top of the stack is
+ * invoked first and may call `next()` to delegate to the previous function
+ * in the stack (typically the default Lexical serializer).
+ *
+ * Returning `null` from the top-most function omits that MIME type from the
+ * resulting {@link LexicalClipboardData}.
+ *
+ * @param selection - The selection to serialize, or `null` if there is none.
+ * @param next - Calls the previous handler in the stack and returns its
+ *   result, or `null` if there is no previous handler.
+ * @returns The serialized string for this MIME type, or `null` to omit it.
+ */
 export type ExportMimeTypeFunction = (
   selection: null | BaseSelection,
   next: () => null | string,
 ) => null | string;
 
+/**
+ * Configuration for {@link GetClipboardDataExtension}.
+ */
 export interface GetClipboardDataConfig {
+  /**
+   * The per-MIME-type serializer stacks used when copying or dragging the
+   * current selection out of the editor. See {@link ExportMimeTypeConfig}.
+   *
+   * Merged with [...prev, ...override]
+   */
   $exportMimeType: ExportMimeTypeConfig;
 }
 
-export type ExportMimeTypeConfig = Record<
-  keyof LexicalClipboardData | (string & {}),
-  ExportMimeTypeFunction[]
->;
+/**
+ * A mapping from MIME type to a stack of {@link ExportMimeTypeFunction}.
+ *
+ * Each entry is an ordered array; the function at the highest index runs
+ * first and may call `next()` to fall through to the function below it.
+ * The default config provides a single fallback handler for
+ * `'application/x-lexical-editor'`, `'text/html'`, and `'text/plain'`.
+ *
+ * When {@link GetClipboardDataExtension} merges a partial config, new
+ * functions are appended to the existing array for each MIME type, so
+ * later-registered handlers run before earlier ones (including the
+ * defaults) and may delegate to them via `next()`. To register a brand new
+ * MIME type, supply a key not present in the default config; arbitrary
+ * string keys are accepted in addition to the keys of
+ * {@link LexicalClipboardData}.
+ */
+export type ExportMimeTypeConfig = {
+  [K in keyof LexicalClipboardData]?: ExportMimeTypeFunction[];
+};
 
-function $getExportConfig() {
-  const editor = $getEditor();
-  const builder = LexicalBuilder.maybeFromEditor(editor);
-  if (builder && builder.hasExtensionByName(GetClipboardDataExtension.name)) {
-    return getExtensionDependencyFromEditor(editor, GetClipboardDataExtension)
-      .output;
-  }
-  return DEFAULT_EXPORT_MIME_TYPE;
+function $getExportConfig(editor = $getEditor()) {
+  const dep = getPeerDependencyFromEditor<typeof GetClipboardDataExtension>(
+    editor,
+    GetClipboardDataExtension.name,
+  );
+  return dep ? dep.output : DEFAULT_EXPORT_MIME_TYPE;
 }
 
 const DEFAULT_EXPORT_MIME_TYPE: ExportMimeTypeConfig = {
@@ -865,9 +894,11 @@ function $getClipboardDataWithConfigFromSelection(
 ): LexicalClipboardData {
   const clipboardData: LexicalClipboardData = {'text/plain': ''};
   for (const [k, fns] of Object.entries($exportMimeType)) {
-    const v = callExportMimeTypeFunctionStack(fns, selection);
-    if (v !== null) {
-      clipboardData[k] = v;
+    if (fns) {
+      const v = callExportMimeTypeFunctionStack(fns, selection);
+      if (v !== null) {
+        clipboardData[k] = v;
+      }
     }
   }
   return clipboardData;
@@ -882,6 +913,27 @@ function callExportMimeTypeFunctionStack(
   return callAt(fns.length - 1);
 }
 
+/**
+ * Serialize the given selection for a single MIME type using the active
+ * editor's configured {@link ExportMimeTypeConfig}. The configured stack is
+ * read from {@link GetClipboardDataExtension} via the editor's peer
+ * dependency lookup; if the extension was not built into the editor, the
+ * default stack is used.
+ *
+ * Useful when only one MIME representation is needed rather than the full
+ * {@link LexicalClipboardData} produced by
+ * {@link $getClipboardDataFromSelection}.
+ *
+ * Must be called from within an editor update or read.
+ *
+ * @param mimeType - The MIME type to serialize, e.g. `'text/html'`,
+ *   `'application/x-lexical-editor'`, `'text/plain'`, or any custom key
+ *   registered in the {@link ExportMimeTypeConfig}.
+ * @param selection - The selection to serialize (defaults to
+ *   `$getSelection()`).
+ * @returns The serialized string for the requested MIME type, or `null` if
+ *   no handler is registered for it or every handler returned `null`.
+ */
 export function $exportMimeTypeFromSelection(
   mimeType: keyof ExportMimeTypeConfig,
   selection: null | BaseSelection = $getSelection(),
@@ -892,6 +944,56 @@ export function $exportMimeTypeFromSelection(
   );
 }
 
+/**
+ * Lexical extension that controls how the current selection is serialized
+ * into clipboard MIME types when copying or dragging out of the editor.
+ *
+ * The extension's config holds an {@link ExportMimeTypeConfig} — a stack of
+ * {@link ExportMimeTypeFunction} per MIME type. Out of the box it provides
+ * fallback serializers for `'application/x-lexical-editor'`, `'text/html'`,
+ * and `'text/plain'` that defer to {@link $getLexicalContent},
+ * {@link $getHtmlContent}, and `selection.getTextContent()` respectively.
+ *
+ * Apps can layer additional handlers on top to customize an existing
+ * payload (delegating to the default via `next()`) or to register an
+ * entirely new MIME type. Functions provided through `mergeConfig` are
+ * appended to the existing stack for each MIME type, so a newly registered
+ * handler runs first and may fall through to the previously registered
+ * handlers via its `next` argument.
+ *
+ * The extension's `output` is the resolved {@link ExportMimeTypeConfig},
+ * which {@link $getClipboardDataFromSelection} and
+ * {@link $exportMimeTypeFromSelection} read via the editor's peer
+ * dependency lookup.
+ *
+ * @example
+ * ```ts
+ * import {configExtension, defineExtension} from '@lexical/extension';
+ * import {GetClipboardDataExtension} from '@lexical/clipboard';
+ *
+ * const MyClipboardExtension = defineExtension({
+ *   name: 'my-app/clipboard',
+ *   dependencies: [
+ *     configExtension(GetClipboardDataExtension, {
+ *       $exportMimeType: {
+ *         // Wrap the default HTML output with an app-specific marker.
+ *         'text/html': [
+ *           (selection, next) => {
+ *             const html = next();
+ *             return html ? wrapWithMyAppMarker(html) : html;
+ *           },
+ *         ],
+ *         // Add a brand-new MIME type.
+ *         'application/vnd.myapp+json': [
+ *           (selection) =>
+ *             selection ? exportMyAppFormat(selection) : null,
+ *         ],
+ *       },
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
 export const GetClipboardDataExtension = defineExtension({
   build(editor, config, state) {
     return config.$exportMimeType;
@@ -904,7 +1006,10 @@ export const GetClipboardDataExtension = defineExtension({
     if (partial.$exportMimeType) {
       const $exportMimeType = {...config.$exportMimeType};
       for (const [k, v] of Object.entries(partial.$exportMimeType)) {
-        $exportMimeType[k] = [...$exportMimeType[k], ...v];
+        if (v) {
+          const prev = $exportMimeType[k];
+          $exportMimeType[k] = prev ? [...prev, ...v] : v;
+        }
       }
       merged.$exportMimeType = $exportMimeType;
     }

--- a/packages/lexical-clipboard/src/index.ts
+++ b/packages/lexical-clipboard/src/index.ts
@@ -19,6 +19,8 @@ export {
   $insertGeneratedNodes,
   $writeDragSourceToDataTransfer,
   copyToClipboard,
+  type GetClipboardDataConfig,
+  GetClipboardDataExtension,
   type LexicalClipboardData,
   setLexicalClipboardDataTransfer,
 } from './clipboard';

--- a/packages/lexical-clipboard/src/index.ts
+++ b/packages/lexical-clipboard/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 export {
+  $exportMimeTypeFromSelection,
   $generateJSONFromSelectedNodes,
   $generateNodesFromSerializedNodes,
   $getClipboardDataFromSelection,
@@ -19,6 +20,8 @@ export {
   $insertGeneratedNodes,
   $writeDragSourceToDataTransfer,
   copyToClipboard,
+  type ExportMimeTypeConfig,
+  type ExportMimeTypeFunction,
   type GetClipboardDataConfig,
   GetClipboardDataExtension,
   type LexicalClipboardData,

--- a/packages/lexical-html/src/RenderContext.ts
+++ b/packages/lexical-html/src/RenderContext.ts
@@ -5,10 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {
-  getExtensionDependencyFromEditor,
-  LexicalBuilder,
-} from '@lexical/extension';
+import {getPeerDependencyFromEditor} from '@lexical/extension';
 import {$getEditor, LexicalEditor} from 'lexical';
 
 import {DOMRenderContextSymbol, DOMRenderExtensionName} from './constants';
@@ -62,11 +59,11 @@ export const RenderContextExport = createRenderState('isExport', Boolean);
 function getDefaultRenderContext(
   editor: LexicalEditor,
 ): undefined | ContextRecord<typeof DOMRenderContextSymbol> {
-  const builder = LexicalBuilder.maybeFromEditor(editor);
-  return builder && builder.hasExtensionByName(DOMRenderExtensionName)
-    ? getExtensionDependencyFromEditor(editor, DOMRenderExtension).output
-        .defaults
-    : undefined;
+  const dep = getPeerDependencyFromEditor<typeof DOMRenderExtension>(
+    editor,
+    DOMRenderExtensionName,
+  );
+  return dep ? dep.output.defaults : undefined;
 }
 
 function getRenderContext(

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -24,7 +24,6 @@ import {MarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlug
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 import {$createHeadingNode} from '@lexical/rich-text';
 import {
-  $addNodeStyle,
   $getSelectionStyleValueForProperty,
   $patchStyleText,
   $setBlocksType,
@@ -2457,7 +2456,6 @@ describe('LexicalSelection tests', () => {
         textNode.setStyle(
           '   font-family  : Arial  ;  color    :   red   ;top     : 50px',
         );
-        $addNodeStyle(textNode);
         paragraph.append(textNode);
         root.append(paragraph);
 
@@ -2513,7 +2511,6 @@ describe('LexicalSelection tests', () => {
         textNode.setStyle(
           'font-family: double:prefix:Arial; color: color:white; font-size: 30px',
         );
-        $addNodeStyle(textNode);
         paragraph.append(textNode);
         root.append(paragraph);
 
@@ -2569,7 +2566,6 @@ describe('LexicalSelection tests', () => {
         textNode.setStyle(
           'background-image: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'></svg>"); /* ignored */ content: "semi;colon:value"; color: red;',
         );
-        $addNodeStyle(textNode);
         paragraph.append(textNode);
         root.append(paragraph);
 
@@ -2622,7 +2618,6 @@ describe('LexicalSelection tests', () => {
           const paragraph = $createParagraphNode();
           const textNode = $createTextNode('Hello, World!');
           textNode.setStyle('font-family: serif; color: red;');
-          $addNodeStyle(textNode);
           paragraph.append(textNode);
           root.append(paragraph);
 
@@ -2675,7 +2670,6 @@ describe('LexicalSelection tests', () => {
           const paragraph = $createParagraphNode();
           const textNode = $createTextNode('Hello, World!');
           textNode.setStyle(`color: ${currentColor};`);
-          $addNodeStyle(textNode);
           paragraph.append(textNode);
           root.append(paragraph);
 


### PR DESCRIPTION
[lexical-clipboard] Chore: Export GetClipboardDataExtension

## Description
This pull request makes a small update to the exports in `packages/lexical-clipboard/src/index.ts`, adding two new clipboard-related types/extensions to the public API. This will allow other parts of the codebase to use these clipboard utilities directly.