### PR TITLE
[lexical] Bug Fix: Resolve --lexical-indent-base-value via CSS var() instead of pre-computing in JS

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/ElementFormat.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ElementFormat.spec.mjs
@@ -40,7 +40,7 @@ test.describe('Element format', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(80px); text-align: center;">
+          style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px)); text-align: center;">
           <span data-lexical-text="true">Hello</span>
           <a class="PlaygroundEditorTheme__link" href="https://lexical.io">
             <span data-lexical-text="true">https://lexical.io</span>

--- a/packages/lexical-playground/__tests__/e2e/Indentation.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Indentation.spec.mjs
@@ -143,19 +143,19 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">foo</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">bar</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">yar</span>
         </p>
         <ul class="PlaygroundEditorTheme__ul" dir="auto">
@@ -190,7 +190,7 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <br />
         </p>
         <table
@@ -204,7 +204,7 @@ test.describe('Identation', () => {
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader PlaygroundEditorTheme__tableCellSelected">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
-                style="padding-inline-start: calc(40px)">
+                style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
                 <span data-lexical-text="true">foo</span>
               </p>
             </th>
@@ -213,7 +213,7 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <br />
         </p>
       `,
@@ -228,19 +228,19 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(80px)">
+          style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">foo</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(80px)">
+          style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">bar</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(80px)">
+          style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">yar</span>
         </p>
         <ul class="PlaygroundEditorTheme__ul" dir="auto">
@@ -281,7 +281,7 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(80px)">
+          style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px))">
           <br />
         </p>
         <table
@@ -295,7 +295,7 @@ test.describe('Identation', () => {
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader PlaygroundEditorTheme__tableCellSelected">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
-                style="padding-inline-start: calc(80px)">
+                style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px))">
                 <span data-lexical-text="true">foo</span>
               </p>
             </th>
@@ -304,7 +304,7 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(80px)">
+          style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px))">
           <br />
         </p>
       `,
@@ -319,19 +319,19 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">foo</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">bar</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">yar</span>
         </p>
         <ul class="PlaygroundEditorTheme__ul" dir="auto">
@@ -366,7 +366,7 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <br />
         </p>
         <table
@@ -380,7 +380,7 @@ test.describe('Identation', () => {
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader PlaygroundEditorTheme__tableCellSelected">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
-                style="padding-inline-start: calc(40px)">
+                style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
                 <span data-lexical-text="true">foo</span>
               </p>
             </th>
@@ -389,7 +389,7 @@ test.describe('Identation', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <br />
         </p>
       `,
@@ -467,7 +467,7 @@ test.describe('Identation', () => {
     await clickIndentButton(page, MAX_INDENT);
 
     const expectedHTML =
-      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent" dir="auto" style="padding-inline-start: calc(240px)"><br /></p>';
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent" dir="auto" style="padding-inline-start: calc(6 * var(--lexical-indent-base-value, 40px))"><br /></p>';
 
     await assertHTML(page, expectedHTML);
     await clickIndentButton(page, MAX_INDENT);

--- a/packages/lexical-playground/__tests__/e2e/KeyboardShortcuts.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/KeyboardShortcuts.spec.mjs
@@ -346,7 +346,7 @@ test.describe('Keyboard shortcuts', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(120px);">
+          style="padding-inline-start: calc(3 * var(--lexical-indent-base-value, 40px));">
           <span data-lexical-text="true">abc</span>
         </p>
       `,
@@ -360,7 +360,7 @@ test.describe('Keyboard shortcuts', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px);">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px));">
           <span data-lexical-text="true">abc</span>
         </p>
       `,

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -889,31 +889,31 @@ test.describe.parallel('Nested List', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(120px)">
+          style="padding-inline-start: calc(3 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">Hello</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(120px)">
+          style="padding-inline-start: calc(3 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">from</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(120px)">
+          style="padding-inline-start: calc(3 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">the</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(120px)">
+          style="padding-inline-start: calc(3 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">other</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(120px)">
+          style="padding-inline-start: calc(3 * var(--lexical-indent-base-value, 40px))">
           <span data-lexical-text="true">side</span>
         </p>
       `,
@@ -2723,7 +2723,7 @@ test.describe.parallel('Nested List', () => {
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
           dir="auto"
-          style="padding-inline-start: calc(40px)">
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
           <br />
         </p>
       `,
@@ -2768,7 +2768,7 @@ test.describe.parallel('Nested List', () => {
           <p
             class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
             dir="auto"
-            style="padding-inline-start: calc(40px)">
+            style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
             <br />
           </p>
           <ul class="PlaygroundEditorTheme__ul" dir="auto">

--- a/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
@@ -81,7 +81,7 @@ test.describe('Tab', () => {
           <p
             class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
             dir="auto"
-            style="padding-inline-start: calc(40px)">
+            style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
             <span data-lexical-text="true">すし</span>
             <span
               class="PlaygroundEditorTheme__tabNode"

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -3148,7 +3148,7 @@ describe('LexicalSelection tests', () => {
         });
       });
       expect(element.innerHTML).toStrictEqual(
-        `<h1 dir="auto"><span data-lexical-text="true">1</span></h1><h1 dir="auto" style="padding-inline-start: calc(40px);"><span data-lexical-text="true">1.1</span></h1>`,
+        `<h1 dir="auto"><span data-lexical-text="true">1</span></h1><h1 dir="auto" style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px));"><span data-lexical-text="true">1.1</span></h1>`,
       );
     });
 
@@ -3186,7 +3186,7 @@ describe('LexicalSelection tests', () => {
         });
       });
       expect(element.innerHTML).toStrictEqual(
-        `<h1 dir="auto" style="padding-inline-start: calc(40px);"><span data-lexical-text="true">1.1</span></h1>`,
+        `<h1 dir="auto" style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px));"><span data-lexical-text="true">1.1</span></h1>`,
       );
     });
   });

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -138,19 +138,11 @@ function setElementIndent(dom: HTMLElement, indent: number): void {
     }
   }
 
