### PR TITLE
[lexical-history] Feature: Add canUndo and canRedo ReadonlySignals to HistoryExtension output

### DIFF
--- a/packages/lexical-history/flow/LexicalHistory.js.flow
+++ b/packages/lexical-history/flow/LexicalHistory.js.flow
@@ -32,16 +32,16 @@ export type HistoryConfig = {
   disabled: boolean;
 }
 
-export interface HistoryExtensionOutput {
+export type HistoryExtensionOutput = {
   /** `true` when there is at least one entry in the undo stack. */
-  canUndo: ReadonlySignal<boolean>;
+  canUndo: ReadonlySignal<boolean>,
   /** `true` when there is at least one entry in the redo stack. */
-  canRedo: ReadonlySignal<boolean>;
-  delay: Signal<number>;
-  disabled: Signal<boolean>;
-  historyState: Signal<HistoryState>;
-  now: Signal<() => number>;
-}
+  canRedo: ReadonlySignal<boolean>,
+  delay: Signal<number>,
+  disabled: Signal<boolean>,
+  historyState: Signal<HistoryState>,
+  now: Signal<() => number>,
+};
 
 declare export var HistoryExtension: LexicalExtension<HistoryConfig, "@lexical/history/History", HistoryExtensionOutput, void>;
 declare export var SharedHistoryExtension: LexicalExtension<ExtensionConfigBase, "@lexical/history/SharedHistory", void, void>;

--- a/packages/lexical-history/flow/LexicalHistory.js.flow
+++ b/packages/lexical-history/flow/LexicalHistory.js.flow
@@ -23,6 +23,8 @@ declare export function registerHistory(
   editor: LexicalEditor,
   historyState: HistoryState,
   delay: number,
+  dateNow?: () => number,
+  onHistoryStateChange?: (historyState: HistoryState) => void,
 ): () => void;
 declare export function createEmptyHistoryState(): HistoryState;
 

--- a/packages/lexical-history/flow/LexicalHistory.js.flow
+++ b/packages/lexical-history/flow/LexicalHistory.js.flow
@@ -7,7 +7,7 @@
  * @flow strict
  */
 import type {LexicalExtension, ExtensionConfigBase, EditorState, BaseSelection, LexicalEditor} from 'lexical';
-import type {NamedSignalsOutput} from '@lexical/extension';
+import type {ReadonlySignal, Signal} from '@lexical/extension';
 
 export type HistoryStateEntry = {
   editor: LexicalEditor,
@@ -31,9 +31,17 @@ export type HistoryConfig = {
   createInitialHistoryState: (editor: LexicalEditor) => HistoryState;
   disabled: boolean;
 }
-declare export var HistoryExtension: LexicalExtension<HistoryConfig, "@lexical/history/History", NamedSignalsOutput<{
-    delay: number;
-    disabled: boolean;
-    historyState: HistoryState;
-}>, void>;
+
+export interface HistoryExtensionOutput {
+  /** `true` when there is at least one entry in the undo stack. */
+  canUndo: ReadonlySignal<boolean>;
+  /** `true` when there is at least one entry in the redo stack. */
+  canRedo: ReadonlySignal<boolean>;
+  delay: Signal<number>;
+  disabled: Signal<boolean>;
+  historyState: Signal<HistoryState>;
+  now: Signal<() => number>;
+}
+
+declare export var HistoryExtension: LexicalExtension<HistoryConfig, "@lexical/history/History", HistoryExtensionOutput, void>;
 declare export var SharedHistoryExtension: LexicalExtension<ExtensionConfigBase, "@lexical/history/SharedHistory", void, void>;

--- a/packages/lexical-history/flow/LexicalHistory.js.flow
+++ b/packages/lexical-history/flow/LexicalHistory.js.flow
@@ -33,10 +33,10 @@ export type HistoryConfig = {
 }
 
 export type HistoryExtensionOutput = {
-  /** `true` when there is at least one entry in the undo stack. */
-  canUndo: ReadonlySignal<boolean>,
   /** `true` when there is at least one entry in the redo stack. */
   canRedo: ReadonlySignal<boolean>,
+  /** `true` when there is at least one entry in the undo stack. */
+  canUndo: ReadonlySignal<boolean>,
   delay: Signal<number>,
   disabled: Signal<boolean>,
   historyState: Signal<HistoryState>,

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -16,6 +16,7 @@ import {
 import {
   createEmptyHistoryState,
   HistoryExtension,
+  type HistoryState,
   registerHistory,
   SharedHistoryExtension,
 } from '@lexical/history';
@@ -546,6 +547,32 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     });
   }
 
+  function buildEditorWithHistory(historyState: HistoryState) {
+    return buildEditorFromExtensions({
+      dependencies: [
+        configExtension(HistoryExtension, {
+          createInitialHistoryState: () => historyState,
+          delay: 0,
+        }),
+      ],
+      name: 'test',
+    });
+  }
+
+  function $appendParagraph(text: string) {
+    $getRoot().append($createParagraphNode().append($createTextNode(text)));
+  }
+
+  // Two updates are required to populate the undoStack: the first update sets
+  // `historyState.current`, the second pushes the previous `current` onto the
+  // stack and dispatches CAN_UNDO_COMMAND.
+  function makeEditorWithOneUndoEntry() {
+    const editor = buildEditor();
+    editor.update(() => $appendParagraph('first'), {discrete: true});
+    editor.update(() => $appendParagraph('second'), {discrete: true});
+    return editor;
+  }
+
   test('signals start as false', () => {
     const editor = buildEditor();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
@@ -553,45 +580,24 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     expect(output.canRedo.value).toBe(false);
   });
 
