### PR TITLE
[lexical-table] Bug Fix: Remove hardcoded background-color from table header cells

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -186,9 +186,6 @@ export class TableCellNode extends ElementNode {
 
       element.style.verticalAlign = this.getVerticalAlign() || 'top';
       element.style.textAlign = 'start';
-      if (this.__backgroundColor === null && this.hasHeader()) {
-        element.style.backgroundColor = '#f2f3f5';
-      }
     }
 
     return output;

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -303,7 +303,6 @@ describe('LexicalTableNode tests', () => {
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
-                            background-color: rgb(242, 243, 245);
                           ">
                           <p><span style="white-space: pre-wrap">0</span></p>
                         </th>
@@ -313,7 +312,6 @@ describe('LexicalTableNode tests', () => {
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
-                            background-color: rgb(242, 243, 245);
                           ">
                           <p><span style="white-space: pre-wrap">1</span></p>
                         </th>
@@ -325,7 +323,6 @@ describe('LexicalTableNode tests', () => {
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
-                            background-color: rgb(242, 243, 245);
                           ">
                           <p><span style="white-space: pre-wrap">2</span></p>
                         </th>
@@ -379,7 +376,6 @@ describe('LexicalTableNode tests', () => {
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
-                            background-color: rgb(242, 243, 245);
                           ">
                           <p><span style="white-space: pre-wrap">1</span></p>
                         </th>


### PR DESCRIPTION
## Description

Table header cells (`<th>`) had a hardcoded `background-color: #f2f3f5` applied via inline style in `createDOM`. Since the playground theme CSS already provides this color via `.PlaygroundEditorTheme__tableFrozenRow` class, the hardcoded inline style is unnecessary and prevents users from customizing header cell appearance through CSS overrides.

Closes #8089

## Test plan

### Before

Table header cells had `background-color: #f2f3f5` applied as an inline style in `createDOM`.

### After

Table header cells no longer have a hardcoded inline background color. The playground theme CSS continues to provide the same visual styling.