### PR TITLE
[lexical] Bug Fix: Treat elements with display:inline as non-block in isBlockDomNode

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1912,7 +1912,16 @@ export function isBlockDomNode(
     /^(address|article|aside|blockquote|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hr|li|main|nav|noscript|ol|p|pre|section|table|td|tfoot|ul|video)$/,
     'i',
   );
-  return node.nodeName.match(blockNodes) !== null;
+  if (!node.nodeName.match(blockNodes)) {
+    return false;
+  }
+  if (isHTMLElement(node)) {
+    const display = node.style.display;
+    if (display !== '' && display.startsWith('inline')) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Description

Currently, `isBlockDomNode` only checks the node's tag name against a block-level regex, without considering CSS `display` styles. This causes paste issues when pasting content from terminals like Ghostty, which set `display: inline` on block-level elements to style content for terminal rendering.

This PR adds a check for the `display` style property -- if an element has `display: inline` (or `display: inline-*`), it is treated as a non-block node regardless of its tag name, matching browser rendering behavior.

## Test plan

### Before

Pasting content from Ghostty or other terminals that use `display: inline` on block elements results in incorrect block structure.

### After

Pasted content from Ghostty correctly preserves inline elements as inline, and the editor structure matches what is rendered in the browser.