### PR TITLE
[lexical-playground] Bug Fix: Prevent crash importing <details> with loose body content

### DIFF
--- a/packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts
@@ -53,7 +53,7 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             const children = (
               container as CollapsibleContainerNode
             ).getChildren();
-            expect(children.length).toBeGreaterThanOrEqual(2);
+            expect(children.length).toBe(2);
             expect($isCollapsibleTitleNode(children[0])).toBe(true);
             expect($isCollapsibleContentNode(children[1])).toBe(true);
             expect((children[0] as CollapsibleTitleNode).getTextContent()).toBe(
@@ -137,16 +137,18 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             const root = $getRoot();
             const container = root
               .getChildren()
-              .find($isCollapsibleContainerNode);
-            expect(container).toBeDefined();
-            for (const child of (
-              container as CollapsibleContainerNode
-            ).getChildren()) {
-              // No raw TextNode should appear directly under the shadow root.
-              expect(['collapsible-title', 'collapsible-content']).toContain(
-                child.getType(),
-              );
-            }
+              .find($isCollapsibleContainerNode) as CollapsibleContainerNode;
+            // The empty CollapsibleTitleNode created for missing <summary>
+            // is removed by CollapsibleTitleNode's $transform, leaving the
+            // body wrapped in a single CollapsibleContentNode. The crucial
+            // invariant is that no raw TextNode sits directly under the
+            // shadow root.
+            const children = container.getChildren();
+            expect(children.length).toBe(1);
+            expect($isCollapsibleContentNode(children[0])).toBe(true);
+            expect(
+              (children[0] as CollapsibleContentNode).getTextContent(),
+            ).toBe('Just some loose text');
           });
         });
 

--- a/packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts
@@ -9,7 +9,7 @@
 import {$generateNodesFromDOM} from '@lexical/html';
 import {$getRoot, $insertNodes} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
-import {describe, expect, it} from 'vitest';
+import {assert, describe, expect, it} from 'vitest';
 
 import {
   $isCollapsibleContainerNode,
@@ -49,23 +49,26 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             const container = root
               .getChildren()
               .find($isCollapsibleContainerNode);
-            expect(container).toBeDefined();
-            const children = (
-              container as CollapsibleContainerNode
-            ).getChildren();
+            assert(
+              container != null,
+              'CollapsibleContainerNode must be a child of RootNode',
+            );
+            const children = container.getChildren();
             expect(children.length).toBe(2);
-            expect($isCollapsibleTitleNode(children[0])).toBe(true);
-            expect($isCollapsibleContentNode(children[1])).toBe(true);
-            expect((children[0] as CollapsibleTitleNode).getTextContent()).toBe(
-              'Details',
+            assert(
+              $isCollapsibleTitleNode(children[0]),
+              'First child must be CollapsibleTitleNode',
             );
-            expect(
-              (children[1] as CollapsibleContentNode).getTextContent().trim(),
-            ).toBe('Something small enough to escape casual notice.');
+            assert(
+              $isCollapsibleContentNode(children[1]),
+              'Second child must be CollapsibleContentNode',
+            );
+            expect(children[0].getTextContent()).toBe('Details');
+            expect(children[1].getTextContent().trim()).toBe(
+              'Something small enough to escape casual notice.',
+            );
             // No `open` attribute on the source element should map to closed.
-            expect((container as CollapsibleContainerNode).getOpen()).toBe(
-              false,
-            );
+            expect(container.getOpen()).toBe(false);
           });
         });
 
@@ -85,7 +88,7 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             const root = $getRoot();
             const container = root
               .getChildren()
-              .find($isCollapsibleContainerNode) as CollapsibleContainerNode;
+              .find($isCollapsibleContainerNode)!;
             expect(container.getOpen()).toBe(true);
           });
         });
@@ -107,17 +110,19 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             const root = $getRoot();
             const container = root
               .getChildren()
-              .find($isCollapsibleContainerNode) as CollapsibleContainerNode;
+              .find($isCollapsibleContainerNode)!;
             const children = container.getChildren();
             expect(children.length).toBe(2);
