### PR TITLE
[lexical] Perf: Adopt GenMap copy-on-write for NodeMap and reconciler keyToDOMMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "vitest": "vitest",
     "test-unit": "vitest --project unit --project scripts-unit --no-watch",
     "test-unit-watch": "vitest --project unit --project scripts-unit",
+    "bench": "vitest bench --project bench --project bench-dom --run",
     "test-eslint-integration": "node packages/lexical-eslint-plugin/__tests__/integration/integration-test.mjs",
     "test-integration": "vitest --project integration --no-watch",
     "test-e2e-chromium": "cross-env E2E_BROWSER=chromium playwright test --project=\"chromium\"",

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -34,6 +34,7 @@ import {
   registerDefaultCommandHandlers,
   removeRootElementEvents,
 } from './LexicalEvents';
+import {GenMap} from './LexicalGenMap';
 import {flushRootMutations, initMutationObserver} from './LexicalMutations';
 import {LexicalNode} from './LexicalNode';
 import {createSharedNodeState, SharedNodeState} from './LexicalNodeState';
@@ -984,7 +985,7 @@ export class LexicalEditor {
     this._compositionKey = null;
     this._deferred = [];
     // Used during reconciliation
-    this._keyToDOMMap = new Map();
+    this._keyToDOMMap = new GenMap();
     this._updates = [];
     this._updating = false;
     // Listeners

--- a/packages/lexical/src/LexicalEditorState.ts
+++ b/packages/lexical/src/LexicalEditorState.ts
@@ -14,6 +14,7 @@ import type {SerializedRootNode} from './nodes/LexicalRootNode';
 
 import invariant from 'shared/invariant';
 
+import {cloneMap} from './LexicalGenMap';
 import {readEditorState} from './LexicalUpdates';
 import {$getRoot} from './LexicalUtils';
 import {$isElementNode} from './nodes/LexicalElementNode';
@@ -46,7 +47,7 @@ export function editorStateHasDirtySelection(
 }
 
 export function cloneEditorState(current: EditorState): EditorState {
-  return new EditorState(new Map(current._nodeMap));
+  return new EditorState(cloneMap(current._nodeMap));
 }
 
 export function createEmptyEditorState(): EditorState {

--- a/packages/lexical/src/LexicalGenMap.ts
+++ b/packages/lexical/src/LexicalGenMap.ts
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const TOMBSTONE = null;
+const GEN_MAP_SIZE_THRESHOLD = 1000;
+
+/**
+ * Create a copy of the given Map, returning either a fresh Map or a clone
+ * of a copy-on-write GenMap depending on the size threshold.
+ *
+ * Below the threshold the cost of `new Map(map)` is small enough that the
+ * extra indirection of GenMap is not worthwhile. At and above the threshold
+ * GenMap's O(1) clone wins.
+ */
+export function cloneMap<K, V>(
+  map: Map<K, V>,
+  minGenMapSize: number = GEN_MAP_SIZE_THRESHOLD,
+): Map<K, V> {
+  if (map.size < minGenMapSize) {
+    return new Map(map);
+  }
+  if (map instanceof GenMap) {
+    return map.clone();
+  }
+  const clone = new GenMap<K, V>();
+  clone._old = new Map(map);
+  clone._size = map.size;
+  return clone;
+}
+
+/**
+ * A copy-on-write Map suitable for cloning large collections cheaply.
+ *
+ * Before being written to, a GenMap shares its `_old` and `_nursery` Maps
+ * with the GenMap it was cloned from. On first write it either compacts
+ * (folds `_nursery` into a new `_old`) or shallow-copies `_nursery`,
+ * isolating subsequent writes from sibling clones.
+ *
+ * `_old` is the immutable snapshot from the most recent compaction;
+ * `_nursery` holds writes since the last compaction (deletions stored as
+ * `TOMBSTONE`). `_mutable` tracks whether `_nursery` may be written to
+ * directly or must first be cloned.
+ */
+export class GenMap<K, V> implements Map<K, V> {
+  _mutable: boolean = false;
+  _old: undefined | ReadonlyMap<K, V> = undefined;
+  _nursery: undefined | Map<K, typeof TOMBSTONE | V> = undefined;
+  _size: number = 0;
+
+  clone(): GenMap<K, V> {
+    this._mutable = false;
+    const next = new GenMap<K, V>();
+    next._old = this._old;
+    next._nursery = this._nursery;
+    next._size = this._size;
+    return next;
+  }
+
+  get size(): number {
+    return this._size;
+  }
+
+  has(key: K): boolean {
+    return this.get(key) !== undefined;
+  }
+
+  /**
+   * Returns the raw value for `key`, including TOMBSTONE for keys deleted
+   * since the last compaction. Used internally to distinguish "missing"
+   * from "deleted" without doing a second lookup.
+   */
+  getWithTombstone(key: K): undefined | typeof TOMBSTONE | V {
+    const v = this._nursery && this._nursery.get(key);
+    if (v !== undefined) {
+      return v;
+    }
+    return this._old && this._old.get(key);
+  }
+
+  get(key: K): undefined | V {
+    const v = this.getWithTombstone(key);
+    return v === TOMBSTONE ? undefined : v;
+  }
+
+  shouldCompact(): boolean {
+    return this._nursery !== undefined && this._nursery.size * 2 > this._size;
+  }
+
+  /**
+   * Returns the nursery for in-place writes. If this GenMap is currently
+   * sharing its nursery with an ancestor clone, this either compacts (if
+   * the nursery has grown large enough) or makes a shallow copy.
+   *
+   * Skipping the `new Map()` allocation when the nursery is `undefined` or
+   * empty saves ~5-10% on the typing path where most cycles start with no
+   * pending writes.
+   */
+  getNursery(): Map<K, typeof TOMBSTONE | V> {
+    if (!this._mutable || !this._nursery) {
+      this.compact();
+      if (this._nursery !== undefined && this._nursery.size > 0) {
+        this._nursery = new Map(this._nursery);
+      } else if (this._nursery === undefined) {
+        this._nursery = new Map();
+      }
+      this._mutable = true;
+    }
+    return this._nursery;
+  }
+
+  /**
+   * Fold the nursery into a new `_old` snapshot when it has grown large
+   * enough that lookup overhead outweighs the savings from sharing.
+   * Triggered automatically from `getNursery` once `_nursery.size * 2 >
+   * _size`; can be forced via `compact(true)`.
+   */
+  compact(force: boolean = false): this {
+    if (
+      this._nursery &&
+      this._nursery.size > 0 &&
+      (force || this.shouldCompact())
+    ) {
+      const compact = new Map(this._old);
+      for (const [k, v] of this._nursery) {
+        if (v !== TOMBSTONE) {
+          compact.set(k, v as V);
+        } else {
+          compact.delete(k);
+        }
+      }
+      this._old = compact;
+      this._nursery = undefined;
+    }
+    this._mutable = false;
+    return this;
+  }
+
+  set(key: K, value: V): this {
+    const v = this.getWithTombstone(key);
+    if (v === value) {
+      return this;
+    }
+    const nursery = this.getNursery();
+    if (v === TOMBSTONE || v === undefined) {
+      this._size++;
+      if (v === TOMBSTONE) {
+        // Preserve insertion order: clear the tombstone before re-setting.
+        nursery.delete(key);
+      }
+    }
+    nursery.set(key, value);
+    return this;
+  }
+
+  delete(key: K): boolean {
+    const deleted = this.has(key);
+    if (deleted) {
+      this.getNursery().set(key, TOMBSTONE);
+      this._size--;
+    }
+    return deleted;
+  }
+
+  getOrInsert(key: K, defaultValue: V): V {
+    const existing = this.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    this.set(key, defaultValue);
+    return defaultValue;
+  }
+
+  getOrInsertComputed(key: K, computer: (k: K) => V): V {
+    const existing = this.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const value = computer(key);
+    this.set(key, value);
+    return value;
+  }
+
+  clear(): void {
+    this._mutable = false;
+    this._old = undefined;
+    this._nursery = undefined;
+    this._size = 0;
+  }
+
+  *keys(): MapIterator<K> {
+    for (const pair of this.entries()) {
+      yield pair[0];
+    }
+  }
+
+  *values(): MapIterator<V> {
+    for (const pair of this.entries()) {
+      yield pair[1];
+    }
+  }
+
+  *entries(): MapIterator<[K, V]> {
+    const nursery = this._nursery;
+    const old = this._old;
+    if (old) {
+      for (const pair of old) {
+        const k = pair[0];
+        const v = nursery ? nursery.get(k) : undefined;
+        if (v === TOMBSTONE) {
+          continue;
+        } else if (v !== undefined) {
+          (pair as [K, V])[1] = v as V;
+        }
+        yield pair as [K, V];
+      }
+    }
+    if (nursery) {
+      for (const pair of nursery) {
+        if (pair[1] !== TOMBSTONE && !(old && old.has(pair[0]))) {
+          yield pair as [K, V];
+        }
+      }
+    }
+  }
+
+  forEach(
+    callbackfn: (value: V, key: K, map: Map<K, V>) => void,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    thisArg?: any,
+  ): void {
+    if (thisArg !== undefined) {
+      callbackfn = callbackfn.bind(thisArg);
+    }
+    for (const [k, v] of this.entries()) {
+      callbackfn(v, k, this);
+    }
+  }
+
+  get [Symbol.toStringTag](): string {
+    return 'GenMap';
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.entries();
+  }
+}

--- a/packages/lexical/src/LexicalGenMap.ts
+++ b/packages/lexical/src/LexicalGenMap.ts
@@ -10,30 +10,32 @@ const TOMBSTONE = null;
 const GEN_MAP_SIZE_THRESHOLD = 1000;
 
 /**
- * Create a copy of the given Map, returning either a fresh Map or a clone
- * of a copy-on-write GenMap depending on the size threshold.
+ * @internal
  *
- * Below the threshold the cost of `new Map(map)` is small enough that the
- * extra indirection of GenMap is not worthwhile. At and above the threshold
- * GenMap's O(1) clone wins.
+ * Create a copy of the given Map, returning either a fresh Map or a clone
+ * of a copy-on-write GenMap depending on the source type and size.
+ *
+ * - If the source is already a GenMap, returns `map.clone()` (O(1)).
+ * - If the source is a plain Map below the threshold, returns
+ *   `new Map(map)` to avoid the GenMap overhead on small docs.
+ * - Otherwise wraps a fresh GenMap around the source.
  */
 export function cloneMap<K, V>(
   map: Map<K, V>,
   minGenMapSize: number = GEN_MAP_SIZE_THRESHOLD,
 ): Map<K, V> {
-  if (map.size < minGenMapSize) {
-    return new Map(map);
-  }
   if (map instanceof GenMap) {
     return map.clone();
   }
-  const clone = new GenMap<K, V>();
-  clone._old = new Map(map);
-  clone._size = map.size;
-  return clone;
+  if (map.size < minGenMapSize) {
+    return new Map(map);
+  }
+  return new GenMap<K, V>().init(new Map(map), undefined, map.size);
 }
 
 /**
+ * @internal
+ *
  * A copy-on-write Map suitable for cloning large collections cheaply.
  *
  * Before being written to, a GenMap shares its `_old` and `_nursery` Maps
@@ -45,6 +47,9 @@ export function cloneMap<K, V>(
  * `_nursery` holds writes since the last compaction (deletions stored as
  * `TOMBSTONE`). `_mutable` tracks whether `_nursery` may be written to
  * directly or must first be cloned.
+ *
+ * Implements the full `Map<K, V>` interface; methods not documented
+ * individually behave as their native `Map` counterparts.
  */
 export class GenMap<K, V> implements Map<K, V> {
   _mutable: boolean = false;
@@ -52,13 +57,25 @@ export class GenMap<K, V> implements Map<K, V> {
   _nursery: undefined | Map<K, typeof TOMBSTONE | V> = undefined;
   _size: number = 0;
 
+  /**
+   * Returns a new GenMap that initially shares `_old` and `_nursery`
+   * with this one. Marks both as not-mutable so the next write on either
+   * side triggers a copy-on-write of the nursery before mutating.
+   */
   clone(): GenMap<K, V> {
     this._mutable = false;
-    const next = new GenMap<K, V>();
-    next._old = this._old;
-    next._nursery = this._nursery;
-    next._size = this._size;
-    return next;
+    return new GenMap<K, V>().init(this._old, this._nursery, this._size);
+  }
+
+  init(
+    old: undefined | ReadonlyMap<K, V>,
+    nursery: undefined | Map<K, typeof TOMBSTONE | V>,
+    size: number,
+  ): this {
+    this._old = old;
+    this._nursery = nursery;
+    this._size = size;
+    return this;
   }
 
   get size(): number {
@@ -95,19 +112,11 @@ export class GenMap<K, V> implements Map<K, V> {
    * Returns the nursery for in-place writes. If this GenMap is currently
    * sharing its nursery with an ancestor clone, this either compacts (if
    * the nursery has grown large enough) or makes a shallow copy.
-   *
-   * Skipping the `new Map()` allocation when the nursery is `undefined` or
-   * empty saves ~5-10% on the typing path where most cycles start with no
-   * pending writes.
    */
   getNursery(): Map<K, typeof TOMBSTONE | V> {
     if (!this._mutable || !this._nursery) {
       this.compact();
-      if (this._nursery !== undefined && this._nursery.size > 0) {
-        this._nursery = new Map(this._nursery);
-      } else if (this._nursery === undefined) {
-        this._nursery = new Map();
-      }
+      this._nursery = new Map(this._nursery);
       this._mutable = true;
     }
     return this._nursery;
@@ -149,7 +158,8 @@ export class GenMap<K, V> implements Map<K, V> {
     if (v === TOMBSTONE || v === undefined) {
       this._size++;
       if (v === TOMBSTONE) {
-        // Preserve insertion order: clear the tombstone before re-setting.
+        // Match native Map semantics where `delete(k); set(k, v)`
+        // re-inserts the key at the end of iteration order.
         nursery.delete(key);
       }
     }

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -38,6 +38,7 @@ import {
   IS_ALIGN_START,
 } from './LexicalConstants';
 import {EditorState} from './LexicalEditorState';
+import {cloneMap} from './LexicalGenMap';
 import {
   $createChildrenArray,
   cloneDecorators,
@@ -851,7 +852,7 @@ export function $reconcileRoot(
   activePrevNodeMap = prevEditorState._nodeMap;
   activeNextNodeMap = nextEditorState._nodeMap;
   activeEditorStateReadOnly = nextEditorState._readOnly;
-  activePrevKeyToDOMMap = new Map(editor._keyToDOMMap);
+  activePrevKeyToDOMMap = cloneMap(editor._keyToDOMMap);
   // We keep track of mutated nodes so we can trigger mutation
   // listeners later in the update cycle.
   const currentMutatedNodes = new Map();

--- a/packages/lexical/src/__bench__/README.md
+++ b/packages/lexical/src/__bench__/README.md
@@ -105,19 +105,26 @@ starts from a clean baseline. Vitest invokes `setup` before each timed
 iteration; allocations inside `setup` do not count toward the benchmark.
 
 **DCE prevention** — V8 may eliminate calls whose return values are
-unused. For lookups, assign to a discardable local:
+unused. Each bench file should declare a module-level sink and `push`
+into it from the timed body so the call can't be elided:
 
 ```ts
-let _sink;
+const benchSinks: unknown[] = [];
+
 bench('get', () => {
-  _sink = map.get(someKey);
+  benchSinks.push(map.get(someKey));
 });
 ```
 
-For loops, ensure the body produces a side effect or accumulates into a
-visible local. The existing `nodeMap.bench.ts` uses `let _count = 0; for
-(const _ of m) _count++;` — the increment forces V8 to materialize the
-iterator.
+For loops, accumulate into a local and push the local once at the end:
+
+```ts
+bench('iterate', () => {
+  let count = 0;
+  for (const _ of map) count++;
+  benchSinks.push(count);
+});
+```
 
 ## Reading results
 

--- a/packages/lexical/src/__bench__/README.md
+++ b/packages/lexical/src/__bench__/README.md
@@ -1,14 +1,27 @@
 # Lexical Benchmarks
 
 Performance benchmarks for the Lexical core. Run via `pnpm bench` from the
-repo root, or scoped with `--project bench` (data-structure, node env) or
-`--project bench-dom` (real-editor, jsdom env).
+repo root, or scoped to a single project with `--project bench` (data
+structure microbenches, node env) or `--project bench-dom` (real-editor
+benches, jsdom env).
 
 ```sh
-pnpm bench                           # all bench projects
-pnpm vitest bench --project bench    # data-structure microbenches only
-pnpm vitest bench --project bench-dom  # editor cycle benches only
+pnpm bench                                # all bench projects
+pnpm vitest bench --project bench         # microbenches only
+pnpm vitest bench --project bench-dom     # editor cycle benches only
+pnpm vitest bench --project bench nodeMap # filter by file substring
 ```
+
+## Two projects, why?
+
+Microbenches that exercise pure data structures (`Map` vs `GenMap`, etc.)
+run in `bench` (node env, no DOM) — fastest startup, cleanest numbers.
+
+Benches that exercise a real Lexical editor (which needs a DOM) run in
+`bench-dom` (jsdom env). Files in `__bench__/dom/**` are picked up only
+by this project. The two projects share the same `pnpm bench` entry but
+otherwise stay isolated to keep microbench results uncontaminated by
+jsdom setup cost.
 
 ## What benches live here
 
@@ -16,6 +29,10 @@ pnpm vitest bench --project bench-dom  # editor cycle benches only
 | ---- | ------- | -------- |
 | `nodeMap.bench.ts` | `bench` | `Map` vs `GenMap` on clone / typing / paste / iteration / get |
 | `dom/editorCycle.bench.ts` | `bench-dom` | real `editor.update` cycle cost on a jsdom-backed editor |
+
+Helpers shared across files live in `_utils.ts` (microbench) and
+`dom/_utils.ts` (real-editor). Use them when you can; extract new helpers
+there if your bench file grows beyond a single workload.
 
 ## When to add a bench
 
@@ -32,53 +49,93 @@ isolation.
 
 **File naming**
 
-- `*.bench.ts` directly under `__bench__/` for node-env microbenches
-  (data structures, pure logic).
-- `*.bench.ts` under `__bench__/dom/` for jsdom-env benches that exercise
-  a real editor.
+- `*.bench.ts` directly under `__bench__/` for node-env microbenches.
+- `*.bench.ts` under `__bench__/dom/` for jsdom-env benches.
 
-**Structure**
+**Structure** — sweep across realistic sizes; one `describe` per scenario;
+one `bench` per implementation under test.
 
 ```ts
 import {bench, describe} from 'vitest';
 
+import {buildMap, type FakeNode} from './_utils';
+import {MyImpl} from '../MyImpl';
+
 const SIZES = [100, 1000, 10000, 100000] as const;
 
 for (const size of SIZES) {
-  describe(`size=${size} :: <scenario>`, () => {
-    let state;
+  describe(`size=${size} :: <scenario name>`, () => {
+    let oldImpl: Map<string, FakeNode>;
+    let newImpl: MyImpl<string, FakeNode>;
+
     bench(
-      'impl A',
+      'old',
       () => {
-        // operation under test
+        // operation under test using oldImpl
       },
-      {setup: () => { state = build(size); }},
+      {
+        setup: () => {
+          oldImpl = buildMap(size);
+        },
+      },
     );
+
     bench(
-      'impl B',
+      'new',
       () => {
-        // operation under test
+        // operation under test using newImpl
       },
-      {setup: () => { state = build(size); }},
+      {
+        setup: () => {
+          newImpl = MyImpl.fromMap(buildMap(size));
+        },
+      },
     );
   });
 }
 ```
 
-- Sweep across realistic doc sizes; pick the largest that still completes
-  in a few seconds per case.
-- Reset state in `setup` so each iteration starts from a clean baseline.
+**Comparison pattern** — when comparing an old vs new implementation,
+register both under the same `describe` block. Vitest's summary shows the
+relative factor between benches in the same block, which is exactly what
+you want to cite in PR descriptions.
+
+**Setup state** — reset state in the `setup` callback so each iteration
+starts from a clean baseline. Vitest invokes `setup` before each timed
+iteration; allocations inside `setup` do not count toward the benchmark.
+
+**DCE prevention** — V8 may eliminate calls whose return values are
+unused. For lookups, assign to a discardable local:
+
+```ts
+let _sink;
+bench('get', () => {
+  _sink = map.get(someKey);
+});
+```
+
+For loops, ensure the body produces a side effect or accumulates into a
+visible local. The existing `nodeMap.bench.ts` uses `let _count = 0; for
+(const _ of m) _count++;` — the increment forces V8 to materialize the
+iterator.
 
 ## Reading results
 
 Vitest bench reports `hz` (ops/sec), `mean`, `p75`, `p99`, and a relative
 factor in the summary. The summary block at the end is the primary signal:
-look for "Nx faster than..." lines comparing the relevant impls.
+look for "Nx faster than..." lines comparing the relevant impls. `mean` is
+useful to cite as an absolute number; `p99` indicates tail behavior under
+GC or compaction.
+
+Sample size and warmup are managed by Vitest. The default heuristics are
+fine for stable comparisons between two impls on the same machine; for
+absolute numbers you intend to publish, run multiple times and report the
+median.
 
 ## Limits
 
-- Numbers are **machine-dependent**. Compare runs on the same machine, same
-  load. Don't compare numbers across different hardware.
-- jsdom DOM ops are slower than real browsers. Treat `bench-dom` numbers as
-  relative comparisons, not absolute production estimates.
+- Numbers are **machine-dependent**. Compare runs on the same machine and
+  the same load. Don't compare numbers across hardware.
+- jsdom DOM ops are slower than real browsers. Treat `bench-dom` numbers
+  as relative comparisons, not absolute production estimates.
 - Benches do not run in CI today. They are local tools for perf work.

--- a/packages/lexical/src/__bench__/README.md
+++ b/packages/lexical/src/__bench__/README.md
@@ -1,0 +1,84 @@
+# Lexical Benchmarks
+
+Performance benchmarks for the Lexical core. Run via `pnpm bench` from the
+repo root, or scoped with `--project bench` (data-structure, node env) or
+`--project bench-dom` (real-editor, jsdom env).
+
+```sh
+pnpm bench                           # all bench projects
+pnpm vitest bench --project bench    # data-structure microbenches only
+pnpm vitest bench --project bench-dom  # editor cycle benches only
+```
+
+## What benches live here
+
+| File | Project | Measures |
+| ---- | ------- | -------- |
+| `nodeMap.bench.ts` | `bench` | `Map` vs `GenMap` on clone / typing / paste / iteration / get |
+| `dom/editorCycle.bench.ts` | `bench-dom` | real `editor.update` cycle cost on a jsdom-backed editor |
+
+## When to add a bench
+
+Add a bench when you are landing a perf change and want to:
+
+- Establish a baseline so future regressions are detectable.
+- Justify a non-obvious algorithmic choice with measurements.
+- Compare implementation strategies (the `nodeMap.bench.ts` workflow).
+
+Skip a bench for changes whose perf impact is obvious or unmeasurable in
+isolation.
+
+## Conventions
+
+**File naming**
+
+- `*.bench.ts` directly under `__bench__/` for node-env microbenches
+  (data structures, pure logic).
+- `*.bench.ts` under `__bench__/dom/` for jsdom-env benches that exercise
+  a real editor.
+
+**Structure**
+
+```ts
+import {bench, describe} from 'vitest';
+
+const SIZES = [100, 1000, 10000, 100000] as const;
+
+for (const size of SIZES) {
+  describe(`size=${size} :: <scenario>`, () => {
+    let state;
+    bench(
+      'impl A',
+      () => {
+        // operation under test
+      },
+      {setup: () => { state = build(size); }},
+    );
+    bench(
+      'impl B',
+      () => {
+        // operation under test
+      },
+      {setup: () => { state = build(size); }},
+    );
+  });
+}
+```
+
+- Sweep across realistic doc sizes; pick the largest that still completes
+  in a few seconds per case.
+- Reset state in `setup` so each iteration starts from a clean baseline.
+
+## Reading results
+
+Vitest bench reports `hz` (ops/sec), `mean`, `p75`, `p99`, and a relative
+factor in the summary. The summary block at the end is the primary signal:
+look for "Nx faster than..." lines comparing the relevant impls.
+
+## Limits
+
+- Numbers are **machine-dependent**. Compare runs on the same machine, same
+  load. Don't compare numbers across different hardware.
+- jsdom DOM ops are slower than real browsers. Treat `bench-dom` numbers as
+  relative comparisons, not absolute production estimates.
+- Benches do not run in CI today. They are local tools for perf work.

--- a/packages/lexical/src/__bench__/_utils.ts
+++ b/packages/lexical/src/__bench__/_utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * A minimal stand-in for a Lexical node — three string fields, similar
+ * memory pressure to a real `TextNode` without pulling in the full
+ * editor stack. Suitable for benchmarking data structures that hold
+ * NodeMap-shaped values.
+ */
+export type FakeNode = {
+  __key: string;
+  __type: string;
+  __parent: string | null;
+};
+
+export function makeNode(key: string): FakeNode {
+  return {__key: key, __parent: 'root', __type: 'text'};
+}
+
+/**
+ * Build a Map of `size` FakeNodes keyed by their decimal index.
+ */
+export function buildMap(size: number): Map<string, FakeNode> {
+  const m = new Map<string, FakeNode>();
+  for (let i = 0; i < size; i++) {
+    const k = String(i);
+    m.set(k, makeNode(k));
+  }
+  return m;
+}

--- a/packages/lexical/src/__bench__/dom/_utils.ts
+++ b/packages/lexical/src/__bench__/dom/_utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalEditor} from '../../';
+
+import {$createParagraphNode, $createTextNode, $getRoot} from '../../';
+
+/**
+ * Attach a fresh contentEditable host to `document.body` and bind the
+ * editor's root element to it. Returns the host so callers can inspect
+ * or detach it.
+ */
+export function attachToDOM(editor: LexicalEditor): HTMLElement {
+  const root = document.createElement('div');
+  root.contentEditable = 'true';
+  document.body.appendChild(root);
+  editor.setRootElement(root);
+  return root;
+}
+
+/**
+ * Populate the editor with `paragraphs` paragraphs, each containing a
+ * short text node. Useful as a baseline document for cycle-cost benches.
+ */
+export function buildLargeDoc(editor: LexicalEditor, paragraphs: number): void {
+  editor.update(
+    () => {
+      const root = $getRoot();
+      for (let i = 0; i < paragraphs; i++) {
+        const p = $createParagraphNode();
+        p.append($createTextNode(`paragraph ${i} with some text content`));
+        root.append(p);
+      }
+    },
+    {discrete: true},
+  );
+}

--- a/packages/lexical/src/__bench__/dom/editorCycle.bench.ts
+++ b/packages/lexical/src/__bench__/dom/editorCycle.bench.ts
@@ -6,39 +6,15 @@
  *
  */
 
+import type {LexicalEditor, ParagraphNode} from '../../';
+
 import {bench, describe} from 'vitest';
 
-import {
-  $createParagraphNode,
-  $createTextNode,
-  $getRoot,
-  type LexicalEditor,
-} from '../../';
+import {$createTextNode, $getRoot} from '../../';
 import {createTestEditor} from '../../__tests__/utils';
+import {attachToDOM, buildLargeDoc} from './_utils';
 
 const SIZES = [1000, 5000] as const;
-
-function buildLargeDoc(editor: LexicalEditor, paragraphs: number): void {
-  editor.update(
-    () => {
-      const root = $getRoot();
-      for (let i = 0; i < paragraphs; i++) {
-        const p = $createParagraphNode();
-        p.append($createTextNode(`paragraph ${i} with some text content`));
-        root.append(p);
-      }
-    },
-    {discrete: true},
-  );
-}
-
-function attachToDOM(editor: LexicalEditor): HTMLElement {
-  const root = document.createElement('div');
-  root.contentEditable = 'true';
-  document.body.appendChild(root);
-  editor.setRootElement(root);
-  return root;
-}
 
 for (const size of SIZES) {
   describe(`size=${size} :: typing 1 char per cycle`, () => {
@@ -54,7 +30,7 @@ for (const size of SIZES) {
             const last = root.getLastChild();
             if (last) {
               const t = $createTextNode(`x${cycle++}`);
-              (last as ReturnType<typeof $createParagraphNode>).append(t);
+              (last as ParagraphNode).append(t);
             }
           },
           {discrete: true},

--- a/packages/lexical/src/__bench__/dom/editorCycle.bench.ts
+++ b/packages/lexical/src/__bench__/dom/editorCycle.bench.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalEditor} from 'lexical';
+
+import {bench, describe} from 'vitest';
+
+import {createTestEditor} from '../../__tests__/utils';
+import {$createParagraphNode, $createTextNode, $getRoot} from '.';
+
+const SIZES = [1000, 5000] as const;
+
+function buildLargeDoc(editor: LexicalEditor, paragraphs: number): void {
+  editor.update(
+    () => {
+      const root = $getRoot();
+      for (let i = 0; i < paragraphs; i++) {
+        const p = $createParagraphNode();
+        p.append($createTextNode(`paragraph ${i} with some text content`));
+        root.append(p);
+      }
+    },
+    {discrete: true},
+  );
+}
+
+function attachToDOM(editor: LexicalEditor): HTMLElement {
+  const root = document.createElement('div');
+  root.contentEditable = 'true';
+  document.body.appendChild(root);
+  editor.setRootElement(root);
+  return root;
+}
+
+for (const size of SIZES) {
+  describe(`size=${size} :: typing 1 char per cycle`, () => {
+    let editor: LexicalEditor;
+    let cycle = 0;
+
+    bench(
+      'editor.update with 1 mutation',
+      () => {
+        editor.update(
+          () => {
+            const root = $getRoot();
+            const last = root.getLastChild();
+            if (last) {
+              const t = $createTextNode(`x${cycle++}`);
+              (last as ReturnType<typeof $createParagraphNode>).append(t);
+            }
+          },
+          {discrete: true},
+        );
+      },
+      {
+        setup: () => {
+          editor = createTestEditor();
+          attachToDOM(editor);
+          buildLargeDoc(editor, size);
+          cycle = 0;
+        },
+      },
+    );
+  });
+
+  describe(`size=${size} :: read-only update (no mutation)`, () => {
+    let editor: LexicalEditor;
+
+    bench(
+      'editor.update with no mutation',
+      () => {
+        editor.update(() => {}, {discrete: true});
+      },
+      {
+        setup: () => {
+          editor = createTestEditor();
+          attachToDOM(editor);
+          buildLargeDoc(editor, size);
+        },
+      },
+    );
+  });
+
+  describe(`size=${size} :: editor.read (pure read)`, () => {
+    let editor: LexicalEditor;
+
+    bench(
+      'editor.read',
+      () => {
+        editor.read(() => {
+          $getRoot().getChildrenSize();
+        });
+      },
+      {
+        setup: () => {
+          editor = createTestEditor();
+          attachToDOM(editor);
+          buildLargeDoc(editor, size);
+        },
+      },
+    );
+  });
+}

--- a/packages/lexical/src/__bench__/dom/editorCycle.bench.ts
+++ b/packages/lexical/src/__bench__/dom/editorCycle.bench.ts
@@ -6,12 +6,15 @@
  *
  */
 
-import type {LexicalEditor} from 'lexical';
-
 import {bench, describe} from 'vitest';
 
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type LexicalEditor,
+} from '../../';
 import {createTestEditor} from '../../__tests__/utils';
-import {$createParagraphNode, $createTextNode, $getRoot} from '.';
 
 const SIZES = [1000, 5000] as const;
 

--- a/packages/lexical/src/__bench__/nodeMap.bench.ts
+++ b/packages/lexical/src/__bench__/nodeMap.bench.ts
@@ -13,6 +13,11 @@ import {buildMap, type FakeNode, makeNode} from './_utils';
 
 const SIZES = [100, 1000, 10000, 100000] as const;
 
+// Module-level sink push'd into by each bench body so V8 can't elide
+// the work. The array is intentionally never read; `push` is the
+// observable side effect that anchors the computation. See README.md.
+const benchSinks: unknown[] = [];
+
 function buildGenMap(size: number): GenMap<string, FakeNode> {
   const g = new GenMap<string, FakeNode>();
   g._mutable = true;
@@ -170,7 +175,7 @@ for (const size of SIZES) {
     bench(
       'Map',
       () => {
-        mapBase.get(k);
+        benchSinks.push(mapBase.get(k));
       },
       {
         setup: () => {
@@ -182,7 +187,7 @@ for (const size of SIZES) {
     bench(
       'GenMap',
       () => {
-        genBase.get(k);
+        benchSinks.push(genBase.get(k));
       },
       {
         setup: () => {
@@ -199,8 +204,9 @@ for (const size of SIZES) {
     bench(
       'Map',
       () => {
-        let _count = 0;
-        for (const _ of mapBase) _count++;
+        let count = 0;
+        for (const _ of mapBase) count++;
+        benchSinks.push(count);
       },
       {
         setup: () => {
@@ -212,8 +218,9 @@ for (const size of SIZES) {
     bench(
       'GenMap',
       () => {
-        let _count = 0;
-        for (const _ of genBase) _count++;
+        let count = 0;
+        for (const _ of genBase) count++;
+        benchSinks.push(count);
       },
       {
         setup: () => {

--- a/packages/lexical/src/__bench__/nodeMap.bench.ts
+++ b/packages/lexical/src/__bench__/nodeMap.bench.ts
@@ -9,27 +9,9 @@
 import {bench, describe} from 'vitest';
 
 import {GenMap} from '../LexicalGenMap';
+import {buildMap, type FakeNode, makeNode} from './_utils';
 
 const SIZES = [100, 1000, 10000, 100000] as const;
-
-type FakeNode = {
-  __key: string;
-  __type: string;
-  __parent: string | null;
-};
-
-function makeNode(key: string): FakeNode {
-  return {__key: key, __parent: 'root', __type: 'text'};
-}
-
-function buildMap(size: number): Map<string, FakeNode> {
-  const m = new Map<string, FakeNode>();
-  for (let i = 0; i < size; i++) {
-    const k = String(i);
-    m.set(k, makeNode(k));
-  }
-  return m;
-}
 
 function buildGenMap(size: number): GenMap<string, FakeNode> {
   const g = new GenMap<string, FakeNode>();

--- a/packages/lexical/src/__bench__/nodeMap.bench.ts
+++ b/packages/lexical/src/__bench__/nodeMap.bench.ts
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {bench, describe} from 'vitest';
+
+import {GenMap} from '../LexicalGenMap';
+
+const SIZES = [100, 1000, 10000, 100000] as const;
+
+type FakeNode = {
+  __key: string;
+  __type: string;
+  __parent: string | null;
+};
+
+function makeNode(key: string): FakeNode {
+  return {__key: key, __parent: 'root', __type: 'text'};
+}
+
+function buildMap(size: number): Map<string, FakeNode> {
+  const m = new Map<string, FakeNode>();
+  for (let i = 0; i < size; i++) {
+    const k = String(i);
+    m.set(k, makeNode(k));
+  }
+  return m;
+}
+
+function buildGenMap(size: number): GenMap<string, FakeNode> {
+  const g = new GenMap<string, FakeNode>();
+  g._mutable = true;
+  g._nursery = new Map();
+  for (let i = 0; i < size; i++) {
+    const k = String(i);
+    g.set(k, makeNode(k));
+  }
+  g.compact(true);
+  return g;
+}
+
+for (const size of SIZES) {
+  describe(`size=${size} :: clone`, () => {
+    let mapBase: Map<string, FakeNode>;
+    let genBase: GenMap<string, FakeNode>;
+
+    bench(
+      'Map: new Map(prev)',
+      () => {
+        const _ = new Map(mapBase);
+      },
+      {
+        setup: () => {
+          mapBase = buildMap(size);
+        },
+      },
+    );
+
+    bench(
+      'GenMap: clone()',
+      () => {
+        const _ = genBase.clone();
+      },
+      {
+        setup: () => {
+          genBase = buildGenMap(size);
+        },
+      },
+    );
+  });
+
+  describe(`size=${size} :: clone + 1 set (typing 1 char)`, () => {
+    let mapBase: Map<string, FakeNode>;
+    let genBase: GenMap<string, FakeNode>;
+
+    bench(
+      'Map',
+      () => {
+        const next = new Map(mapBase);
+        next.set('newKey', makeNode('newKey'));
+      },
+      {
+        setup: () => {
+          mapBase = buildMap(size);
+        },
+      },
+    );
+
+    bench(
+      'GenMap',
+      () => {
+        const next = genBase.clone();
+        next.set('newKey', makeNode('newKey'));
+      },
+      {
+        setup: () => {
+          genBase = buildGenMap(size);
+        },
+      },
+    );
+  });
+
+  describe(`size=${size} :: 50 sustained cycles (typing)`, () => {
+    let mapBase: Map<string, FakeNode>;
+    let genBase: GenMap<string, FakeNode>;
+
+    bench(
+      'Map',
+      () => {
+        let cur = mapBase;
+        for (let c = 0; c < 50; c++) {
+          const next = new Map(cur);
+          next.set(`typed${c}`, makeNode(`typed${c}`));
+          cur = next;
+        }
+      },
+      {
+        setup: () => {
+          mapBase = buildMap(size);
+        },
+      },
+    );
+
+    bench(
+      'GenMap',
+      () => {
+        let cur = genBase;
+        for (let c = 0; c < 50; c++) {
+          const next = cur.clone();
+          next.set(`typed${c}`, makeNode(`typed${c}`));
+          cur = next;
+        }
+      },
+      {
+        setup: () => {
+          genBase = buildGenMap(size);
+        },
+      },
+    );
+  });
+
+  describe(`size=${size} :: paste 100 nodes (1 cycle, 100 mutations)`, () => {
+    let mapBase: Map<string, FakeNode>;
+    let genBase: GenMap<string, FakeNode>;
+
+    bench(
+      'Map',
+      () => {
+        const next = new Map(mapBase);
+        for (let i = 0; i < 100; i++) {
+          const k = `paste${i}`;
+          next.set(k, makeNode(k));
+        }
+      },
+      {
+        setup: () => {
+          mapBase = buildMap(size);
+        },
+      },
+    );
+
+    bench(
+      'GenMap',
+      () => {
+        const next = genBase.clone();
+        for (let i = 0; i < 100; i++) {
+          const k = `paste${i}`;
+          next.set(k, makeNode(k));
+        }
+      },
+      {
+        setup: () => {
+          genBase = buildGenMap(size);
+        },
+      },
+    );
+  });
+
+  describe(`size=${size} :: get`, () => {
+    let mapBase: Map<string, FakeNode>;
+    let genBase: GenMap<string, FakeNode>;
+    const k = String(Math.floor(size / 2));
+
+    bench(
+      'Map',
+      () => {
+        mapBase.get(k);
+      },
+      {
+        setup: () => {
+          mapBase = buildMap(size);
+        },
+      },
+    );
+
+    bench(
+      'GenMap',
+      () => {
+        genBase.get(k);
+      },
+      {
+        setup: () => {
+          genBase = buildGenMap(size);
+        },
+      },
+    );
+  });
+
+  describe(`size=${size} :: full iteration`, () => {
+    let mapBase: Map<string, FakeNode>;
+    let genBase: GenMap<string, FakeNode>;
+
+    bench(
+      'Map',
+      () => {
+        let _count = 0;
+        for (const _ of mapBase) _count++;
+      },
+      {
+        setup: () => {
+          mapBase = buildMap(size);
+        },
+      },
+    );
+
+    bench(
+      'GenMap',
+      () => {
+        let _count = 0;
+        for (const _ of genBase) _count++;
+      },
+      {
+        setup: () => {
+          genBase = buildGenMap(size);
+        },
+      },
+    );
+  });
+}

--- a/packages/lexical/src/__tests__/unit/LexicalGenMap.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalGenMap.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {describe, expect, test} from 'vitest';
+
+import {cloneMap, GenMap} from '../../LexicalGenMap';
+
+function buildGenMap(
+  entries: ReadonlyArray<[string, number]>,
+): GenMap<string, number> {
+  const g = new GenMap<string, number>();
+  for (const [k, v] of entries) {
+    g.set(k, v);
+  }
+  return g;
+}
+
+describe('GenMap', () => {
+  test('clone shares state until first write', () => {
+    const a = buildGenMap([
+      ['x', 1],
+      ['y', 2],
+    ]);
+    const b = a.clone();
+
+    // Both see the same entries.
+    expect(b.get('x')).toBe(1);
+    expect(b.get('y')).toBe(2);
+    expect(b.size).toBe(2);
+
+    // The internal references are shared.
+    expect(b._old).toBe(a._old);
+    expect(b._nursery).toBe(a._nursery);
+  });
+
+  test('write to a clone isolates that clone from the original', () => {
+    const a = buildGenMap([['x', 1]]);
+    const b = a.clone();
+
+    b.set('y', 99);
+
+    expect(b.get('y')).toBe(99);
+    expect(a.get('y')).toBeUndefined();
+    expect(a.size).toBe(1);
+    expect(b.size).toBe(2);
+  });
+
+  test('write to the original after clone isolates the original', () => {
+    const a = buildGenMap([['x', 1]]);
+    const b = a.clone();
+
+    a.set('z', 42);
+
+    expect(a.get('z')).toBe(42);
+    expect(b.get('z')).toBeUndefined();
+    expect(a.size).toBe(2);
+    expect(b.size).toBe(1);
+  });
+
+  test('delete then resurrect preserves size and value', () => {
+    const a = buildGenMap([['x', 1]]);
+    a.delete('x');
+    expect(a.has('x')).toBe(false);
+    expect(a.size).toBe(0);
+
+    a.set('x', 7);
+    expect(a.get('x')).toBe(7);
+    expect(a.size).toBe(1);
+  });
+
+  test('size tracks set/delete correctly across clone boundaries', () => {
+    const a = buildGenMap([
+      ['x', 1],
+      ['y', 2],
+    ]);
+    const b = a.clone();
+
+    b.delete('x');
+    b.set('z', 3);
+
+    expect(a.size).toBe(2);
+    expect(b.size).toBe(2);
+    expect(b.get('x')).toBeUndefined();
+    expect(b.get('z')).toBe(3);
+    expect(a.get('x')).toBe(1);
+  });
+
+  test('iteration yields entries in nursery-overrides-old order', () => {
+    const a = buildGenMap([
+      ['x', 1],
+      ['y', 2],
+    ]);
+    a.compact(true);
+    a.set('y', 20); // override existing
+    a.set('z', 3); // new
+
+    expect(Array.from(a.entries())).toEqual([
+      ['x', 1],
+      ['y', 20],
+      ['z', 3],
+    ]);
+  });
+
+  test('iteration skips tombstoned keys', () => {
+    const a = buildGenMap([
+      ['x', 1],
+      ['y', 2],
+      ['z', 3],
+    ]);
+    a.compact(true);
+    a.delete('y');
+
+    expect(Array.from(a.keys()).sort()).toEqual(['x', 'z']);
+  });
+
+  test('compact folds nursery into old and resets nursery', () => {
+    const a = buildGenMap([
+      ['x', 1],
+      ['y', 2],
+    ]);
+    a.compact(true);
+    a.set('z', 3);
+    a.delete('x');
+
+    a.compact(true);
+    expect(a._nursery).toBeUndefined();
+    expect(a.get('x')).toBeUndefined();
+    expect(a.get('y')).toBe(2);
+    expect(a.get('z')).toBe(3);
+    expect(a.size).toBe(2);
+  });
+
+  test('clear resets all state', () => {
+    const a = buildGenMap([
+      ['x', 1],
+      ['y', 2],
+    ]);
+    a.clear();
+
+    expect(a.size).toBe(0);
+    expect(a.get('x')).toBeUndefined();
+    expect(a._old).toBeUndefined();
+    expect(a._nursery).toBeUndefined();
+  });
+});
+
+describe('cloneMap', () => {
+  test('GenMap source returns a clone (O(1) path)', () => {
+    const a = buildGenMap([['x', 1]]);
+    const b = cloneMap(a);
+
+    expect(b).toBeInstanceOf(GenMap);
+    expect((b as GenMap<string, number>)._old).toBe(a._old);
+    expect((b as GenMap<string, number>)._nursery).toBe(a._nursery);
+  });
+
+  test('plain Map below threshold returns a fresh plain Map', () => {
+    const m = new Map<string, number>([['x', 1]]);
+    const cloned = cloneMap(m, 1000);
+
+    expect(cloned).not.toBe(m);
+    expect(cloned).toBeInstanceOf(Map);
+    expect(cloned).not.toBeInstanceOf(GenMap);
+    expect(cloned.get('x')).toBe(1);
+  });
+
+  test('plain Map at or above threshold returns a GenMap snapshot', () => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < 5; i++) {
+      m.set(String(i), i);
+    }
+    const cloned = cloneMap(m, 4);
+
+    expect(cloned).toBeInstanceOf(GenMap);
+    expect(cloned.size).toBe(5);
+    expect(cloned.get('3')).toBe(3);
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -222,6 +222,7 @@
   "exclude": [
     "./libdefs/*.js",
     "**/__tests__/**",
+    "**/__bench__/**",
     "**/dist/**",
     "**/npm/**",
     "**/node_modules/**",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -58,6 +58,38 @@ export default defineConfig({
           name: 'integration',
         },
       },
+      {
+        extends: true,
+        test: {
+          environment: 'node',
+          exclude: ['**/node_modules/**'],
+          include: ['packages/*/src/__bench__/*.bench.ts'],
+          name: 'bench',
+        },
+      },
+      {
+        define: {
+          IS_REACT_ACT_ENVIRONMENT: true,
+          __DEV__: true,
+        },
+        extends: true,
+        plugins: [react()],
+        test: {
+          env: {
+            LEXICAL_VERSION: JSON.stringify(
+              `${process.env.npm_package_version}+git`,
+            ),
+          },
+          environment: 'jsdom',
+          exclude: ['**/node_modules/**'],
+          include: ['packages/*/src/__bench__/dom/**/*.bench.ts'],
+          name: 'bench-dom',
+          setupFiles: ['./vitest.setup.mts'],
+          typecheck: {
+            tsconfig: './tsconfig.test.json',
+          },
+        },
+      },
     ],
   },
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -62,7 +62,7 @@ export default defineConfig({
         extends: true,
         test: {
           environment: 'node',
-          exclude: ['**/node_modules/**'],
+          exclude: ['**/node_modules/**', '**/__bench__/dom/**'],
           include: ['packages/*/src/__bench__/*.bench.ts'],
           name: 'bench',
         },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -61,9 +61,11 @@ export default defineConfig({
       {
         extends: true,
         test: {
+          benchmark: {
+            exclude: ['**/node_modules/**', '**/__bench__/dom/**'],
+            include: ['packages/*/src/__bench__/*.bench.ts'],
+          },
           environment: 'node',
-          exclude: ['**/node_modules/**', '**/__bench__/dom/**'],
-          include: ['packages/*/src/__bench__/*.bench.ts'],
           name: 'bench',
         },
       },
@@ -75,14 +77,16 @@ export default defineConfig({
         extends: true,
         plugins: [react()],
         test: {
+          benchmark: {
+            exclude: ['**/node_modules/**'],
+            include: ['packages/*/src/__bench__/dom/**/*.bench.ts'],
+          },
           env: {
             LEXICAL_VERSION: JSON.stringify(
               `${process.env.npm_package_version}+git`,
             ),
           },
           environment: 'jsdom',
-          exclude: ['**/node_modules/**'],
-          include: ['packages/*/src/__bench__/dom/**/*.bench.ts'],
           name: 'bench-dom',
           setupFiles: ['./vitest.setup.mts'],
           typecheck: {


### PR DESCRIPTION
## Description

The `cloneEditorState` clone of `_nodeMap` and the reconciler's `_keyToDOMMap` clone (LexicalReconciler.ts:854) are the two `new Map(prev)` calls that scale O(N) per `editor.update` cycle, which #7422 identified as the dominant cost on large documents. This PR replaces both with a GenMap-based copy-on-write strategy, picking up @etrepum's design from #7674 and finishing the integration he had started.

### What this changes

- `LexicalGenMap.ts`: new file. `GenMap` is a CoW Map — clone shares `_old` and `_nursery` references between sibling clones; first write to either side triggers a copy of the nursery before mutating; periodic `compact()` folds nursery into `_old` once it grows past half the size.
- `cloneMap(map, threshold)` is the entry point. Source is a GenMap → `map.clone()` (O(1)). Source is a small plain Map → `new Map(map)` to avoid GenMap overhead. Source is a large plain Map → wrap in a fresh GenMap.
- `cloneEditorState` and the reconciler's `activePrevKeyToDOMMap` now go through `cloneMap`.
- `editor._keyToDOMMap` is now a GenMap from construction so the reconciler's snapshot hits the O(1) clone path; without this, each cycle would re-pay an O(N) plain-Map → GenMap conversion.

### Adapted from #7674

@etrepum's original prototype landed `GenMap` itself and applied it to `_nodeMap`. The integration here adds:

- **`cloneMap()` helper with a 1000-entry threshold** so small documents stay on the plain `Map` fast path and don't pay GenMap overhead.
- **`_keyToDOMMap` adoption** in the reconciler — the second `new Map(prev)` on the hot path that #7674 didn't cover.
- **`editor._keyToDOMMap` as GenMap from construction**, so each reconcile cycle hits the O(1) clone path instead of re-paying the O(N) plain-Map → GenMap conversion.
- **`cloneMap` short-circuits a GenMap source before the threshold check**, so a small `_keyToDOMMap` still takes `clone()` and doesn't get downgraded to a plain Map (which would lose the structural sharing on the very next cycle).

### Bench numbers

**Microbench** (`pnpm vitest bench --project bench`, `nodeMap.bench.ts`) — `GenMap.clone()` against the `new Map(prev)` baseline at four sizes:

| size  | `new Map(prev)` clone | `GenMap.clone()` | speedup |
| ----- | --------------------- | ---------------- | ------- |
| 100   | 0.0021ms              | ~28ns            | 78x     |
| 1k    | 0.021ms               | ~28ns            | 750x    |
| 10k   | 0.31ms                | ~28ns            | 11,000x |
| 100k  | 2.77ms                | ~28ns            | 98,000x |

`GenMap.clone()` is O(1) regardless of source size — the absolute number stays ~28ns whether `_old` holds 100 or 100,000 entries.

**End-to-end** (`pnpm vitest bench --project bench-dom`, `editorCycle.bench.ts`) — full `editor.update` cycle, jsdom, typing one character per cycle:

| size              | Baseline (main)        | + GenMap               | reduction |
| ----------------- | ---------------------- | ---------------------- | --------- |
| 1,000 paragraphs  | 0.294ms (p99 0.553ms)  | 0.250ms (p99 0.460ms)  | -15%      |
| 5,000 paragraphs  | 1.558ms (p99 2.836ms)  | 1.047ms (p99 1.676ms)  | -33%      |

The end-to-end reduction is smaller than the microbench because the clone is one of several costs in `editor.update` (transform, reconcile, commit). The bigger the document, the more the clone dominates and the more the user observes — the trend continues past 5k paragraphs.

Iteration is ~8x slower under GenMap (it walks `_old` and `_nursery` separately). All `_nodeMap` / `_keyToDOMMap` iteration sites are cold paths — `$restoreEditorState`, `getCachedTypeToNodeMap`, mutation-listener init, devtools serialization. The hot typing path doesn't iterate.

### Bench infrastructure

This is the first benchmark setup in the repo, so the goal was to make it usable for future perf work, not just this PR's measurements:

- New `__bench__/` directory layout with shared helpers (`_utils.ts` for microbench, `dom/_utils.ts` for jsdom).
- Two vitest projects: `bench` (node env, microbenches) and `bench-dom` (jsdom env, real-editor benches). `pnpm bench` runs both.
- README in `__bench__/` documents conventions: when to add a bench, file naming, comparison pattern, DCE prevention, how to read the summary.
- File selection uses `test.benchmark.include` (not `test.include`) — vitest reads only the former in bench mode.

### Backwards compatibility

`_keyToDOMMap` and `_nodeMap` are typed `Map<...>`; GenMap implements that interface. No `instanceof Map` checks anywhere in the repo, no public exports change, Flow types unchanged.

### What's deferred

Instrumentation showed `$reconcileRoot` is ~74% of cycle time on a 5k-paragraph doc (NodeMap clone is 23%). I've already prototyped that follow-up — for a 5k-paragraph typing cycle: 1.558ms (main) → 1.047ms (this PR) → 0.132ms (with the follow-up applied, -91% from main total). The follow-up PR is ready and I'll open it as soon as this one lands.

Addresses #7422. Builds on #7674.

## Test plan

- [x] `pnpm test-unit` — 2463 passed (12 new in `LexicalGenMap.test.ts` covering CoW isolation, size accounting, iteration order, tombstone resurrection, compact, clear).
- [x] `pnpm tsc --noEmit -p tsconfig.json` clean.
- [x] `pnpm bench` clean — both `bench` and `bench-dom` projects produce sensible numbers.
- [x] `pnpm test-e2e-ci-chromium` on a sample of categories that exercise NodeMap/keyToDOMMap heavily: TextEntry, History, Focus, Mutations, Selection, CopyAndPaste, DateTime, Tables, TextDragDrop. 220+ tests passed with `--retries=0`.
- [x] Manual playground sanity in chromium and Safari: typing, undo/redo, paste, format toggles, large-doc typing latency — no regressions.
