### PR TITLE
[lexical-website] Documentation: Add missing @lexical/react plugin docs

### DIFF
--- a/packages/lexical-website/docs/react/plugins.md
+++ b/packages/lexical-website/docs/react/plugins.md
@@ -71,6 +71,14 @@ React wrapper for `@lexical/rich-text` that adds major features for rich text ed
 />
 ```
 
+### `LexicalAutoFocusPlugin`
+
+Automatically focuses the editor when the component mounts and optionally places the cursor at the start or end of the root content.
+
+```jsx
+<AutoFocusPlugin defaultSelection="rootEnd" />
+```
+
 ### `LexicalOnChangePlugin`
 
 Plugin that calls `onChange` whenever Lexical state is updated. Using `ignoreHistoryMergeTagChange` (`true` by default) and `ignoreSelectionChange` (`false` by default) can give more granular control over changes that are causing `onChange` call.
@@ -93,6 +101,16 @@ React wrapper for `@lexical/link` that adds support for links, including `$toggl
 
 ```jsx
 <LinkPlugin />
+```
+
+### `LexicalClickableLinkPlugin`
+
+Makes `LinkNode` elements in the editor clickable, navigating to the link URL on click. Set `disabled` to `true` to turn off the behavior, or `newTab` to control whether links open in a new tab.
+
+> Note: Requires `LinkNode` from `@lexical/link` to be registered.
+
+```jsx
+<ClickableLinkPlugin newTab={true} disabled={false} />
 ```
 
 ### `LexicalListPlugin`
