### PR TITLE
[lexical][lexical-list][lexical-rich-text][lexical-code-core] Bug Fix: Drop empty inline ElementNode children during collapseAtStart

### DIFF
--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -25,6 +25,7 @@ import type {
 
 import {getPeerDependencyFromEditor} from '@lexical/extension';
 import {
+  $collapseChildrenInto,
   $create,
   $createLineBreakNode,
   $createParagraphNode,
@@ -370,8 +371,7 @@ export class CodeNode extends ElementNode {
 
   collapseAtStart(): boolean {
     const paragraph = $createParagraphNode();
-    const children = this.getChildren();
-    children.forEach(child => paragraph.append(child));
+    $collapseChildrenInto(this, paragraph);
     this.replace(paragraph);
     return true;
   }

--- a/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
@@ -8,9 +8,12 @@
 
 import type {EditorConfig} from 'lexical';
 
-import {$getRoot} from 'lexical';
-import {initializeUnitTest} from 'lexical/src/__tests__/utils';
-import {describe, expect, it} from 'vitest';
+import {$getRoot, $isParagraphNode} from 'lexical';
+import {
+  $createTestInlineElementNode,
+  initializeUnitTest,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, it} from 'vitest';
 
 import {$createCodeNode} from '../../CodeNode';
 
@@ -70,6 +73,28 @@ describe('CodeNode', () => {
         expect(exportedElement).not.toBeNull();
         expect(exportedElement!.style.padding).toBe('1px');
         expect(exportedElement!.style.color).toBe('blue');
+      });
+
+      it('drops empty inline ElementNode children during collapseAtStart', () => {
+        const {editor} = testEnv;
+        editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const code = $createCodeNode('javascript');
+            code.append($createTestInlineElementNode());
+            root.append(code);
+            code.collapseAtStart();
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          const paragraph = root.getFirstChild();
+          assert($isParagraphNode(paragraph), 'code replaced by paragraph');
+          expect(paragraph.getChildrenSize()).toBe(0);
+        });
       });
     },
     {

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -29,6 +29,7 @@ import {
 } from '@lexical/utils';
 import {
   $applyNodeReplacement,
+  $collapseChildrenInto,
   $copyNode,
   $createParagraphNode,
   $getSiblingCaret,
@@ -379,8 +380,7 @@ export class ListItemNode extends ElementNode {
 
   collapseAtStart(selection: RangeSelection): true {
     const paragraph = $createParagraphNode();
-    const children = this.getChildren();
-    children.forEach(child => paragraph.append(child));
+    $collapseChildrenInto(this, paragraph);
     const listNode = this.getParentOrThrow();
     const listNodeParent = listNode.getParentOrThrow();
     const isIndented = $isListItemNode(listNodeParent);

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -25,6 +25,7 @@ import {
   TextNode,
 } from 'lexical';
 import {
+  $createTestInlineElementNode,
   expectHtmlToBeEqual,
   html,
   initializeUnitTest,
@@ -1846,6 +1847,37 @@ describe('LexicalListItemNode tests', () => {
           expect(wrapper.getFirstChildOrThrow().getTextContent()).toBe(
             'orphan',
           );
+        });
+      });
+    });
+
+    describe('ListItemNode.collapseAtStart() with empty inline children', () => {
+      test('drops empty inline ElementNode children instead of carrying them over', () => {
+        const {editor} = testEnv;
+
+        editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const listItem = $createListItemNode();
+            listItem.append($createTestInlineElementNode());
+            const list = $createListNode('bullet').append(listItem);
+            root.append(list);
+
+            listItem.collapseAtStart(listItem.select(0, 0));
+          },
+          {discrete: true},
+        );
+
+        editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          const paragraph = root.getFirstChild();
+          assert(
+            $isParagraphNode(paragraph),
+            'list collapsed into a paragraph',
+          );
+          expect(paragraph.getChildrenSize()).toBe(0);
         });
       });
     });

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
@@ -15,11 +15,15 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $isElementNode,
   ParagraphNode,
   RangeSelection,
 } from 'lexical';
-import {initializeUnitTest} from 'lexical/src/__tests__/utils';
-import {describe, expect, test} from 'vitest';
+import {
+  $createTestInlineElementNode,
+  initializeUnitTest,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',
@@ -238,6 +242,33 @@ describe('LexicalHeadingNode tests', () => {
       expect(testEnv.outerHTML).toBe(
         `<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><h2 dir="auto"><span data-lexical-text="true">${text}</span></h2><p dir="auto"><br></p></div>`,
       );
+    });
+
+    describe('HeadingNode.collapseAtStart() with empty inline children', () => {
+      test('drops empty inline ElementNode children instead of carrying them over', () => {
+        const {editor} = testEnv;
+        editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const heading = $createHeadingNode('h2');
+            heading.append($createTestInlineElementNode());
+            root.append(heading);
+            heading.collapseAtStart();
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          const replacement = root.getFirstChild();
+          assert(
+            $isElementNode(replacement),
+            'heading replaced by an ElementNode',
+          );
+          expect(replacement.getChildrenSize()).toBe(0);
+        });
+      });
     });
   });
 });

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
@@ -7,9 +7,17 @@
  */
 
 import {$createQuoteNode, QuoteNode} from '@lexical/rich-text';
