### PR TITLE
[lexical-yjs] Bug Fix: Handle node state being removed on non-TextNodes in collab v2

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -10,6 +10,7 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $getState,
   $setState,
   createState,
   ParagraphNode,
@@ -26,6 +27,10 @@ import {
   TestConnection,
   waitForReact,
 } from '../utils';
+
+const state = createState('foo', {
+  parse: value => (value ? (value as string) : undefined),
+});
 
 describe('Collaboration', () => {
   let container: null | HTMLDivElement = null;
@@ -522,17 +527,13 @@ describe('Collaboration', () => {
       client.start(container!);
       const editor = client.getEditor();
 
-      const state = createState('foo', {
-        parse: value => (value as {foo: string}) || {foo: 'foo'},
-      });
-
       act(() => {
         editor.update(
           () => {
             const root = $getRoot().clear();
             const paragraph = $createParagraphNode();
             const text = $createTextNode('Hello');
-            $setState(paragraph, state, {foo: 'foo'});
+            $setState(paragraph, state, 'bar');
             paragraph.append(text);
             root.append(paragraph);
           },
@@ -550,7 +551,7 @@ describe('Collaboration', () => {
       editor.update(
         () => {
           const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
-          $setState(paragraph, state, {foo: 'foo'});
+          $setState(paragraph, state, 'bar');
           // Include another update otherwise equalYTypePNode would return true
           paragraph.append($createTextNode('!'));
         },
@@ -558,6 +559,46 @@ describe('Collaboration', () => {
       );
 
       expect(updated).toBe(false);
+    });
+
+    it('Should sync the removal of node state from element nodes', async () => {
+      const client1 = connector.createClient('1');
+      const client2 = connector.createClient('2');
+      client1.start(container!);
+      client2.start(container!);
+
+      await expectCorrectInitialContent(client1, client2);
+
+      await waitForReact(() => {
+        client1.update(() => {
+          const root = $getRoot().clear();
+          const paragraph = $createParagraphNode();
+          $setState(paragraph, state, 'bar');
+          root.append(paragraph);
+        });
+      });
+
+      let editor2State = client2.getEditorState().read(() => {
+        const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+        return $getState(paragraph, state);
+      });
+      expect(editor2State).toEqual('bar');
+
+      await waitForReact(() => {
+        client1.update(() => {
+          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          $setState(paragraph, state, undefined);
+        });
+      });
+
+      editor2State = client2.getEditorState().read(() => {
+        const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+        return $getState(paragraph, state);
+      });
+      expect(editor2State).toBeUndefined();
+
+      client1.stop();
+      client2.stop();
     });
   });
 });

--- a/packages/lexical-yjs/src/SyncV2.ts
+++ b/packages/lexical-yjs/src/SyncV2.ts
@@ -181,14 +181,12 @@ export const $createOrUpdateNodeFromYElement = (
   $syncPropertiesFromYjs(binding, properties, node, keysChanged);
   if (!keysChanged) {
     $getWritableNodeState(node).updateFromJSON(state);
-  } else {
-    const stateKeysChanged = Object.keys(state).filter(k =>
-      keysChanged.has(stateKeyToAttrKey(k)),
-    );
-    if (stateKeysChanged.length > 0) {
-      const writableState = $getWritableNodeState(node);
-      for (const k of stateKeysChanged) {
-        writableState.updateFromUnknown(k, state[k]);
+  } else if (keysChanged.size > 0) {
+    const writableState = $getWritableNodeState(node);
+    for (const changedKey of keysChanged) {
+      if (changedKey.startsWith(STATE_KEY_PREFIX)) {
+        const stateKey = attrKeyToStateKey(changedKey);
+        writableState.updateFromUnknown(stateKey, state[stateKey]);
       }
     }
   }


### PR DESCRIPTION
## Description

Fixes an issue in collab v2 where the removal of node state (or setting it back to default value) for non-`TextNode`s would not be synced into the editor state of other clients.

## Test plan

Added unit test, only for collab v2 though as collab v1 [isn't targeted](https://github.com/facebook/lexical/blob/7c93eb4/packages/lexical-yjs/src/Utils.ts#L314-L319) about which node state keys to sync from Yjs.