### PR TITLE
[ci] Bug Fix: Only cancel in-progress workflows on newer commits

### DIFF
--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -10,7 +10,10 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel an in-progress run when a newer commit lands on the same ref.
+  # Other events (labeled, reopened, manual approval re-runs, etc.) get a
+  # distinct group so they never cancel a run that is already underway.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'pull_request' && github.event.action != 'synchronize' && github.run_id || 'commit' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,10 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel an in-progress run when a newer commit lands on the same ref.
+  # Other events (labeled, reopened, manual approval re-runs, etc.) get a
+  # distinct group so they never cancel a run that is already underway.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'pull_request' && github.event.action != 'synchronize' && github.run_id || 'commit' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

The `tests.yml` and `tests-extended.yml` workflows used a concurrency group keyed only by `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. That meant *any* `pull_request` event on the same ref landed in the same group and canceled an already-running workflow — including:

- Adding a label (e.g. `extended-tests`, `dependencies`)
- Reopening a PR
- A maintainer clicking "Approve and run" on a first-time contributor's PR

When that happened, the in-progress run was canceled and had to be manually re-run, which was confusing and wasted CI time.

This PR appends the event action to the concurrency group so that:

- `pull_request` `synchronize` events (new commits) keep sharing a group → newer commit still cancels the older run, as intended.
- `push` and `merge_group` events also keep sharing a group keyed on `github.ref` → newer pushes still cancel older ones on the same branch.
- All other `pull_request` events (`labeled`, `opened`, `reopened`, etc.) get a unique group keyed by `github.run_id` → they never cancel another run.

Net effect: only a newer commit on the same ref cancels an in-progress run.

## Test plan

### Before

- Open a PR, push a commit so `Lexical Tests` starts running.
- While it's running, add the `extended-tests` label (or have a maintainer click "Approve and run").
- Observe that the in-progress `Lexical Tests` / `Lexical Tests (Extended)` run is canceled and must be re-run manually.

### After

- Open a PR, push a commit so `Lexical Tests` starts running.
- While it's running, add the `extended-tests` label (or have a maintainer click "Approve and run").
- The in-progress run continues to completion; the new event spawns its own independent run.
- Pushing a follow-up commit still cancels the prior run for that PR (verified via `synchronize` group sharing).