### PR TITLE
[lexical] Bug Fix: keep caret above the on-screen keyboard after Enter

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs
@@ -6,8 +6,8 @@
  *
  */
 
+import {toggleBulletList} from '../keyboardShortcuts/index.mjs';
 import {
-  click,
   evaluate,
   expect,
   focusEditor,
@@ -91,11 +91,6 @@ test.describe('Auto scroll while typing', () => {
 
 test.describe('Auto scroll respects mobile visual viewport', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-
-  async function toggleBulletList(page) {
-    await click(page, '.block-controls');
-    await click(page, '.dropdown .icon.bullet-list');
-  }
 
   // Replace window.visualViewport with a stub reporting a smaller height,
   // simulating an on-screen keyboard occupying the lower part of the viewport.
@@ -210,6 +205,9 @@ test.describe('Auto scroll respects mobile visual viewport', () => {
     );
 
     expect(bottom).not.toBeNull();
-    expect(bottom).toBeLessThanOrEqual(visualViewportBottom);
+    // Sub-pixel tolerance: Firefox can return e.g. 300.27 when the scroll
+    // target is exactly 300 due to fractional layout rounding. The original
+    // bug overshoots by ~280 px, so 1 px still catches it cleanly.
+    expect(bottom).toBeLessThanOrEqual(visualViewportBottom + 1);
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs
@@ -7,6 +7,7 @@
  */
 
 import {
+  click,
   evaluate,
   expect,
   focusEditor,
@@ -85,5 +86,130 @@ test.describe('Auto scroll while typing', () => {
         }
       });
     });
+  });
+});
+
+test.describe('Auto scroll respects mobile visual viewport', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+
+  async function toggleBulletList(page) {
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .icon.bullet-list');
+  }
+
+  // Replace window.visualViewport with a stub reporting a smaller height,
+  // simulating an on-screen keyboard occupying the lower part of the viewport.
+  // Layout viewport (window.innerHeight) stays unchanged, only the visible
+  // area shrinks, like it does on a real mobile browser.
+  //
+  // Dispatch a 'resize' event right after installing the stub to mirror the real
+  // browser sequence (keyboard appears -> visualViewport.onresize fires).
+  async function shrinkVisualViewport(page, visibleHeight) {
+    await evaluate(
+      page,
+      h => {
+        const target = new EventTarget();
+        const stub = {
+          addEventListener: target.addEventListener.bind(target),
+          dispatchEvent: target.dispatchEvent.bind(target),
+          height: h,
+          offsetLeft: 0,
+          offsetTop: 0,
+          onresize: null,
+          onscroll: null,
+          pageLeft: window.scrollX,
+          pageTop: window.scrollY,
+          removeEventListener: target.removeEventListener.bind(target),
+          scale: 1,
+          width: window.innerWidth,
+        };
+        Object.defineProperty(window, 'visualViewport', {
+          configurable: true,
+          get() {
+            return stub;
+          },
+        });
+        target.dispatchEvent(new Event('resize'));
+      },
+      visibleHeight,
+    );
+  }
+
+  // Returns the bottom (in layout-viewport coords) of the current caret.
+  // Read-only: no DOM mutation, so Lexical's mutation observer / reconciler is
+  // not triggered.
+  // For an element-anchor we take the child at focusOffset (the placeholder <br> inserted in empty blocks),
+  // otherwise we fall back to the range's own rect.
+  async function caretBottom(page) {
+    return await evaluate(page, () => {
+      const sel = document.getSelection();
+      if (!sel || sel.rangeCount === 0) {
+        return null;
+      }
+      const focusNode = sel.focusNode;
+      if (focusNode && focusNode.nodeType === 1) {
+        const child = focusNode.childNodes[sel.focusOffset];
+        if (child && child.nodeType === 1) {
+          return child.getBoundingClientRect().bottom;
+        }
+      }
+      const range = sel.getRangeAt(0);
+      const r = range.getBoundingClientRect();
+      if (r.top === 0 && r.bottom === 0 && r.width === 0 && r.height === 0) {
+        return null;
+      }
+      return r.bottom;
+    });
+  }
+
+  // Wait one animation frame so Lexical's post-update DOM/scroll settles before we measure positions.
+  async function waitForFrame(page) {
+    await evaluate(
+      page,
+      () =>
+        new Promise(resolve => {
+          requestAnimationFrame(() => requestAnimationFrame(resolve));
+        }),
+    );
+  }
+
+  // Half-screen keyboard: visible area on top, hidden area below.
+  const VIEWPORT_HEIGHT = 600;
+  const KEYBOARD_HEIGHT = VIEWPORT_HEIGHT / 2;
+
+  test('Pressing Enter scrolls new caret above the on-screen keyboard', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await page.setViewportSize({height: VIEWPORT_HEIGHT, width: 400});
+    await focusEditor(page);
+    await toggleBulletList(page);
+
+    // Fill the list past overflow so the last item lives below the keyboard.
+    for (let i = 0; i < 30; i++) {
+      await page.keyboard.insertText(`Item ${i}`);
+      await page.keyboard.press('Enter');
+    }
+    await page.keyboard.insertText('Last');
+
+    // Mirrors the real mobile sequence: focus -> keyboard appears -> visualViewport resize event fires.
+    await shrinkVisualViewport(page, VIEWPORT_HEIGHT - KEYBOARD_HEIGHT);
+    await waitForFrame(page);
+
+    await page.keyboard.press('Enter');
+    await waitForFrame(page);
+
+    const bottom = await caretBottom(page);
+    // offsetTop + height (not just height) so the assertion stays correct
+    // on iOS where the visual viewport can be offset within the layout.
+    const visualViewportBottom = await evaluate(
+      page,
+      () => window.visualViewport.offsetTop + window.visualViewport.height,
+    );
+
+    expect(bottom).not.toBeNull();
+    expect(bottom).toBeLessThanOrEqual(visualViewportBottom);
   });
 });

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1427,8 +1427,20 @@ export function scrollIntoViewIfNeeded(
   while (element !== null) {
     const isBodyElement = element === doc.body;
     if (isBodyElement) {
-      targetTop = 0;
-      targetBottom = getWindow(editor).innerHeight;
+      // On mobile, the on-screen keyboard shrinks the visual viewport but
+      // not the layout viewport (innerHeight).
+      // selectionRect comes from getBoundingClientRect in layout-viewport coords,
+      // so we must compare against visualViewport bounds,
+      // or the caret stays behind the keyboard.
+      const visualViewport = defaultView.visualViewport;
+      if (visualViewport) {
+        const offsetTop = visualViewport.offsetTop;
+        targetTop = offsetTop;
+        targetBottom = offsetTop + visualViewport.height;
+      } else {
+        targetTop = 0;
+        targetBottom = getWindow(editor).innerHeight;
+      }
       // Account for CSS scroll-padding on the document element
       const computedStyle = defaultView.getComputedStyle(doc.documentElement);
       const scrollPaddingTop = parseFloat(computedStyle.scrollPaddingTop);


### PR DESCRIPTION
## Summary

On mobile, after pressing **Enter** (in a list, paragraph, heading, table cell ...), the new caret often lands behind the on-screen keyboard. The browser's own auto-scroll only kicks in once the user starts typing, typically on the second character. 
In a list this is particularly painful: users press Enter again, thinking nothing happened, which exits the list and destroys the item they were trying to add.

### Before / After

- Before: Chrome / Android, long bullet list. Enter -> new item is hidden behind the keyboard until you type 2 characters.

https://github.com/user-attachments/assets/2b52ab22-aa07-4a34-810b-a16d8ceaa599

- After: same scenario, scroll is immediate on Enter, no double-Enter, the new item appears above the keyboard.

https://github.com/user-attachments/assets/cc14aa2a-3e95-48dd-8444-b476ea7ed672

### Root cause

`scrollIntoViewIfNeeded`(LexicalUtils.ts) compares the selection rect against `window.innerHeight` in the body-scroll branch. On a desktop, layout viewport is more or less = visual viewport, so this is correct. 
On mobile with the keyboard open, the layout viewport stays full-screen while the visual viewport shrinks to the area above the keyboard. The function therefore concludes the caret is already in view (`currentBottom <= innerHeight`) and does not scroll, even though visually the caret is behind the keyboard.

When the user starts typing, the browser's native auto-scroll-into-visual-viewport heuristic eventually catches up, that's why "the second character fixes it."

### Fix

In the body-scroll branch, read `window.visualViewport` when available; fall back to `innerHeight` for environments without it.

```ts
const visualViewport = defaultView.visualViewport;
if (visualViewport) {
  const offsetTop = visualViewport.offsetTop;
  targetTop = offsetTop;
  targetBottom = offsetTop + visualViewport.height;
} else {
  targetTop = 0;
  targetBottom = getWindow(editor).innerHeight;
}
```

`getBoundingClientRect` already reports in layout-viewport coordinates, and `visualViewport.offsetTop + height` is the visible-area bottom in those same coordinates, so the surrounding math (`currentBottom > targetBottom` -> `scrollBy(0, diff)`) stays consistent. 
The CSS `scroll-padding` accounting from #8218 is unchanged. 
The non-body branch (in-editor overflow) is untouched.

### Scope

The bug affects every Enter/return key that creates a new block: paragraphs, list items (`<li>`), headings, table cells, custom decorator nodes, and more generally any post-update selection change that hits the body-scroll branch. 
Lists make it particularly user-visible because the natural workaround (press Enter again) destroys data. Fixing the underlying scroll math fixes all of them at once.

## Test Plan

- New e2e test `Auto scroll respects mobile visual viewport > Pressing Enter scrolls new caret above the on-screen keyboard` (in `packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs`):
  - Sets a 400*600 viewport, fills a bullet list past overflow, then stubs `window.visualViewport` via a real `EventTarget` that reports `height: 300` and dispatches the `resize` event to mirror the real "keyboard appears" sequence.
  - Reads the caret position read-only via the element-anchor child rect (no DOM mutation, so Lexical's mutation observer / reconciler is not triggered).
  - Asserts `caretRect.bottom <= visualViewport.offsetTop + visualViewport.height` (so iOS-style non-zero `offsetTop` is also covered).
  - **Fails before the fix** with `caretRect.bottom ~ 600` (sat at `innerHeight`, behind the simulated keyboard); 
  - **passes after** with `caretRect.bottom ~ 280`.
- Existing "Auto scroll while typing" suite still passes. The fix only changes the body-scroll branch; tests that scroll the editor container itself (`addScroll(...)`) hit the unchanged `else` branch.
- Manual repro: Chrome on Android (real device), long bullet list at the bottom of the editor; before -> keyboard hides the new item until the second character; after -> immediate scroll on Enter.

### Known limitations of the test setup

- The stub doesn't simulate the timing of a real keyboard animation (focus -> keyboard slides up -> relayout -> IME events). The synchronous read in `scrollIntoViewIfNeeded` doesn't depend on that timing, but a future iOS-specific test might want to.
- iOS WebKit `offsetTop > 0` cases (visual viewport offset when the URL bar collapses) are exercised by the assertion math but not by the stub values