-            expect($isCollapsibleTitleNode(children[0])).toBe(true);
-            expect($isCollapsibleContentNode(children[1])).toBe(true);
-            expect((children[0] as CollapsibleTitleNode).getTextContent()).toBe(
-              'Title',
+            assert(
+              $isCollapsibleTitleNode(children[0]),
+              'First child must be CollapsibleTitleNode',
             );
-            expect(
-              (children[1] as CollapsibleContentNode).getTextContent().trim(),
-            ).toBe('Body before');
+            assert(
+              $isCollapsibleContentNode(children[1]),
+              'Second child must be CollapsibleContentNode',
+            );
+            expect(children[0].getTextContent()).toBe('Title');
+            expect(children[1].getTextContent().trim()).toBe('Body before');
           });
         });
 
@@ -137,7 +142,7 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             const root = $getRoot();
             const container = root
               .getChildren()
-              .find($isCollapsibleContainerNode) as CollapsibleContainerNode;
+              .find($isCollapsibleContainerNode)!;
             // The empty CollapsibleTitleNode created for missing <summary>
             // is removed by CollapsibleTitleNode's $transform, leaving the
             // body wrapped in a single CollapsibleContentNode. The crucial
@@ -145,10 +150,11 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             // shadow root.
             const children = container.getChildren();
             expect(children.length).toBe(1);
-            expect($isCollapsibleContentNode(children[0])).toBe(true);
-            expect(
-              (children[0] as CollapsibleContentNode).getTextContent(),
-            ).toBe('Just some loose text');
+            assert(
+              $isCollapsibleContentNode(children[0]),
+              'Sole child must be CollapsibleContentNode',
+            );
+            expect(children[0].getTextContent()).toBe('Just some loose text');
           });
         });
 
@@ -169,15 +175,18 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             const root = $getRoot();
             const container = root
               .getChildren()
-              .find($isCollapsibleContainerNode) as CollapsibleContainerNode;
+              .find($isCollapsibleContainerNode)!;
             const children = container.getChildren();
             expect(children.length).toBe(2);
-            expect($isCollapsibleTitleNode(children[0])).toBe(true);
-            expect($isCollapsibleContentNode(children[1])).toBe(true);
-            const contentChildren = (
-              children[1] as CollapsibleContentNode
-            ).getChildren();
-            expect(contentChildren.length).toBe(2);
+            assert(
+              $isCollapsibleTitleNode(children[0]),
+              'First child must be CollapsibleTitleNode',
+            );
+            assert(
+              $isCollapsibleContentNode(children[1]),
+              'Second child must be CollapsibleContentNode',
+            );
+            expect(children[1].getChildren().length).toBe(2);
           });
         });
 
@@ -203,14 +212,17 @@ describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
             const root = $getRoot();
             const container = root
               .getChildren()
-              .find($isCollapsibleContainerNode);
-            expect(container).toBeDefined();
-            const children = (
-              container as CollapsibleContainerNode
-            ).getChildren();
+              .find($isCollapsibleContainerNode)!;
+            const children = container.getChildren();
             expect(children.length).toBe(2);
-            expect($isCollapsibleTitleNode(children[0])).toBe(true);
-            expect($isCollapsibleContentNode(children[1])).toBe(true);
+            assert(
+              $isCollapsibleTitleNode(children[0]),
+              'First child must be CollapsibleTitleNode',
+            );
+            assert(
+              $isCollapsibleContentNode(children[1]),
+              'Second child must be CollapsibleContentNode',
+            );
           });
         });
       });

