### PR TITLE
[lexical] Documentation: Add TSDoc for LexicalNodeReplacement and withKlass

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -228,22 +228,20 @@ export type LexicalNodeReplacement = {
    */
   replace: Klass<LexicalNode>;
   /**
-   * Called from `$applyNodeReplacement` (invoked by the `$create*` factories
-   * for `replace`) with the freshly-constructed original. Return the
-   * substitute node — must be an instance of `withKlass` when that is set.
-   * Direct `new` calls bypass this hook.
+   * Called by the `$create*` factories for `replace` with the
+   * freshly-constructed original. Returns the substitute node, which must be
+   * an instance of `withKlass` when set.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   with: <T extends {new (...args: any): any}>(
     node: InstanceType<T>,
   ) => LexicalNode;
   /**
-   * The replacement class returned by `with`. Must extend `replace`
-   * (asserted in dev). When set, {@link LexicalEditor.registerNodeTransform}
-   * subscriptions on `replace` also run on the replacement, and
-   * {@link LexicalEditor.registerMutationListener} subscriptions on `replace`
-   * are redirected to the replacement. Will be required in a future version
-   * — a runtime warning is emitted when omitted.
+   * The replacement class returned by `with`. Must extend `replace`. When
+   * set, {@link LexicalEditor.registerNodeTransform} and
+   * {@link LexicalEditor.registerMutationListener} subscriptions registered
+   * against `replace` also fire for the replacement. Will be required in a
+   * future version.
    */
   withKlass?: Klass<LexicalNode>;
 };

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -215,12 +215,38 @@ export interface EditorConfig {
   theme: EditorThemeClasses;
 }
 
+/**
+ * Configuration entry passed in {@link CreateEditorArgs.nodes} to substitute
+ * every instance of a core node class with an instance of a custom subclass.
+ * Combined with {@link withKlass}, this lets node transforms and mutation
+ * listeners that target the original class continue to fire on the
+ * replacement.
+ *
+ * See [Node Replacement](https://lexical.dev/docs/concepts/node-replacement)
+ * for a full example. Don't forget to also list the replacement class in
+ * {@link CreateEditorArgs.nodes}.
+ */
 export type LexicalNodeReplacement = {
+  /**
+   * The core node class whose instances should be replaced.
+   */
   replace: Klass<LexicalNode>;
+  /**
+   * Factory called whenever {@link replace} is constructed. The argument is
+   * the original instance about to be created; return the replacement node.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   with: <T extends {new (...args: any): any}>(
     node: InstanceType<T>,
   ) => LexicalNode;
+  /**
+   * The replacement class returned by {@link with}. Pass it so that
+   * {@link LexicalEditor.registerNodeTransform} and
+   * {@link LexicalEditor.registerMutationListener} subscriptions targeting
+   * the original {@link replace} class continue to fire on the substituted
+   * instances. Currently optional, but a runtime warning is emitted when
+   * omitted and it is expected to become required in a future version.
+   */
   withKlass?: Klass<LexicalNode>;
 };
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -217,14 +217,10 @@ export interface EditorConfig {
 
 /**
  * Configuration entry passed in {@link CreateEditorArgs.nodes} to substitute
- * every instance of a core node class with an instance of a custom subclass.
- * Combined with {@link withKlass}, this lets node transforms and mutation
- * listeners that target the original class continue to fire on the
- * replacement.
+ * a core node class with a custom subclass. The replacement class itself
+ * must also appear in `nodes`.
  *
- * See [Node Replacement](https://lexical.dev/docs/concepts/node-replacement)
- * for a full example. Don't forget to also list the replacement class in
- * {@link CreateEditorArgs.nodes}.
+ * See [Node Replacement](https://lexical.dev/docs/concepts/node-replacement).
  */
 export type LexicalNodeReplacement = {
   /**
@@ -232,20 +228,22 @@ export type LexicalNodeReplacement = {
    */
   replace: Klass<LexicalNode>;
   /**
-   * Factory called whenever {@link replace} is constructed. The argument is
-   * the original instance about to be created; return the replacement node.
+   * Called from `$applyNodeReplacement` (invoked by the `$create*` factories
+   * for `replace`) with the freshly-constructed original. Return the
+   * substitute node — must be an instance of `withKlass` when that is set.
+   * Direct `new` calls bypass this hook.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   with: <T extends {new (...args: any): any}>(
     node: InstanceType<T>,
   ) => LexicalNode;
   /**
-   * The replacement class returned by {@link with}. Pass it so that
-   * {@link LexicalEditor.registerNodeTransform} and
-   * {@link LexicalEditor.registerMutationListener} subscriptions targeting
-   * the original {@link replace} class continue to fire on the substituted
-   * instances. Currently optional, but a runtime warning is emitted when
-   * omitted and it is expected to become required in a future version.
+   * The replacement class returned by `with`. Must extend `replace`
+   * (asserted in dev). When set, {@link LexicalEditor.registerNodeTransform}
+   * subscriptions on `replace` also run on the replacement, and
+   * {@link LexicalEditor.registerMutationListener} subscriptions on `replace`
+   * are redirected to the replacement. Will be required in a future version
+   * — a runtime warning is emitted when omitted.
    */
   withKlass?: Klass<LexicalNode>;
 };


### PR DESCRIPTION
## Summary

Addresses the API-documentation portion of #6398 — the concept page was added in #6890, but `LexicalNodeReplacement` itself had no TSDoc, so readers who hit the runtime *"`withKlass` will be required in a future version"* warning had nothing in-source to explain what to pass or why.

This PR adds TSDoc on the type and each of its three fields:

- **`replace`** — the core node class whose instances should be replaced.
- **`with`** — factory called whenever `replace` is constructed; returns the substituted node.
- **`withKlass`** — explains why it matters: `LexicalEditor.registerNodeTransform` and `LexicalEditor.registerMutationListener` subscriptions targeting the original class only continue to fire on the substituted instances if `withKlass` is provided. Notes the future-required status that the runtime warning at line 772 hints at.

The type-level TSDoc links to the existing [Node Replacement](https://lexical.dev/docs/concepts/node-replacement) concept page rather than duplicating the full example here.

## Scope

Pure docstring change — no logic, no behavior change, no test changes. Single file (`packages/lexical/src/LexicalEditor.ts`), +26 / -0.

The stackblitz-example sub-task that was discussed in the issue thread (and attempted in the now-closed #6930) is intentionally **not** in scope here; this PR addresses only the unchecked *"API documentation is still missing"* checkbox.

Closes #6398