### PR TITLE
[lexical-table] Bug Fix: Attach window pointerdown handler when root element is set after register

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -180,52 +180,60 @@ export function registerTableWindowHandlers(
   editor: LexicalEditor,
   tableObservers: TableObservers,
 ) {
-  const rootElement = editor.getRootElement();
-  const editorWindow = editor._window;
-  if (!rootElement || !editorWindow) {
-    return () => {};
-  }
-
-  const pointerDownCallback = (event: PointerEvent) => {
-    const target = event.target;
-    if (
-      event.button !== 0 ||
-      !isDOMNode(target) ||
-      !rootElement.contains(target)
-    ) {
+  // Use registerRootListener so the pointerdown handler is (re)attached
+  // whenever the root element is set. This is required for the Extension API,
+  // where register() runs before the ContentEditable mounts and getRootElement()
+  // is still null.
+  return editor.registerRootListener(rootElement => {
+    if (rootElement === null) {
       return;
     }
-    const selectionInfo = getTableObserverFromCellNode(target);
+    const editorWindow = editor._window;
+    if (editorWindow === null) {
+      return;
+    }
 
-    editor.update(() => {
-      // Clear highlights from all tables (even one we're actively clicking on)
-      const selection = $getSelection();
-      if ($isTableSelection(selection)) {
-        for (const [observer] of tableObservers.observers.values()) {
-          observer.$clearHighlight(false);
-        }
-        $setSelection(null);
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
-      }
-      if (!selectionInfo) {
+    const pointerDownCallback = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        event.button !== 0 ||
+        !isDOMNode(target) ||
+        !rootElement.contains(target)
+      ) {
         return;
       }
-      const {tableObserver, tableElement, cellElement} = selectionInfo;
-      $handleTableClick(
-        editor,
-        event,
-        cellElement,
-        tableElement,
-        tableObserver,
-        tableObservers,
-      );
-    });
-  };
+      const selectionInfo = getTableObserverFromCellNode(target);
 
-  editorWindow.addEventListener('pointerdown', pointerDownCallback);
-  return () => {
-    editorWindow.removeEventListener('pointerdown', pointerDownCallback);
-  };
+      editor.update(() => {
+        // Clear highlights from all tables (even one we're actively clicking on)
+        const selection = $getSelection();
+        if ($isTableSelection(selection)) {
+          for (const [observer] of tableObservers.observers.values()) {
+            observer.$clearHighlight(false);
+          }
+          $setSelection(null);
+          editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+        }
+        if (!selectionInfo) {
+          return;
+        }
+        const {tableObserver, tableElement, cellElement} = selectionInfo;
+        $handleTableClick(
+          editor,
+          event,
+          cellElement,
+          tableElement,
+          tableObserver,
+          tableObservers,
+        );
+      });
+    };
+
+    editorWindow.addEventListener('pointerdown', pointerDownCallback);
+    return () => {
+      editorWindow.removeEventListener('pointerdown', pointerDownCallback);
+    };
+  });
 }
 
 function $handleTableClick(

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -696,4 +696,104 @@ describe('TableExtension', () => {
       });
     });
   });
