### PR TITLE
[lexical-playground] Bug Fix: Prevent FloatingLinkEditor toolbar from being clipped near the editor's bottom edge

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -118,6 +118,8 @@ function FloatingLinkEditor({
       }),
       shift({
         boundary: scrollerElem || undefined,
+        crossAxis: true,
+        mainAxis: true,
         padding: 10,
       }),
     ],


### PR DESCRIPTION
## Summary
- Fixes #8421. When a link is near the editor scroller's bottom edge, the toolbar was rendered below the link and clipped by the boundary. This is most common with image links since the image's tall rect leaves no room for `flip` to land the toolbar above the link either — `flip`'s `bestFit` strategy then keeps the overflowing bottom placement.                                                                                                                                  
- Enabling `shift`'s `mainAxis` and `crossAxis` together lets the toolbar slide into the boundary on both axes when no `flip` placement fully fits, keeping it visible (it can overlap the reference, but no longer clipped out of view).                                                                                     
   
### Before                                                                                                                                                     

<img width="2260" height="714" alt="image" src="https://github.com/user-attachments/assets/ad375d6f-e549-4261-92cf-faa517def5a0" />
                                                                                                                                                     

### After
<img width="1762" height="1654" alt="image" src="https://github.com/user-attachments/assets/90f557a9-8ac4-47f9-a8eb-654c37d847fc" />


## Test plan
- [x] Single-line text link near editor bottom: toolbar flips above the link
- [x] Multi-line text link near editor bottom: toolbar flips above the last line                                                                               
- [x] Image link near editor bottom: toolbar slides up within the boundary (overlaps the image but no longer clipped)
- [x] Link not near edge: no regression in default placement                                                                                                   
- [x] Link near right edge: cross-axis shift keeps the toolbar visible 