### PR TITLE
[lexical-playground] Fix: Prevent auto-zoom when focusing in the editor in iOS Safari

### DIFF
--- a/examples/extension-react-table/src/styles.css
+++ b/examples/extension-react-table/src/styles.css
@@ -69,7 +69,7 @@ h1 {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;
@@ -85,7 +85,7 @@ h1 {
   text-overflow: ellipsis;
   top: 15px;
   left: 10px;
-  font-size: 15px;
+  font-size: 16px;
   user-select: none;
   display: inline-block;
   pointer-events: none;
@@ -231,7 +231,7 @@ h1 {
 }
 
 .editor-heading-h2 {
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -243,7 +243,7 @@ h1 {
 .editor-quote {
   margin: 0;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/examples/node-replacement/src/styles.css
+++ b/examples/node-replacement/src/styles.css
@@ -69,7 +69,7 @@ h1 {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;
@@ -85,7 +85,7 @@ h1 {
   text-overflow: ellipsis;
   top: 15px;
   left: 10px;
-  font-size: 15px;
+  font-size: 16px;
   user-select: none;
   display: inline-block;
   pointer-events: none;
@@ -231,7 +231,7 @@ h1 {
 }
 
 .editor-heading-h2 {
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -243,7 +243,7 @@ h1 {
 .editor-quote {
   margin: 0;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/examples/node-state-style/src/styles.css
+++ b/examples/node-state-style/src/styles.css
@@ -71,7 +71,7 @@ h1 {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;
@@ -87,7 +87,7 @@ h1 {
   text-overflow: ellipsis;
   top: 15px;
   left: 10px;
-  font-size: 15px;
+  font-size: 16px;
   user-select: none;
   display: inline-block;
   pointer-events: none;
@@ -233,7 +233,7 @@ h1 {
 }
 
 .editor-heading-h2 {
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -245,7 +245,7 @@ h1 {
 .editor-quote {
   margin: 0;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/examples/react-plain-text/src/styles.css
+++ b/examples/react-plain-text/src/styles.css
@@ -46,7 +46,7 @@ body {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;

--- a/examples/react-rich-collab/src/styles.css
+++ b/examples/react-rich-collab/src/styles.css
@@ -71,7 +71,7 @@ h1 {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;
@@ -87,7 +87,7 @@ h1 {
   text-overflow: ellipsis;
   top: 15px;
   left: 10px;
-  font-size: 15px;
+  font-size: 16px;
   user-select: none;
   display: inline-block;
   pointer-events: none;
@@ -233,7 +233,7 @@ h1 {
 }
 
 .editor-heading-h2 {
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -245,7 +245,7 @@ h1 {
 .editor-quote {
   margin: 0;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/examples/react-rich/src/styles.css
+++ b/examples/react-rich/src/styles.css
@@ -69,7 +69,7 @@ h1 {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;
@@ -85,7 +85,7 @@ h1 {
   text-overflow: ellipsis;
   top: 15px;
   left: 10px;
-  font-size: 15px;
+  font-size: 16px;
   user-select: none;
   display: inline-block;
   pointer-events: none;
@@ -231,7 +231,7 @@ h1 {
 }
 
 .editor-heading-h2 {
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -243,7 +243,7 @@ h1 {
 .editor-quote {
   margin: 0;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/examples/react-table/src/styles.css
+++ b/examples/react-table/src/styles.css
@@ -69,7 +69,7 @@ h1 {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;
@@ -85,7 +85,7 @@ h1 {
   text-overflow: ellipsis;
   top: 15px;
   left: 10px;
-  font-size: 15px;
+  font-size: 16px;
   user-select: none;
   display: inline-block;
   pointer-events: none;
@@ -231,7 +231,7 @@ h1 {
 }
 
 .editor-heading-h2 {
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -243,7 +243,7 @@ h1 {
 .editor-quote {
   margin: 0;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/examples/vanilla-js-iframe/src/styles.css
+++ b/examples/vanilla-js-iframe/src/styles.css
@@ -18,7 +18,7 @@
   margin: 0;
   margin-left: 20px;
   margin-bottom: 10px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/examples/vanilla-js/src/styles.css
+++ b/examples/vanilla-js/src/styles.css
@@ -18,7 +18,7 @@
   margin: 0;
   margin-left: 20px;
   margin-bottom: 10px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -454,7 +454,7 @@ test.describe.parallel('Auto Links', () => {
       page,
       html`
         <p dir="auto">
-          <span style="font-size: 19px;" data-lexical-text="true">
+          <span style="font-size: 20px;" data-lexical-text="true">
             Hellohttp://example.com and more
           </span>
         </p>
@@ -472,13 +472,13 @@ test.describe.parallel('Auto Links', () => {
       page,
       html`
         <p dir="auto">
-          <span style="font-size: 19px;" data-lexical-text="true">Hello</span>
+          <span style="font-size: 20px;" data-lexical-text="true">Hello</span>
           <a href="http://example.com">
-            <span style="font-size: 19px;" data-lexical-text="true">
+            <span style="font-size: 20px;" data-lexical-text="true">
               http://example.com
             </span>
           </a>
-          <span style="font-size: 19px;" data-lexical-text="true">
+          <span style="font-size: 20px;" data-lexical-text="true">
             and more
           </span>
         </p>

--- a/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
@@ -42,7 +42,7 @@ test.describe('Autocomplete', () => {
             <span data-lexical-text="true">Sort by alpha</span>
             <span
               class="PlaygroundEditorTheme__autocomplete"
-              style="font-size: 15px"
+              style="font-size: 16px"
               data-lexical-text="true">
               betical (TAB)
             </span>
@@ -53,7 +53,7 @@ test.describe('Autocomplete', () => {
             <span data-lexical-text="true">Sort by alpha</span>
             <span
               class="PlaygroundEditorTheme__autocomplete"
-              style="font-size: 15px; display: none"
+              style="font-size: 16px; display: none"
               data-lexical-text="true">
               betical (TAB)
             </span>
@@ -67,7 +67,7 @@ test.describe('Autocomplete', () => {
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
             <span data-lexical-text="true">Sort by alpha</span>
-            <span style="font-size: 15px" data-lexical-text="true">
+            <span style="font-size: 16px" data-lexical-text="true">
               betical order:
             </span>
           </p>
@@ -97,13 +97,13 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__autocomplete"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             imonials (TAB)
           </strong>
@@ -113,13 +113,13 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__autocomplete"
-            style="font-size: 17px; display: none"
+            style="font-size: 18px; display: none"
             data-lexical-text="true">
             imonials (TAB)
           </strong>
@@ -143,17 +143,17 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             imonials
           </strong>
-          <span style="font-size: 15px;" data-lexical-text="true">2024</span>
+          <span style="font-size: 16px;" data-lexical-text="true">2024</span>
         </p>
       `,
     );
@@ -182,13 +182,13 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__autocomplete"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             imonials (TAB)
           </strong>
@@ -198,13 +198,13 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__autocomplete"
-            style="font-size: 17px; display: none"
+            style="font-size: 18px; display: none"
             data-lexical-text="true">
             imonials (TAB)
           </strong>
@@ -220,13 +220,13 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             imonials
           </strong>
@@ -236,13 +236,13 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px; display: none"
+            style="font-size: 18px; display: none"
             data-lexical-text="true">
             imonials
           </strong>
@@ -258,13 +258,13 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__autocomplete"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             imonials (TAB)
           </strong>
@@ -274,13 +274,13 @@ test.describe('Autocomplete', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
-            style="font-size: 17px;"
+            style="font-size: 18px;"
             data-lexical-text="true">
             Test
           </strong>
           <strong
             class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__autocomplete"
-            style="font-size: 17px; display: none"
+            style="font-size: 18px; display: none"
             data-lexical-text="true">
             imonials (TAB)
           </strong>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/ContextMenuCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/ContextMenuCopyAndPaste.spec.mjs
@@ -88,12 +88,12 @@ test.describe('ContextMenuCopyAndPaste', () => {
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-          <span style="font-size: 17px;" data-lexical-text="true">
+          <span style="font-size: 18px;" data-lexical-text="true">
             MLH Fellowship
           </span>
         </p>
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-          <span style="font-size: 17px;" data-lexical-text="true">
+          <span style="font-size: 18px;" data-lexical-text="true">
             Fall 2024Fellowship
           </span>
         </p>

--- a/packages/lexical-playground/__tests__/e2e/KeyboardShortcuts.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/KeyboardShortcuts.spec.mjs
@@ -256,9 +256,9 @@ test.describe('Keyboard shortcuts', () => {
       });
     };
 
-    expect(await getFontSize()).toBe('17');
+    expect(await getFontSize()).toBe('18');
     await decreaseFontSize(page);
-    expect(await getFontSize()).toBe('15');
+    expect(await getFontSize()).toBe('16');
   });
 
   test('Can clear formatting with the shortcut', async ({

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1981,7 +1981,7 @@ test.describe.parallel('Tables', () => {
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
           </tr>
-          <tr style="height: 87px">
+          <tr style="height: 89px">
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
@@ -2010,7 +2010,7 @@ test.describe.parallel('Tables', () => {
         // flaky fix: +- 1px for the height assertion
         actualHtml.replace(
           '<tr style="height: 88px">',
-          '<tr style="height: 87px">',
+          '<tr style="height: 89px">',
         ),
     );
   });

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -7872,39 +7872,40 @@ test.describe.parallel('Tables', () => {
       });
     });
 
-    test('Range-select from inside nested table to text above it selects the entire table, but not the outer table', async ({
-      browserName,
-      page,
-      isPlainText,
-      isCollab,
-    }) => {
-      test.skip(isPlainText);
-      test.skip(isCollab);
-      test.fixme(
-        browserName === 'firefox',
-        'Erroneously selects the entire outer cell',
-      );
-      await initialize({hasNestedTables: true, page});
+    test(
+      'Range-select from inside nested table to text above it selects the entire table, but not the outer table',
+      {
+        tag: '@flaky',
+      },
+      async ({browserName, page, isPlainText, isCollab}) => {
+        test.skip(isPlainText);
+        test.skip(isCollab);
+        test.fixme(
+          browserName === 'firefox',
+          'Erroneously selects the entire outer cell',
+        );
+        await initialize({hasNestedTables: true, page});
 
-      await setupTables(page);
+        await setupTables(page);
 
-      const pageOrFrame = getPageOrFrame(page);
+        const pageOrFrame = getPageOrFrame(page);
 
-      await pageOrFrame
-        .locator('table table > tr:first-of-type > th:first-of-type')
-        .click();
-      await page.keyboard.down('Shift');
-      await pageOrFrame.locator('p').filter({hasText: 'before'}).click();
-      await page.keyboard.up('Shift');
+        await pageOrFrame
+          .locator('table table > tr:first-of-type > th:first-of-type')
+          .click();
+        await page.keyboard.down('Shift');
+        await pageOrFrame.locator('p').filter({hasText: 'before'}).click();
+        await page.keyboard.up('Shift');
 
-      // Assert the selection is a range selection solely within the cell containing the nested table.
-      await assertSelection(page, {
-        anchorOffset: 1, // anchor moves to the end of the table
-        anchorPath: END_OF_INNER_TABLE,
-        focusOffset: 5,
-        focusPath: TEXT_BEFORE_NESTED_TABLE,
-      });
-    });
+        // Assert the selection is a range selection solely within the cell containing the nested table.
+        await assertSelection(page, {
+          anchorOffset: 1, // anchor moves to the end of the table
+          anchorPath: END_OF_INNER_TABLE,
+          focusOffset: 5,
+          focusPath: TEXT_BEFORE_NESTED_TABLE,
+        });
+      },
+    );
 
     test('Range-select from inside nested table to text below it selects the entire table, but not the outer table', async ({
       browserName,

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -13,6 +13,7 @@ import {
   moveRight,
   moveToEditorBeginning,
   moveToEditorEnd,
+  moveToLineEnd,
   moveUp,
   pressBackspace,
   selectAll,
@@ -7824,6 +7825,8 @@ test.describe.parallel('Tables', () => {
         .locator('p')
         .filter({hasText: 'before'})
         .click({force: true}); // `force` to ignore playwright blocking due to TableCellResizer interception
+      // move the cursor to the end of the word
+      await moveToLineEnd(page);
       await page.keyboard.down('Shift');
       await pageOrFrame
         .locator('table table > tr:first-of-type > th:first-of-type')
@@ -7832,7 +7835,7 @@ test.describe.parallel('Tables', () => {
 
       // Assert the selection is a range selection solely within the cell containing the nested table.
       await assertSelection(page, {
-        anchorOffset: 5, // at the end of the word "before"
+        anchorOffset: 6, // at the end of the word "before"
         anchorPath: TEXT_BEFORE_NESTED_TABLE,
         focusOffset: 1,
         focusPath: END_OF_INNER_TABLE,

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -8,6 +8,7 @@
 
 import {
   deleteBackward,
+  extendToNextWord,
   moveDown,
   moveLeft,
   moveRight,
@@ -7872,40 +7873,43 @@ test.describe.parallel('Tables', () => {
       });
     });
 
-    test(
-      'Range-select from inside nested table to text above it selects the entire table, but not the outer table',
-      {
-        tag: '@flaky',
-      },
-      async ({browserName, page, isPlainText, isCollab}) => {
-        test.skip(isPlainText);
-        test.skip(isCollab);
-        test.fixme(
-          browserName === 'firefox',
-          'Erroneously selects the entire outer cell',
-        );
-        await initialize({hasNestedTables: true, page});
+    test('Range-select from inside nested table to text above it selects the entire table, but not the outer table', async ({
+      browserName,
+      page,
+      isPlainText,
+      isCollab,
+    }) => {
+      test.skip(isPlainText);
+      test.skip(isCollab);
+      test.fixme(
+        browserName === 'firefox',
+        'Erroneously selects the entire outer cell',
+      );
+      await initialize({hasNestedTables: true, page});
 
-        await setupTables(page);
+      await setupTables(page);
 
-        const pageOrFrame = getPageOrFrame(page);
+      const pageOrFrame = getPageOrFrame(page);
 
-        await pageOrFrame
-          .locator('table table > tr:first-of-type > th:first-of-type')
-          .click();
-        await page.keyboard.down('Shift');
-        await pageOrFrame.locator('p').filter({hasText: 'before'}).click();
-        await page.keyboard.up('Shift');
+      await pageOrFrame
+        .locator('table table > tr:first-of-type > th:first-of-type')
+        .click();
+      await page.keyboard.down('Shift');
 
-        // Assert the selection is a range selection solely within the cell containing the nested table.
-        await assertSelection(page, {
-          anchorOffset: 1, // anchor moves to the end of the table
-          anchorPath: END_OF_INNER_TABLE,
-          focusOffset: 5,
-          focusPath: TEXT_BEFORE_NESTED_TABLE,
-        });
-      },
-    );
+      // workaround to ensure you reach the end of the word
+      await pageOrFrame.locator('p span').filter({hasText: 'before'}).click();
+      await extendToNextWord(page);
+
+      await page.keyboard.up('Shift');
+
+      // Assert the selection is a range selection solely within the cell containing the nested table.
+      await assertSelection(page, {
+        anchorOffset: 1, // anchor moves to the end of the table
+        anchorPath: END_OF_INNER_TABLE,
+        focusOffset: 6,
+        focusPath: TEXT_BEFORE_NESTED_TABLE,
+      });
+    });
 
     test('Range-select from inside nested table to text below it selects the entire table, but not the outer table', async ({
       browserName,
@@ -7927,7 +7931,11 @@ test.describe.parallel('Tables', () => {
 
       await pageOrFrame.locator('table table td').click();
       await page.keyboard.down('Shift');
-      await pageOrFrame.locator('p').filter({hasText: 'after'}).click();
+
+      // workaround to ensure you reach the end of the word
+      await pageOrFrame.locator('p span').filter({hasText: 'after'}).click();
+      await extendToNextWord(page);
+
       await page.keyboard.up('Shift');
 
       // Assert the selection is a range selection solely within the cell containing the nested table.

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -554,7 +554,7 @@ test.describe.parallel('TextFormatting', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello</span>
-          <span style="font-size: 17px;" data-lexical-text="true">world</span>
+          <span style="font-size: 18px;" data-lexical-text="true">world</span>
           <span data-lexical-text="true">!</span>
         </p>
       `,
@@ -586,8 +586,8 @@ test.describe.parallel('TextFormatting', () => {
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-          <span style="font-size: 17px;" data-lexical-text="true">Hello</span>
-          <span style="font-size: 19px;" data-lexical-text="true">world!</span>
+          <span style="font-size: 18px;" data-lexical-text="true">Hello</span>
+          <span style="font-size: 20px;" data-lexical-text="true">world!</span>
         </p>
       `,
     );
@@ -618,7 +618,7 @@ test.describe.parallel('TextFormatting', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello</span>
-          <span style="font-size: 13px;" data-lexical-text="true">world</span>
+          <span style="font-size: 14px;" data-lexical-text="true">world</span>
           <span data-lexical-text="true">!</span>
         </p>
       `,
@@ -650,7 +650,7 @@ test.describe.parallel('TextFormatting', () => {
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-          <span style="font-size: 13px;" data-lexical-text="true">Hello</span>
+          <span style="font-size: 14px;" data-lexical-text="true">Hello</span>
           <span style="font-size: 12px;" data-lexical-text="true">world!</span>
         </p>
       `,
@@ -683,7 +683,7 @@ test.describe.parallel('TextFormatting', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello</span>
-          <span style="font-size: 17px;" data-lexical-text="true">world</span>
+          <span style="font-size: 18px;" data-lexical-text="true">world</span>
           <span data-lexical-text="true">!</span>
         </p>
       `,
@@ -705,7 +705,7 @@ test.describe.parallel('TextFormatting', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello</span>
           <span
-            style="font-size: 17px; font-family: Georgia;"
+            style="font-size: 18px; font-family: Georgia;"
             data-lexical-text="true">
             world
           </span>
@@ -729,7 +729,7 @@ test.describe.parallel('TextFormatting', () => {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello</span>
           <span
-            style="font-size: 15px; font-family: Georgia;"
+            style="font-size: 16px; font-family: Georgia;"
             data-lexical-text="true">
             world
           </span>

--- a/packages/lexical-playground/esm/styles.css
+++ b/packages/lexical-playground/esm/styles.css
@@ -18,7 +18,7 @@
   margin: 0;
   margin-left: 20px;
   margin-bottom: 10px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/packages/lexical-playground/src/context/ToolbarContext.tsx
+++ b/packages/lexical-playground/src/context/ToolbarContext.tsx
@@ -21,7 +21,7 @@ import React, {
 
 export const MIN_ALLOWED_FONT_SIZE = 8;
 export const MAX_ALLOWED_FONT_SIZE = 72;
-export const DEFAULT_FONT_SIZE = 15;
+export const DEFAULT_FONT_SIZE = 16;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const rootTypeToRootName = {

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -8,6 +8,10 @@
 
 @import 'https://fonts.googleapis.com/css?family=Reenie+Beanie';
 
+:root {
+  --playground-font-size: 16px;
+}
+
 body {
   margin: 0;
   font-family:
@@ -352,8 +356,6 @@ pre::-webkit-scrollbar-thumb {
   padding: 8px;
   color: #050505;
   cursor: pointer;
-  line-height: 16px;
-  font-size: 15px;
   display: flex;
   align-content: center;
   flex-direction: row;
@@ -677,7 +679,7 @@ i.page-setup,
   padding: 8px 12px;
   border-radius: 15px;
   background-color: #eee;
-  font-size: 15px;
+  font-size: var(--playground-font-size);
   color: rgb(5, 5, 5);
   border: 0;
   outline: 0;
@@ -691,7 +693,7 @@ i.page-setup,
   margin: 8px 12px;
   padding: 8px 12px;
   border-radius: 15px;
-  font-size: 15px;
+  font-size: var(--playground-font-size);
   color: rgb(5, 5, 5);
   border: 0;
   outline: 0;
@@ -827,7 +829,7 @@ i.page-setup,
   color: #050505;
   cursor: pointer;
   line-height: 16px;
-  font-size: 15px;
+  font-size: var(--playground-font-size);
   display: flex;
   align-content: center;
   flex-direction: row;
@@ -988,7 +990,7 @@ i.page-setup,
 }
 
 .switches {
-  z-index: 6;
+  z-index: 20;
   position: fixed;
   left: 10px;
   bottom: 70px;
@@ -1496,20 +1498,6 @@ button.action-button:disabled {
   text-decoration: underline;
 }
 
-.connecting {
-  font-size: 15px;
-  color: #999;
-  overflow: hidden;
-  position: absolute;
-  text-overflow: ellipsis;
-  top: 10px;
-  left: 10px;
-  user-select: none;
-  white-space: nowrap;
-  display: inline-block;
-  pointer-events: none;
-}
-
 .toolbar {
   display: flex;
   margin-bottom: 1px;
@@ -1809,22 +1797,6 @@ button.item.dropdown-item-active {
 
 button.item.dropdown-item-active i {
   opacity: 1;
-}
-
-.TableNode__contentEditable {
-  min-height: 20px;
-  border: 0px;
-  resize: none;
-  cursor: text;
-  display: block;
-  position: relative;
-  outline: 0px;
-  padding: 0;
-  user-select: text;
-  font-size: 15px;
-  white-space: pre-wrap;
-  word-break: break-word;
-  z-index: 3;
 }
 
 .dialog-dropdown {

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.css
@@ -134,7 +134,7 @@ i.add-comment {
   border: 1px solid #ccc;
   background-color: #fff;
   border-radius: 5px;
-  font-size: 15px;
+  font-size: var(--playground-font-size);
   caret-color: rgb(5, 5, 5);
   display: block;
   padding: 9px 10px 10px 9px;
@@ -220,7 +220,7 @@ i.comments {
   border: 1px solid #ccc;
   background-color: #fff;
   border-radius: 5px;
-  font-size: 15px;
+  font-size: var(--playground-font-size);
   caret-color: rgb(5, 5, 5);
   display: block;
   padding: 9px 10px 10px 9px;
@@ -273,7 +273,6 @@ i.send {
 
 .CommentPlugin_CommentsPanel_Empty {
   color: #777;
-  font-size: 15px;
   text-align: center;
   position: absolute;
   top: calc(50% - 15px);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -72,6 +72,7 @@ import {Dispatch, useCallback, useEffect, useState} from 'react';
 import {useSettings} from '../../context/SettingsContext';
 import {
   blockTypeToBlockName,
+  DEFAULT_FONT_SIZE,
   useToolbarState,
 } from '../../context/ToolbarContext';
 import useModal from '../../hooks/useModal';
@@ -743,7 +744,11 @@ export default function ToolbarPlugin({
       updateToolbarState('isCode', selection.hasFormat('code'));
       updateToolbarState(
         'fontSize',
-        $getSelectionStyleValueForProperty(selection, 'font-size', '15px'),
+        $getSelectionStyleValueForProperty(
+          selection,
+          'font-size',
+          `${DEFAULT_FONT_SIZE}px`,
+        ),
       );
       updateToolbarState('isLowercase', selection.hasFormat('lowercase'));
       updateToolbarState('isUppercase', selection.hasFormat('uppercase'));

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -17,7 +17,6 @@
   margin: 0;
   margin-left: 20px;
   margin-bottom: 10px;
-  font-size: 15px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;
@@ -31,7 +30,6 @@
   margin: 0;
 }
 .PlaygroundEditorTheme__h2 {
-  font-size: 15px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -666,7 +664,7 @@
   color: #050505;
   border: 0;
   border-radius: 0px;
-  font-size: 15px;
+  font-size: var(--playground-font-size);
   text-align: left;
   line-height: 20px;
   padding: 8px;

--- a/packages/lexical-playground/src/ui/ContentEditable.css
+++ b/packages/lexical-playground/src/ui/ContentEditable.css
@@ -8,7 +8,7 @@
  */
 .ContentEditable__root {
   border: 0;
-  font-size: 15px;
+  font-size: 16px;
   display: block;
   position: relative;
   outline: 0;
@@ -23,7 +23,7 @@
 }
 
 .ContentEditable__placeholder {
-  font-size: 15px;
+  font-size: 16px;
   color: #999;
   overflow: hidden;
   position: absolute;

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/src/components/styles.css
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/src/components/styles.css
@@ -65,7 +65,7 @@ h1 {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;
@@ -81,7 +81,7 @@ h1 {
   text-overflow: ellipsis;
   top: 15px;
   left: 10px;
-  font-size: 15px;
+  font-size: 16px;
   user-select: none;
   display: inline-block;
   pointer-events: none;
@@ -227,7 +227,7 @@ h1 {
 }
 
 .editor-heading-h2 {
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -239,7 +239,7 @@ h1 {
 .editor-quote {
   margin: 0;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/app/styles.css
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/app/styles.css
@@ -65,7 +65,7 @@ h1 {
 .editor-input {
   min-height: 150px;
   resize: none;
-  font-size: 15px;
+  font-size: 16px;
   caret-color: rgb(5, 5, 5);
   position: relative;
   tab-size: 1;
@@ -81,7 +81,7 @@ h1 {
   text-overflow: ellipsis;
   top: 15px;
   left: 10px;
-  font-size: 15px;
+  font-size: 16px;
   user-select: none;
   display: inline-block;
   pointer-events: none;
@@ -227,7 +227,7 @@ h1 {
 }
 
 .editor-heading-h2 {
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
@@ -239,7 +239,7 @@ h1 {
 .editor-quote {
   margin: 0;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(101, 103, 107);
   border-left-color: rgb(206, 208, 212);
   border-left-width: 4px;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

The main change here is that the default font size is now 16px, since Safari on iOS automatically scales the page when focus is placed on a textarea with a font size smaller than 16px. Also, to maintain consistency with the Playground design, the font size for non-focused elements has been changed from 15px to 16px

This change will make it easier to test features in the mobile version of Safari

## Test plan

### Before

https://github.com/user-attachments/assets/4546fe7e-13d1-43f8-a38e-39b7c8876a76

### After

https://github.com/user-attachments/assets/edd32553-95f3-4876-9698-f96dc27a966e