+
+  describe('drag selection', () => {
+    // Polyfill PointerEvent for jsdom
+    interface PointerEventInit extends EventInit {
+      button?: number;
+      buttons?: number;
+      pointerType?: string;
+      clientX?: number;
+      clientY?: number;
+    }
+    if (
+      typeof (globalThis as {PointerEvent?: unknown}).PointerEvent ===
+      'undefined'
+    ) {
+      (globalThis as unknown as {PointerEvent: unknown}).PointerEvent =
+        class PointerEvent extends Event {
+          button: number;
+          buttons: number;
+          pointerType: string;
+          clientX: number;
+          clientY: number;
+          constructor(type: string, options: PointerEventInit = {}) {
+            super(type, options);
+            this.button = options.button || 0;
+            this.buttons = options.buttons ?? 1;
+            this.pointerType = options.pointerType || 'mouse';
+            this.clientX = options.clientX ?? 0;
+            this.clientY = options.clientY ?? 0;
+          }
+        };
+    }
+
+    it('attaches the window pointerdown handler when setRootElement is called after register', () => {
+      // The TableExtension registers handlers during buildEditor, before any
+      // root element is mounted. Regression test for the bug where the
+      // pointerdown listener on editorWindow was never attached because
+      // editor.getRootElement() was null at register() time, breaking drag
+      // selection. See https://github.com/facebook/lexical/issues/8491
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      try {
+        editor.setRootElement(container);
+        editor.update(
+          () => {
+            const root = $getRoot().clear();
+            const table = $createTableNodeWithDimensions(2, 2, false);
+            root.append(table);
+            const firstRow = table.getFirstChild();
+            assert($isTableRowNode(firstRow), 'Expected first row');
+            const firstCell = firstRow.getFirstChild();
+            assert($isTableCellNode(firstCell), 'Expected first cell');
+            const paragraph = firstCell.getFirstChild();
+            assert($isParagraphNode(paragraph), 'Expected paragraph in cell');
+            paragraph.selectStart();
+          },
+          {discrete: true},
+        );
+
+        const firstCellElement = container.querySelector('td');
+        assert(firstCellElement !== null, 'Expected first cell element');
+        const tableElement = container.querySelector('table');
+        assert(tableElement !== null, 'Expected table element');
+
+        // Before the pointerdown, no anchor cell is set on the TableObserver.
+        const observerKey = '__lexicalTableSelection';
+        const observerBefore = (
+          tableElement as unknown as Record<string, {anchorCell: unknown}>
+        )[observerKey];
+        assert(observerBefore !== undefined, 'Expected TableObserver to exist');
+        expect(observerBefore.anchorCell).toBeNull();
+
+        const pointerEvent = new (
+          globalThis as unknown as {
+            PointerEvent: new (
+              type: string,
+              options?: PointerEventInit,
+            ) => Event;
+          }
+        ).PointerEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          buttons: 1,
+          cancelable: true,
+          pointerType: 'mouse',
+        });
+        firstCellElement.dispatchEvent(pointerEvent);
+
+        // After the pointerdown, the window-level pointerdown handler should
+        // have run and set the anchor cell on the observer. If the handler
+        // was never attached, the anchor remains null.
+        const observerAfter = (
+          tableElement as unknown as Record<string, {anchorCell: unknown}>
+        )[observerKey];
+        expect(observerAfter.anchorCell).not.toBeNull();
+      } finally {
+        editor.setRootElement(null);
+        document.body.removeChild(container);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description

`registerTableWindowHandlers` reads `editor.getRootElement()` at call time and returns a no-op cleanup when it is null. With `TablePlugin` this is fine because the registration runs from a `useEffect`, which fires after `<ContentEditable>` has mounted and called `editor.setRootElement(...)`. With `TableExtension`, the extension's `register()` runs synchronously inside `buildEditor()` — before any root element is mounted — so the window-level `pointerdown` listener that drives table cell drag selection was never attached. The user sees only the browser's native cell selection, which gets clobbered after a couple of cells, producing the "drag selection stops after ~2 cells" symptom reported in the issue.

This PR rewrites `registerTableWindowHandlers` to use `editor.registerRootListener(...)` so the `pointerdown` listener is attached whenever a non-null root element is present and is torn down cleanly when the root element changes or the listener is disposed. No other call sites or behavior change for `TablePlugin`.

A regression test in `LexicalTableExtension.test.ts` builds an editor via `buildEditorFromExtensions(TableExtension)`, calls `setRootElement` after registration, dispatches a `pointerdown` on a `<td>`, and asserts that the attached `TableObserver.anchorCell` is populated — which is only true if the window handler actually ran.

Closes #8491

## Test plan

### Before

Running the new regression test against `main`:

```
× attaches the window pointerdown handler when setRootElement is called after register
  AssertionError: expected null not to be null
    expect(observerAfter.anchorCell).not.toBeNull();
```

In the Stackblitz reproduction from the issue, dragging across cells in the `TableExtension` editor stops extending the selection after ~2 cells, while the equivalent `TablePlugin` editor continues selecting until pointerup.

### After

Full unit suite passes (3058 tests, 1 new):

```
Test Files  118 passed (118)
     Tests  3058 passed | 1 skipped (3059)
```

Drag selection in the `TableExtension` reproduction now matches `TablePlugin`: the selection extends continuously across cells until the pointer is released.