### PR TITLE
[lexical] Feature: Add html.isInlineDomNode API for custom inline DOM elements

### DIFF
--- a/packages/lexical-extension/src/LexicalBuilder.ts
+++ b/packages/lexical-extension/src/LexicalBuilder.ts
@@ -410,6 +410,7 @@ export class LexicalBuilder {
     >();
     const htmlExport: NonNullable<HTMLConfig['export']> = new Map();
     const htmlImport: NonNullable<HTMLConfig['import']> = {};
+    let htmlIsInlineDomNode: HTMLConfig['isInlineDomNode'];
     const theme: EditorThemeClasses = {};
     const extensionReps = this.sortedExtensionReps();
     for (const extensionRep of extensionReps) {
@@ -459,6 +460,13 @@ export class LexicalBuilder {
         if (extension.html.import) {
           Object.assign(htmlImport, extension.html.import);
         }
+        if (extension.html.isInlineDomNode) {
+          const prev = htmlIsInlineDomNode;
+          const next = extension.html.isInlineDomNode;
+          htmlIsInlineDomNode = prev
+            ? (node: Node) => prev(node) || next(node)
+            : next;
+        }
       }
       if (extension.theme) {
         deepThemeMergeInPlace(theme, extension.theme);
@@ -472,13 +480,16 @@ export class LexicalBuilder {
     }
     const hasImport = Object.keys(htmlImport).length > 0;
     const hasExport = htmlExport.size > 0;
-    if (hasImport || hasExport) {
+    if (hasImport || hasExport || htmlIsInlineDomNode) {
       config.html = {};
       if (hasImport) {
         config.html.import = htmlImport;
       }
       if (hasExport) {
         config.html.export = htmlExport;
+      }
+      if (htmlIsInlineDomNode) {
+        config.html.isInlineDomNode = htmlIsInlineDomNode;
       }
     }
     for (const extensionRep of extensionReps) {

--- a/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
@@ -422,4 +422,104 @@ describe('HTML', () => {
       expect(importAndGetDirection(html)).toBe(expected);
     });
   });
+
+  describe('html.isInlineDomNode preserves whitespace around custom inline elements', () => {
+    test('whitespace is stripped around unknown custom elements by default', () => {
+      const editor = createHeadlessEditor();
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(
+            '<p>Hello <tooltip>world</tooltip> foo</p>',
+            'text/html',
+          );
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().append(...nodes);
+        },
+        {discrete: true},
+      );
+
+      const text = editor.read(() => $getRoot().getTextContent());
+      // Without isInlineDomNode config, spaces around <tooltip> are stripped
+      expect(text).toBe('Helloworldfoo');
+    });
+
+    test('whitespace is preserved around custom elements when isInlineDomNode is provided', () => {
+      const editor = createHeadlessEditor({
+        html: {
+          isInlineDomNode: (node: Node) =>
+            node.nodeName.toLowerCase() === 'tooltip',
+        },
+      });
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(
+            '<p>Hello <tooltip>world</tooltip> foo</p>',
+            'text/html',
+          );
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().append(...nodes);
+        },
+        {discrete: true},
+      );
+
+      const text = editor.read(() => $getRoot().getTextContent());
+      // With isInlineDomNode config, spaces around <tooltip> are preserved
+      expect(text).toBe('Hello world foo');
+    });
+
+    test('isInlineDomNode works with multiple custom elements', () => {
+      const customInlineTags = new Set(['tooltip', 'mention', 'badge']);
+      const editor = createHeadlessEditor({
+        html: {
+          isInlineDomNode: (node: Node) =>
+            customInlineTags.has(node.nodeName.toLowerCase()),
+        },
+      });
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(
+            '<p>Hello <mention>@user</mention> and <badge>admin</badge> here</p>',
+            'text/html',
+          );
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().append(...nodes);
+        },
+        {discrete: true},
+      );
+
+      const text = editor.read(() => $getRoot().getTextContent());
+      expect(text).toBe('Hello @user and admin here');
+    });
+
+    test('isInlineDomNode does not affect native inline elements', () => {
+      const editor = createHeadlessEditor({
+        html: {
+          isInlineDomNode: () => false,
+        },
+      });
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(
+            '<p>Hello <span>world</span> foo</p>',
+            'text/html',
+          );
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().append(...nodes);
+        },
+        {discrete: true},
+      );
+
+      const text = editor.read(() => $getRoot().getTextContent());
+      // Native inline elements still preserve whitespace regardless of custom check
+      expect(text).toBe('Hello world foo');
+    });
+  });
 });

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -406,6 +406,7 @@ export type HTMLConfig = {
     (editor: LexicalEditor, target: LexicalNode) => DOMExportOutput,
   >,
   import?: DOMConversionMap,
+  isInlineDomNode?: (node: Node) => boolean,
 };
 
 declare export function createEditor(editorConfig?: {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -227,6 +227,7 @@ export type LexicalNodeReplacement = {
 export type HTMLConfig = {
   export?: DOMExportOutputMap;
   import?: DOMConversionMap;
+  isInlineDomNode?: (node: Node) => boolean;
 };
 
 /**

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -84,6 +84,7 @@ import {
   errorOnReadOnly,
   getActiveEditor,
   getActiveEditorState,
+  internalGetActiveEditor,
   internalGetActiveEditorState,
   isCurrentlyReadOnlyMode,
   triggerCommandListeners,
@@ -1895,9 +1896,22 @@ const INLINE_TAG_RE =
 export function isInlineDomNode(
   node: Node,
 ): node is (HTMLElement | Text) & {[InlineDOMBrand]: never} {
-  return isHTMLElement(node) && node.style.display.startsWith('inline')
-    ? true
-    : INLINE_TAG_RE.test(node.nodeName);
+  if (isHTMLElement(node) && node.style.display.startsWith('inline')) {
+    return true;
+  }
+  if (INLINE_TAG_RE.test(node.nodeName)) {
+    return true;
+  }
+  const editor = internalGetActiveEditor();
+  if (editor !== null) {
+    const args = editor._createEditorArgs;
+    const customCheck =
+      args != null && args.html != null ? args.html.isInlineDomNode : undefined;
+    if (customCheck != null && customCheck(node)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 const BlockDOMBrand = Symbol.for('@lexical/BlockDOMBrand');


### PR DESCRIPTION
## Summary

Closes #8391

When importing HTML into Lexical, whitespace is only preserved around known native HTML inline elements (like `<span>`, `<b>`, `<a>`) or elements with explicit `display: inline` CSS. Custom elements like `<tooltip>` or `<mention>` are not recognized as inline, causing adjacent whitespace to be stripped during import.

This PR adds an `isInlineDomNode` option to `HTMLConfig` that accepts a predicate function, allowing users to declare which custom DOM elements should be treated as inline during HTML import.

### Usage

```js
createEditor({
  html: {
    isInlineDomNode: (node) => node.nodeName.toLowerCase() === 'tooltip',
  },
});
```

### Changes

- **`packages/lexical/src/LexicalEditor.ts`** — Added `isInlineDomNode` to `HTMLConfig` type
- **`packages/lexical/src/LexicalUtils.ts`** — Modified `isInlineDomNode()` to check the active editor's custom predicate as a fallback when built-in checks fail
- **`packages/lexical/flow/Lexical.js.flow`** — Flow type parity
- **`packages/lexical-extension/src/LexicalBuilder.ts`** — Fixed `LexicalBuilder` to forward `isInlineDomNode` config through the Extension system (it was only forwarding `import` and `export`)
- **`packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts`** — 4 tests covering: default behavior (whitespace stripped), fix working (whitespace preserved), multiple custom elements, and native elements unaffected

### Before (bug)

```html
<p>Hello <tooltip>world</tooltip> foo</p>
```
Produces: `"Helloworldfoo"` — spaces around `<tooltip>` are stripped

### After (fix)

With `isInlineDomNode` configured, produces: `"Hello world foo"` — spaces preserved

## Test plan

- [x] All 3042 existing unit tests pass (0 regressions)
- [x] 4 new tests added and passing
- [x] TypeScript check passes
- [x] ESLint/Prettier pass (pre-commit hooks)
- [x] Flow types updated