### PR TITLE
[lexical-website] Documentation Update: Document NodeState in $config JSON serialization

### DIFF
--- a/packages/lexical-website/docs/concepts/node-state.md
+++ b/packages/lexical-website/docs/concepts/node-state.md
@@ -189,10 +189,10 @@ to the default returned by its `parse` function — see
 
 :::note
 
-Only one declaration per key is allowed per node. A flat state key must
-not collide with a property already serialized by the superclass (e.g.
-`text` on `TextNode`). If it does, registration will throw at editor
-construction.
+Don't reuse a flat key that a superclass already serializes (e.g. `text`
+on `TextNode`). There's no runtime check, but the resulting JSON will be
+ambiguous: the superclass field wins on serialize, and on parse the value
+will be lifted into NodeState — corrupting both fields.
 
 :::
 
@@ -275,7 +275,7 @@ export class ColoredNode extends TextNode {
 :::tip
 
 To stage the migration without breaking existing payloads, keep the
-serialized key name the same as the old property name (the second
+serialized key name the same as the old property name (the first
 argument to `createState`) and keep the default value identical to the
 one your old `parse`/`updateFromJSON` produced for missing or invalid
 input. Existing JSON will then deserialize unchanged.

--- a/packages/lexical-website/docs/concepts/node-state.md
+++ b/packages/lexical-website/docs/concepts/node-state.md
@@ -118,16 +118,13 @@ the node and its NodeState *won't* be marked dirty.
 The NodeState for a node, if any values are set to non-default values, is
 serialized to a record under a single
 [NODE_STATE_KEY](/docs/api/modules/lexical#node_state_key)
-which is equal to `'$'`. In the future, it is expected that nodes will be
-able to declare required state and lift those values to the top-level of
-their serialized nodes
-(see [#7260](https://github.com/facebook/lexical/issues/7260)).
+which is equal to `'$'`.
 
 ```json
 {
   "type": "poll",
   "$": {
-    "question": "Are you planning to use NodeState?",
+    "question": "Are you planning to use NodeState?"
   }
 }
 ```
@@ -139,6 +136,149 @@ but for advanced use cases you may use values such as Date, Map, or Set
 that need to be transformed before JSON serialization. See the
 [StateValueConfig](/docs/api/interfaces/lexical.StateValueConfig)
 API documentation.
+
+:::
+
+### Flat serialization with `$config`
+
+Nodes that declare a `StateConfig` in [`$config`](nodes.mdx#creating-custom-nodes-with-config-and-nodestate)
+with `flat: true` lift that key to the top level of the serialized node
+instead of nesting it under `'$'`. This makes the JSON shape identical
+to a legacy node that stored the value as a `__property` instance
+variable, so existing payloads continue to round-trip after the node is
+migrated to NodeState.
+
+For example, a `ColoredNode` that extends `TextNode` and declares a flat
+`color` state (see [Extending TextNode with `$config`](nodes.mdx#extending-textnode-with-config)):
+
+```ts
+$config() {
+  return this.config('colored', {
+    extends: TextNode,
+    stateConfigs: [{flat: true, stateConfig: colorState}],
+  });
+}
+```
+
+serializes as:
+
+```json
+{
+  "type": "colored",
+  "text": "hello",
+  "color": "red"
+}
+```
+
+A non-flat (default) state on the same node would instead appear under
+`'$'`:
+
+```json
+{
+  "type": "colored",
+  "text": "hello",
+  "$": {
+    "color": "red"
+  }
+}
+```
+
+In both cases, a key is only emitted when the current value is not equal
+to the default returned by its `parse` function — see
+[Efficiency](#efficiency).
+
+:::note
+
+Only one declaration per key is allowed per node. A flat state key must
+not collide with a property already serialized by the superclass (e.g.
+`text` on `TextNode`). If it does, registration will throw at editor
+construction.
+
+:::
+
+### Upgrading a legacy JSON property to NodeState
+
+A node that stores data as a `__property` instance variable with custom
+`exportJSON`/`importJSON`/`updateFromJSON` can be migrated to NodeState
+with `flat: true` without changing its serialized JSON shape.
+
+Before — `ColoredNode` with a `__color` property and hand-written
+serialization (see the full legacy example in
+[Extending TextNode with `$config`](nodes.mdx#extending-textnode-with-config)):
+
+```ts
+export type SerializedColoredNode = Spread<
+  {color?: string},
+  SerializedTextNode
+>;
+
+export class ColoredNode extends TextNode {
+  __color: string;
+
+  constructor(text: string = '', color: string = DEFAULT_COLOR, key?: NodeKey) {
+    super(text, key);
+    this.__color = color;
+  }
+
+  static getType(): string {
+    return 'colored';
+  }
+
+  static clone(node: ColoredNode): ColoredNode {
+    return new ColoredNode(node.__text, node.__color, node.__key);
+  }
+
+  static importJSON(serializedNode: SerializedColoredNode) {
+    return new ColoredNode().updateFromJSON(serializedNode);
+  }
+
+  updateFromJSON(serializedNode: SerializedColoredNode) {
+    const self = super.updateFromJSON(serializedNode);
+    self.__color =
+      typeof serializedNode.color === 'string'
+        ? serializedNode.color
+        : DEFAULT_COLOR;
+    return self;
+  }
+
+  exportJSON(): SerializedColoredNode {
+    return {
+      ...super.exportJSON(),
+      color: this.__color === DEFAULT_COLOR ? undefined : this.__color,
+    };
+  }
+}
+```
+
+After — same on-the-wire JSON, no hand-written serialization:
+
+```ts
+const colorState = createState('color', {
+  parse: (v) => (typeof v === 'string' ? v : DEFAULT_COLOR),
+});
+
+export class ColoredNode extends TextNode {
+  $config() {
+    return this.config('colored', {
+      extends: TextNode,
+      stateConfigs: [{flat: true, stateConfig: colorState}],
+    });
+  }
+}
+```
+
+`exportJSON`, `importJSON`, `updateFromJSON`, `clone`, and
+`afterCloneFrom` are all generated from `$config`. Read the color via
+`$getState(node, colorState)` and write it via
+`$setState(node, colorState, value)` instead of `node.__color`.
+
+:::tip
+
+To stage the migration without breaking existing payloads, keep the
+serialized key name the same as the old property name (the second
+argument to `createState`) and keep the default value identical to the
+one your old `parse`/`updateFromJSON` produced for missing or invalid
+input. Existing JSON will then deserialize unchanged.
 
 :::
 

--- a/packages/lexical-website/docs/concepts/node-state.md
+++ b/packages/lexical-website/docs/concepts/node-state.md
@@ -190,13 +190,7 @@ to the default returned by its `parse` function — see
 :::note
 
 Don't reuse a flat key that a superclass already serializes (e.g. `text`
-on `TextNode`). There's no runtime check, but the resulting JSON shape is
-ambiguous and not round-trip stable: which value wins on serialize depends
-on the order the superclass's `exportJSON` spreads its own fields and
-`super.exportJSON()`, and on parse the top-level value is lifted into
-NodeState while the superclass's `updateFromJSON` may also reassign it to
-the original property — leaving both representations populated and prone
-to drift.
+on `TextNode`).
 
 :::
 
@@ -278,11 +272,12 @@ export class ColoredNode extends TextNode {
 
 :::tip
 
-To stage the migration without breaking existing payloads, keep the
-serialized key name the same as the old property name (the first
-argument to `createState`) and keep the default value identical to the
-one your old `parse`/`updateFromJSON` produced for missing or invalid
-input. Existing JSON will then deserialize unchanged.
+For a seamless migration, keep the JSON key name the same — for a flat
+state, that's the first argument to `createState`. Migrating from a
+non-flat NodeState to a flat NodeState also works: state that appears
+under the `$` (`NODE_STATE_KEY`) is still parsed even when the state is
+configured as flat, and the flat value takes precedence when both are
+present.
 
 :::
 

--- a/packages/lexical-website/docs/concepts/node-state.md
+++ b/packages/lexical-website/docs/concepts/node-state.md
@@ -265,9 +265,11 @@ export class ColoredNode extends TextNode {
 }
 ```
 
-`exportJSON`, `importJSON`, `updateFromJSON`, `clone`, and
-`afterCloneFrom` are all generated from `$config`. Read the color via
-`$getState(node, colorState)` and write it via
+No `exportJSON`, `importJSON`, `updateFromJSON`, `clone`, or
+`afterCloneFrom` override is needed: `$config` installs `clone` and
+`importJSON`, and the base `exportJSON`/`updateFromJSON`/`afterCloneFrom`
+on `LexicalNode`/`TextNode` already round-trip NodeState. Read the color
+via `$getState(node, colorState)` and write it via
 `$setState(node, colorState, value)` instead of `node.__color`.
 
 :::tip

--- a/packages/lexical-website/docs/concepts/node-state.md
+++ b/packages/lexical-website/docs/concepts/node-state.md
@@ -190,9 +190,13 @@ to the default returned by its `parse` function — see
 :::note
 
 Don't reuse a flat key that a superclass already serializes (e.g. `text`
-on `TextNode`). There's no runtime check, but the resulting JSON will be
-ambiguous: the superclass field wins on serialize, and on parse the value
-will be lifted into NodeState — corrupting both fields.
+on `TextNode`). There's no runtime check, but the resulting JSON shape is
+ambiguous and not round-trip stable: which value wins on serialize depends
+on the order the superclass's `exportJSON` spreads its own fields and
+`super.exportJSON()`, and on parse the top-level value is lifted into
+NodeState while the superclass's `updateFromJSON` may also reassign it to
+the original property — leaving both representations populated and prone
+to drift.
 
 :::
 

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -331,6 +331,17 @@ function patchStyleConversion(
 
 ## JSON
 
+:::tip
+
+If your custom node uses [`$config`](./nodes.mdx#creating-custom-nodes-with-config-and-nodestate)
+with `NodeState`, `exportJSON`, `importJSON`, and `updateFromJSON` are
+generated for you. Flat state keys are lifted to the top level of the
+serialized node and the rest are nested under `'$'` — see
+[Flat serialization with `$config`](./node-state.md#flat-serialization-with-config)
+and the [legacy-property upgrade recipe](./node-state.md#upgrading-a-legacy-json-property-to-nodestate).
+
+:::
+
 ### Lexical -> JSON
 To generate a JSON snapshot from an `EditorState`, you can call the `toJSON()` method on the `EditorState` object.
 


### PR DESCRIPTION
## Summary

Addresses #7781:

- New `### Flat serialization with $config` subsection in `node-state.md` covering how flat keys appear at the top level of a node's JSON and when each key is emitted vs. omitted (default-equality check).
- New `### Upgrading a legacy JSON property to NodeState` recipe with a `Before`/`After` ColoredNode example, copied/adapted from the existing `Extending TextNode with $config` example as suggested in the issue.
- Parallel pointer in `serialization.md` JSON section linking readers to the NodeState content before they roll their own `exportJSON`/`importJSON`.

The `In the future ... see #7260` paragraph is replaced — that issue shipped (it's what this PR documents). A trailing comma in an existing JSON code fence (`"question": ...,`) was removed in passing.

## Test plan

- [x] `pnpm -C packages/lexical-website run build` succeeds with `onBrokenAnchors: 'throw'` and `onBrokenMarkdownLinks: 'throw'`
- [x] `prettier` clean
- [x] All cross-link anchors verified to resolve

Closes #7781