### PR TITLE
[lexical-playground] Bug Fix: Set font-size for h2

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -30,6 +30,7 @@
   margin: 0;
 }
 .PlaygroundEditorTheme__h2 {
+  font-size: 16px;
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Follow-up https://github.com/facebook/lexical/pull/8480

CSS properties of heading tags must be overrided; otherwise, they will inherit the default properties from the user agent

## Test plan

### Before

<img width="484" height="216" alt="image" src="https://github.com/user-attachments/assets/580d21cf-b175-4d98-a338-2dda11e56626" />

### After

<img width="482" height="200" alt="image" src="https://github.com/user-attachments/assets/db2aa663-b44a-4fe1-8508-227cdd8c47c4" />
