### PR TITLE
[examples] Chore: Disable skipLibCheck in react-rich for lib-types regression coverage (#7093)

### DIFF
--- a/examples/react-rich/tsconfig.json
+++ b/examples/react-rich/tsconfig.json
@@ -4,7 +4,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "skipLibCheck": true,
+    "skipLibCheck": false,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

Closes #7093 — the follow-up to #7080: *"we don't currently have a way to verify that there aren't any skipLibCheck false regressions. It would make sense to have at least one of our examples configured as such with React 19 and a newer typescript."*

Sets `skipLibCheck: false` on `examples/react-rich/tsconfig.json`. The example's existing `tsc && vite build` step is exercised by the integration tests in `scripts/__tests__/integration/prepare-release.test.mjs` (which calls `describeExample` for every `examples/*`), so any future `@types/react` or typescript-lib regression in the published Lexical `.d.ts` surface will fail that build.

`react-rich` was picked because it already pins the modern stack you specified (`react@^19.2.5`, `typescript@^5.9.2`) and is the canonical React example exercising the bulk of `@lexical/react`.

## CI surface

The integration-tests workflow runs on `after-approval.yml` and on `tests-extended.yml` when a maintainer adds the `extended-tests` or `dependencies` label. It does **not** run on every PR by default (`tests.yml` has `paths-ignore: examples/**`). So this is passive regression coverage that triggers post-approval / on-label, not a per-PR gate.

## Verification

```
$ cd examples/react-rich
$ ./node_modules/.bin/tsc --noEmit
$ echo $?
0
```

## Scope

One-line config flip in `examples/react-rich/tsconfig.json`. No source / build-script / CI workflow changes. The sibling `tsconfig.node.json` is intentionally left alone — plain `tsc` (used by `npm run build`) doesn't walk project references, so flipping it would have been dead weight.

Closes #7093