### PR TITLE
[lexical-plain-text] Feature: Add escape key handler matching rich-text behavior

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -41,6 +41,7 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
+  KEY_ESCAPE_COMMAND,
   PASTE_COMMAND,
   PASTE_TAG,
   REMOVE_TEXT_COMMAND,
@@ -409,6 +410,18 @@ export function registerPlainText(editor: LexicalEditor): () => void {
         if (!selection.isCollapsed() && event.dataTransfer !== null) {
           $writeDragSourceToDataTransfer(event.dataTransfer, editor);
         }
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand(
+      KEY_ESCAPE_COMMAND,
+      () => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          return false;
+        }
+        editor.blur();
         return true;
       },
       COMMAND_PRIORITY_EDITOR,


### PR DESCRIPTION
## Description

Currently, the plain-text plugin does not handle the Escape key, unlike the rich-text plugin which blurs (unfocuses) the editor on Escape. This creates an inconsistent UX between plain-text and rich-text editors.

This PR adds a `KEY_ESCAPE_COMMAND` handler to `registerPlainText` that calls `editor.blur()` when the selection is a range selection, matching the rich-text behavior.

Closes #5922

## Test plan

### Before

Pressing Escape in a plain-text editor does nothing -- the editor keeps focus.

### After

Pressing Escape in a plain-text editor blurs the editor, consistent with the rich-text editor behavior.