-  if (indent === 0) {
-    dom.style.setProperty('padding-inline-start', '');
-    return;
-  }
-
-  const indentationBaseValue =
-    getComputedStyle(activeEditor._rootElement || dom).getPropertyValue(
-      '--lexical-indent-base-value',
-    ) || DEFAULT_INDENT_VALUE;
-
   dom.style.setProperty(
     'padding-inline-start',
-    `calc(${indent} * ${indentationBaseValue})`,
+    indent === 0
+      ? ''
+      : `calc(${indent} * var(--lexical-indent-base-value, ${DEFAULT_INDENT_VALUE}))`,
   );
 }
 

--- a/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
@@ -258,7 +258,11 @@ describe('@lexical/list tests', () => {
               </ul>
             </li>
           </ul>
-          <p dir="auto" style="padding-inline-start: calc(40px)"><br /></p>
+          <p
+            dir="auto"
+            style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
+            <br />
+          </p>
         </div>
       `,
     );
@@ -290,7 +294,9 @@ describe('@lexical/list tests', () => {
               </ul>
             </li>
           </ul>
-          <p dir="auto" style="padding-inline-start: calc(40px)">
+          <p
+            dir="auto"
+            style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
             <span data-lexical-text="true">more text</span>
           </p>
           <p dir="auto"><span data-lexical-text="true">even more text</span></p>

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
 import {
   $createLineBreakNode,
   $createParagraphNode,
@@ -389,6 +391,69 @@ describe('LexicalReconciler', () => {
         expect(editor.getElementByKey(keyA)).toBe(domA);
         expect(editor.getElementByKey(keyB)).toBe(domB);
         expect(editor.getElementByKey(keyC)).toBe(domC);
+      });
+    });
+  });
+
+  describe('setElementIndent', () => {
+    test('emits a CSS variable reference rather than a pre-resolved value', () => {
+      using editor = buildEditorFromExtensions(
+        RichTextExtension,
+        defineExtension({
+          $initialEditorState: () => {
+            const para = $createParagraphNode().append(
+              $createTextNode('hello'),
+            );
+            para.setIndent(3);
+            $getRoot().clear().append(para);
+          },
+          name: 'set-element-indent-var',
+        }),
+      );
+      editor.setRootElement(document.createElement('div'));
+
+      editor.read(() => {
+        const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+        const dom = editor.getElementByKey(para.getKey());
+        // The resolved CSS variable would only cascade after the element is
+        // attached and styled. Emitting `var(...)` defers resolution to the
+        // browser, so the inline style works regardless of where
+        // `--lexical-indent-base-value` is defined or whether the element is
+        // mounted at the time `setElementIndent` runs.
+        expect(dom!.style.paddingInlineStart).toBe(
+          'calc(3 * var(--lexical-indent-base-value, 40px))',
+        );
+      });
+    });
+
+    test('clears padding when indent returns to 0', () => {
+      using editor = buildEditorFromExtensions(
+        RichTextExtension,
+        defineExtension({
+          $initialEditorState: () => {
+            const para = $createParagraphNode().append(
+              $createTextNode('hello'),
+            );
+            para.setIndent(2);
+            $getRoot().clear().append(para);
+          },
+          name: 'set-element-indent-clear',
+        }),
+      );
+      editor.setRootElement(document.createElement('div'));
+
+      editor.update(
+        () => {
+          const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          para.setIndent(0);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+        const dom = editor.getElementByKey(para.getKey());
+        expect(dom!.style.paddingInlineStart).toBe('');
       });
     });
   });

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
@@ -133,7 +133,7 @@ describe('LexicalTabNode tests', () => {
         new KeyboardEvent('keydown'),
       );
       expect(testEnv.innerHTML).toBe(
-        '<p dir="auto" style="padding-inline-start: calc(40px);"><span data-lexical-text="true">foo</span></p>',
+        '<p dir="auto" style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px));"><span data-lexical-text="true">foo</span></p>',
       );
     });
 
@@ -166,8 +166,8 @@ describe('LexicalTabNode tests', () => {
         new KeyboardEvent('keydown'),
       );
       expect(testEnv.innerHTML).toBe(
-        '<p dir="auto" style="padding-inline-start: calc(40px);"><span data-lexical-text="true">foo</span></p>' +
-          '<h1 dir="auto" style="padding-inline-start: calc(40px);"><span data-lexical-text="true">bar</span></h1>' +
+        '<p dir="auto" style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px));"><span data-lexical-text="true">foo</span></p>' +
+          '<h1 dir="auto" style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px));"><span data-lexical-text="true">bar</span></h1>' +
           '<ol dir="auto"><li value="1"><ol><li value="1"><span data-lexical-text="true">xyz</span></li></ol></li></ol>',
       );
     });


### PR DESCRIPTION
## Description

`setElementIndent` read `--lexical-indent-base-value` via `getComputedStyle(activeEditor._rootElement || dom)` and substituted the resolved value into a `calc(...)` expression on `padding-inline-start`. This was brittle in two ways: `getComputedStyle` only sees the CSS variable if it cascades to `_rootElement` or `dom`, so themes that put the variable on the indent class itself (or any selector below the root) silently fell back to `DEFAULT_INDENT_VALUE` (`40px`); and when called from `$createNode` before the new DOM is attached to its parent, no cascade has happened yet, so even the same selector layout could miss the variable depending on timing. The reported symptom was that copy/pasted paragraphs ignored a custom `--lexical-indent-base-value` setting and used `40px` instead.

`setElementIndent` now writes `padding-inline-start: calc(N * var(--lexical-indent-base-value, 40px))` directly. The CSS variable reference is preserved in the inline style, so the browser resolves it at cascade time using whichever scope defines the variable. Mount timing no longer matters, and `getComputedStyle` (which forces layout) is no longer called per indent change. This is the approach etrepum suggested in the issue thread.

Existing test snapshots that asserted the old pre-resolved string (`calc(40px)`, `calc(80px)`, etc.) were updated to the new `calc(N * var(--..., 40px))` form. Two regression tests were added in `LexicalReconciler.test.ts` covering the var() output and the indent=0 padding clear.

Closes #7730

## Test plan

- [x] `pnpm tsc` clean.
- [x] `pnpm test-unit` — 117 files / 3038 pass (was 3036 before, +2 new regression tests in `LexicalReconciler.test.ts`).
- [x] Manual playground reproduction (Chromium): with `--lexical-indent-base-value` defined on the indent class only, paragraphs lost their custom indent value before the fix; after the fix the value cascades correctly.
- [ ] e2e suite: snapshot updates are mechanical, deferring to CI in real browsers.