### PR TITLE
[lexical-code-shiki] Feature: Multi-theme / CSS-variable color mode

### DIFF
--- a/packages/lexical-code-shiki/flow/LexicalCodeShiki.js.flow
+++ b/packages/lexical-code-shiki/flow/LexicalCodeShiki.js.flow
@@ -18,6 +18,17 @@ import type {CodeNode} from '@lexical/code';
  * LexicalCodeShiki
  */
 
+export type ShikiThemeDef = string | {light: string, dark: string};
+export type ShikiThemeSpec =
+  | ShikiThemeDef
+  | ((codeNode: CodeNode) => ShikiThemeDef);
+export type ShikiThemeContext = {
+  themes: {[name: string]: ShikiThemeSpec},
+  defaultTheme: string,
+  resolveTheme: (codeNode: CodeNode) => ShikiThemeDef,
+};
+
+/** @deprecated Provide CodeShikiConfig.defaultLanguage and $tokenize directly. */
 export type Tokenizer = {
   defaultLanguage: string;
   defaultTheme: string;
@@ -25,7 +36,15 @@ export type Tokenizer = {
 }
 export type CodeShikiConfig = {
   disabled: boolean,
-  tokenizer: Tokenizer,
+  defaultLanguage: string,
+  $tokenize: (
+    codeNode: CodeNode,
+    lang: string,
+    themeContext: ShikiThemeContext,
+  ) => LexicalNode[],
+  themes: {[name: string]: ShikiThemeSpec},
+  defaultTheme: string,
+  tokenizer: Tokenizer | null,
 };
 declare export var ShikiTokenizer: Tokenizer;
 declare export var CodeShikiExtension: LexicalExtension<CodeShikiConfig, "@lexical/code-shiki", NamedSignalsOutput<CodeShikiConfig>, void>;

--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -31,6 +31,7 @@ import {
   defineExtension,
   mergeRegister,
   safeCast,
+  shallowMergeConfig,
   TextNode,
 } from 'lexical';
 
@@ -42,6 +43,42 @@ import {
   loadCodeTheme,
 } from './FacadeShiki';
 
+/**
+ * A Shiki theme. A bare string is a single theme id and renders inline
+ * as the `color` / `background-color` style. A `{light, dark}` pair
+ * renders as `--shiki-light` / `--shiki-dark` CSS variables with no
+ * inline color, so the consuming page's CSS picks the active scheme.
+ */
+export type ShikiThemeDef = string | {light: string; dark: string};
+
+/**
+ * A registry entry. Either a static {@link ShikiThemeDef} or a function
+ * that resolves to one for a given code node, allowing per-node theme
+ * decisions at runtime.
+ */
+export type ShikiThemeSpec =
+  | ShikiThemeDef
+  | ((codeNode: CodeNode) => ShikiThemeDef);
+
+/**
+ * The theme context handed to {@link CodeShikiConfig.$tokenize}. Holds
+ * the registry, the active default key, and a `resolveTheme` helper
+ * that picks the right entry for a given code node (per-node
+ * `__theme` first, {@link defaultTheme} fallback, raw Shiki id with a
+ * dev warning for keys missing from the registry).
+ */
+export interface ShikiThemeContext {
+  themes: Record<string, ShikiThemeSpec>;
+  defaultTheme: string;
+  resolveTheme(codeNode: CodeNode): ShikiThemeDef;
+}
+
+/**
+ * @deprecated Provide {@link CodeShikiConfig.defaultLanguage} and
+ * {@link CodeShikiConfig.$tokenize} directly. Kept exported for
+ * backward compatibility with {@link CodeHighlighterShikiExtension} and
+ * existing direct callers of {@link registerCodeHighlighting}.
+ */
 export interface Tokenizer {
   defaultLanguage: string;
   defaultTheme: string;
@@ -53,6 +90,7 @@ export interface Tokenizer {
 }
 
 const DEFAULT_CODE_THEME = 'one-light';
+const DEFAULT_THEME_KEY = 'default';
 
 export const ShikiTokenizer: Tokenizer = {
   $tokenize(
@@ -60,15 +98,73 @@ export const ShikiTokenizer: Tokenizer = {
     codeNode: CodeNode,
     language?: string,
   ): LexicalNode[] {
-    return $getHighlightNodes(codeNode, language || this.defaultLanguage);
+    // Honor the per-node `__theme` override before falling back to the
+    // tokenizer's default. Mirrors the historical behavior of the
+    // pre-multi-theme `$getHighlightNodes` (`codeNode.getTheme() || theme`)
+    // so legacy `registerCodeHighlighting` callers and
+    // `CodeHighlighterShikiExtension` users with custom tokenizers keep
+    // working when a code node carries a per-node theme.
+    return $getHighlightNodes(
+      codeNode,
+      language || this.defaultLanguage,
+      codeNode.getTheme() || this.defaultTheme,
+    );
   },
   defaultLanguage: DEFAULT_CODE_LANGUAGE,
   defaultTheme: DEFAULT_CODE_THEME,
 };
 
+function createThemeContext(
+  themes: Record<string, ShikiThemeSpec>,
+  defaultTheme: string,
+): ShikiThemeContext {
+  // Dedupe missing-key warnings per (editor instance, theme key). Without
+  // this the warn fires once per transform invocation, which on a long
+  // document with N code nodes turns into N warnings per edit.
+  const warnedKeys = new Set<string>();
+  return {
+    defaultTheme,
+    resolveTheme(codeNode) {
+      const themeKey = codeNode.getTheme() || defaultTheme;
+      const spec = themes[themeKey];
+      if (spec === undefined) {
+        if (!warnedKeys.has(themeKey)) {
+          warnedKeys.add(themeKey);
+          console.warn(
+            `[lexical-code-shiki] Theme "${themeKey}" is not in CodeShikiConfig.themes; treating it as a raw Shiki theme id. Add it to the registry for explicit registration.`,
+          );
+        }
+        return themeKey;
+      }
+      return typeof spec === 'function' ? spec(codeNode) : spec;
+    },
+    themes,
+  };
+}
+
+function $defaultShikiTokenize(
+  codeNode: CodeNode,
+  lang: string,
+  themeContext: ShikiThemeContext,
+): LexicalNode[] {
+  return $getHighlightNodes(
+    codeNode,
+    lang,
+    themeContext.resolveTheme(codeNode),
+  );
+}
+
+type TokenizeFn = (
+  codeNode: CodeNode,
+  lang: string,
+  themeContext: ShikiThemeContext,
+) => LexicalNode[];
+
 function $textNodeTransform(
   editor: LexicalEditor,
-  tokenizer: Tokenizer,
+  tokenize: TokenizeFn,
+  defaultLanguage: string,
+  themeContext: ShikiThemeContext,
   transformState: TransformState,
   node: TextNode,
 ): void {
@@ -76,7 +172,14 @@ function $textNodeTransform(
   // if node's parent is a code node and run highlighting if so
   const parentNode = node.getParent();
   if ($isCodeNode(parentNode)) {
-    $codeNodeTransform(editor, tokenizer, transformState, parentNode);
+    $codeNodeTransform(
+      editor,
+      tokenize,
+      defaultLanguage,
+      themeContext,
+      transformState,
+      parentNode,
+    );
   } else if ($isCodeHighlightNode(node)) {
     // When code block converted into paragraph or other element
     // code highlight nodes converted back to normal text
@@ -119,7 +222,9 @@ interface TransformState {
 
 function $codeNodeTransform(
   editor: LexicalEditor,
-  tokenizer: Tokenizer,
+  tokenize: TokenizeFn,
+  defaultLanguage: string,
+  themeContext: ShikiThemeContext,
   transformState: TransformState,
   node: CodeNode,
 ) {
@@ -129,21 +234,24 @@ function $codeNodeTransform(
   // When new code block inserted it might not have language selected
   let language = node.getLanguage();
   if (!language) {
-    language = tokenizer.defaultLanguage;
+    language = defaultLanguage;
     node.setLanguage(language);
   }
 
-  let theme = node.getTheme();
-  if (!theme) {
-    theme = tokenizer.defaultTheme;
-    node.setTheme(theme);
-  }
-
-  // dynamic import of themes
+  // Resolve the theme spec for this node and ensure all underlying
+  // Shiki themes are loaded. The registry may produce either a single
+  // theme id (inline path) or a `{light, dark}` pair (vars-only path).
   let inFlight = false;
-  if (!isCodeThemeLoaded(theme)) {
-    loadCodeTheme(theme, editor, nodeKey);
-    inFlight = true;
+  const resolvedSpec = themeContext.resolveTheme(node);
+  const themeIdsToLoad =
+    typeof resolvedSpec === 'string'
+      ? [resolvedSpec]
+      : [resolvedSpec.light, resolvedSpec.dark];
+  for (const themeId of themeIdsToLoad) {
+    if (!isCodeThemeLoaded(themeId)) {
+      loadCodeTheme(themeId, editor, nodeKey);
+      inFlight = true;
+    }
   }
 
   // dynamic import of languages
@@ -183,8 +291,8 @@ function $codeNodeTransform(
       return false;
     }
 
-    const lang = currentNode.getLanguage() || tokenizer.defaultLanguage;
-    const highlightNodes = tokenizer.$tokenize(currentNode, lang);
+    const lang = currentNode.getLanguage() || defaultLanguage;
+    const highlightNodes = tokenize(currentNode, lang, themeContext);
     const diffRange = getDiffRange(currentNode.getChildren(), highlightNodes);
     const {from, to, nodesForReplacement} = diffRange;
 
@@ -343,7 +451,9 @@ function isEqual(nodeA: LexicalNode, nodeB: LexicalNode): boolean {
  */
 export function registerHighlightingOnly(
   editor: LexicalEditor,
-  tokenizer: Tokenizer,
+  tokenize: TokenizeFn,
+  defaultLanguage: string,
+  themeContext: ShikiThemeContext,
 ): () => void {
   const registrations = [];
 
@@ -376,15 +486,36 @@ export function registerHighlightingOnly(
   registrations.push(
     editor.registerNodeTransform(
       CodeNode,
-      $codeNodeTransform.bind(null, editor, tokenizer, transformState),
+      $codeNodeTransform.bind(
+        null,
+        editor,
+        tokenize,
+        defaultLanguage,
+        themeContext,
+        transformState,
+      ),
     ),
     editor.registerNodeTransform(
       TextNode,
-      $textNodeTransform.bind(null, editor, tokenizer, transformState),
+      $textNodeTransform.bind(
+        null,
+        editor,
+        tokenize,
+        defaultLanguage,
+        themeContext,
+        transformState,
+      ),
     ),
     editor.registerNodeTransform(
       CodeHighlightNode,
-      $textNodeTransform.bind(null, editor, tokenizer, transformState),
+      $textNodeTransform.bind(
+        null,
+        editor,
+        tokenize,
+        defaultLanguage,
+        themeContext,
+        transformState,
+      ),
     ),
   );
 
@@ -406,8 +537,22 @@ export function registerCodeHighlighting(
       'CodeHighlightPlugin: CodeNode or CodeHighlightNode not registered on editor',
     );
   }
+  // Wrap the legacy `Tokenizer` shape into the new tokenize signature.
+  // The legacy `defaultTheme` is mapped to a singleton registry so per-
+  // node `__theme` resolution still works the same way.
+  const $tokenize: TokenizeFn = (codeNode, lang, _themeContext) =>
+    tokenizer.$tokenize(codeNode, lang);
+  const themeContext = createThemeContext(
+    {[DEFAULT_THEME_KEY]: tokenizer.defaultTheme},
+    DEFAULT_THEME_KEY,
+  );
   return mergeRegister(
-    registerHighlightingOnly(editor, tokenizer),
+    registerHighlightingOnly(
+      editor,
+      $tokenize,
+      tokenizer.defaultLanguage,
+      themeContext,
+    ),
     registerCodeIndentation(editor),
   );
 }
@@ -420,7 +565,70 @@ export interface CodeShikiConfig {
    * highlighters without rebuilding the editor.
    */
   disabled: boolean;
-  tokenizer: Tokenizer;
+  /**
+   * The default language for code blocks that have no explicit language
+   * set. Applied via {@link CodeNode.setLanguage} on first transform.
+   *
+   * Top-level wins over the deprecated {@link tokenizer}'s
+   * `defaultLanguage`; the legacy value is consulted only when this
+   * field equals the framework default (`@lexical/code-core`'s
+   * `DEFAULT_CODE_LANGUAGE`). Setting this field to the framework
+   * default value alongside a legacy tokenizer with a custom
+   * `defaultLanguage` will silently route through the tokenizer's
+   * value — prefer setting this field directly to avoid the footgun.
+   */
+  defaultLanguage: string;
+  /**
+   * Tokenize function. Receives a code node, the resolved language, and
+   * a {@link ShikiThemeContext}. The default implementation reads the
+   * per-node theme via `themeContext.resolveTheme(codeNode)` and
+   * dispatches: a string spec renders inline (single theme), a
+   * `{light, dark}` spec renders as CSS variables (multi-theme,
+   * vars-only).
+   *
+   * Top-level wins over the deprecated {@link tokenizer}'s `$tokenize`;
+   * the legacy implementation is consulted only when this field is the
+   * exact `$defaultShikiTokenize` reference. Replacing the reference
+   * with a structurally identical function disables the BC fallback.
+   */
+  $tokenize: TokenizeFn;
+  /**
+   * Registry of theme specs keyed by string. Per-node `__theme` and the
+   * top-level {@link defaultTheme} are looked up here.
+   *
+   * Static entries are either a single Shiki theme id (rendered inline)
+   * or a `{light, dark}` pair (rendered as `--shiki-light` /
+   * `--shiki-dark` CSS variables, no inline color). Function entries
+   * `(codeNode) => ShikiThemeDef` resolve at tokenize time, allowing
+   * per-node decisions.
+   */
+  themes: Record<string, ShikiThemeSpec>;
+  /**
+   * Default registry key. Used when a code node's per-node `__theme` is
+   * unset. Should be a key of {@link themes}; unknown keys fall back to
+   * being treated as a raw Shiki theme id with a development warning.
+   */
+  defaultTheme: string;
+  /**
+   * @deprecated Provide {@link defaultLanguage} and {@link $tokenize}
+   * directly on the config. Kept for backward compatibility with the
+   * legacy {@link CodeHighlighterShikiExtension} wrapper.
+   */
+  tokenizer: Tokenizer | null;
+}
+
+function mergeShikiConfig(
+  config: CodeShikiConfig,
+  overrides: Partial<CodeShikiConfig>,
+): CodeShikiConfig {
+  const merged = shallowMergeConfig(config, overrides);
+  // `themes` is a registry. Without a deep merge, two `configExtension(...)`
+  // calls each contributing different theme keys would have the second
+  // wholesale replace the first.
+  if (overrides.themes) {
+    merged.themes = {...config.themes, ...overrides.themes};
+  }
+  return merged;
 }
 
 /**
@@ -435,10 +643,15 @@ export interface CodeShikiConfig {
 export const CodeShikiExtension = defineExtension({
   build: (editor, config) => namedSignals(config),
   config: safeCast<CodeShikiConfig>({
+    $tokenize: $defaultShikiTokenize,
+    defaultLanguage: DEFAULT_CODE_LANGUAGE,
+    defaultTheme: DEFAULT_THEME_KEY,
     disabled: false,
-    tokenizer: ShikiTokenizer,
+    themes: {[DEFAULT_THEME_KEY]: DEFAULT_CODE_THEME},
+    tokenizer: null,
   }),
   dependencies: [CodeExtension, CodeIndentExtension],
+  mergeConfig: mergeShikiConfig,
   name: '@lexical/code-shiki',
   register: (editor, config, state) => {
     const stores = state.getOutput();
@@ -446,7 +659,39 @@ export const CodeShikiExtension = defineExtension({
       if (stores.disabled.value) {
         return;
       }
-      return registerHighlightingOnly(editor, stores.tokenizer.value);
+      const themes = stores.themes.value;
+      const defaultTheme = stores.defaultTheme.value;
+      const userDefaultLanguage = stores.defaultLanguage.value;
+      const userTokenize = stores.$tokenize.value;
+      const tokenizer = stores.tokenizer.value;
+
+      // BC routing: top-level `$tokenize` always wins. If the user only
+      // supplied a legacy `tokenizer` (top-level `$tokenize` is still
+      // the framework default), route through that tokenizer.
+      const tokenize: TokenizeFn =
+        userTokenize !== $defaultShikiTokenize
+          ? userTokenize
+          : tokenizer
+            ? (codeNode, lang, _ctx) => tokenizer.$tokenize(codeNode, lang)
+            : $defaultShikiTokenize;
+
+      // Same identity-equality fallback for `defaultLanguage`. Top-level
+      // wins; the legacy tokenizer's value only applies when top-level
+      // is still at the framework default.
+      const defaultLanguage =
+        userDefaultLanguage !== DEFAULT_CODE_LANGUAGE
+          ? userDefaultLanguage
+          : tokenizer
+            ? tokenizer.defaultLanguage
+            : userDefaultLanguage;
+
+      const themeContext = createThemeContext(themes, defaultTheme);
+      return registerHighlightingOnly(
+        editor,
+        tokenize,
+        defaultLanguage,
+        themeContext,
+      );
     });
   },
 });
@@ -474,7 +719,8 @@ export const CodeHighlighterShikiExtension = defineExtension({
   dependencies: [CodeShikiExtension],
   init: (editorConfig, config, state) => {
     // Forward the flat Tokenizer config to CodeShikiExtension's `tokenizer`
-    // field before it builds.
+    // field before it builds. Top-level `defaultLanguage` and `$tokenize`
+    // routing then picks up the legacy values via the BC fallback.
     state.getDependency(CodeShikiExtension).config.tokenizer = config;
   },
   name: '@lexical/code-shiki/legacy',

--- a/packages/lexical-code-shiki/src/FacadeShiki.ts
+++ b/packages/lexical-code-shiki/src/FacadeShiki.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import type {ShikiThemeDef} from './CodeHighlighterShiki';
 import type {CodeNode} from '@lexical/code-core';
 import type {ThemedToken, TokensResult} from '@shikijs/types';
 import type {LexicalEditor, LexicalNode, NodeKey} from 'lexical';
@@ -138,21 +139,39 @@ export function normalizeCodeLanguage(language: string): string {
 export function $getHighlightNodes(
   codeNode: CodeNode,
   language: string,
+  themeSpec: ShikiThemeDef,
 ): LexicalNode[] {
   const DIFF_LANGUAGE_REGEX = /^diff-([\w-]+)/i;
   const diffLanguageMatch = DIFF_LANGUAGE_REGEX.exec(language);
   const code: string = codeNode.getTextContent();
-  const tokensResult: TokensResult = shiki.codeToTokens(code, {
-    lang: diffLanguageMatch ? diffLanguageMatch[1] : language,
-    theme: codeNode.getTheme() || 'poimandres',
-  });
-  const {tokens, bg, fg} = tokensResult;
+  const lang = diffLanguageMatch ? diffLanguageMatch[1] : language;
+  // String spec: inline single-theme path. Shiki returns a single-theme
+  // tokensResult with `bg` / `fg` strings.
+  // Object spec ({light, dark}): multi-theme vars-only path. Shiki
+  // populates `rootStyle` with `--shiki-light(-bg)` / `--shiki-dark(-bg)`
+  // CSS variables, no inline color, and the consuming page's CSS owns
+  // the active scheme.
+  const tokensResult: TokensResult =
+    typeof themeSpec === 'string'
+      ? shiki.codeToTokens(code, {lang, theme: themeSpec})
+      : shiki.codeToTokens(code, {
+          defaultColor: false,
+          lang,
+          themes: themeSpec,
+        });
+  const {tokens, bg, fg, rootStyle} = tokensResult;
   let style = '';
-  if (bg) {
-    style += `background-color: ${bg};`;
-  }
-  if (fg) {
-    style += `color: ${fg};`;
+  if (rootStyle) {
+    // Set only on the multi-theme path; bg/fg are variable lists, not
+    // values that could be appended to `background-color: ${bg}`.
+    style = rootStyle;
+  } else {
+    if (bg) {
+      style += `background-color: ${bg};`;
+    }
+    if (fg) {
+      style += `color: ${fg};`;
+    }
   }
   if (codeNode.getStyle() !== style) {
     codeNode.setStyle(style);

--- a/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeShikiMultiTheme.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeShikiMultiTheme.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createCodeNode, $isCodeNode} from '@lexical/code';
+import {
+  CodeHighlighterShikiExtension,
+  CodeShikiExtension,
+  isCodeLanguageLoaded,
+  loadCodeLanguage,
+  loadCodeTheme,
+  ShikiTokenizer,
+} from '@lexical/code-shiki';
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {$createTextNode, $getRoot, $isTextNode, configExtension} from 'lexical';
+import {assert, beforeAll, describe, expect, test} from 'vitest';
+
+import {isCodeThemeLoaded} from '../../FacadeShiki';
+
+const LIGHT_THEME = 'one-light';
+const DARK_THEME = 'one-dark-pro';
+
+function $populateCodeBlock(): void {
+  const codeNode = $createCodeNode();
+  codeNode.append($createTextNode('const x = 1;'));
+  $getRoot().clear().append(codeNode);
+}
+
+describe('Shiki multi-theme color mode', () => {
+  beforeAll(async () => {
+    await loadCodeLanguage(ShikiTokenizer.defaultLanguage);
+    expect(isCodeLanguageLoaded(ShikiTokenizer.defaultLanguage)).toBe(true);
+    await loadCodeTheme(ShikiTokenizer.defaultTheme);
+    await loadCodeTheme(LIGHT_THEME);
+    await loadCodeTheme(DARK_THEME);
+    expect(isCodeThemeLoaded(LIGHT_THEME)).toBe(true);
+    expect(isCodeThemeLoaded(DARK_THEME)).toBe(true);
+  });
+
+  test('default config: single-theme inline rgb (no CSS work)', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: $populateCodeBlock,
+      dependencies: [RichTextExtension, CodeShikiExtension],
+      name: 'shiki-default-inline',
+    });
+
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node));
+      const codeStyle = node.getStyle();
+      expect(codeStyle).toMatch(/^background-color:\s*#[0-9a-fA-F]+/);
+      expect(codeStyle).not.toContain('--shiki-');
+      const firstChild = node.getFirstChild();
+      assert($isTextNode(firstChild));
+      expect(firstChild.getStyle()).toMatch(/^color:\s*#[0-9a-fA-F]+$/);
+    });
+  });
+
+  test('{light, dark} registry entry emits only CSS variables, no inline color', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: $populateCodeBlock,
+      dependencies: [
+        RichTextExtension,
+        configExtension(CodeShikiExtension, {
+          themes: {default: {dark: DARK_THEME, light: LIGHT_THEME}},
+        }),
+      ],
+      name: 'shiki-vars-only',
+    });
+
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node));
+      const rootStyle = node.getStyle();
+      // Both themes exposed only as variables; no inline color fallback.
+      expect(rootStyle).toContain('--shiki-light-bg:');
+      expect(rootStyle).toContain('--shiki-dark-bg:');
+      expect(rootStyle).toContain('--shiki-light:');
+      expect(rootStyle).toContain('--shiki-dark:');
+      expect(rootStyle).not.toMatch(/^background-color:/);
+    });
+  });
+
+  test('per-node setTheme picks the matching registry entry', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const codeNode = $createCodeNode();
+        codeNode.append($createTextNode('const x = 1;'));
+        codeNode.setTheme('mono');
+        $getRoot().clear().append(codeNode);
+      },
+      dependencies: [
+        RichTextExtension,
+        configExtension(CodeShikiExtension, {
+          // Two entries: a paired vars-only entry and a single-theme
+          // inline entry. Per-node `mono` should select the inline one.
+          defaultTheme: 'paired',
+          themes: {
+            mono: LIGHT_THEME,
+            paired: {dark: DARK_THEME, light: LIGHT_THEME},
+          },
+        }),
+      ],
+      name: 'shiki-per-node-registry',
+    });
+
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node));
+      const rootStyle = node.getStyle();
+      // `mono` is a single-theme entry, so the node renders inline rgb
+      // and emits no `--shiki-*` variables.
+      expect(rootStyle).toMatch(/^background-color:\s*#[0-9a-fA-F]+/);
+      expect(rootStyle).not.toContain('--shiki-');
+    });
+  });
+
+  test('function registry entry receives the code node', () => {
+    let receivedKey: string | null = null;
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: $populateCodeBlock,
+      dependencies: [
+        RichTextExtension,
+        configExtension(CodeShikiExtension, {
+          themes: {
+            default: codeNode => {
+              receivedKey = codeNode.getKey();
+              return LIGHT_THEME;
+            },
+          },
+        }),
+      ],
+      name: 'shiki-function-spec',
+    });
+
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node));
+      expect(receivedKey).toBe(node.getKey());
+      // Function returned a string spec, so output is single-theme inline.
+      expect(node.getStyle()).toMatch(/^background-color:\s*#[0-9a-fA-F]+/);
+    });
+  });
+
+  test('legacy CodeHighlighterShikiExtension honors per-node setTheme', () => {
+    // Regression for the BC route: ShikiTokenizer.$tokenize must read
+    // codeNode.getTheme() before falling back to its own defaultTheme,
+    // matching the historical $getHighlightNodes behavior.
+    using lightEditor = buildEditorFromExtensions({
+      $initialEditorState: $populateCodeBlock,
+      dependencies: [RichTextExtension, CodeHighlighterShikiExtension],
+      name: 'shiki-legacy-default-theme',
+    });
+    using darkEditor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const codeNode = $createCodeNode();
+        codeNode.append($createTextNode('const x = 1;'));
+        codeNode.setTheme(DARK_THEME);
+        $getRoot().clear().append(codeNode);
+      },
+      dependencies: [RichTextExtension, CodeHighlighterShikiExtension],
+      name: 'shiki-legacy-pernode-dark',
+    });
+
+    let lightStyle = '';
+    let darkStyle = '';
+    lightEditor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node));
+      lightStyle = node.getStyle();
+    });
+    darkEditor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node));
+      darkStyle = node.getStyle();
+    });
+
+    expect(lightStyle).toMatch(/^background-color:\s*#[0-9a-fA-F]+/);
+    expect(darkStyle).toMatch(/^background-color:\s*#[0-9a-fA-F]+/);
+    // Two different themes produce two different inline backgrounds.
+    expect(lightStyle).not.toBe(darkStyle);
+  });
+
+  test('themes override preserves the default registry entry (deep merge)', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: $populateCodeBlock,
+      dependencies: [
+        RichTextExtension,
+        configExtension(CodeShikiExtension, {
+          themes: {extra: DARK_THEME},
+        }),
+      ],
+      name: 'shiki-merge-preserve-default',
+    });
+
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node));
+      // No per-node theme set, so the resolver looks up `defaultTheme`
+      // ('default') in the registry. mergeShikiConfig must deep-merge
+      // the override's `themes: {extra: ...}` with the framework
+      // default's `themes: {default: 'one-light'}` so both keys
+      // co-exist. A shallow replace would drop the `default` entry,
+      // sending the resolver to the raw-id fallback for `default` (not
+      // a real Shiki theme), which loadCodeTheme would silently no-op
+      // on, leaving the node with an empty style.
+      expect(node.getStyle()).toMatch(/^background-color:\s*#[0-9a-fA-F]+/);
+    });
+  });
+
+  test('unknown per-node theme key falls back to a raw Shiki id', () => {
+    // Per-node `__theme` set to a Shiki theme id that isn't in the
+    // registry. The resolver treats the key as a raw id (with a dev
+    // warning) so legacy `setTheme('one-light')` flows keep working.
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const codeNode = $createCodeNode();
+        codeNode.append($createTextNode('const x = 1;'));
+        codeNode.setTheme(LIGHT_THEME);
+        $getRoot().clear().append(codeNode);
+      },
+      dependencies: [
+        RichTextExtension,
+        configExtension(CodeShikiExtension, {
+          themes: {default: DARK_THEME},
+        }),
+      ],
+      name: 'shiki-unknown-key-fallback',
+    });
+
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node));
+      // Falls back to LIGHT_THEME inline despite default registry being DARK.
+      expect(node.getStyle()).toMatch(/^background-color:\s*#[0-9a-fA-F]+/);
+    });
+  });
+});

--- a/packages/lexical-code-shiki/src/index.ts
+++ b/packages/lexical-code-shiki/src/index.ts
@@ -12,6 +12,9 @@ export {
   type CodeShikiConfig,
   CodeShikiExtension,
   registerCodeHighlighting,
+  type ShikiThemeContext,
+  type ShikiThemeDef,
+  type ShikiThemeSpec,
   ShikiTokenizer,
   type Tokenizer,
 } from './CodeHighlighterShiki';

--- a/packages/lexical-playground/src/plugins/CodeHighlightExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/CodeHighlightExtension/index.ts
@@ -33,7 +33,13 @@ export const CodeHighlightExtension = defineExtension({
   config: safeCast<CodeHighlightConfig>({mode: 'off'}),
   dependencies: [
     configExtension(CodePrismExtension, {disabled: true}),
-    configExtension(CodeShikiExtension, {disabled: true}),
+    configExtension(CodeShikiExtension, {
+      disabled: true,
+      // `{light, dark}` registry entry => vars-only output (no inline
+      // color); `PlaygroundEditorTheme.css` reads `--shiki-light(-bg)`
+      // / `--shiki-dark(-bg)` to apply the active scheme.
+      themes: {default: {dark: 'one-dark-pro', light: 'one-light'}},
+    }),
     configExtension(CodeIndentExtension, {tabSize: 2}),
   ],
   name: '@lexical/playground/CodeHighlight',

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -163,7 +163,10 @@
   }
 }
 .PlaygroundEditorTheme__code {
-  background-color: rgb(240, 242, 245);
+  /* `--shiki-light(-bg)` is set inline by CodeShikiExtension when
+     defaultThemeName is null. The var() fallback covers off/Prism mode. */
+  background-color: var(--shiki-light-bg, rgb(240, 242, 245));
+  color: var(--shiki-light);
   font-family: Menlo, Consolas, Monaco, monospace;
   display: block;
   line-height: 1.53;
@@ -178,6 +181,9 @@
   white-space: pre;
   max-width: 100%;
   box-sizing: border-box;
+}
+.PlaygroundEditorTheme__code span[style*='--shiki-light'] {
+  color: var(--shiki-light);
 }
 .PlaygroundEditorTheme__code:before {
   content: attr(data-gutter);

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -164,9 +164,10 @@
 }
 .PlaygroundEditorTheme__code {
   /* `--shiki-light(-bg)` is set inline by CodeShikiExtension when
-     defaultThemeName is null. The var() fallback covers off/Prism mode. */
+     defaultTheme uses a paired {light, dark} spec. The var() fallback
+     covers off/Prism mode. */
   background-color: var(--shiki-light-bg, rgb(240, 242, 245));
-  color: var(--shiki-light);
+  color: var(--shiki-light, inherit);
   font-family: Menlo, Consolas, Monaco, monospace;
   display: block;
   line-height: 1.53;
@@ -183,7 +184,7 @@
   box-sizing: border-box;
 }
 .PlaygroundEditorTheme__code span[style*='--shiki-light'] {
-  color: var(--shiki-light);
+  color: var(--shiki-light, inherit);
 }
 .PlaygroundEditorTheme__code:before {
   content: attr(data-gutter);


### PR DESCRIPTION
## Description

Issue #8108 has two complaints:

1. Shiki output puts theme colors in each token's inline `style` as `rgb(...)`, so a runtime dark/light toggle requires re-tokenizing.
2. HTML exported from Lexical carries the original scheme's colors and can't be reskinned at the consuming page.

The issue suggests "use vars instead of rgb values," which is exactly what Shiki's [multi-theme mode](https://shiki.matsu.io/guide/dual-themes) emits when given a `themes` map. This PR exposes that mode through `CodeShikiExtension` config.

### Config

```ts
configExtension(CodeShikiExtension, {
  themes: {light: 'one-light', dark: 'one-dark-pro'},
  defaultColor: 'light',
});
```

`CodeShikiConfig` gains:

- `themes: Record<string, string> | null` — multi-theme map. `null` keeps the existing single-theme behavior.
- `defaultColor: string | false | undefined` — forwarded to Shiki's `codeToTokens({themes, defaultColor})`:
  - a key from `themes`: that theme renders inline as the fallback; the others become `--shiki-{name}` / `--shiki-{name}-bg` variables.
  - `'light-dark()'`: CSS-native `light-dark(...)` fallback (Baseline 2024). Requires `light` + `dark` keys.
  - `false`: emit only CSS variables, no inline color. The page's CSS owns the active scheme.
  - omitted: defers to Shiki's own default of `'light'` (Shiki throws if `themes` lacks a `light` key).

Per-node `CodeNode.__theme`, `Tokenizer.defaultTheme`, and a custom `tokenizer.$tokenize` are skipped in multi-theme mode. Themes are a Shiki-specific feature with no equivalent in the generic `Tokenizer` abstraction, so the multi-theme path goes straight to Shiki's `codeToTokens`.

### Backwards compatibility

- `registerCodeHighlighting` signature unchanged.
- The Extension's `register` effect calls the existing internal `registerHighlightingOnly` directly with `themes` / `defaultColor`. The legacy export doesn't gain a `themes` parameter.
- `Tokenizer` interface unchanged.

### Playground

`CodeHighlightExtension` (the playground aggregator) configures `CodeShikiExtension` with `themes: {light: 'one-light', dark: 'one-dark-pro'}, defaultColor: 'light'`, so QA in Shiki mode shows the feature directly.

### Design notes

A few alternatives I considered, easy to swap if you'd prefer a different shape:

- `themes` / `defaultColor` on `CodeShikiExtension.config` (this PR) vs. extending `Tokenizer`. Putting them on the highlighter-level config seemed cleaner since themes are Shiki-specific, but a `Tokenizer.themes` field is also workable.
- Multi-theme bypasses `Tokenizer.$tokenize` entirely; a custom Tokenizer is consulted only in single-theme mode. The alternative is extending `Tokenizer.$tokenize` to take theme args. The bypass keeps the generic interface unchanged at the cost of leaving custom tokenizers single-theme-only.
- The playground demo defaults to `defaultColor: 'light'` so the feature is visible without any extra CSS. `false` (vars-only) would force every consumer to add CSS rules — verified to work but felt rough as a default.

Closes #8108

## Test plan

- [x] `pnpm vitest run --project unit -t "Shiki multi-theme"` — 4 cases pass:
  - Single-theme mode keeps inline rgb color (BC)
  - `defaultColor: 'dark'` selects the inline theme; the other becomes a CSS variable
  - `defaultColor: false` emits only CSS variables, no inline color
  - Multi-theme mode ignores per-node `setTheme`
- [x] Tests exercise behavior through `CodeShikiExtension` config (extension scenario), not the internal helper.
- [x] Full unit suite (2450 tests) passes.
- [x] tsc / flow / prettier / eslint clean.
- [x] Manual playground (Shiki mode, `defaultColor: 'light'`):
  - `<code>` has inline `background-color: rgb(...)` (light) + `--shiki-dark-bg: #...`. Each token has inline `color: rgb(...)` (light) + `--shiki-dark: #...`.
  - In DevTools: `document.querySelectorAll('code, code span').forEach(el => el.style.color = 'var(--shiki-dark)')` flips colors to the dark scheme without re-tokenizing.
  - "Convert to HTML" preserves the inline `style` including CSS variables.
- [x] Manual playground with `defaultColor: false` (temporary swap):
  - `<code>` and each token carry only `--shiki-light(-bg)` and `--shiki-dark(-bg)` variables. No inline `color:` / `background-color:` declarations.

### Example CSS for runtime toggle

```css
/* defaultColor: 'light' — light is inline, dark is exposed as variable */
[data-theme="dark"] code {
  background-color: var(--shiki-dark-bg);
  color: var(--shiki-dark);
}
[data-theme="dark"] code span {
  color: var(--shiki-dark);
}
```