### PR TITLE
[lexical][lexical-html] Bug Fix: Prevent crash when importing unknown block elements like <details>

### DIFF
--- a/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
@@ -422,4 +422,50 @@ describe('HTML', () => {
       expect(importAndGetDirection(html)).toBe(expected);
     });
   });
+
+  describe('importDOM handles unknown block elements', () => {
+    function importAndExport(html: string): string {
+      const editor = createHeadlessEditor();
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(html, 'text/html');
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().selectEnd();
+          const selection = $getRoot().select(0);
+          selection.insertNodes(nodes);
+        },
+        {discrete: true},
+      );
+      return editor.getEditorState().read(() => $generateHtmlFromNodes(editor));
+    }
+
+    test('wraps text inside unknown block element in paragraph', () => {
+      const html = importAndExport(
+        '<details><summary>Details</summary>Something small enough to escape casual notice.</details>',
+      );
+      expect(html).toContain('Something small enough to escape casual notice');
+      expect(() =>
+        importAndExport(
+          '<details><summary>Details</summary>Something</details>',
+        ),
+      ).not.toThrow();
+    });
+
+    test('wraps text inside unknown nested element in paragraph', () => {
+      expect(() =>
+        importAndExport(
+          '<details><summary>Details</summary><foo>Something</foo></details>',
+        ),
+      ).not.toThrow();
+    });
+
+    test('handles summary element as block', () => {
+      expect(() =>
+        importAndExport('<summary>Click me</summary>'),
+      ).not.toThrow();
+      const html = importAndExport('<summary>Click me</summary>');
+      expect(html).toContain('Click me');
+    });
+  });
 });

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -467,7 +467,16 @@ function $createNodesFromDOM(
   if (currentLexicalNode == null) {
     if (childLexicalNodes.length > 0) {
       // If it hasn't been converted to a LexicalNode, we hoist its children
-      // up to the same level as it.
+      // up to the same level as it. Wrap inline children in paragraphs
+      // if the parent does not have a block ancestor to avoid inserting
+      // text or inline nodes directly into a root node.
+      if (!hasBlockAncestorLexicalNode) {
+        childLexicalNodes = wrapContinuousInlines(
+          node,
+          childLexicalNodes,
+          $createParagraphNode,
+        );
+      }
       for (const childNode of childLexicalNodes) {
         lexicalNodes.push(childNode);
       }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1902,7 +1902,7 @@ const BlockDOMBrand = Symbol.for('@lexical/BlockDOMBrand');
 const InlineDOMBrand = Symbol.for('@lexical/InlineDOMBrand');
 
 const BLOCK_TAG_RE =
-  /^(address|article|aside|blockquote|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hr|li|main|nav|noscript|ol|p|pre|section|table|td|tfoot|ul|video)$/i;
+  /^(address|article|aside|blockquote|canvas|dd|details|div|dl|dt|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hr|li|main|nav|noscript|ol|p|pre|section|summary|table|td|tfoot|ul|video)$/i;
 
 /**
  *


### PR DESCRIPTION
## Description

When importing DOM that contains unknown block-level elements (like `<details>`, `<summary>`, or other non-standard block elements), the HTML importer could crash because `getConversionFunction` returns `null` for these elements, causing their inline/text children to be hoisted directly into a block-only context (e.g., root node).

This PR:
- Adds `<details>` and `<summary>` to the `isBlockDomNode` block-level element list
- Adds a safety check in `$createNodesFromDOM` to wrap hoisted inline children in paragraphs when the parent context does not have a block ancestor

Closes #8407

## Test plan

### Before

Importing `<details><summary>Details</summary>Something</details>` would crash the editor with "Only element or decorator nodes can be inserted in to the root node"

### After

Unknown block elements are handled gracefully — their inline/text children are wrapped in paragraphs before being inserted at the parent level.