### PR TITLE
[lexical-code-core] Bug Fix: detect nested br elements in pasted code

### DIFF
--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -63,7 +63,9 @@ function hasChildDOMNodeTag(node: Node, tagName: string) {
     if (isHTMLElement(child) && child.tagName === tagName) {
       return true;
     }
-    hasChildDOMNodeTag(child, tagName);
+    if (hasChildDOMNodeTag(child, tagName)) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/lexical/src/__tests__/unit/CodeBlock.test.ts
+++ b/packages/lexical/src/__tests__/unit/CodeBlock.test.ts
@@ -92,6 +92,11 @@ describe('CodeBlock tests', () => {
           pastedHTML: `<meta charset='utf-8'><code>1<br>2</code>`,
         },
         {
+          expectedHTML: `<code spellcheck="false" dir="auto"><span data-lexical-text="true">1</span><br><span data-lexical-text="true">2</span></code>`,
+          name: 'Multiline <code> with nested <br>',
+          pastedHTML: `<meta charset='utf-8'><code><span>1<br>2</span></code>`,
+        },
+        {
           expectedHTML: `<p dir="auto"><strong class="editor-text-bold editor-text-italic editor-text-underline" data-lexical-text="true">Hello </strong><sub data-lexical-text="true"><strong class="editor-text-bold editor-text-italic">World </strong></sub><sup data-lexical-text="true"><strong class="editor-text-bold editor-text-italic editor-text-underline">Lexical</strong></sup></p>`,
           name: 'Multiple text formats',
           pastedHTML: `<strong style="font-weight: 700; font-style: italic; text-decoration: underline; color: rgb(0, 0, 0); font-size: 15px; text-align: left; text-indent: 0px; background-color: rgb(255, 255, 255);">Hello </strong><sub style="color: rgb(0, 0, 0); font-style: normal; font-weight: 400; text-align: left; text-indent: 0px; background-color: rgb(255, 255, 255);"><strong style="font-weight: 700; font-style: italic; text-decoration: line-through; font-size: 0.8em; vertical-align: sub !important;">World </strong></sub><sup style="color: rgb(0, 0, 0); font-style: normal; font-weight: 400; text-align: left; text-indent: 0px; background-color: rgb(255, 255, 255);"><strong style="font-weight: 700; font-style: italic; text-decoration: underline line-through; font-size: 0.8em; vertical-align: super;">Lexical</strong></sup>`,


### PR DESCRIPTION
## Summary

Fixes multiline code detection during HTML import when a `<br>` is nested inside inline markup within a `<code>` element.

`CodeNode.importDOM()` already treats multiline `<code>` content as a code block, but the recursive `hasChildDOMNodeTag()` helper did not return recursive matches. As a result, markup such as `<code><span>1<br>2</span></code>` could be imported as inline code instead of a code block.

This updates the helper to return nested matches and adds regression coverage for the nested `<br>` case.

## Test Plan

- Ran `pnpm.cmd exec vitest --project unit packages/lexical/src/__tests__/unit/CodeBlock.test.ts --run`