### PR TITLE
[lexical] Bug Fix: scroll collapsed selection horizontally in overflow containers

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3208,11 +3208,35 @@ export function $updateDOMSelection(
       } else {
         selectionRect = selectionTarget.getBoundingClientRect();
       }
-      scrollIntoViewIfNeeded(editor, selectionRect, rootElement);
+      scrollIntoViewIfNeeded(
+        editor,
+        selectionRect,
+        rootElement,
+        getDOMScrollChainStartForCaret(selectionTarget),
+      );
     }
   }
 
   markSelectionChangeFromDOMUpdate();
+}
+
+function getDOMScrollChainStartForCaret(
+  selectionTarget: Range | HTMLElement | Text,
+): HTMLElement | null {
+  if (selectionTarget instanceof Text) {
+    return selectionTarget.parentElement;
+  }
+  if (selectionTarget instanceof HTMLElement) {
+    return selectionTarget;
+  }
+  const startContainer = selectionTarget.startContainer;
+  if (startContainer.nodeType === Node.TEXT_NODE) {
+    return (startContainer as Text).parentElement;
+  }
+  if (startContainer.nodeType === Node.ELEMENT_NODE) {
+    return startContainer as HTMLElement;
+  }
+  return null;
 }
 
 export function $insertNodes(nodes: Array<LexicalNode>) {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -87,6 +87,7 @@ import {
   getElementByKeyOrThrow,
   getWindow,
   INTERNAL_$isBlock,
+  isDOMTextNode,
   isHTMLElement,
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
@@ -3201,7 +3202,7 @@ export function $updateDOMSelection(
           : null;
     if (selectionTarget !== null) {
       let selectionRect: DOMRect;
-      if (selectionTarget instanceof Text) {
+      if (isDOMTextNode(selectionTarget)) {
         const range = document.createRange();
         range.selectNode(selectionTarget);
         selectionRect = range.getBoundingClientRect();
@@ -3223,18 +3224,18 @@ export function $updateDOMSelection(
 function getDOMScrollChainStartForCaret(
   selectionTarget: Range | HTMLElement | Text,
 ): HTMLElement | null {
-  if (selectionTarget instanceof Text) {
+  if (isDOMTextNode(selectionTarget)) {
     return selectionTarget.parentElement;
   }
-  if (selectionTarget instanceof HTMLElement) {
+  if (isHTMLElement(selectionTarget)) {
     return selectionTarget;
   }
   const startContainer = selectionTarget.startContainer;
-  if (startContainer.nodeType === Node.TEXT_NODE) {
-    return (startContainer as Text).parentElement;
+  if (isDOMTextNode(startContainer)) {
+    return startContainer.parentElement;
   }
-  if (startContainer.nodeType === Node.ELEMENT_NODE) {
-    return startContainer as HTMLElement;
+  if (isHTMLElement(startContainer)) {
+    return startContainer;
   }
   return null;
 }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1408,10 +1408,19 @@ export function getDOMOwnerDocument(
       : null;
 }
 
+/**
+ * Scrolls the window and ancestor scroll containers so `selectionRect` is
+ * visible vertically and horizontally.
+ *
+ * @param scrollChainStartElement When provided, the walk toward `document.body`
+ * begins at this element so horizontally scrollable ancestors between the caret
+ * and the editor root (for example a code block) are updated.
+ */
 export function scrollIntoViewIfNeeded(
   editor: LexicalEditor,
   selectionRect: DOMRect,
   rootElement: HTMLElement,
+  scrollChainStartElement?: HTMLElement | null,
 ): void {
   const doc = getDOMOwnerDocument(rootElement);
   const defaultView = getDefaultView(doc);
@@ -1419,13 +1428,23 @@ export function scrollIntoViewIfNeeded(
   if (doc === null || defaultView === null) {
     return;
   }
-  let {top: currentTop, bottom: currentBottom} = selectionRect;
+  let {
+    top: currentTop,
+    bottom: currentBottom,
+    left: currentLeft,
+    right: currentRight,
+  } = selectionRect;
   let targetTop = 0;
   let targetBottom = 0;
-  let element: HTMLElement | null = rootElement;
+  let targetLeft = 0;
+  let targetRight = 0;
+  const element: HTMLElement | null =
+    scrollChainStartElement != null ? scrollChainStartElement : rootElement;
 
-  while (element !== null) {
-    const isBodyElement = element === doc.body;
+  let walk: HTMLElement | null = element;
+
+  while (walk !== null) {
+    const isBodyElement = walk === doc.body;
     if (isBodyElement) {
       // On mobile, the on-screen keyboard shrinks the visual viewport but
       // not the layout viewport (innerHeight).
@@ -1435,26 +1454,41 @@ export function scrollIntoViewIfNeeded(
       const visualViewport = defaultView.visualViewport;
       if (visualViewport) {
         const offsetTop = visualViewport.offsetTop;
+        const offsetLeft = visualViewport.offsetLeft;
         targetTop = offsetTop;
         targetBottom = offsetTop + visualViewport.height;
+        targetLeft = offsetLeft;
+        targetRight = offsetLeft + visualViewport.width;
       } else {
         targetTop = 0;
         targetBottom = getWindow(editor).innerHeight;
+        targetLeft = 0;
+        targetRight = getWindow(editor).innerWidth;
       }
       // Account for CSS scroll-padding on the document element
       const computedStyle = defaultView.getComputedStyle(doc.documentElement);
       const scrollPaddingTop = parseFloat(computedStyle.scrollPaddingTop);
       const scrollPaddingBottom = parseFloat(computedStyle.scrollPaddingBottom);
+      const scrollPaddingLeft = parseFloat(computedStyle.scrollPaddingLeft);
+      const scrollPaddingRight = parseFloat(computedStyle.scrollPaddingRight);
       if (isFinite(scrollPaddingTop)) {
         targetTop += scrollPaddingTop;
       }
       if (isFinite(scrollPaddingBottom)) {
         targetBottom -= scrollPaddingBottom;
       }
+      if (isFinite(scrollPaddingLeft)) {
+        targetLeft += scrollPaddingLeft;
+      }
+      if (isFinite(scrollPaddingRight)) {
+        targetRight -= scrollPaddingRight;
+      }
     } else {
-      const targetRect = element.getBoundingClientRect();
+      const targetRect = walk.getBoundingClientRect();
       targetTop = targetRect.top;
       targetBottom = targetRect.bottom;
+      targetLeft = targetRect.left;
+      targetRight = targetRect.right;
     }
     let diff = 0;
 
@@ -1464,22 +1498,40 @@ export function scrollIntoViewIfNeeded(
       diff = currentBottom - targetBottom;
     }
 
-    if (diff !== 0) {
+    let diffX = 0;
+    if (currentLeft < targetLeft) {
+      diffX = -(targetLeft - currentLeft);
+    } else if (currentRight > targetRight) {
+      diffX = currentRight - targetRight;
+    }
+
+    if (diff !== 0 || diffX !== 0) {
       if (isBodyElement) {
-        // Only handles scrolling of Y axis
-        defaultView.scrollBy(0, diff);
+        defaultView.scrollBy(diffX, diff);
       } else {
-        const scrollTop = element.scrollTop;
-        element.scrollTop += diff;
-        const yOffset = element.scrollTop - scrollTop;
-        currentTop -= yOffset;
-        currentBottom -= yOffset;
+        if (diff !== 0) {
+          const scrollTop = walk.scrollTop;
+          walk.scrollTop += diff;
+          const yOffset = walk.scrollTop - scrollTop;
+          currentTop -= yOffset;
+          currentBottom -= yOffset;
+        }
+        if (diffX !== 0) {
+          const maxScrollX = walk.scrollWidth - walk.clientWidth;
+          if (maxScrollX > 0) {
+            const scrollLeft = walk.scrollLeft;
+            walk.scrollLeft += diffX;
+            const xOffset = walk.scrollLeft - scrollLeft;
+            currentLeft -= xOffset;
+            currentRight -= xOffset;
+          }
+        }
       }
     }
     if (isBodyElement) {
       break;
     }
-    element = getParentElement(element);
+    walk = getParentElement(walk);
   }
 }
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1438,13 +1438,10 @@ export function scrollIntoViewIfNeeded(
   let targetBottom = 0;
   let targetLeft = 0;
   let targetRight = 0;
-  const element: HTMLElement | null =
-    scrollChainStartElement != null ? scrollChainStartElement : rootElement;
+  let element: HTMLElement | null = scrollChainStartElement || rootElement;
 
-  let walk: HTMLElement | null = element;
-
-  while (walk !== null) {
-    const isBodyElement = walk === doc.body;
+  while (element !== null) {
+    const isBodyElement = element === doc.body;
     if (isBodyElement) {
       // On mobile, the on-screen keyboard shrinks the visual viewport but
       // not the layout viewport (innerHeight).
@@ -1484,7 +1481,7 @@ export function scrollIntoViewIfNeeded(
         targetRight -= scrollPaddingRight;
       }
     } else {
-      const targetRect = walk.getBoundingClientRect();
+      const targetRect = element.getBoundingClientRect();
       targetTop = targetRect.top;
       targetBottom = targetRect.bottom;
       targetLeft = targetRect.left;
@@ -1510,18 +1507,18 @@ export function scrollIntoViewIfNeeded(
         defaultView.scrollBy(diffX, diff);
       } else {
         if (diff !== 0) {
-          const scrollTop = walk.scrollTop;
-          walk.scrollTop += diff;
-          const yOffset = walk.scrollTop - scrollTop;
+          const scrollTop = element.scrollTop;
+          element.scrollTop += diff;
+          const yOffset = element.scrollTop - scrollTop;
           currentTop -= yOffset;
           currentBottom -= yOffset;
         }
         if (diffX !== 0) {
-          const maxScrollX = walk.scrollWidth - walk.clientWidth;
+          const maxScrollX = element.scrollWidth - element.clientWidth;
           if (maxScrollX > 0) {
-            const scrollLeft = walk.scrollLeft;
-            walk.scrollLeft += diffX;
-            const xOffset = walk.scrollLeft - scrollLeft;
+            const scrollLeft = element.scrollLeft;
+            element.scrollLeft += diffX;
+            const xOffset = element.scrollLeft - scrollLeft;
             currentLeft -= xOffset;
             currentRight -= xOffset;
           }
@@ -1531,7 +1528,7 @@ export function scrollIntoViewIfNeeded(
     if (isBodyElement) {
       break;
     }
-    walk = getParentElement(walk);
+    element = getParentElement(element);
   }
 }
 

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -545,6 +545,88 @@ describe('LexicalUtils tests', () => {
         doc.documentElement.style.scrollPaddingTop = '';
       }
     });
+
+    test('scrollIntoViewIfNeeded scrolls horizontally inside overflow container', () => {
+      const {editor} = testEnv;
+      const rootElement = editor.getRootElement()!;
+      const doc = rootElement.ownerDocument;
+      const shell = doc.createElement('div');
+      const inner = doc.createElement('div');
+      inner.textContent = 'x';
+      shell.appendChild(inner);
+      rootElement.appendChild(shell);
+
+      const shellRect = {
+        bottom: 40,
+        height: 40,
+        left: 0,
+        right: 100,
+        toJSON: () => shellRect,
+        top: 0,
+        width: 100,
+        x: 0,
+        y: 0,
+      };
+      vi.spyOn(shell, 'getBoundingClientRect').mockReturnValue(
+        shellRect as unknown as DOMRect,
+      );
+      Object.defineProperty(shell, 'clientWidth', {
+        configurable: true,
+        value: 100,
+      });
+      Object.defineProperty(shell, 'scrollWidth', {
+        configurable: true,
+        value: 500,
+      });
+      shell.scrollLeft = 0;
+
+      const selectionRect = new DOMRect(350, 10, 5, 16);
+
+      scrollIntoViewIfNeeded(editor, selectionRect, rootElement, inner);
+
+      expect(shell.scrollLeft).toBeGreaterThan(0);
+    });
+
+    test('scrollIntoViewIfNeeded scrolls left when caret is left of scroll container viewport', () => {
+      const {editor} = testEnv;
+      const rootElement = editor.getRootElement()!;
+      const doc = rootElement.ownerDocument;
+      const shell = doc.createElement('div');
+      const inner = doc.createElement('div');
+      inner.textContent = 'x';
+      shell.appendChild(inner);
+      rootElement.appendChild(shell);
+
+      const shellRect = {
+        bottom: 40,
+        height: 40,
+        left: 100,
+        right: 200,
+        toJSON: () => shellRect,
+        top: 0,
+        width: 100,
+        x: 100,
+        y: 0,
+      };
+      vi.spyOn(shell, 'getBoundingClientRect').mockReturnValue(
+        shellRect as unknown as DOMRect,
+      );
+      Object.defineProperty(shell, 'clientWidth', {
+        configurable: true,
+        value: 100,
+      });
+      Object.defineProperty(shell, 'scrollWidth', {
+        configurable: true,
+        value: 500,
+      });
+      shell.scrollLeft = 200;
+
+      const selectionRect = new DOMRect(95, 10, 5, 16);
+
+      scrollIntoViewIfNeeded(editor, selectionRect, rootElement, inner);
+
+      expect(shell.scrollLeft).toBeLessThan(200);
+    });
   });
 });
 describe('$applyNodeReplacement', () => {


### PR DESCRIPTION
## Description

**Current behavior:** When the caret sits inside a horizontally scrollable block (for example a code block with long lines and `overflow-x: auto`), moving the collapsed selection with keyboard shortcuts such as Ctrl+ArrowLeft / Ctrl+ArrowRight can place the caret outside the visible scroll region. `scrollIntoViewIfNeeded` only adjusted vertical scroll and only walked ancestors starting from the editor root, so inner scroll containers were not scrolled on the X axis.

**This PR:** Extends `scrollIntoViewIfNeeded` to:

- Walk scroll ancestors starting from an optional DOM “chain start” (the caret’s DOM node chain), so nested horizontal scrollers are included.
- Apply horizontal scrolling on elements that can scroll horizontally (`scrollWidth > clientWidth`), updating `scrollLeft` similarly to the existing `scrollTop` logic.
- Scroll the window on both axes via `scrollBy`, using `visualViewport` when present and applying horizontal `scroll-padding` on the document element in addition to the existing vertical padding.

Collapsed selection updates in `LexicalSelection` pass the chain start derived from the active `Range` / `Text` / `HTMLElement` target.

Related to #8459 (addresses the horizontal auto-scroll / caret visibility part; VS Code–style word wrap remains a possible follow-up).

## Test plan

### Automated

- `pnpm exec vitest run packages/lexical/src/__tests__/unit/LexicalUtils.test.ts -t "scrollIntoViewIfNeeded" --project=unit`
- New tests: horizontal overflow scrolls right; caret left of the visible region scrolls left.

### Manual

1. Run playground, insert a code block, paste or type a **very long single line** so a horizontal scrollbar appears on the code block.
2. Put the caret in the middle of that line; use **Ctrl+ArrowRight** to move to end of line (or **Ctrl+ArrowLeft** to start) and confirm the code block **scrolls horizontally** so the caret stays visible.
3. Repeat with normal arrow keys along the line to confirm scrolling still feels correct.

### Before

Caret could move off-screen horizontally inside the code block while the block’s `scrollLeft` did not follow.

### After

Caret stays within the visible horizontal range of the code block (and other scrollable ancestors) when the collapsed selection is updated.