-import {$createRangeSelection, $getRoot, ParagraphNode} from 'lexical';
-import {initializeUnitTest} from 'lexical/src/__tests__/utils';
-import {describe, expect, test} from 'vitest';
+import {
+  $createRangeSelection,
+  $getRoot,
+  $isParagraphNode,
+  ParagraphNode,
+} from 'lexical';
+import {
+  $createTestInlineElementNode,
+  initializeUnitTest,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',
@@ -92,6 +100,30 @@ describe('LexicalQuoteNode tests', () => {
         expect(quoteNode.__type).toEqual(createdQuoteNode.__type);
         expect(quoteNode.__parent).toEqual(createdQuoteNode.__parent);
         expect(quoteNode.__key).not.toEqual(createdQuoteNode.__key);
+      });
+    });
+
+    describe('QuoteNode.collapseAtStart() with empty inline children', () => {
+      test('drops empty inline ElementNode children instead of carrying them over', () => {
+        const {editor} = testEnv;
+        editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const quote = $createQuoteNode();
+            quote.append($createTestInlineElementNode());
+            root.append(quote);
+            quote.collapseAtStart();
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          const paragraph = root.getFirstChild();
+          assert($isParagraphNode(paragraph), 'quote replaced by paragraph');
+          expect(paragraph.getChildrenSize()).toBe(0);
+        });
       });
     });
   });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -52,6 +52,7 @@ import {
 } from '@lexical/utils';
 import {
   $applyNodeReplacement,
+  $collapseChildrenInto,
   $createParagraphNode,
   $createRangeSelection,
   $createTabNode,
@@ -203,8 +204,7 @@ export class QuoteNode extends ElementNode {
 
   collapseAtStart(): true {
     const paragraph = $createParagraphNode();
-    const children = this.getChildren();
-    children.forEach(child => paragraph.append(child));
+    $collapseChildrenInto(this, paragraph);
     this.replace(paragraph);
     return true;
   }
@@ -405,8 +405,7 @@ export class HeadingNode extends ElementNode {
     const newElement = !this.isEmpty()
       ? $createHeadingNode(this.getTag())
       : $createParagraphNode();
-    const children = this.getChildren();
-    children.forEach(child => newElement.append(child));
+    $collapseChildrenInto(this, newElement);
     this.replace(newElement);
     return true;
   }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -902,6 +902,10 @@ declare export class ElementNode extends LexicalNode {
 declare export function $isElementNode(
   node: ?LexicalNode,
 ): node is ElementNode;
+declare export function $collapseChildrenInto(
+  source: ElementNode,
+  target: ElementNode,
+): void;
 
 /**
  * ElementDOMSlot

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -2347,3 +2347,25 @@ export function $createChildrenArray(
   }
   return children;
 }
+
+/**
+ * @internal
+ *
+ * Building block for `collapseAtStart` implementations. Moves each
+ * child of `source` into `target`, dropping any direct child that is
+ * an empty inline ElementNode. Without this filter, a custom inline
+ * ElementNode with `canBeEmpty()=true` survives its parent's collapse
+ * as an orphan empty element (see #8205).
+ */
+export function $collapseChildrenInto(
+  source: ElementNode,
+  target: ElementNode,
+): void {
+  for (const child of source.getChildren()) {
+    if ($isElementNode(child) && child.isInline() && child.isEmpty()) {
+      child.remove(true);
+      continue;
+    }
+    target.append(child);
+  }
+}

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -8,6 +8,7 @@
 
 import {
   $applyNodeReplacement,
+  $collapseChildrenInto,
   $copyNode,
   $createParagraphNode,
   $createTextNode,
@@ -39,7 +40,11 @@ import {
   scheduleMicroTask,
   scrollIntoViewIfNeeded,
 } from '../../LexicalUtils';
-import {initializeUnitTest} from '../utils';
+import {
+  $createTestElementNode,
+  $createTestInlineElementNode,
+  initializeUnitTest,
+} from '../utils';
 
 describe('LexicalUtils tests', () => {
   initializeUnitTest(testEnv => {
@@ -921,6 +926,98 @@ describe('$copyNode', () => {
       expect($getState(copiedParagraph, STRING_STATE)).toBe('non-default');
       expect(initialParagraph.__string).toBe('not-aliased');
       expect(copiedParagraph.__string).toBe('non-default');
+    });
+  });
+});
+
+describe('$collapseChildrenInto', () => {
+  initializeUnitTest(testEnv => {
+    test('drops empty inline ElementNode children', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const source = $createParagraphNode();
+          const target = $createParagraphNode();
+          source.append($createTestInlineElementNode());
+          $getRoot().append(source, target);
+          $collapseChildrenInto(source, target);
+          expect(source.getChildrenSize()).toBe(0);
+          expect(target.getChildrenSize()).toBe(0);
+        },
+        {discrete: true},
+      );
+    });
+
+    test('preserves non-empty inline ElementNode children', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const source = $createParagraphNode();
+          const target = $createParagraphNode();
+          const inline = $createTestInlineElementNode();
+          inline.append($createTextNode('keep'));
+          source.append(inline);
+          $getRoot().append(source, target);
+          $collapseChildrenInto(source, target);
+          expect(target.getChildrenSize()).toBe(1);
+          expect(target.getTextContent()).toBe('keep');
+        },
+        {discrete: true},
+      );
+    });
+
+    test('preserves empty non-inline (block) ElementNode children', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const source = $createParagraphNode();
+          const target = $createParagraphNode();
+          source.append($createTestElementNode());
+          $getRoot().append(source, target);
+          $collapseChildrenInto(source, target);
+          expect(target.getChildrenSize()).toBe(1);
+        },
+        {discrete: true},
+      );
+    });
+
+    test('preserves TextNode children', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const source = $createParagraphNode();
+          const target = $createParagraphNode();
+          source.append($createTextNode('plain'));
+          $getRoot().append(source, target);
+          $collapseChildrenInto(source, target);
+          expect(target.getChildrenSize()).toBe(1);
+          expect(target.getTextContent()).toBe('plain');
+        },
+        {discrete: true},
+      );
+    });
+
+    test('preserves child order with mixed children', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const source = $createParagraphNode();
+          const target = $createParagraphNode();
+          const inlineWithText = $createTestInlineElementNode();
+          inlineWithText.append($createTextNode('b'));
+          source.append(
+            $createTextNode('a'),
+            $createTestInlineElementNode(),
+            inlineWithText,
+            $createTextNode('c'),
+          );
+          $getRoot().append(source, target);
+          $collapseChildrenInto(source, target);
+          expect(target.getChildrenSize()).toBe(3);
+          expect(target.getTextContent()).toBe('abc');
+        },
+        {discrete: true},
+      );
     });
   });
 });

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -252,6 +252,7 @@ export {
   $applyNodeReplacement,
   $cloneWithProperties,
   $cloneWithPropertiesEphemeral,
+  $collapseChildrenInto,
   $copyNode,
   $create,
   $createChildrenArray,


### PR DESCRIPTION
## Description

A custom inline `ElementNode` with `canBeEmpty()=true` that is the only child of a block (`ListItemNode`, `QuoteNode`, `HeadingNode`, `CodeNode`) survives the block's `collapseAtStart` as an orphan empty element. The four `collapseAtStart` implementations move children to a new container with `children.forEach(child => target.append(child))`, with no cleanup pass for the empty-inline case that the `canBeEmpty()=true` override allows. Built-in inline nodes such as `LinkNode` (`canBeEmpty()=false`) avoid this because their existing transform deletes empty instances, but custom emptyable inlines have no such guard.

### Fix

A new `@internal` helper `$collapseChildrenInto(source, target)` is added to `lexical` core. It moves each child of `source` to `target`, dropping any direct child that is an empty inline `ElementNode`. `ListItemNode`, `QuoteNode`, `HeadingNode`, and `CodeNode` switch their `children.forEach` loop to the helper. The filter is direct-child only — nested empty inline cases are out of scope here and can be handled in a follow-up if reported.

`CollapsibleContainerNode` (lexical-playground) has a different collapse shape that flattens grandchildren rather than copying direct children, so it does not fit this helper signature and is not part of this PR.

### Backwards compatibility

`collapseAtStart` method signatures are unchanged. The behavior change is internal to the four built-in implementations: an empty inline `ElementNode` direct child is no longer carried over into the replacement container. No reported use case relies on the prior carry-over (the carry-over itself is what #8205 reports as the bug). User overrides of `collapseAtStart` are unaffected since they do not opt into this helper unless they call it.

Closes #8205

## Test plan

- [x] `pnpm vitest run --project unit` — 2459 pass. +5 new tests for `$collapseChildrenInto` (drop empty inline / preserve non-empty inline / preserve block / preserve text / mixed-order with multiple kinds). +4 regression tests at each `collapseAtStart` call site.
- [x] `pnpm tsc` clean.
- [x] `pnpm lint-flow` — `$collapseChildrenInto` flow declaration registered.