### PR TITLE
[lexical-website] Fix copyright statement to pass OSS automated checkup

### DIFF
--- a/packages/lexical-website/src/theme/Footer/index.tsx
+++ b/packages/lexical-website/src/theme/Footer/index.tsx
@@ -21,7 +21,7 @@ function Footer() {
       }}>
       <div className="flex flex-col items-center gap-2 px-6 py-10">
         <div className="pt-6 text-center text-sm">
-          Copyright © {new Date().getFullYear()} Meta Platforms, Inc. Built with
+          Copyright ©{new Date().getFullYear()} Meta Platforms, Inc. Built with
           Docusaurus.
         </div>
         <div className="space-x-4">


### PR DESCRIPTION
## Summary
- Remove the space between `©` and the year in the website footer copyright statement so it matches Meta's OSS automated checkup regex: `/(Copyright|©|Copyright\s+©)(20[0-9]{2},?)\s+Meta Platforms,\s+Inc/`
- The rendered text changes from `Copyright © 2026 Meta Platforms, Inc.` to `Copyright ©2026 Meta Platforms, Inc.` — the regex requires the year to immediately follow the copyright symbol with no intervening space.

## Test plan
- [x] Verify the Docusaurus site builds without errors
- [x] Confirm the footer renders correctly on the homepage at lexical.dev

<img width="500" height="95" alt="Screenshot 2026-05-05 at 3 31 18 PM" src="https://github.com/user-attachments/assets/82e2b9a3-30e9-4fa5-b7d4-34e7ca66d9f9" />