-  test('canUndo becomes true after an edit, canRedo stays false', () => {
-    const editor = buildEditor();
+  test('canUndo becomes true after a push, canRedo stays false', () => {
+    const editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    editor.update(
-      () =>
-        $getRoot().append(
-          $createParagraphNode().append($createTextNode('hello')),
-        ),
-      {discrete: true},
-    );
     expect(output.canUndo.value).toBe(true);
     expect(output.canRedo.value).toBe(false);
   });
 
   test('canRedo becomes true after undo, canUndo goes false', () => {
-    const editor = buildEditor();
+    const editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    editor.update(
-      () =>
-        $getRoot().append(
-          $createParagraphNode().append($createTextNode('hello')),
-        ),
-      {discrete: true},
-    );
     editor.dispatchCommand(UNDO_COMMAND, undefined);
     expect(output.canUndo.value).toBe(false);
     expect(output.canRedo.value).toBe(true);
   });
 
   test('canRedo clears after redo, canUndo returns true', () => {
-    const editor = buildEditor();
+    const editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    editor.update(
-      () =>
-        $getRoot().append(
-          $createParagraphNode().append($createTextNode('hello')),
-        ),
-      {discrete: true},
-    );
     editor.dispatchCommand(UNDO_COMMAND, undefined);
     editor.dispatchCommand(REDO_COMMAND, undefined);
     expect(output.canUndo.value).toBe(true);
@@ -599,15 +605,8 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   });
 
   test('signals reset to false after CLEAR_HISTORY_COMMAND', () => {
-    const editor = buildEditor();
+    const editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    editor.update(
-      () =>
-        $getRoot().append(
-          $createParagraphNode().append($createTextNode('hello')),
-        ),
-      {discrete: true},
-    );
     expect(output.canUndo.value).toBe(true);
     editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
     expect(output.canUndo.value).toBe(false);
@@ -615,75 +614,35 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   });
 
   test('canRedo clears when a new edit is made after undo', () => {
-    const editor = buildEditor();
+    const editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    editor.update(
-      () =>
-        $getRoot().append(
-          $createParagraphNode().append($createTextNode('hello')),
-        ),
-      {discrete: true},
-    );
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    // Wrap UNDO dispatch in editor.update so that the HISTORIC_TAG from
+    // undo's setEditorState does not leak into the subsequent edit.
+    editor.update(() => editor.dispatchCommand(UNDO_COMMAND, undefined), {
+      discrete: true,
+    });
     expect(output.canRedo.value).toBe(true);
-    editor.update(
-      () =>
-        $getRoot().append(
-          $createParagraphNode().append($createTextNode('world')),
-        ),
-      {discrete: true},
-    );
+    editor.update(() => $appendParagraph('third'), {discrete: true});
     expect(output.canRedo.value).toBe(false);
     expect(output.canUndo.value).toBe(true);
   });
 
   test('canUndo is true immediately when initialized with a non-empty undoStack', () => {
-    // Build a donor editor and populate its history.
-    const donor = buildEditorFromExtensions({
-      dependencies: [configExtension(HistoryExtension, {delay: 0})],
-      name: 'donor',
-    });
-    donor.update(
-      () =>
-        $getRoot().append(
-          $createParagraphNode().append($createTextNode('hello')),
-        ),
-      {discrete: true},
-    );
+    const donor = makeEditorWithOneUndoEntry();
     const donorHistory = getExtensionDependencyFromEditor(
       donor,
       HistoryExtension,
     ).output.historyState.peek();
     expect(donorHistory.undoStack.length).toBeGreaterThan(0);
 
-    // A second editor that starts with the donor's history state.
-    const editor = buildEditorFromExtensions({
-      dependencies: [
-        configExtension(HistoryExtension, {
-          createInitialHistoryState: () => donorHistory,
-          delay: 0,
-        }),
-      ],
-      name: 'test',
-    });
+    const editor = buildEditorWithHistory(donorHistory);
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(output.canUndo.value).toBe(true);
     expect(output.canRedo.value).toBe(false);
   });
 
   test('canRedo is true immediately when initialized with a non-empty redoStack', () => {
-    // Build a donor editor with an item on the redo stack.
-    const donor = buildEditorFromExtensions({
-      dependencies: [configExtension(HistoryExtension, {delay: 0})],
-      name: 'donor',
-    });
-    donor.update(
-      () =>
-        $getRoot().append(
-          $createParagraphNode().append($createTextNode('hello')),
-        ),
-      {discrete: true},
-    );
+    const donor = makeEditorWithOneUndoEntry();
     donor.dispatchCommand(UNDO_COMMAND, undefined);
     const donorHistory = getExtensionDependencyFromEditor(
       donor,
@@ -691,27 +650,15 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     ).output.historyState.peek();
     expect(donorHistory.redoStack.length).toBeGreaterThan(0);
 
-    const editor = buildEditorFromExtensions({
-      dependencies: [
-        configExtension(HistoryExtension, {
-          createInitialHistoryState: () => donorHistory,
-          delay: 0,
-        }),
-      ],
-      name: 'test',
-    });
+    const editor = buildEditorWithHistory(donorHistory);
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(output.canUndo.value).toBe(false);
     expect(output.canRedo.value).toBe(true);
   });
 
   test('signals update when historyState signal is reassigned to a populated state', () => {
-    // Start with an empty history, then swap historyState to one with entries,
-    // simulating what SharedHistoryExtension does when it inherits parent state.
-    const editor = buildEditorFromExtensions({
-      dependencies: [configExtension(HistoryExtension, {delay: 0})],
-      name: 'test',
-    });
+    // Simulates what SharedHistoryExtension does when it inherits parent state.
+    const editor = buildEditor();
     const dep = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(dep.output.canUndo.value).toBe(false);
 

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -636,6 +636,95 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     expect(output.canRedo.value).toBe(false);
     expect(output.canUndo.value).toBe(true);
   });
+
+  test('canUndo is true immediately when initialized with a non-empty undoStack', () => {
+    // Build a donor editor and populate its history.
+    const donor = buildEditorFromExtensions({
+      dependencies: [configExtension(HistoryExtension, {delay: 0})],
+      name: 'donor',
+    });
+    donor.update(
+      () =>
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        ),
+      {discrete: true},
+    );
+    const donorHistory = getExtensionDependencyFromEditor(
+      donor,
+      HistoryExtension,
+    ).output.historyState.peek();
+    expect(donorHistory.undoStack.length).toBeGreaterThan(0);
+
+    // A second editor that starts with the donor's history state.
+    const editor = buildEditorFromExtensions({
+      dependencies: [
+        configExtension(HistoryExtension, {
+          delay: 0,
+          createInitialHistoryState: () => donorHistory,
+        }),
+      ],
+      name: 'test',
+    });
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    expect(output.canUndo.value).toBe(true);
+    expect(output.canRedo.value).toBe(false);
+  });
+
+  test('canRedo is true immediately when initialized with a non-empty redoStack', () => {
+    // Build a donor editor with an item on the redo stack.
+    const donor = buildEditorFromExtensions({
+      dependencies: [configExtension(HistoryExtension, {delay: 0})],
+      name: 'donor',
+    });
+    donor.update(
+      () =>
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        ),
+      {discrete: true},
+    );
+    donor.dispatchCommand(UNDO_COMMAND, undefined);
+    const donorHistory = getExtensionDependencyFromEditor(
+      donor,
+      HistoryExtension,
+    ).output.historyState.peek();
+    expect(donorHistory.redoStack.length).toBeGreaterThan(0);
+
+    const editor = buildEditorFromExtensions({
+      dependencies: [
+        configExtension(HistoryExtension, {
+          delay: 0,
+          createInitialHistoryState: () => donorHistory,
+        }),
+      ],
+      name: 'test',
+    });
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    expect(output.canUndo.value).toBe(false);
+    expect(output.canRedo.value).toBe(true);
+  });
+
+  test('signals update when historyState signal is reassigned to a populated state', () => {
+    // Start with an empty history, then swap historyState to one with entries,
+    // simulating what SharedHistoryExtension does when it inherits parent state.
+    const editor = buildEditorFromExtensions({
+      dependencies: [configExtension(HistoryExtension, {delay: 0})],
+      name: 'test',
+    });
+    const dep = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    expect(dep.output.canUndo.value).toBe(false);
+
+    const populated = createEmptyHistoryState();
+    populated.undoStack.push({
+      editor,
+      editorState: editor.getEditorState(),
+    });
+
+    dep.output.historyState.value = populated;
+    expect(dep.output.canUndo.value).toBe(true);
+    expect(dep.output.canRedo.value).toBe(false);
+  });
 });
 
 describe('SharedHistoryExtension', () => {

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -538,6 +538,106 @@ describe('LexicalHistory tests', () => {
   });
 });
 
