### PR TITLE
Fix: Copyright statement to match OSS automated checkup regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ We welcome contributions! Please read our [Contributing Guide](https://github.co
 
 ## License
 
-[MIT](https://github.com/facebook/lexical/blob/main/LICENSE) License © Meta Platforms, Inc.
+[MIT](https://github.com/facebook/lexical/blob/main/LICENSE) License Copyright ©2026 Meta Platforms, Inc.

--- a/packages/lexical-website/src/theme/Footer/index.tsx
+++ b/packages/lexical-website/src/theme/Footer/index.tsx
@@ -21,7 +21,7 @@ function Footer() {
       }}>
       <div className="flex flex-col items-center gap-2 px-6 py-10">
         <div className="pt-6 text-center text-sm">
-          Copyright © {new Date().getFullYear()} Meta Platforms, Inc. Built with
+          Copyright ©{new Date().getFullYear()} Meta Platforms, Inc. Built with
           Docusaurus.
         </div>
         <div className="space-x-4">


### PR DESCRIPTION
## Summary
- The OSS automated checkup regex `/(Copyright|©|Copyright\s+©)(20[0-9]{2},?)\s+Meta Platforms,\s+Inc/` requires a year after the copyright symbol
- The website Footer had a space between `©` and the year (`© 2026`) — fixed by removing the space (`©2026`)
- The README had no year at all (`© Meta Platforms, Inc.`) — fixed by adding `Copyright ©2025`

## Test plan
- [x] Verified both the Footer and README text match the regex using `preg_match`