--- a/packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$generateNodesFromDOM} from '@lexical/html';
+import {$getRoot, $insertNodes} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
+
+import {
+  $isCollapsibleContainerNode,
+  CollapsibleContainerNode,
+} from '../../src/plugins/CollapsibleExtension/CollapsibleContainerNode';
+import {
+  $isCollapsibleContentNode,
+  CollapsibleContentNode,
+} from '../../src/plugins/CollapsibleExtension/CollapsibleContentNode';
+import {
+  $isCollapsibleTitleNode,
+  CollapsibleTitleNode,
+} from '../../src/plugins/CollapsibleExtension/CollapsibleTitleNode';
+
+describe('CollapsibleContainerNode HTML import (issue #8407)', () => {
+  initializeUnitTest(
+    testEnv => {
+      describe('importDOM', () => {
+        it('imports <details> with loose text body without crashing', async () => {
+          const {editor} = testEnv;
+          const parser = new DOMParser();
+          const htmlString =
+            '<details>\n' +
+            '  <summary>Details</summary>\n' +
+            '  Something small enough to escape casual notice.\n' +
+            '</details>';
+          const dom = parser.parseFromString(htmlString, 'text/html');
+
+          await editor.update(() => {
+            const nodes = $generateNodesFromDOM(editor, dom);
+            $getRoot().select();
+            $insertNodes(nodes);
+          });
+
+          editor.read(() => {
+            const root = $getRoot();
+            const container = root
+              .getChildren()
+              .find($isCollapsibleContainerNode);
+            expect(container).toBeDefined();
+            const children = (
+              container as CollapsibleContainerNode
+            ).getChildren();
+            expect(children.length).toBeGreaterThanOrEqual(2);
+            expect($isCollapsibleTitleNode(children[0])).toBe(true);
+            expect($isCollapsibleContentNode(children[1])).toBe(true);
+            expect((children[0] as CollapsibleTitleNode).getTextContent()).toBe(
+              'Details',
+            );
+            expect(
+              (children[1] as CollapsibleContentNode).getTextContent().trim(),
+            ).toBe('Something small enough to escape casual notice.');
+            // No `open` attribute on the source element should map to closed.
+            expect((container as CollapsibleContainerNode).getOpen()).toBe(
+              false,
+            );
+          });
+        });
+
+        it('preserves the open attribute on import', async () => {
+          const {editor} = testEnv;
+          const parser = new DOMParser();
+          const htmlString = '<details open><summary>S</summary>body</details>';
+          const dom = parser.parseFromString(htmlString, 'text/html');
+
+          await editor.update(() => {
+            const nodes = $generateNodesFromDOM(editor, dom);
+            $getRoot().select();
+            $insertNodes(nodes);
+          });
+
+          editor.read(() => {
+            const root = $getRoot();
+            const container = root
+              .getChildren()
+              .find($isCollapsibleContainerNode) as CollapsibleContainerNode;
+            expect(container.getOpen()).toBe(true);
+          });
+        });
+
+        it('handles <summary> appearing after body content', async () => {
+          const {editor} = testEnv;
+          const parser = new DOMParser();
+          const htmlString =
+            '<details><p>Body before</p><summary>Title</summary></details>';
+          const dom = parser.parseFromString(htmlString, 'text/html');
+
+          await editor.update(() => {
+            const nodes = $generateNodesFromDOM(editor, dom);
+            $getRoot().select();
+            $insertNodes(nodes);
+          });
+
+          editor.read(() => {
+            const root = $getRoot();
+            const container = root
+              .getChildren()
+              .find($isCollapsibleContainerNode) as CollapsibleContainerNode;
+            const children = container.getChildren();
+            expect(children.length).toBe(2);
+            expect($isCollapsibleTitleNode(children[0])).toBe(true);
+            expect($isCollapsibleContentNode(children[1])).toBe(true);
+            expect((children[0] as CollapsibleTitleNode).getTextContent()).toBe(
+              'Title',
+            );
+            expect(
+              (children[1] as CollapsibleContentNode).getTextContent().trim(),
+            ).toBe('Body before');
+          });
+        });
+
+        it('imports <details> with no <summary> without crashing', async () => {
+          const {editor} = testEnv;
+          const parser = new DOMParser();
+          const htmlString = '<details>Just some loose text</details>';
+          const dom = parser.parseFromString(htmlString, 'text/html');
+
+          await editor.update(() => {
+            const nodes = $generateNodesFromDOM(editor, dom);
+            $getRoot().select();
+            $insertNodes(nodes);
+          });
+
+          editor.read(() => {
+            const root = $getRoot();
+            const container = root
+              .getChildren()
+              .find($isCollapsibleContainerNode);
+            expect(container).toBeDefined();
+            for (const child of (
+              container as CollapsibleContainerNode
+            ).getChildren()) {
+              // No raw TextNode should appear directly under the shadow root.
+              expect(['collapsible-title', 'collapsible-content']).toContain(
+                child.getType(),
+              );
+            }
+          });
+        });
+
+        it('imports <details> with summary and block body siblings', async () => {
+          const {editor} = testEnv;
+          const parser = new DOMParser();
+          const htmlString =
+            '<details><summary>Title</summary><p>Para one.</p><p>Para two.</p></details>';
+          const dom = parser.parseFromString(htmlString, 'text/html');
+
+          await editor.update(() => {
+            const nodes = $generateNodesFromDOM(editor, dom);
+            $getRoot().select();
+            $insertNodes(nodes);
+          });
+
+          editor.read(() => {
+            const root = $getRoot();
+            const container = root
+              .getChildren()
+              .find($isCollapsibleContainerNode) as CollapsibleContainerNode;
+            const children = container.getChildren();
+            expect(children.length).toBe(2);
+            expect($isCollapsibleTitleNode(children[0])).toBe(true);
+            expect($isCollapsibleContentNode(children[1])).toBe(true);
+            const contentChildren = (
+              children[1] as CollapsibleContentNode
+            ).getChildren();
+            expect(contentChildren.length).toBe(2);
+          });
+        });
+
+        it('imports <details> with element body (round-trip shape)', async () => {
+          const {editor} = testEnv;
+          const parser = new DOMParser();
+          const htmlString =
+            '<details open="true" class="Collapsible__container">' +
+            '<summary class="Collapsible__title">Title</summary>' +
+            '<div class="Collapsible__content" data-lexical-collapsible-content="true">' +
+            '<p>Body</p>' +
+            '</div>' +
+            '</details>';
+          const dom = parser.parseFromString(htmlString, 'text/html');
+
+          await editor.update(() => {
+            const nodes = $generateNodesFromDOM(editor, dom);
+            $getRoot().select();
+            $insertNodes(nodes);
+          });
+
+          editor.read(() => {
+            const root = $getRoot();
+            const container = root
+              .getChildren()
+              .find($isCollapsibleContainerNode);
+            expect(container).toBeDefined();
+            const children = (
+              container as CollapsibleContainerNode
+            ).getChildren();
+            expect(children.length).toBe(2);
+            expect($isCollapsibleTitleNode(children[0])).toBe(true);
+            expect($isCollapsibleContentNode(children[1])).toBe(true);
+          });
+        });
+      });
+    },
+    {
+      nodes: [
+        CollapsibleContainerNode,
+        CollapsibleContentNode,
+        CollapsibleTitleNode,
+      ],
+    },
+  );
+});

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
@@ -30,6 +30,7 @@ import {
 import {
   $createCollapsibleContentNode,
   $isCollapsibleContentNode,
+  CollapsibleContentNode,
 } from './CollapsibleContentNode';
 import {
   $createCollapsibleTitleNode,
@@ -59,15 +60,22 @@ export function $convertDetailsElement(
       // expected structure so the editor doesn't end up with TextNodes
       // directly under the shadow root.
       let titleNode: CollapsibleTitleNode | null = null;
+      let contentNode: CollapsibleContentNode | null = null;
       const bodyNodes: LexicalNode[] = [];
       for (const child of childLexicalNodes) {
         if (titleNode === null && $isCollapsibleTitleNode(child)) {
           titleNode = child;
         } else if ($isCollapsibleContentNode(child)) {
-          // Lexical-exported markup wraps the body in a CollapsibleContentNode;
-          // unwrap so we can rebuild a single canonical content node.
-          for (const grandchild of child.getChildren()) {
-            bodyNodes.push(grandchild);
+          if (contentNode === null) {
+            // Lexical-exported markup wraps the body in a
+            // CollapsibleContentNode; reuse it instead of rebuilding.
+            contentNode = child;
+          } else {
+            // Multiple content nodes (rare): fold the extras into bodyNodes
+            // so they get appended to the canonical one below.
+            for (const grandchild of child.getChildren()) {
+              bodyNodes.push(grandchild);
+            }
           }
         } else {
           bodyNodes.push(child);
@@ -76,7 +84,9 @@ export function $convertDetailsElement(
       if (titleNode === null) {
         titleNode = $createCollapsibleTitleNode();
       }
-      const contentNode = $createCollapsibleContentNode();
+      if (contentNode === null) {
+        contentNode = $createCollapsibleContentNode();
+      }
       // CollapsibleContentNode is also a shadow root, so wrap any inline
       // siblings in a paragraph before appending.
       let pending: LexicalNode[] = [];

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
@@ -8,7 +8,9 @@
 
 import {IS_CHROME, IS_FIREFOX} from '@lexical/utils';
 import {
+  $createParagraphNode,
   $getSiblingCaret,
+  $isBlockElementNode,
   $isElementNode,
   $rewindSiblingCaret,
   DOMConversionMap,
@@ -25,6 +27,15 @@ import {
   Spread,
 } from 'lexical';
 
+import {
+  $createCollapsibleContentNode,
+  $isCollapsibleContentNode,
+} from './CollapsibleContentNode';
+import {
+  $createCollapsibleTitleNode,
+  $isCollapsibleTitleNode,
+  CollapsibleTitleNode,
+} from './CollapsibleTitleNode';
 import {setDomHiddenUntilFound} from './CollapsibleUtils';
 
 type SerializedCollapsibleContainerNode = Spread<
@@ -40,6 +51,55 @@ export function $convertDetailsElement(
   const isOpen = domNode.open !== undefined ? domNode.open : true;
   const node = $createCollapsibleContainerNode(isOpen);
   return {
+    after: childLexicalNodes => {
+      // CollapsibleContainerNode is a shadow root that requires exactly two
+      // children: a CollapsibleTitleNode (from <summary>) followed by a
+      // CollapsibleContentNode. Arbitrary <details> markup may include loose
+      // text or block siblings; reshape the imported children into the
+      // expected structure so the editor doesn't end up with TextNodes
+      // directly under the shadow root.
+      let titleNode: CollapsibleTitleNode | null = null;
+      const bodyNodes: LexicalNode[] = [];
+      for (const child of childLexicalNodes) {
+        if (titleNode === null && $isCollapsibleTitleNode(child)) {
+          titleNode = child;
+        } else if ($isCollapsibleContentNode(child)) {
+          // Lexical-exported markup wraps the body in a CollapsibleContentNode;
+          // unwrap so we can rebuild a single canonical content node.
+          for (const grandchild of child.getChildren()) {
+            bodyNodes.push(grandchild);
+          }
+        } else {
+          bodyNodes.push(child);
+        }
+      }
+      if (titleNode === null) {
+        titleNode = $createCollapsibleTitleNode();
+      }
+      const contentNode = $createCollapsibleContentNode();
+      // CollapsibleContentNode is also a shadow root, so wrap any inline
+      // siblings in a paragraph before appending.
+      let pending: LexicalNode[] = [];
+      const flushPending = () => {
+        if (pending.length === 0) {
+          return;
+        }
+        const paragraph = $createParagraphNode();
+        paragraph.append(...pending);
+        contentNode.append(paragraph);
+        pending = [];
+      };
+      for (const body of bodyNodes) {
+        if ($isBlockElementNode(body)) {
+          flushPending();
+          contentNode.append(body);
+        } else {
+          pending.push(body);
+        }
+      }
+      flushPending();
+      return [titleNode, contentNode];
+    },
     node,
   };
 }


### PR DESCRIPTION
## Description

Closes #8407.

The playground's `<details>` importer (`$convertDetailsElement`) returned a bare `CollapsibleContainerNode`. Because that node is a shadow root, lexical-html's traversal could leave loose text or non-summary elements as direct children, producing a malformed tree that crashed downstream rendering with `Only element or decorator nodes can be inserted in to the root node`.

The fix adds an `after` callback that reshapes the imported children into the canonical `[CollapsibleTitleNode, CollapsibleContentNode]` structure. Loose inline siblings inside the content are wrapped in a `ParagraphNode` since `CollapsibleContentNode` is also a shadow root. Round-trip imports of lexical-exported markup produce the same tree.

Scope is strictly the playground's `CollapsibleExtension`, per the maintainer's triage on the issue.

## Test plan

- New unit suite `packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts` covers: loose text body, `open` attribute preservation, summary-after-content ordering, no-summary input, multi-paragraph body, round-trip shape.
- Full unit suite (3004 tests) passes.
- `pnpm run prettier` / `pnpm run tsc` / `pnpm run lint` all clean.

### Before

Pasting the issue's HTML and switching back to wysiwyg crashed the editor with `Only element or decorator nodes can be inserted in to the root node`.

### After

Imports as a working Details widget with the canonical structure:

\`\`\`
root
└ collapsible-container
  ├ collapsible-title
  │ └ text "Details"
  └ collapsible-content
    └ paragraph
      └ text "Something small enough to escape casual notice."
\`\`\`

No console errors; expanding the disclosure shows the body content.