@@ -121,12 +139,40 @@ React wrapper for `@lexical/table` that adds support for tables.
 <TablePlugin />
 ```
 
+### `LexicalHorizontalRulePlugin`
+
+Registers a command handler for `INSERT_HORIZONTAL_RULE_COMMAND`. When dispatched, it inserts a `HorizontalRuleNode` at the current selection.
+
+> Note: Requires `HorizontalRuleNode` to be registered. This plugin is deprecated in favor of `HorizontalRuleExtension` from `@lexical/extension`.
+
+```jsx
+import {HorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
+
+const config = {nodes: [HorizontalRuleNode]};
+
+<HorizontalRulePlugin />
+```
+
 ### `LexicalTabIndentationPlugin`
 
 Plugin that allows tab indentation in combination with `@lexical/rich-text`.
 
 ```jsx
 <TabIndentationPlugin />
+```
+
+### `LexicalHashtagPlugin`
+
+Automatically detects hashtag patterns (e.g., `#hello`) in text as the user types and converts them into `HashtagNode` instances with distinct styling.
+
+> Note: Requires `HashtagNode` from `@lexical/hashtag` to be registered.
+
+```jsx
+import {HashtagNode} from '@lexical/hashtag';
+
+const config = {nodes: [HashtagNode]};
+
+<HashtagPlugin />
 ```
 
 ### `LexicalAutoLinkPlugin`
@@ -157,6 +203,48 @@ const MATCHERS = [
 ...
 
 <AutoLinkPlugin matchers={MATCHERS} />
+```
+
+### `LexicalAutoEmbedPlugin`
+
+Watches for pasted links that match any of the provided embed configurations (e.g., YouTube, Twitter URLs). When a match is found, it shows a menu offering to replace the link with an embedded node.
+
+> Note: Requires `LinkNode` and `AutoLinkNode` from `@lexical/link` to be registered.
+
+```jsx
+import {LexicalAutoEmbedPlugin, EmbedConfig, AutoEmbedOption} from '@lexical/react/LexicalAutoEmbedPlugin';
+
+const YouTubeEmbedConfig = {
+  type: 'youtube',
+  parseUrl: (url) => {
+    const match = url.match(/youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/);
+    return match ? {url, id: match[1]} : null;
+  },
+  insertNode: (editor, result) => {
+    // Insert your custom embed node here
+  },
+};
+
+<LexicalAutoEmbedPlugin
+  embedConfigs={[YouTubeEmbedConfig]}
+  onOpenEmbedModalForConfig={(config) => {/* open modal */}}
+  getMenuOptions={(config, embedFn, dismissFn) => [
+    new AutoEmbedOption('Embed', {onSelect: embedFn}),
+    new AutoEmbedOption('Dismiss', {onSelect: dismissFn}),
+  ]}
+/>
+```
+
+### `LexicalCharacterLimitPlugin`
+
+Tracks the number of characters in the editor and renders a count of remaining characters. Uses `OverflowNode` to visually indicate when the limit is exceeded.
+
+> Note: Requires `OverflowNode` from `@lexical/overflow` to be registered.
+
+```jsx
+import {CharacterLimitPlugin} from '@lexical/react/LexicalCharacterLimitPlugin';
+
+<CharacterLimitPlugin charset="UTF-16" maxLength={280} />
 ```
 
 ### `LexicalClearEditorPlugin`
@@ -203,6 +291,145 @@ from a separate part of your application.
 ```jsx
 const editorRef = useRef(null);
 <EditorRefPlugin editorRef={editorRef} />;
+```
+
+### `LexicalCollaborationPlugin`
+
+Integrates Yjs-based real-time collaborative editing into Lexical. Creates a Yjs binding between the editor state and a shared Yjs document, renders remote user cursors, and provides collaborative undo/redo history.
+
+```jsx
+import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
+import {WebsocketProvider} from 'y-websocket';
+import {Doc} from 'yjs';
+
+function createProvider(id, yjsDocMap) {
+  const doc = new Doc();
+  yjsDocMap.set(id, doc);
+  return new WebsocketProvider('ws://localhost:1234', id, doc);
+}
+
+<CollaborationPlugin
+  id="my-document"
+  providerFactory={createProvider}
+  shouldBootstrap={true}
+  username="Alice"
+  cursorColor="#FF0000"
+/>
+```
+
+### `LexicalDraggableBlockPlugin`
+
+Adds a draggable block handle that appears next to top-level block nodes when hovered. Users can drag and drop blocks to reorder them. A target line indicates the drop position.
+
+> Note: This plugin is experimental.
+
+```jsx
+import {DraggableBlockPlugin_EXPERIMENTAL} from '@lexical/react/LexicalDraggableBlockPlugin';
+
+const menuRef = useRef(null);
+const targetLineRef = useRef(null);
+
+<DraggableBlockPlugin_EXPERIMENTAL
+  anchorElem={document.body}
+  menuRef={menuRef}
+  targetLineRef={targetLineRef}
+  menuComponent={<div ref={menuRef} className="drag-handle">::</div>}
+  targetLineComponent={<div ref={targetLineRef} className="target-line" />}
+  isOnMenu={(el) => menuRef.current?.contains(el) ?? false}
+/>
+```
+
+### `LexicalNodeEventPlugin`
+
+Attaches a DOM event listener on the editor root element that fires only when the event target corresponds to a node of the specified type.
+
+```jsx
+import {NodeEventPlugin} from '@lexical/react/LexicalNodeEventPlugin';
+
+<NodeEventPlugin
+  nodeType={ImageNode}
+  eventType="click"
+  eventListener={(event, editor, nodeKey) => {
+    console.log('Clicked on node:', nodeKey);
+  }}
+/>
+```
+
+### `LexicalNodeMenuPlugin`
+
+Renders a menu anchored to a specific Lexical node identified by `nodeKey`. Provides keyboard navigation (arrow keys, enter, escape) through the menu options.
+
+```jsx
+import {LexicalNodeMenuPlugin, MenuOption} from '@lexical/react/LexicalNodeMenuPlugin';
+
+<LexicalNodeMenuPlugin
+  nodeKey={selectedNodeKey}
+  options={menuOptions}
+  onSelectOption={(option, textNode, closeMenu) => {
+    option.action();
+    closeMenu();
+  }}
+  menuRenderFn={(anchorRef, {options, selectedIndex, selectOptionAndCleanUp}) =>
+    anchorRef.current
+      ? createPortal(
+          <ul>
+            {options.map((opt, i) => (
+              <li key={opt.key} onClick={() => selectOptionAndCleanUp(opt)}>
+                {opt.title}
+              </li>
+            ))}
+          </ul>,
+          anchorRef.current,
+        )
+      : null
+  }
+  onClose={() => setSelectedNodeKey(null)}
+/>
+```
+
+### `LexicalTypeaheadMenuPlugin`
+
+Provides a typeahead/autocomplete menu that appears when the user types a trigger character (e.g., `@` for mentions, `:` for emoji). It listens to text changes, runs a trigger function against text before the cursor, and when a match is found, positions a menu at the trigger location.
+
+```jsx
+import {
+  LexicalTypeaheadMenuPlugin,
+  useBasicTypeaheadTriggerMatch,
+} from '@lexical/react/LexicalTypeaheadMenuPlugin';
+
+const triggerMatch = useBasicTypeaheadTriggerMatch('@', {minLength: 1});
+
+<LexicalTypeaheadMenuPlugin
+  triggerFn={triggerMatch}
+  options={mentionOptions}
+  onQueryChange={setQuery}
+  onSelectOption={(option, textNode, closeMenu) => {
+    editor.update(() => {
+      const mentionNode = $createMentionNode(option.name);
+      if (textNode) {
+        textNode.replace(mentionNode);
+      }
+      closeMenu();
+    });
+  }}
+  menuRenderFn={(anchorRef, {options, selectedIndex, selectOptionAndCleanUp}) =>
+    anchorRef.current
+      ? createPortal(
+          <ul className="typeahead-menu">
+            {options.map((opt, i) => (
+              <li
+                key={opt.key}
+                className={i === selectedIndex ? 'selected' : ''}
+                onClick={() => selectOptionAndCleanUp(opt)}>
+                {opt.name}
+              </li>
+            ))}
+          </ul>,
+          anchorRef.current,
+        )
+      : null
+  }
+/>
 ```
 
 ### `LexicalSelectionAlwaysOnDisplay`

--- a/packages/lexical-website/docs/react/plugins.md
+++ b/packages/lexical-website/docs/react/plugins.md
@@ -1,6 +1,18 @@
 # Lexical Plugins
 
-React-based plugins are using Lexical editor instance from `<LexicalComposer>` context:
+:::tip
+
+Most of these plugins are available as modern
+[Lexical Extensions](../extensions/intro.md), which do not require separate
+configuration and can have more efficient implementations.
+You should prefer using extensions over plugins where available, and
+[migrate](../extensions/migration.mdx) any project to extensions with
+LexicalExtensionComposer or LexicalExtensionEditorComposer if it is still
+using LexicalComposer.
+
+:::
+
+React-based plugins use a Lexical editor instance from `<LexicalExtensionComposer>` or `<LexicalComposer>` (legacy) context:
 
 ```js
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
@@ -55,6 +67,12 @@ React wrapper for `@lexical/plain-text` that adds major features for plain text 
 />
 ```
 
+:::tip
+
+Use [PlainTextExtension](/docs/api/modules/lexical_plain-text#plaintextextension) when using extensions
+
+:::
+
 ### `LexicalRichTextPlugin`
 
 React wrapper for `@lexical/rich-text` that adds major features for rich text editing, including typing, deletion, copy/pasting, indent/outdent and bold/italic/underline/strikethrough text formatting.
@@ -71,6 +89,12 @@ React wrapper for `@lexical/rich-text` that adds major features for rich text ed
 />
 ```
 
+:::tip
+
+Use [RichTextExtension](/docs/api/modules/lexical_rich-text#richtextextension) when using extensions
+
+:::
+
 ### `LexicalAutoFocusPlugin`
 
 Automatically focuses the editor when the component mounts and optionally places the cursor at the start or end of the root content.
@@ -78,6 +102,12 @@ Automatically focuses the editor when the component mounts and optionally places
 ```jsx
 <AutoFocusPlugin defaultSelection="rootEnd" />
 ```
+
+:::tip
+
+Use [AutoFocusExtension](/docs/api/modules/lexical_extension#autofocusextension) when using extensions
+
+:::
 
 ### `LexicalOnChangePlugin`
 
@@ -87,6 +117,12 @@ Plugin that calls `onChange` whenever Lexical state is updated. Using `ignoreHis
 <OnChangePlugin onChange={onChange} />
 ```
 
+:::tip
+
+When using extensions, subscribe to [EditorStateExtension](/docs/api/modules/lexical_extension#editorstateextension) for a signal-based equivalent
+
+:::
+
 ### `LexicalHistoryPlugin`
 
 React wrapper for `@lexical/history` that adds support for history stack management and `undo` / `redo` commands.
@@ -95,6 +131,12 @@ React wrapper for `@lexical/history` that adds support for history stack managem
 <HistoryPlugin />
 ```
 
+:::tip
+
+Use [HistoryExtension](/docs/api/modules/lexical_history#historyextension) when using extensions
+
+:::
+
 ### `LexicalLinkPlugin`
 
 React wrapper for `@lexical/link` that adds support for links, including `$toggleLink` command support that toggles link for selected text.
@@ -102,6 +144,12 @@ React wrapper for `@lexical/link` that adds support for links, including `$toggl
 ```jsx
 <LinkPlugin />
 ```
+
+:::tip
+
+Use [LinkExtension](/docs/api/modules/lexical_link#linkextension) when using extensions
+
+:::
 
 ### `LexicalClickableLinkPlugin`
 
@@ -113,6 +161,12 @@ Makes `LinkNode` elements in the editor clickable, navigating to the link URL on
 <ClickableLinkPlugin newTab={true} disabled={false} />
 ```
 
+:::tip
+
+Use [ClickableLinkExtension](/docs/api/modules/lexical_link#clickablelinkextension) when using extensions
+
+:::
+
 ### `LexicalListPlugin`
 
 React wrapper for `@lexical/list` that adds support for lists (ordered and unordered)
@@ -121,6 +175,12 @@ React wrapper for `@lexical/list` that adds support for lists (ordered and unord
 <ListPlugin />
 ```
 
+:::tip
+
+Use [ListExtension](/docs/api/modules/lexical_list#listextension) when using extensions
+
+:::
+
 ### `LexicalCheckListPlugin`
 
 React wrapper for `@lexical/list` that adds support for check lists. Note that it requires some css to render check/uncheck marks. See PlaygroundEditorTheme.css for details.
@@ -128,6 +188,12 @@ React wrapper for `@lexical/list` that adds support for check lists. Note that i
 ```jsx
 <CheckListPlugin />
 ```
+
+:::tip
+
+Use [CheckListExtension](/docs/api/modules/lexical_list#checklistextension) when using extensions
+
+:::
 
 ### `LexicalTablePlugin`
 
@@ -138,6 +204,12 @@ React wrapper for `@lexical/table` that adds support for tables.
 ```jsx
 <TablePlugin />
 ```
+
+:::tip
+
+Use [TableExtension](/docs/api/modules/lexical_table#tableextension) when using extensions
+
+:::
 
 ### `LexicalHorizontalRulePlugin`
 
@@ -153,6 +225,12 @@ const config = {nodes: [HorizontalRuleNode]};
 <HorizontalRulePlugin />
 ```
 
+:::tip
+
+Use [HorizontalRuleExtension](/docs/api/modules/lexical_extension#horizontalruleextension) when using extensions
+
+:::
+
 ### `LexicalTabIndentationPlugin`
 
 Plugin that allows tab indentation in combination with `@lexical/rich-text`.
@@ -160,6 +238,12 @@ Plugin that allows tab indentation in combination with `@lexical/rich-text`.
 ```jsx
 <TabIndentationPlugin />
 ```
+
+:::tip
+
+Use [TabIndentationExtension](/docs/api/modules/lexical_extension#tabindentationextension) when using extensions
+
+:::
 
 ### `LexicalHashtagPlugin`
 
@@ -174,6 +258,12 @@ const config = {nodes: [HashtagNode]};
 
 <HashtagPlugin />
 ```
+
+:::tip
+
+Use [HashtagExtension](/docs/api/modules/lexical_hashtag#hashtagextension) when using extensions
+
+:::
 
 ### `LexicalAutoLinkPlugin`
 
@@ -204,6 +294,12 @@ const MATCHERS = [
 
 <AutoLinkPlugin matchers={MATCHERS} />
 ```
+
+:::tip
+
+Use [AutoLinkExtension](/docs/api/modules/lexical_link#autolinkextension) when using extensions
+
+:::
 
 ### `LexicalAutoEmbedPlugin`
 
@@ -247,6 +343,12 @@ import {CharacterLimitPlugin} from '@lexical/react/LexicalCharacterLimitPlugin';
 <CharacterLimitPlugin charset="UTF-16" maxLength={280} />
 ```
 
+:::tip
+
+Use [OverflowExtension](/docs/api/modules/lexical_overflow#overflowextension) when using extensions
+
+:::
+
 ### `LexicalClearEditorPlugin`
 
 Adds `clearEditor` command support to clear editor's content.
@@ -254,6 +356,12 @@ Adds `clearEditor` command support to clear editor's content.
 ```jsx
 <ClearEditorPlugin />
 ```
+
+:::tip
+
+Use [ClearEditorExtension](/docs/api/modules/lexical_extension#cleareditorextension) when using extensions
+
+:::
 
 ### `LexicalMarkdownShortcutPlugin`
 
@@ -439,3 +547,9 @@ By default, browser text selection becomes invisible when clicking away from the
 ```jsx
 <SelectionAlwaysOnDisplay />
 ```
+
+:::tip
+
+Use [SelectionAlwaysOnDisplayExtension](/docs/api/modules/lexical_extension#selectionalwaysondisplayextension) when using extensions
+
+:::


### PR DESCRIPTION
## Description

Addresses #1527

Adds documentation for 12 `@lexical/react` plugins that were previously missing from the [plugins reference page](https://lexical.dev/docs/react/plugins). The existing page only documented 13 of the 25 available plugins.

### Newly documented plugins:

| Plugin | Description |
|--------|-------------|
| `LexicalAutoFocusPlugin` | Auto-focuses editor on mount |
| `LexicalAutoEmbedPlugin` | Converts pasted links to embedded nodes |
| `LexicalCharacterLimitPlugin` | Character count with overflow styling |
| `LexicalClickableLinkPlugin` | Makes links clickable for navigation |
| `LexicalCollaborationPlugin` | Yjs-based real-time collaboration |
| `LexicalDraggableBlockPlugin` | Drag-and-drop block reordering |
| `LexicalHashtagPlugin` | Auto-detects and styles hashtags |
| `LexicalHorizontalRulePlugin` | Inserts horizontal rule nodes |
| `LexicalNodeEventPlugin` | DOM event listener for specific node types |
| `LexicalNodeMenuPlugin` | Menu anchored to a specific node |
| `LexicalTypeaheadMenuPlugin` | Typeahead/autocomplete menu (e.g., mentions) |

Each entry includes a brief description, required node registrations, and a usage example consistent with the existing documentation style.

## Test plan

- [x] Verified all plugin names match actual exports in `packages/lexical-react/src/`
- [x] Verified code examples use correct import paths
- [x] Verified required node dependencies are noted where applicable
- [x] Documentation follows existing style and formatting conventions