+describe('HistoryExtension canUndo/canRedo signals', () => {
+  function buildEditor() {
+    return buildEditorFromExtensions({
+      dependencies: [configExtension(HistoryExtension, {delay: 0})],
+      name: 'test',
+    });
+  }
+
+  test('signals start as false', () => {
+    const editor = buildEditor();
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    expect(output.canUndo.value).toBe(false);
+    expect(output.canRedo.value).toBe(false);
+  });
+
+  test('canUndo becomes true after an edit, canRedo stays false', () => {
+    const editor = buildEditor();
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    editor.update(
+      () =>
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        ),
+      {discrete: true},
+    );
+    expect(output.canUndo.value).toBe(true);
+    expect(output.canRedo.value).toBe(false);
+  });
+
+  test('canRedo becomes true after undo, canUndo goes false', () => {
+    const editor = buildEditor();
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    editor.update(
+      () =>
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        ),
+      {discrete: true},
+    );
+    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    expect(output.canUndo.value).toBe(false);
+    expect(output.canRedo.value).toBe(true);
+  });
+
+  test('canRedo clears after redo, canUndo returns true', () => {
+    const editor = buildEditor();
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    editor.update(
+      () =>
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        ),
+      {discrete: true},
+    );
+    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(REDO_COMMAND, undefined);
+    expect(output.canUndo.value).toBe(true);
+    expect(output.canRedo.value).toBe(false);
+  });
+
+  test('signals reset to false after CLEAR_HISTORY_COMMAND', () => {
+    const editor = buildEditor();
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    editor.update(
+      () =>
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        ),
+      {discrete: true},
+    );
+    expect(output.canUndo.value).toBe(true);
+    editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+    expect(output.canUndo.value).toBe(false);
+    expect(output.canRedo.value).toBe(false);
+  });
+
+  test('canRedo clears when a new edit is made after undo', () => {
+    const editor = buildEditor();
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    editor.update(
+      () =>
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        ),
+      {discrete: true},
+    );
+    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    expect(output.canRedo.value).toBe(true);
+    editor.update(
+      () =>
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('world')),
+        ),
+      {discrete: true},
+    );
+    expect(output.canRedo.value).toBe(false);
+    expect(output.canUndo.value).toBe(true);
+  });
+});
+
 describe('SharedHistoryExtension', () => {
   test('can create a parent editor', async () => {
     const clock = Date.now();

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -574,21 +574,21 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   }
 
   test('signals start as false', () => {
-    const editor = buildEditor();
+    using editor = buildEditor();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(output.canUndo.value).toBe(false);
     expect(output.canRedo.value).toBe(false);
   });
 
   test('canUndo becomes true after a push, canRedo stays false', () => {
-    const editor = makeEditorWithOneUndoEntry();
+    using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(output.canUndo.value).toBe(true);
     expect(output.canRedo.value).toBe(false);
   });
 
   test('canRedo becomes true after undo, canUndo goes false', () => {
-    const editor = makeEditorWithOneUndoEntry();
+    using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     editor.dispatchCommand(UNDO_COMMAND, undefined);
     expect(output.canUndo.value).toBe(false);
@@ -596,7 +596,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   });
 
   test('canRedo clears after redo, canUndo returns true', () => {
-    const editor = makeEditorWithOneUndoEntry();
+    using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     editor.dispatchCommand(UNDO_COMMAND, undefined);
     editor.dispatchCommand(REDO_COMMAND, undefined);
@@ -605,7 +605,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   });
 
   test('signals reset to false after CLEAR_HISTORY_COMMAND', () => {
-    const editor = makeEditorWithOneUndoEntry();
+    using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(output.canUndo.value).toBe(true);
     editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
@@ -614,7 +614,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   });
 
   test('canRedo clears when a new edit is made after undo', () => {
-    const editor = makeEditorWithOneUndoEntry();
+    using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     // Wrap UNDO dispatch in editor.update so that the HISTORIC_TAG from
     // undo's setEditorState does not leak into the subsequent edit.
@@ -628,21 +628,21 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   });
 
   test('canUndo is true immediately when initialized with a non-empty undoStack', () => {
-    const donor = makeEditorWithOneUndoEntry();
+    using donor = makeEditorWithOneUndoEntry();
     const donorHistory = getExtensionDependencyFromEditor(
       donor,
       HistoryExtension,
     ).output.historyState.peek();
     expect(donorHistory.undoStack.length).toBeGreaterThan(0);
 
-    const editor = buildEditorWithHistory(donorHistory);
+    using editor = buildEditorWithHistory(donorHistory);
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(output.canUndo.value).toBe(true);
     expect(output.canRedo.value).toBe(false);
   });
 
   test('canRedo is true immediately when initialized with a non-empty redoStack', () => {
-    const donor = makeEditorWithOneUndoEntry();
+    using donor = makeEditorWithOneUndoEntry();
     donor.dispatchCommand(UNDO_COMMAND, undefined);
     const donorHistory = getExtensionDependencyFromEditor(
       donor,
@@ -650,7 +650,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     ).output.historyState.peek();
     expect(donorHistory.redoStack.length).toBeGreaterThan(0);
 
-    const editor = buildEditorWithHistory(donorHistory);
+    using editor = buildEditorWithHistory(donorHistory);
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(output.canUndo.value).toBe(false);
     expect(output.canRedo.value).toBe(true);
@@ -658,7 +658,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
 
   test('signals update when historyState signal is reassigned to a populated state', () => {
     // Simulates what SharedHistoryExtension does when it inherits parent state.
-    const editor = buildEditor();
+    using editor = buildEditor();
     const dep = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(dep.output.canUndo.value).toBe(false);
 

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -576,23 +576,23 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   test('signals start as false', () => {
     using editor = buildEditor();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    expect(output.canUndo.value).toBe(false);
-    expect(output.canRedo.value).toBe(false);
+    expect(output.canUndo.peek()).toBe(false);
+    expect(output.canRedo.peek()).toBe(false);
   });
 
   test('canUndo becomes true after a push, canRedo stays false', () => {
     using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    expect(output.canUndo.value).toBe(true);
-    expect(output.canRedo.value).toBe(false);
+    expect(output.canUndo.peek()).toBe(true);
+    expect(output.canRedo.peek()).toBe(false);
   });
 
   test('canRedo becomes true after undo, canUndo goes false', () => {
     using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     editor.dispatchCommand(UNDO_COMMAND, undefined);
-    expect(output.canUndo.value).toBe(false);
-    expect(output.canRedo.value).toBe(true);
+    expect(output.canUndo.peek()).toBe(false);
+    expect(output.canRedo.peek()).toBe(true);
   });
 
   test('canRedo clears after redo, canUndo returns true', () => {
@@ -600,17 +600,17 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     editor.dispatchCommand(UNDO_COMMAND, undefined);
     editor.dispatchCommand(REDO_COMMAND, undefined);
-    expect(output.canUndo.value).toBe(true);
-    expect(output.canRedo.value).toBe(false);
+    expect(output.canUndo.peek()).toBe(true);
+    expect(output.canRedo.peek()).toBe(false);
   });
 
   test('signals reset to false after CLEAR_HISTORY_COMMAND', () => {
     using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    expect(output.canUndo.value).toBe(true);
+    expect(output.canUndo.peek()).toBe(true);
     editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
-    expect(output.canUndo.value).toBe(false);
-    expect(output.canRedo.value).toBe(false);
+    expect(output.canUndo.peek()).toBe(false);
+    expect(output.canRedo.peek()).toBe(false);
   });
 
   test('canRedo clears when a new edit is made after undo', () => {
@@ -621,10 +621,10 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     editor.update(() => editor.dispatchCommand(UNDO_COMMAND, undefined), {
       discrete: true,
     });
-    expect(output.canRedo.value).toBe(true);
+    expect(output.canRedo.peek()).toBe(true);
     editor.update(() => $appendParagraph('third'), {discrete: true});
-    expect(output.canRedo.value).toBe(false);
-    expect(output.canUndo.value).toBe(true);
+    expect(output.canRedo.peek()).toBe(false);
+    expect(output.canUndo.peek()).toBe(true);
   });
 
   test('canUndo is true immediately when initialized with a non-empty undoStack', () => {
@@ -637,8 +637,8 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
 
     using editor = buildEditorWithHistory(donorHistory);
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    expect(output.canUndo.value).toBe(true);
-    expect(output.canRedo.value).toBe(false);
+    expect(output.canUndo.peek()).toBe(true);
+    expect(output.canRedo.peek()).toBe(false);
   });
 
   test('canRedo is true immediately when initialized with a non-empty redoStack', () => {
@@ -652,15 +652,15 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
 
     using editor = buildEditorWithHistory(donorHistory);
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    expect(output.canUndo.value).toBe(false);
-    expect(output.canRedo.value).toBe(true);
+    expect(output.canUndo.peek()).toBe(false);
+    expect(output.canRedo.peek()).toBe(true);
   });
 
   test('signals update when historyState signal is reassigned to a populated state', () => {
     // Simulates what SharedHistoryExtension does when it inherits parent state.
     using editor = buildEditor();
     const dep = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    expect(dep.output.canUndo.value).toBe(false);
+    expect(dep.output.canUndo.peek()).toBe(false);
 
     const populated = createEmptyHistoryState();
     populated.undoStack.push({
@@ -669,8 +669,8 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     });
 
     dep.output.historyState.value = populated;
-    expect(dep.output.canUndo.value).toBe(true);
-    expect(dep.output.canRedo.value).toBe(false);
+    expect(dep.output.canUndo.peek()).toBe(true);
+    expect(dep.output.canRedo.peek()).toBe(false);
   });
 });
 

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -660,8 +660,8 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     const editor = buildEditorFromExtensions({
       dependencies: [
         configExtension(HistoryExtension, {
-          delay: 0,
           createInitialHistoryState: () => donorHistory,
+          delay: 0,
         }),
       ],
       name: 'test',
@@ -694,8 +694,8 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     const editor = buildEditorFromExtensions({
       dependencies: [
         configExtension(HistoryExtension, {
-          delay: 0,
           createInitialHistoryState: () => donorHistory,
+          delay: 0,
         }),
       ],
       name: 'test',

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -10,11 +10,13 @@ import type {EditorState, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {
   batch,
+  computed,
   effect,
   getPeerDependencyFromEditor,
   namedSignals,
   ReadonlySignal,
   Signal,
+  signal,
 } from '@lexical/extension';
 import {mergeRegister} from '@lexical/utils';
 import {
@@ -558,33 +560,63 @@ export interface HistoryConfig {
   now: () => number;
 }
 
-type HistoryExtensionOutput = {
-  canRedo: ReadonlySignal<boolean>;
+/** Internal writable signals created during the init phase. */
+interface HistoryExtensionInit {
+  canRedo: Signal<boolean>;
+  canUndo: Signal<boolean>;
+}
+
+/**
+ * The output signals exposed by {@link HistoryExtension}.
+ *
+ * Config-derived signals (`delay`, `disabled`, `historyState`, `now`) are
+ * writable so that peer extensions such as {@link SharedHistoryExtension} can
+ * redirect them at runtime.  The `canUndo` / `canRedo` signals are
+ * **readonly** for consumers — they are derived from the current
+ * {@link HistoryState} and kept in sync automatically.
+ */
+export interface HistoryExtensionOutput {
+  /**
+   * `true` when there is at least one entry in the undo stack, i.e. the
+   * editor can perform an undo.
+   */
   canUndo: ReadonlySignal<boolean>;
+  /**
+   * `true` when there is at least one entry in the redo stack, i.e. the
+   * editor can perform a redo.
+   */
+  canRedo: ReadonlySignal<boolean>;
+  /** The merge-delay in milliseconds forwarded to {@link registerHistory}. */
   delay: Signal<number>;
+  /** When `true` the history listener is not registered. */
   disabled: Signal<boolean>;
+  /** The active {@link HistoryState} instance. */
   historyState: Signal<HistoryState>;
+  /** The clock function forwarded to {@link registerHistory}. */
   now: Signal<() => number>;
-};
+}
 
 /**
  * Registers necessary listeners to manage undo/redo history stack and related
  * editor commands, via the \@lexical/history module.
  */
-
 export const HistoryExtension = defineExtension({
+  init: (): HistoryExtensionInit => ({
+    canRedo: signal(false),
+    canUndo: signal(false),
+  }),
   build: (
     editor,
     {delay, createInitialHistoryState, disabled, now},
-  ): HistoryExtensionOutput =>
-    namedSignals({
-      canRedo: false,
-      canUndo: false,
-      delay,
-      disabled,
-      historyState: createInitialHistoryState(editor),
-      now,
-    }) as HistoryExtensionOutput,
+    state,
+  ): HistoryExtensionOutput => {
+    const {canUndo, canRedo} = state.getInitResult();
+    return {
+      ...namedSignals({delay, disabled, historyState: createInitialHistoryState(editor), now}),
+      canRedo: computed(() => canRedo.value),
+      canUndo: computed(() => canUndo.value),
+    };
+  },
   config: safeCast<HistoryConfig>({
     createInitialHistoryState: createEmptyHistoryState,
     delay: 300,
@@ -593,14 +625,13 @@ export const HistoryExtension = defineExtension({
   }),
   name: '@lexical/history/History',
   register: (editor, config, state) => {
+    const {canUndo, canRedo} = state.getInitResult();
     const stores = state.getOutput();
-    const canUndoSignal = stores.canUndo as Signal<boolean>;
-    const canRedoSignal = stores.canRedo as Signal<boolean>;
     return mergeRegister(
       effect(() => {
         if (stores.disabled.value) {
-          canUndoSignal.value = false;
-          canRedoSignal.value = false;
+          canUndo.value = false;
+          canRedo.value = false;
           return undefined;
         }
         return registerHistory(
@@ -612,16 +643,16 @@ export const HistoryExtension = defineExtension({
       }),
       editor.registerCommand(
         CAN_UNDO_COMMAND,
-        (canUndo) => {
-          canUndoSignal.value = canUndo;
+        () => {
+          canUndo.value = stores.historyState.peek().undoStack.length > 0;
           return false;
         },
         COMMAND_PRIORITY_EDITOR,
       ),
       editor.registerCommand(
         CAN_REDO_COMMAND,
-        (canRedo) => {
-          canRedoSignal.value = canRedo;
+        () => {
+          canRedo.value = stores.historyState.peek().redoStack.length > 0;
           return false;
         },
         COMMAND_PRIORITY_EDITOR,

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -14,6 +14,7 @@ import {
   getPeerDependencyFromEditor,
   namedSignals,
   ReadonlySignal,
+  Signal,
 } from '@lexical/extension';
 import {mergeRegister} from '@lexical/utils';
 import {
@@ -557,19 +558,33 @@ export interface HistoryConfig {
   now: () => number;
 }
 
+type HistoryExtensionOutput = {
+  canRedo: ReadonlySignal<boolean>;
+  canUndo: ReadonlySignal<boolean>;
+  delay: Signal<number>;
+  disabled: Signal<boolean>;
+  historyState: Signal<HistoryState>;
+  now: Signal<() => number>;
+};
+
 /**
  * Registers necessary listeners to manage undo/redo history stack and related
  * editor commands, via the \@lexical/history module.
  */
 
 export const HistoryExtension = defineExtension({
-  build: (editor, {delay, createInitialHistoryState, disabled, now}) =>
+  build: (
+    editor,
+    {delay, createInitialHistoryState, disabled, now},
+  ): HistoryExtensionOutput =>
     namedSignals({
+      canRedo: false,
+      canUndo: false,
       delay,
       disabled,
       historyState: createInitialHistoryState(editor),
       now,
-    }),
+    }) as HistoryExtensionOutput,
   config: safeCast<HistoryConfig>({
     createInitialHistoryState: createEmptyHistoryState,
     delay: 300,
@@ -579,12 +594,38 @@ export const HistoryExtension = defineExtension({
   name: '@lexical/history/History',
   register: (editor, config, state) => {
     const stores = state.getOutput();
-    return effect(() =>
-      stores.disabled.value
-        ? undefined
-        : registerHistory(editor, stores.historyState.value, stores.delay, () =>
-            stores.now.peek()(),
-          ),
+    const canUndoSignal = stores.canUndo as Signal<boolean>;
+    const canRedoSignal = stores.canRedo as Signal<boolean>;
+    return mergeRegister(
+      effect(() => {
+        if (stores.disabled.value) {
+          canUndoSignal.value = false;
+          canRedoSignal.value = false;
+          return undefined;
+        }
+        return registerHistory(
+          editor,
+          stores.historyState.value,
+          stores.delay,
+          () => stores.now.peek()(),
+        );
+      }),
+      editor.registerCommand(
+        CAN_UNDO_COMMAND,
+        (canUndo) => {
+          canUndoSignal.value = canUndo;
+          return false;
+        },
+        COMMAND_PRIORITY_EDITOR,
+      ),
+      editor.registerCommand(
+        CAN_REDO_COMMAND,
+        (canRedo) => {
+          canRedoSignal.value = canRedo;
+          return false;
+        },
+        COMMAND_PRIORITY_EDITOR,
+      ),
     );
   },
 });

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -10,7 +10,6 @@ import type {EditorState, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {
   batch,
-  computed,
   effect,
   getPeerDependencyFromEditor,
   namedSignals,
@@ -646,7 +645,11 @@ export const HistoryExtension = defineExtension({
     {delay, createInitialHistoryState, disabled, now},
     state,
   ): HistoryExtensionOutput => {
-    const {canUndo, canRedo} = state.getInitResult();
+    // The init phase already created writable Signal<boolean> instances for
+    // canUndo/canRedo. Signal<T> extends ReadonlySignal<T>, so exposing them
+    // through the HistoryExtensionOutput type (which declares them as
+    // ReadonlySignal<boolean>) is sufficient to prevent consumers from
+    // mutating them — no computed() wrapper required.
     return {
       ...namedSignals({
         delay,
@@ -654,8 +657,7 @@ export const HistoryExtension = defineExtension({
         historyState: createInitialHistoryState(editor),
         now,
       }),
-      canRedo: computed(() => canRedo.value),
-      canUndo: computed(() => canUndo.value),
+      ...state.getInitResult(),
     };
   },
   config: safeCast<HistoryConfig>({
@@ -672,28 +674,28 @@ export const HistoryExtension = defineExtension({
   register: (editor, config, state) => {
     const {canUndo, canRedo} = state.getInitResult();
     const stores = state.getOutput();
+    // Single update path: passing `null` resets both signals (used for the
+    // disabled state); passing a HistoryState derives them from its stacks
+    // (used by registerHistory on init and after every mutation). The batch
+    // ensures subscribers to both signals are only notified once per change.
+    const syncFromHistoryState = (historyState: HistoryState | null) =>
+      batch(() => {
+        canUndo.value =
+          historyState != null && historyState.undoStack.length > 0;
+        canRedo.value =
+          historyState != null && historyState.redoStack.length > 0;
+      });
     return effect(() => {
       if (stores.disabled.value) {
-        batch(() => {
-          canUndo.value = false;
-          canRedo.value = false;
-        });
+        syncFromHistoryState(null);
         return undefined;
       }
-      // registerHistory invokes our callback on initialization and after every
-      // mutation of historyState, so canUndo/canRedo are always derived
-      // directly from the current HistoryState. The batch ensures that
-      // subscribers to both signals are only notified once per change.
       return registerHistory(
         editor,
         stores.historyState.value,
         stores.delay,
         () => stores.now.peek()(),
-        historyState =>
-          batch(() => {
-            canUndo.value = historyState.undoStack.length > 0;
-            canRedo.value = historyState.redoStack.length > 0;
-          }),
+        syncFromHistoryState,
       );
     });
   },

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -634,9 +634,15 @@ export const HistoryExtension = defineExtension({
           canRedo.value = false;
           return undefined;
         }
+        const historyState = stores.historyState.value;
+        // Sync immediately whenever historyState is (re-)assigned, so that
+        // pre-populated stacks (e.g. from SharedHistoryExtension) are
+        // reflected without waiting for a command to be dispatched.
+        canUndo.value = historyState.undoStack.length > 0;
+        canRedo.value = historyState.redoStack.length > 0;
         return registerHistory(
           editor,
-          stores.historyState.value,
+          historyState,
           stores.delay,
           () => stores.now.peek()(),
         );

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -577,15 +577,15 @@ interface HistoryExtensionInit {
  */
 export interface HistoryExtensionOutput {
   /**
-   * `true` when there is at least one entry in the undo stack, i.e. the
-   * editor can perform an undo.
-   */
-  canUndo: ReadonlySignal<boolean>;
-  /**
    * `true` when there is at least one entry in the redo stack, i.e. the
    * editor can perform a redo.
    */
   canRedo: ReadonlySignal<boolean>;
+  /**
+   * `true` when there is at least one entry in the undo stack, i.e. the
+   * editor can perform an undo.
+   */
+  canUndo: ReadonlySignal<boolean>;
   /** The merge-delay in milliseconds forwarded to {@link registerHistory}. */
   delay: Signal<number>;
   /** When `true` the history listener is not registered. */
@@ -612,7 +612,12 @@ export const HistoryExtension = defineExtension({
   ): HistoryExtensionOutput => {
     const {canUndo, canRedo} = state.getInitResult();
     return {
-      ...namedSignals({delay, disabled, historyState: createInitialHistoryState(editor), now}),
+      ...namedSignals({
+        delay,
+        disabled,
+        historyState: createInitialHistoryState(editor),
+        now,
+      }),
       canRedo: computed(() => canRedo.value),
       canUndo: computed(() => canUndo.value),
     };

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -356,7 +356,11 @@ function createMergeActionGetter(
   };
 }
 
-function redo(editor: LexicalEditor, historyState: HistoryState): void {
+function redo(
+  editor: LexicalEditor,
+  historyState: HistoryState,
+  onChange?: (state: HistoryState) => void,
+): void {
   const redoStack = historyState.redoStack;
   const undoStack = historyState.undoStack;
 
@@ -376,6 +380,10 @@ function redo(editor: LexicalEditor, historyState: HistoryState): void {
 
     historyState.current = historyStateEntry || null;
 
+    if (onChange) {
+      onChange(historyState);
+    }
+
     if (historyStateEntry) {
       historyStateEntry.editor.setEditorState(historyStateEntry.editorState, {
         tag: HISTORIC_TAG,
@@ -384,7 +392,11 @@ function redo(editor: LexicalEditor, historyState: HistoryState): void {
   }
 }
 
-function undo(editor: LexicalEditor, historyState: HistoryState): void {
+function undo(
+  editor: LexicalEditor,
+  historyState: HistoryState,
+  onChange?: (state: HistoryState) => void,
+): void {
   const redoStack = historyState.redoStack;
   const undoStack = historyState.undoStack;
   const undoStackLength = undoStack.length;
@@ -404,6 +416,10 @@ function undo(editor: LexicalEditor, historyState: HistoryState): void {
 
     historyState.current = historyStateEntry || null;
 
+    if (onChange) {
+      onChange(historyState);
+    }
+
     if (historyStateEntry) {
       historyStateEntry.editor.setEditorState(historyStateEntry.editorState, {
         tag: HISTORIC_TAG,
@@ -412,10 +428,16 @@ function undo(editor: LexicalEditor, historyState: HistoryState): void {
   }
 }
 
-function clearHistory(historyState: HistoryState) {
+function clearHistory(
+  historyState: HistoryState,
+  onChange?: (state: HistoryState) => void,
+): void {
   historyState.undoStack = [];
   historyState.redoStack = [];
   historyState.current = null;
+  if (onChange) {
+    onChange(historyState);
+  }
 }
 
 /**
@@ -511,8 +533,7 @@ export function registerHistory(
     editor.registerCommand(
       UNDO_COMMAND,
       () => {
-        undo(editor, historyState);
-        notifyChange();
+        undo(editor, historyState, onHistoryStateChange);
         return true;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -520,8 +541,7 @@ export function registerHistory(
     editor.registerCommand(
       REDO_COMMAND,
       () => {
-        redo(editor, historyState);
-        notifyChange();
+        redo(editor, historyState, onHistoryStateChange);
         return true;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -529,8 +549,7 @@ export function registerHistory(
     editor.registerCommand(
       CLEAR_EDITOR_COMMAND,
       () => {
-        clearHistory(historyState);
-        notifyChange();
+        clearHistory(historyState, onHistoryStateChange);
         return false;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -538,10 +557,9 @@ export function registerHistory(
     editor.registerCommand(
       CLEAR_HISTORY_COMMAND,
       () => {
-        clearHistory(historyState);
+        clearHistory(historyState, onHistoryStateChange);
         editor.dispatchCommand(CAN_REDO_COMMAND, false);
         editor.dispatchCommand(CAN_UNDO_COMMAND, false);
-        notifyChange();
         return true;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -656,22 +674,26 @@ export const HistoryExtension = defineExtension({
     const stores = state.getOutput();
     return effect(() => {
       if (stores.disabled.value) {
-        canUndo.value = false;
-        canRedo.value = false;
+        batch(() => {
+          canUndo.value = false;
+          canRedo.value = false;
+        });
         return undefined;
       }
       // registerHistory invokes our callback on initialization and after every
       // mutation of historyState, so canUndo/canRedo are always derived
-      // directly from the current HistoryState.
+      // directly from the current HistoryState. The batch ensures that
+      // subscribers to both signals are only notified once per change.
       return registerHistory(
         editor,
         stores.historyState.value,
         stores.delay,
         () => stores.now.peek()(),
-        historyState => {
-          canUndo.value = historyState.undoStack.length > 0;
-          canRedo.value = historyState.redoStack.length > 0;
-        },
+        historyState =>
+          batch(() => {
+            canUndo.value = historyState.undoStack.length > 0;
+            canRedo.value = historyState.redoStack.length > 0;
+          }),
       );
     });
   },

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -425,6 +425,12 @@ function clearHistory(historyState: HistoryState) {
  * @param historyState - The history state, containing the current state and the undo/redo stack.
  * @param delay - The time (in milliseconds) the editor should delay generating a new history stack,
  * instead of merging the current changes with the current stack.
+ * @param dateNow - The clock function used for delay-based merging.
+ * @param onHistoryStateChange - Optional callback invoked once on registration
+ * and again any time `historyState` is mutated (push, pop, clear, etc.). It is
+ * NOT invoked when a candidate update is discarded without changing the
+ * stacks. Useful for keeping derived values (e.g. signals) in sync with the
+ * current `HistoryState`.
  * @returns The listeners cleanup callback function.
  */
 export function registerHistory(
@@ -432,8 +438,15 @@ export function registerHistory(
   historyState: HistoryState,
   delay: number | ReadonlySignal<number>,
   dateNow: () => number = Date.now,
+  onHistoryStateChange?: (state: HistoryState) => void,
 ): () => void {
   const getMergeAction = createMergeActionGetter(editor, delay, dateNow);
+
+  const notifyChange = () => {
+    if (onHistoryStateChange) {
+      onHistoryStateChange(historyState);
+    }
+  };
 
   const applyChange = ({
     editorState,
@@ -487,13 +500,19 @@ export function registerHistory(
       editor,
       editorState,
     };
+    notifyChange();
   };
+
+  // Allow consumers (e.g. HistoryExtension) to read pre-populated stacks
+  // immediately, without waiting for the first edit.
+  notifyChange();
 
   return mergeRegister(
     editor.registerCommand(
       UNDO_COMMAND,
       () => {
         undo(editor, historyState);
+        notifyChange();
         return true;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -502,6 +521,7 @@ export function registerHistory(
       REDO_COMMAND,
       () => {
         redo(editor, historyState);
+        notifyChange();
         return true;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -510,6 +530,7 @@ export function registerHistory(
       CLEAR_EDITOR_COMMAND,
       () => {
         clearHistory(historyState);
+        notifyChange();
         return false;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -520,6 +541,7 @@ export function registerHistory(
         clearHistory(historyState);
         editor.dispatchCommand(CAN_REDO_COMMAND, false);
         editor.dispatchCommand(CAN_UNDO_COMMAND, false);
+        notifyChange();
         return true;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -601,10 +623,6 @@ export interface HistoryExtensionOutput {
  * editor commands, via the \@lexical/history module.
  */
 export const HistoryExtension = defineExtension({
-  init: (): HistoryExtensionInit => ({
-    canRedo: signal(false),
-    canUndo: signal(false),
-  }),
   build: (
     editor,
     {delay, createInitialHistoryState, disabled, now},
@@ -628,47 +646,34 @@ export const HistoryExtension = defineExtension({
     disabled: typeof window === 'undefined',
     now: Date.now,
   }),
+  init: (): HistoryExtensionInit => ({
+    canRedo: signal(false),
+    canUndo: signal(false),
+  }),
   name: '@lexical/history/History',
   register: (editor, config, state) => {
     const {canUndo, canRedo} = state.getInitResult();
     const stores = state.getOutput();
-    return mergeRegister(
-      effect(() => {
-        if (stores.disabled.value) {
-          canUndo.value = false;
-          canRedo.value = false;
-          return undefined;
-        }
-        const historyState = stores.historyState.value;
-        // Sync immediately whenever historyState is (re-)assigned, so that
-        // pre-populated stacks (e.g. from SharedHistoryExtension) are
-        // reflected without waiting for a command to be dispatched.
-        canUndo.value = historyState.undoStack.length > 0;
-        canRedo.value = historyState.redoStack.length > 0;
-        return registerHistory(
-          editor,
-          historyState,
-          stores.delay,
-          () => stores.now.peek()(),
-        );
-      }),
-      editor.registerCommand(
-        CAN_UNDO_COMMAND,
-        () => {
-          canUndo.value = stores.historyState.peek().undoStack.length > 0;
-          return false;
+    return effect(() => {
+      if (stores.disabled.value) {
+        canUndo.value = false;
+        canRedo.value = false;
+        return undefined;
+      }
+      // registerHistory invokes our callback on initialization and after every
+      // mutation of historyState, so canUndo/canRedo are always derived
+      // directly from the current HistoryState.
+      return registerHistory(
+        editor,
+        stores.historyState.value,
+        stores.delay,
+        () => stores.now.peek()(),
+        historyState => {
+          canUndo.value = historyState.undoStack.length > 0;
+          canRedo.value = historyState.redoStack.length > 0;
         },
-        COMMAND_PRIORITY_EDITOR,
-      ),
-      editor.registerCommand(
-        CAN_REDO_COMMAND,
-        () => {
-          canRedo.value = stores.historyState.peek().redoStack.length > 0;
-          return false;
-        },
-        COMMAND_PRIORITY_EDITOR,
-      ),
-    );
+      );
+    });
   },
 });
 


### PR DESCRIPTION
## Description

Adds `canUndo: ReadonlySignal<boolean>` and `canRedo: ReadonlySignal<boolean>` to `HistoryExtension`'s output, kept in sync via `CAN_UNDO_COMMAND` and `CAN_REDO_COMMAND` listeners. Signals reset to `false` when the extension is disabled.

The `CAN_UNDO_COMMAND` and `CAN_REDO_COMMAND` are hard to keep in sync because it's tricky to read the initial state of them, it's better to have signals that directly expose the correct values.

## Test plan

New unit tests