### PR TITLE
[lexical][lexical-list] Bug Fix: Reuse DOM when reconciling cross-parent node moves

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -533,55 +533,52 @@ function $setListItemThemeClassNames(
   editorThemeClasses: EditorThemeClasses,
   node: ListItemNode,
 ): void {
-  const classesToAdd = [];
-  const classesToRemove = [];
   const listTheme = editorThemeClasses.list;
-  const listItemClassName = listTheme ? listTheme.listitem : undefined;
-  let nestedListItemClassName;
-
-  if (listTheme && listTheme.nested) {
-    nestedListItemClassName = listTheme.nested.listitem;
+  if (!listTheme) {
+    return;
   }
 
-  if (listItemClassName !== undefined) {
-    classesToAdd.push(...normalizeClassNames(listItemClassName));
+  const listItemClassName = listTheme.listitem;
+  const nestedListItemClassName = listTheme.nested && listTheme.nested.listitem;
+  const parentNode = node.getParent();
+  const isCheckList =
+    $isListNode(parentNode) && parentNode.getListType() === 'check';
+  const checked = node.getChecked();
+  const isNested = node.getChildren().some(child => $isListNode(child));
+
+  // Always remove the variable theme classes first so that the className
+  // string stays in a canonical order regardless of how the dom got here
+  // (fresh create vs. cross-parent reuse). classList.remove on a missing
+  // class is a no-op, so this is safe even on a freshly-created element.
+  const classesToRemove: string[] = [];
+  if (listTheme.listitemChecked !== undefined) {
+    classesToRemove.push(listTheme.listitemChecked);
   }
-
-  if (listTheme) {
-    const parentNode = node.getParent();
-    const isCheckList =
-      $isListNode(parentNode) && parentNode.getListType() === 'check';
-    const checked = node.getChecked();
-
-    if (!isCheckList || checked) {
-      classesToRemove.push(listTheme.listitemUnchecked);
-    }
-
-    if (!isCheckList || !checked) {
-      classesToRemove.push(listTheme.listitemChecked);
-    }
-
-    if (isCheckList) {
-      classesToAdd.push(
-        checked ? listTheme.listitemChecked : listTheme.listitemUnchecked,
-      );
-    }
+  if (listTheme.listitemUnchecked !== undefined) {
+    classesToRemove.push(listTheme.listitemUnchecked);
   }
-
   if (nestedListItemClassName !== undefined) {
-    const nestedListItemClasses = normalizeClassNames(nestedListItemClassName);
-
-    if (node.getChildren().some(child => $isListNode(child))) {
-      classesToAdd.push(...nestedListItemClasses);
-    } else {
-      classesToRemove.push(...nestedListItemClasses);
-    }
+    classesToRemove.push(...normalizeClassNames(nestedListItemClassName));
   }
-
   if (classesToRemove.length > 0) {
     removeClassNamesFromElement(dom, ...classesToRemove);
   }
 
+  const classesToAdd: string[] = [];
+  if (listItemClassName !== undefined) {
+    classesToAdd.push(...normalizeClassNames(listItemClassName));
+  }
+  if (isCheckList) {
+    const checkClassName = checked
+      ? listTheme.listitemChecked
+      : listTheme.listitemUnchecked;
+    if (checkClassName !== undefined) {
+      classesToAdd.push(checkClassName);
+    }
+  }
+  if (nestedListItemClassName !== undefined && isNested) {
+    classesToAdd.push(...normalizeClassNames(nestedListItemClassName));
+  }
   if (classesToAdd.length > 0) {
     addClassNamesToElement(dom, ...classesToAdd);
   }
@@ -605,15 +602,10 @@ function updateListItemChecked(
   } else {
     dom.setAttribute('role', 'checkbox');
     dom.setAttribute('tabIndex', '-1');
-    if (
-      !prevListItemNode ||
-      listItemNode.__checked !== prevListItemNode.__checked
-    ) {
-      dom.setAttribute(
-        'aria-checked',
-        listItemNode.getChecked() ? 'true' : 'false',
-      );
-    }
+    dom.setAttribute(
+      'aria-checked',
+      listItemNode.getChecked() ? 'true' : 'false',
+    );
   }
 }
 

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -67,6 +67,11 @@ let activeEditorDOMRenderConfig: EditorDOMRenderConfig;
 
 function $destroyNode(key: NodeKey, parentDOM: null | HTMLElement): void {
   const node = activePrevNodeMap.get(key);
+  // A node "moved" across parents in the same transaction still exists in
+  // the next node map. We only detach its DOM from the old parent here;
+  // the new parent's $createNode call will reuse it. Skip child destruction
+  // and mutation marking — $reconcileNode will mark it 'updated' instead.
+  const isMoved = activeNextNodeMap.has(key);
 
   if (parentDOM !== null) {
     const dom = getPrevElementByKeyOrThrow(key);
@@ -75,11 +80,13 @@ function $destroyNode(key: NodeKey, parentDOM: null | HTMLElement): void {
     }
   }
 
+  if (isMoved) {
+    return;
+  }
+
   // This logic is really important, otherwise we will leak DOM nodes
   // when their corresponding LexicalNodes are removed from the editor state.
-  if (!activeNextNodeMap.has(key)) {
-    activeEditor._keyToDOMMap.delete(key);
-  }
+  activeEditor._keyToDOMMap.delete(key);
 
   if ($isElementNode(node)) {
     const children = $createChildrenArray(node, activePrevNodeMap);
@@ -199,6 +206,25 @@ function $createNode(key: NodeKey, slot: ElementDOMSlot | null): HTMLElement {
   if (node === undefined) {
     invariant(false, 'createNode: node does not exist in nodeMap');
   }
+
+  // Cross-parent move: the same key existed in the previous tree under a
+  // different parent. Reuse the existing DOM so React decorator portals,
+  // contentEditable focus, etc. survive the reparenting. Without this the
+  // DecoratorNode's wrapper is recreated and React unmounts/remounts the
+  // child component (visible as a 1-frame flicker in Safari).
+  // Requires a slot so $reconcileNode has a valid parentDOM in case the
+  // moved node also reports updateDOM=true and needs an in-place replace.
+  if (slot !== null) {
+    const prevNode = activePrevNodeMap.get(key);
+    if (prevNode !== undefined && prevNode.__parent !== node.__parent) {
+      const existingDOM = activePrevKeyToDOMMap.get(key);
+      if (existingDOM !== undefined) {
+        slot.insertChild(existingDOM);
+        return $reconcileNode(key, slot.element);
+      }
+    }
+  }
+
   const dom = activeEditorDOMRenderConfig.$createDOM(node, activeEditor);
   storeDOMWithKey(key, dom, activeEditor);
 
@@ -406,7 +432,14 @@ function $reconcileChildren(
       const lastDOM = getPrevElementByKeyOrThrow(prevFirstChildKey);
       const replacementDOM = $createNode(nextFirstChildKey, null);
       try {
-        dom.replaceChild(replacementDOM, lastDOM);
+        if (lastDOM.parentNode === dom) {
+          dom.replaceChild(replacementDOM, lastDOM);
+        } else {
+          // lastDOM was reused as a descendant of replacementDOM (cross-parent
+          // move, e.g. wrapping an image in a link). It's already detached
+          // from `dom`, so just insert the replacement.
+          slot.insertChild(replacementDOM);
+        }
       } catch (error) {
         if (typeof error === 'object' && error != null) {
           const msg = `${error.toString()} Parent: ${
@@ -596,7 +629,11 @@ function $reconcileNode(
       subTreeTextContent += text;
     }
 
-    if (treatAllNodesAsDirty || nextNode.__dir !== prevNode.__dir) {
+    if (
+      treatAllNodesAsDirty ||
+      nextNode.__dir !== prevNode.__dir ||
+      nextNode.__parent !== prevNode.__parent
+    ) {
       $setElementDirection(dom, nextNode);
       if (
         // Root node direction changing from set to unset (or vice versa)

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -11,12 +11,19 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  type NodeMutation,
   ParagraphNode,
 } from 'lexical';
-import {describe, expect, test} from 'vitest';
+import {afterEach, describe, expect, test, vi} from 'vitest';
 
 import {$getReconciledDirection} from '../../LexicalReconciler';
-import {initializeUnitTest} from '../utils';
+import {
+  $createTestDecoratorNode,
+  $createTestElementNode,
+  initializeUnitTest,
+  TestDecoratorNode,
+  TestElementNode,
+} from '../utils';
 
 describe('LexicalReconciler', () => {
   initializeUnitTest(testEnv => {
@@ -159,6 +166,230 @@ describe('LexicalReconciler', () => {
           .map(child => $getReconciledDirection(child));
       });
       expect(directions).toEqual(['auto', 'ltr']);
+    });
+
+    describe('Cross-parent moves reuse DOM (regression #8420)', () => {
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      test('Decorator wrapped in another element reuses its DOM', async () => {
+        const {editor} = testEnv;
+        let decoratorKey = '';
+        await editor.update(() => {
+          const decorator = $createTestDecoratorNode();
+          decoratorKey = decorator.getKey();
+          $getRoot().clear().append($createParagraphNode().append(decorator));
+        });
+
+        const domBefore = editor.getElementByKey(decoratorKey);
+        expect(domBefore).not.toBeNull();
+
+        const mutations: NodeMutation[] = [];
+        editor.registerMutationListener(
+          TestDecoratorNode,
+          nodes => {
+            for (const m of nodes.values()) {
+              mutations.push(m);
+            }
+          },
+          {skipInitialization: true},
+        );
+
+        await editor.update(() => {
+          const decorator = $getRoot()
+            .getFirstChildOrThrow<ParagraphNode>()
+            .getFirstChildOrThrow<TestDecoratorNode>();
+          const wrapper = $createTestElementNode();
+          decorator.insertBefore(wrapper);
+          wrapper.append(decorator);
+        });
+
+        expect(editor.getElementByKey(decoratorKey)).toBe(domBefore);
+        expect(domBefore?.parentElement?.tagName).toBe('DIV');
+        expect(mutations).toEqual(['updated']);
+      });
+
+      test('Element subtree move preserves descendant DOM identities', async () => {
+        const {editor} = testEnv;
+        let elementKey = '';
+        let textKey = '';
+        await editor.update(() => {
+          const element = $createTestElementNode();
+          const text = $createTextNode('hello');
+          elementKey = element.getKey();
+          textKey = text.getKey();
+          element.append(text);
+          $getRoot().clear().append($createParagraphNode().append(element));
+        });
+
+        const elementDOMBefore = editor.getElementByKey(elementKey);
+        const textDOMBefore = editor.getElementByKey(textKey);
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const newParagraph = $createParagraphNode();
+          root.append(newParagraph);
+          const element = root
+            .getFirstChildOrThrow<ParagraphNode>()
+            .getFirstChildOrThrow<TestElementNode>();
+          newParagraph.append(element);
+        });
+
+        expect(editor.getElementByKey(elementKey)).toBe(elementDOMBefore);
+        expect(editor.getElementByKey(textKey)).toBe(textDOMBefore);
+      });
+
+      test('Multi-level nested subtree move preserves all descendant DOMs', async () => {
+        const {editor} = testEnv;
+        let outerKey = '';
+        let innerKey = '';
+        let leafKey = '';
+        await editor.update(() => {
+          const outer = $createTestElementNode();
+          const inner = $createTestElementNode();
+          const leaf = $createTextNode('leaf');
+          outerKey = outer.getKey();
+          innerKey = inner.getKey();
+          leafKey = leaf.getKey();
+          inner.append(leaf);
+          outer.append(inner);
+          $getRoot().clear().append($createParagraphNode().append(outer));
+        });
+
+        const outerDOMBefore = editor.getElementByKey(outerKey);
+        const innerDOMBefore = editor.getElementByKey(innerKey);
+        const leafDOMBefore = editor.getElementByKey(leafKey);
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const newParagraph = $createParagraphNode();
+          root.append(newParagraph);
+          const outer = root
+            .getFirstChildOrThrow<ParagraphNode>()
+            .getFirstChildOrThrow<TestElementNode>();
+          newParagraph.append(outer);
+        });
+
+        expect(editor.getElementByKey(outerKey)).toBe(outerDOMBefore);
+        expect(editor.getElementByKey(innerKey)).toBe(innerDOMBefore);
+        expect(editor.getElementByKey(leafKey)).toBe(leafDOMBefore);
+      });
+
+      test('Wrapping decorator emits a single "updated" listener event and re-decorates', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTestDecoratorNode()));
+        });
+
+        const decorateSpy = vi.spyOn(TestDecoratorNode.prototype, 'decorate');
+        const events: Array<{klass: string; mutation: NodeMutation}> = [];
+        const recordMutations =
+          (klass: string) => (nodes: Map<string, NodeMutation>) => {
+            for (const m of nodes.values()) {
+              events.push({klass, mutation: m});
+            }
+          };
+        editor.registerMutationListener(
+          TestDecoratorNode,
+          recordMutations('decorator'),
+          {skipInitialization: true},
+        );
+        editor.registerMutationListener(
+          TestElementNode,
+          recordMutations('element'),
+          {skipInitialization: true},
+        );
+
+        await editor.update(() => {
+          const decorator = $getRoot()
+            .getFirstChildOrThrow<ParagraphNode>()
+            .getFirstChildOrThrow<TestDecoratorNode>();
+          const wrapper = $createTestElementNode();
+          decorator.insertBefore(wrapper);
+          wrapper.append(decorator);
+        });
+
+        expect(events.filter(e => e.klass === 'decorator')).toEqual([
+          {klass: 'decorator', mutation: 'updated'},
+        ]);
+        expect(decorateSpy).toHaveBeenCalled();
+      });
+
+      test('Cross-parent swap with updateDOM=true does not throw', async () => {
+        // Two single-child paragraphs swap their decorator children, and one
+        // of the decorators also reports updateDOM=true (block flag flipped).
+        // Without a slot guard in $createNode's reuse branch, the prev=1/
+        // next=1 fast path would call $reconcileNode(key, null) and the
+        // updateDOM=true replacement path would hit a parentDOM=null
+        // invariant. With the guard, the reuse is skipped for slot=null
+        // call sites and the move falls back to the regular create path.
+        const {editor} = testEnv;
+        let keyA = '';
+        let keyB = '';
+        await editor.update(() => {
+          const a = $createTestDecoratorNode();
+          const b = $createTestDecoratorNode();
+          keyA = a.getKey();
+          keyB = b.getKey();
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append(a))
+            .append($createParagraphNode().append(b));
+        });
+
+        // Should not throw — slot=null call sites fall back to the regular
+        // create path when reuse would be unsafe.
+        await editor.update(() => {
+          const [pX, pY] = $getRoot().getChildren<ParagraphNode>();
+          const a = pX.getFirstChildOrThrow<TestDecoratorNode>();
+          const b = pY.getFirstChildOrThrow<TestDecoratorNode>();
+          a.setIsInline(false); // forces updateDOM=true on a
+          pY.append(a);
+          pX.append(b);
+        });
+
+        // Final structure: pX -> [b], pY -> [a (now block)]
+        expect(editor.getElementByKey(keyA)?.tagName).toBe('DIV');
+        expect(editor.getElementByKey(keyB)?.tagName).toBe('SPAN');
+      });
+
+      test('Same-parent reorder is unaffected by the reuse branch', async () => {
+        // Reordering siblings goes through the slow-path "Move next" branch,
+        // not $createNode. DOM identities for all reordered children must
+        // survive, regardless of the new reuse logic.
+        const {editor} = testEnv;
+        let keyA = '';
+        let keyB = '';
+        let keyC = '';
+        await editor.update(() => {
+          const a = $createParagraphNode().append($createTextNode('a'));
+          const b = $createParagraphNode().append($createTextNode('b'));
+          const c = $createParagraphNode().append($createTextNode('c'));
+          keyA = a.getKey();
+          keyB = b.getKey();
+          keyC = c.getKey();
+          $getRoot().clear().append(a, b, c);
+        });
+
+        const domA = editor.getElementByKey(keyA);
+        const domB = editor.getElementByKey(keyB);
+        const domC = editor.getElementByKey(keyC);
+
+        await editor.update(() => {
+          const root = $getRoot();
+          // Reorder [a, b, c] → [c, a, b] within the same parent.
+          const c = root.getLastChildOrThrow<ParagraphNode>();
+          c.remove();
+          root.getFirstChildOrThrow<ParagraphNode>().insertBefore(c);
+        });
+
+        expect(editor.getElementByKey(keyA)).toBe(domA);
+        expect(editor.getElementByKey(keyB)).toBe(domB);
+        expect(editor.getElementByKey(keyC)).toBe(domC);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

When a node moves to a different parent in the same transaction (for example, wrapping an image in a link via `$toggleLink`), the reconciler destroyed the old DOM and created a fresh one in the new parent. For `DecoratorNode` this swapped the React portal target, so `useDecorators` unmounted and remounted the rendered
component. On Safari this shows up as a 1-frame flicker for image links (#8420).

The same destroy-then-create produced a secondary symptom too: floating-UI plugins that measured the reference element during this window saw the wrapper span collapsed to its line-height, so the toolbar appeared at the wrong position on the first toggle.

## Fix

### Reconciler (`packages/lexical`)

`$createNode` now detects cross-parent moves by comparing `prevNode.__parent` to `node.__parent`. When they differ and the prev DOM is still in `activePrevKeyToDOMMap`, the existing DOM is reused and reconciled via `$reconcileNode` instead of being recreated. This keeps the DOM identity intact, which React portals and contentEditable selection both rely on. The reuse branch is gated on `slot !== null` so call sites that pass a null slot (used for in-place replacements) keep their existing behavior, and `$reconcileNode` is never invoked with `parentDOM=null`.

Supporting changes:

- `$destroyNode` short-circuits when the key still exists in `activeNextNodeMap` (the node moved). It only detaches from the old parent; mutation marking and child destruction are skipped. The mutation marker stays `'updated'`, since `setMutatedNode` already folded `'destroyed' + 'created'` to `'updated'`, and listeners that branch on mutation type now see a single event instead of a fold-pair.
- `$reconcileNode` re-evaluates element direction when `__parent` changes, because `$getReconciledDirection`'s implicit `'auto'` depends on the parent. Otherwise the reused DOM would keep its old `dir="auto"` after moving away from a root child.
- The `prev=1, next=1` fast path in `$reconcileChildren` falls back to `slot.insertChild` when `lastDOM` was reused inside `replacementDOM`. At that point `lastDOM.parentNode` is no longer the slot element, so `replaceChild` would throw.

### lexical-list (`packages/lexical-list`)

The reuse path exposed two latent fragilities in `ListItemNode`:

- `$setListItemThemeClassNames` now removes all variable theme classes (`listitemChecked`, `listitemUnchecked`, `nested.listitem`) before re-adding the ones that should be present. Previously, the className string only ended up in canonical order on a fresh `createDOM` call, since `classList.add` is a no-op for existing classes. After a list-type toggle (which reparents items), the reused DOM kept classes in their original insertion order.
- `updateListItemChecked` now sets `aria-checked` unconditionally inside the `isCheckbox` branch, mirroring `role` and `tabIndex`. The previous conditional only set the attribute when the node's own `__checked` changed, so a list item moved into a check list ended up missing `aria-checked`.

While #8420 is the immediate motivation, the change applies to all cross-parent moves, including drag/drop into a different paragraph, list indent/outdent, and list-type toggles.

## Test plan

- [x] `pnpm test-unit` — 2386 pass. New tests in
  `LexicalReconciler.test.ts` cover decorator reuse, multi-level
  element subtree reuse, the single-`'updated'` mutation event, the
  `slot !== null` guard via a cross-parent swap with
  `updateDOM=true`, and a same-parent reorder regression.
- [x] `pnpm test-e2e-chromium` — local run of `List.spec.mjs`
  passes the two scenarios that originally failed CI:
  - `Nested List > Can toggle format for multi-line list of each type without losing indentation state`
  - `Nested List > Can create check list, toggle it to bullet-list and back`
- [x] Manual playground (Safari + Chrome):
  - Image link wrap/unwrap (5x toggle): no flicker, single
    `'updated'` listener event.
  - Image drag and drop across paragraphs: image preserved, resize
    handles work.
  - List indent / outdent (`Tab` / `Shift+Tab` 5x): text and cursor
    preserved.
  - Image link undo / redo (5x, repeated with accumulated state):
    no DOM divergence.
  - Korean IME input followed by link toggle: no character loss.
  - Equation node wrapped in a link: no flicker.
- [x] CI e2e (chromium / firefox / webkit, including collab).

Fixes: #8420