### PR TITLE
[lexical] Bug Fix: Preserve queued updates and tags through setRootElement

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -562,11 +562,32 @@ export type SerializedEditor = {
   editorState: SerializedEditorState;
 };
 
+/** @internal */
+export type ResetEditorOptions = {
+  /**
+   * When `true`, `_updates` and `_updateTags` are kept intact across the
+   * reset. Used by callers that preserve `pendingEditorState` and intend
+   * the queued updates to commit against it (notably `setRootElement`).
+   * Without this, queued callbacks tagged for the upcoming commit would
+   * be silently dropped despite the state being kept.
+   */
+  preserveUpdateQueue?: boolean;
+};
+
+/**
+ * @internal
+ *
+ * Resets the editor's transient state — DOM mappings, dirty tracking,
+ * composition, and (by default) the queued updates and tags — while
+ * applying the given pendingEditorState. Used during root element
+ * transitions and reconciler error recovery.
+ */
 export function resetEditor(
   editor: LexicalEditor,
   prevRootElement: null | HTMLElement,
   nextRootElement: null | HTMLElement,
   pendingEditorState: EditorState,
+  options?: ResetEditorOptions,
 ): void {
   const keyNodeMap = editor._keyToDOMMap;
   keyNodeMap.clear();
@@ -578,8 +599,10 @@ export function resetEditor(
   editor._dirtyLeaves = new Set();
   editor._dirtyElements.clear();
   editor._normalizedNodes = new Set();
-  editor._updateTags = new Set();
-  editor._updates = [];
+  if (!options || !options.preserveUpdateQueue) {
+    editor._updateTags = new Set();
+    editor._updates = [];
+  }
   editor._blockCursorElement = null;
 
   const observer = editor._observer;
@@ -1376,7 +1399,9 @@ export class LexicalEditor {
       const classNames = getCachedClassNameArray(this._config.theme, 'root');
       const pendingEditorState = this._pendingEditorState || this._editorState;
       this._rootElement = nextRootElement;
-      resetEditor(this, prevRootElement, nextRootElement, pendingEditorState);
+      resetEditor(this, prevRootElement, nextRootElement, pendingEditorState, {
+        preserveUpdateQueue: true,
+      });
 
       if (prevRootElement !== null) {
         // TODO: remove this flag once we no longer use UEv2 internally

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1352,6 +1352,42 @@ describe('LexicalEditor tests', () => {
     });
   }
 
+  it('setRootElement preserves queued updates and tags across reset (#7360)', () => {
+    const rootElement = document.createElement('div');
+    rootElement.contentEditable = 'true';
+    document.body.appendChild(rootElement);
+
+    const newEditor = createTestEditor({onError: vi.fn()});
+
+    let queuedRan = false;
+    newEditor._updates.push([
+      () => {
+        queuedRan = true;
+      },
+      undefined,
+    ]);
+    newEditor._updateTags.add('custom_tag');
+
+    let listenerTags: Set<string> | null = null;
+    newEditor.registerUpdateListener(({tags}) => {
+      if (tags.has('custom_tag')) {
+        listenerTags = tags;
+      }
+    });
+
+    newEditor.setRootElement(rootElement);
+
+    // setRootElement calls $commitPendingUpdates which drains _updates via
+    // $triggerEnqueuedUpdates. Before the fix, resetEditor wiped _updates
+    // and _updateTags despite preserving _pendingEditorState, so the queued
+    // callback never ran and the tag never reached update listeners.
+    expect(queuedRan).toBe(true);
+    expect(listenerTags).not.toBeNull();
+    expect(listenerTags!.has('custom_tag')).toBe(true);
+
+    document.body.removeChild(rootElement);
+  });
+
   describe('With node decorators', () => {
     function useDecorators() {
       const [decorators, setDecorators] = useState(() =>


### PR DESCRIPTION
## Description

`editor.setRootElement` calls `resetEditor` to reset the editor's transient state when the root DOM element changes. The caller passes `_pendingEditorState` explicitly so it's preserved across the reset, but `resetEditor` also wipes `_updates` (queued nested updates) and `_updateTags` — the very state that was tagged for the upcoming commit against that preserved pending. Queued callbacks from `editor.update(...)` calls in flight are silently dropped, and tags meant for the next update listener call don't reach it.

### Fix

`resetEditor` gains an optional `ResetEditorOptions` parameter with a `preserveUpdateQueue?` flag. `setRootElement` passes `{preserveUpdateQueue: true}` so the queued state survives the reset and reaches the `$commitPendingUpdates` call right after. The other transient fields (DOM mappings, dirty tracking, composition, block cursor) keep their default reset since `setRootElement` either has no use for them after the root swap or re-sets them on the next line (`_dirtyType = FULL_RECONCILE`).

The error-recovery caller in `LexicalUpdates.ts` (the catch path in `$commitPendingUpdates`) keeps default behavior — that path intentionally drops queued callbacks because the editor state was rolled back, and running queued updates against a recovery state risks further errors.

Closes #7360

## Test plan

- [x] `pnpm vitest run --project unit` — 2451 pass + 1 skipped, no regressions. New regression test in `LexicalEditor.test.tsx` seeds `_updates` and `_updateTags` directly, calls `setRootElement`, and verifies the queued callback fires (via `$triggerEnqueuedUpdates`) and the tag reaches an update listener. The test fails as expected when the fix is reverted.
- [x] `pnpm tsc` clean.
- [x] `pnpm lint-flow` — no new warnings (`resetEditor` is internal, not in `Lexical.js.flow` or re-exported from the package entry).