### PR TITLE
[Breaking Change][lexical] Bug Fix: Adjust selection when removeFromParent callers move a node out of its parent

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1303,11 +1303,16 @@ export class LexicalNode {
     writableReplaceWith.__next = nextKey;
     writableReplaceWith.__parent = parentKey;
     writableParent.__size = size;
+    // Snapshot replaceWith's children count before children transfer so
+    // element-anchored selections on `this` can map to the equivalent offset
+    // in writableReplaceWith.
+    let prevSizeBeforeChildrenTransfer = 0;
     if (includeChildren) {
       invariant(
         $isElementNode(this) && $isElementNode(writableReplaceWith),
         'includeChildren should only be true for ElementNodes',
       );
+      prevSizeBeforeChildrenTransfer = writableReplaceWith.getChildrenSize();
       this.getChildren().forEach((child: LexicalNode) => {
         writableReplaceWith.append(child);
       });
@@ -1316,11 +1321,34 @@ export class LexicalNode {
       $setSelection(selection);
       const anchor = selection.anchor;
       const focus = selection.focus;
+      // For an element-anchored point on `this` with includeChildren, the
+      // transferred children land at offsets [prevSize ... prevSize + N) in
+      // writableReplaceWith, so the equivalent point is at
+      // `prevSize + originalOffset`. Without this remap the caller (e.g.
+      // `$setBlocksType`) has to re-anchor afterwards from a stale clone.
+      // For non-element points or !includeChildren the children are gone, so
+      // fall back to the previous "move to end" behavior.
       if (anchor.key === toReplaceKey) {
-        $moveSelectionPointToEnd(anchor, writableReplaceWith);
+        if (includeChildren && anchor.type === 'element') {
+          anchor.set(
+            writableReplaceWith.__key,
+            prevSizeBeforeChildrenTransfer + anchor.offset,
+            'element',
+          );
+        } else {
+          $moveSelectionPointToEnd(anchor, writableReplaceWith);
+        }
       }
       if (focus.key === toReplaceKey) {
-        $moveSelectionPointToEnd(focus, writableReplaceWith);
+        if (includeChildren && focus.type === 'element') {
+          focus.set(
+            writableReplaceWith.__key,
+            prevSizeBeforeChildrenTransfer + focus.offset,
+            'element',
+          );
+        } else {
+          $moveSelectionPointToEnd(focus, writableReplaceWith);
+        }
       }
     }
     if ($getCompositionKey() === toReplaceKey) {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1263,7 +1263,23 @@ export class LexicalNode {
     const writableReplaceWith = replaceWith.getWritable();
     const writableParent = this.getParentOrThrow().getWritable();
     const size = writableParent.__size;
+    // Capture replaceWith's old parent / index before removeFromParent so the
+    // cloned selection's element offsets in that old parent can be adjusted
+    // afterwards. See #6031.
+    const replaceWithOldParent = writableReplaceWith.getParent();
+    const replaceWithOldIndex =
+      replaceWithOldParent !== null
+        ? writableReplaceWith.getIndexWithinParent()
+        : -1;
     removeFromParent(writableReplaceWith);
+    if (replaceWithOldParent !== null && $isRangeSelection(selection)) {
+      $updateElementSelectionOnCreateDeleteNode(
+        selection,
+        replaceWithOldParent,
+        replaceWithOldIndex,
+        -1,
+      );
+    }
     const prevSibling = self.getPreviousSibling();
     const nextSibling = self.getNextSibling();
     const prevKey = self.__prev;
@@ -1332,7 +1348,6 @@ export class LexicalNode {
     if (oldParent !== null) {
       // TODO: this is O(n), can we improve?
       const oldIndex = nodeToInsert.getIndexWithinParent();
-      removeFromParent(writableNodeToInsert);
       if ($isRangeSelection(selection)) {
         const oldParentKey = oldParent.__key;
         const anchor = selection.anchor;
@@ -1345,6 +1360,21 @@ export class LexicalNode {
           focus.type === 'element' &&
           focus.key === oldParentKey &&
           focus.offset === oldIndex + 1;
+      }
+      removeFromParent(writableNodeToInsert);
+      // Adjust element-anchored offsets in oldParent to track its reduced
+      // child count. The boolean flags captured above
+      // (elementAnchorSelectionOnNode / elementFocusSelectionOnNode) recorded
+      // whether anchor/focus sat at oldIndex+1 before this removal; the
+      // post-insertion block below uses them to re-anchor onto the moved
+      // node in its new parent. See #6031.
+      if (restoreSelection && $isRangeSelection(selection)) {
+        $updateElementSelectionOnCreateDeleteNode(
+          selection,
+          oldParent,
+          oldIndex,
+          -1,
+        );
       }
     }
     const nextSibling = this.getNextSibling();
@@ -1396,7 +1426,28 @@ export class LexicalNode {
     const writableSelf = this.getWritable();
     const writableNodeToInsert = nodeToInsert.getWritable();
     const insertKey = writableNodeToInsert.__key;
+    const selection = $getSelection();
+    // Capture nodeToInsert's old parent / index before detaching so the
+    // selection's element offsets in that old parent can be adjusted
+    // afterwards. See #6031.
+    const insertOldParent = writableNodeToInsert.getParent();
+    const insertOldIndex =
+      insertOldParent !== null
+        ? writableNodeToInsert.getIndexWithinParent()
+        : -1;
     removeFromParent(writableNodeToInsert);
+    if (
+      insertOldParent !== null &&
+      restoreSelection &&
+      $isRangeSelection(selection)
+    ) {
+      $updateElementSelectionOnCreateDeleteNode(
+        selection,
+        insertOldParent,
+        insertOldIndex,
+        -1,
+      );
+    }
     const prevSibling = this.getPreviousSibling();
     const writableParent = this.getParentOrThrow().getWritable();
     const prevKey = writableSelf.__prev;
@@ -1413,7 +1464,6 @@ export class LexicalNode {
     writableNodeToInsert.__prev = prevKey;
     writableNodeToInsert.__next = writableSelf.__key;
     writableNodeToInsert.__parent = writableSelf.__parent;
-    const selection = $getSelection();
     if (restoreSelection && $isRangeSelection(selection)) {
       const parent = this.getParentOrThrow();
       $updateElementSelectionOnCreateDeleteNode(selection, parent, index);

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -397,10 +397,15 @@ function internalMarkParentElementsAsDirty(
   }
 }
 
-// TODO #6031 this function or their callers have to adjust selection (i.e. insertBefore)
 /**
  * Removes a node from its parent, updating all necessary pointers and links.
  * @internal
+ *
+ * This function does not adjust the editor's current selection. Callers
+ * that need element-anchored offsets in the old parent to track the child
+ * count change must call `$updateElementSelectionOnCreateDeleteNode` (with
+ * `times = -1`) after invoking this — see `$removeNode`, `replace`,
+ * `insertBefore`, and `insertAfter` for the pattern.
  *
  * This function is for internal use of the library.
  * Please do not use it as it may change in the future.

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -8,6 +8,7 @@
 
 import {
   $create,
+  $createLineBreakNode,
   $createRangeSelection,
   $getRoot,
   $getSelection,
@@ -1871,6 +1872,186 @@ describe('Element-anchored selection on old parent (#6031)', () => {
           });
         },
       );
+    });
+  });
+});
+
+describe('replace(other, includeChildren) selection mapping', () => {
+  initializeUnitTest(testEnv => {
+    // When `replace` transfers `this`'s children into `other`, the
+    // transferred children land at offsets [prevSize ... prevSize + N) in
+    // the receiver. An element-anchored point on `this` at offset K used
+    // to be relocated to the receiver's end via `$moveSelectionPointToEnd`,
+    // forcing callers like `$setBlocksType` to re-anchor afterwards. The
+    // receiver now natively maps that point to offset `prevSize + K`.
+
+    test('element-anchored point maps to prevSize + originalOffset (etrepum example)', () => {
+      const {editor} = testEnv;
+      let newParentKey = '';
+      let prevSize = 0;
+      editor.update(
+        () => {
+          const parent = $createParagraphNode().append(
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+          );
+          $getRoot().clear().append(parent);
+          parent.select(1, 1);
+          const newParent = $createParagraphNode().append(
+            $createTextNode('before'),
+          );
+          prevSize = newParent.getChildrenSize();
+          newParentKey = newParent.__key;
+          parent.replace(newParent, true);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.isCollapsed()).toBe(true);
+        expect(sel.anchor.key).toBe(newParentKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(prevSize + 1);
+      });
+    });
+
+    test('non-collapsed element-anchored anchor and focus both shift by prevSize', () => {
+      const {editor} = testEnv;
+      let newParentKey = '';
+      editor.update(
+        () => {
+          const parent = $createParagraphNode().append(
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+          );
+          $getRoot().clear().append(parent);
+          parent.select(1, 3);
+          // Use LineBreakNodes (atomic, no auto-merge) for the receiver's
+          // pre-existing children so prevSize stays stable across reconcile.
+          // Adjacent TextNodes would get merged by normalization and shift
+          // post-cycle offsets, which is orthogonal to what this test pins.
+          const newParent = $createParagraphNode().append(
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+          );
+          newParentKey = newParent.__key;
+          parent.replace(newParent, true);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(newParentKey);
+        expect(sel.anchor.type).toBe('element');
+        // prevSize = 2 (two line breaks pre-transfer)
+        expect(sel.anchor.offset).toBe(2 + 1);
+        expect(sel.focus.key).toBe(newParentKey);
+        expect(sel.focus.type).toBe('element');
+        expect(sel.focus.offset).toBe(2 + 3);
+      });
+    });
+
+    test('text-anchored selection inside transferred children is unaffected', () => {
+      const {editor} = testEnv;
+      let textKey = '';
+      editor.update(
+        () => {
+          const parent = $createParagraphNode();
+          const t1 = $createTextNode('hello');
+          parent.append(t1);
+          $getRoot().clear().append(parent);
+          textKey = t1.__key;
+          t1.select(2, 2);
+          // Receiver has a LineBreakNode (atomic, no text adjacency) so
+          // `t1` doesn't get merged into a sibling text on transfer; the
+          // text point's key and offset must follow `t1` as-is.
+          const newParent = $createParagraphNode().append(
+            $createLineBreakNode(),
+          );
+          parent.replace(newParent, true);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        // The TextNode's key did not change across the transfer; the text
+        // point follows the node into newParent without remapping.
+        expect(sel.anchor.key).toBe(textKey);
+        expect(sel.anchor.type).toBe('text');
+        expect(sel.anchor.offset).toBe(2);
+      });
+    });
+
+    test('replace without includeChildren falls back to the legacy moveSelectionPointToEnd', () => {
+      const {editor} = testEnv;
+      let newParentKey = '';
+      let prefixKey = '';
+      editor.update(
+        () => {
+          const parent = $createParagraphNode().append(
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+          );
+          $getRoot().clear().append(parent);
+          parent.select(1, 1);
+          const prefix = $createTextNode('prefix');
+          const newParent = $createParagraphNode().append(prefix);
+          newParentKey = newParent.__key;
+          prefixKey = prefix.__key;
+          parent.replace(newParent, false);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        // !includeChildren takes the legacy `$moveSelectionPointToEnd`
+        // branch — selection ends up as a text point on the receiver's last
+        // descendant. The exact text offset is `$moveSelectionPointToEnd`'s
+        // own (offset preserved from the source point) and is not the
+        // contract we're pinning; what matters is that the new prevSize+
+        // mapping is NOT taken (anchor isn't element-anchored on newParent).
+        expect(sel.anchor.type).toBe('text');
+        expect(sel.anchor.key).toBe(prefixKey);
+        expect(sel.anchor.getNode().getParentOrThrow().__key).toBe(
+          newParentKey,
+        );
+      });
+    });
+
+    test('$setBlocksType-style pattern (prevSize=0 fresh receiver) preserves original offset', () => {
+      const {editor} = testEnv;
+      let newParentKey = '';
+      editor.update(
+        () => {
+          const parent = $createParagraphNode().append(
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+          );
+          $getRoot().clear().append(parent);
+          parent.select(2, 2);
+          const newParent = $createParagraphNode();
+          newParentKey = newParent.__key;
+          parent.replace(newParent, true);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        // prevSize=0 → offset preserved as the original 2. This matches the
+        // override that `$setBlocksType` used to apply after replace; with
+        // the native mapping in place, the override is now redundant.
+        expect(sel.anchor.key).toBe(newParentKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(2);
+      });
     });
   });
 });

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -27,6 +27,7 @@ import {
   SerializedTextNode,
   TextNode,
 } from 'lexical';
+import invariant from 'shared/invariant';
 import {
   afterAll,
   beforeAll,
@@ -41,6 +42,7 @@ import {LexicalNode} from '../../LexicalNode';
 import {$createParagraphNode} from '../../nodes/LexicalParagraphNode';
 import {$createTextNode} from '../../nodes/LexicalTextNode';
 import {
+  $createTestElementNode,
   $createTestInlineElementNode,
   initializeUnitTest,
   TestElementNode,
@@ -1614,6 +1616,263 @@ describe('LexicalNode tests', () => {
       theme: {},
     },
   );
+});
+
+describe('Element-anchored selection on old parent (#6031)', () => {
+  type Mover = (target: ElementNode, mover: ElementNode) => void;
+  type MethodSpec = {
+    name: string;
+    act: Mover;
+    actNoRestore: Mover | null;
+  };
+  const methods: ReadonlyArray<MethodSpec> = [
+    {
+      act: (target, mover) => target.insertBefore(mover),
+      actNoRestore: (target, mover) => target.insertBefore(mover, false),
+      name: 'insertBefore',
+    },
+    {
+      act: (target, mover) => target.insertAfter(mover),
+      actNoRestore: (target, mover) => target.insertAfter(mover, false),
+      name: 'insertAfter',
+    },
+    {
+      act: (target, mover) => target.replace(mover),
+      actNoRestore: null,
+      name: 'replace',
+    },
+  ];
+  const methodsWithRestoreFlag = methods.filter(
+    (m): m is MethodSpec & {actNoRestore: Mover} => m.actNoRestore !== null,
+  );
+
+  describe('cross-parent move', () => {
+    initializeUnitTest(testEnv => {
+      // Setup: root contains two TestElementNode containers. `source` holds
+      // [mover, a2, a3]; `target` holds [inTarget]. Each test acts via one
+      // of the three methods to move `mover` from source into target so
+      // source's child count drops from 3 to 2.
+      type Refs = {
+        source: ElementNode;
+        target: ElementNode;
+        mover: ElementNode;
+        inTarget: ElementNode;
+      };
+      const $setupTwoContainers = (out: Refs) => {
+        const root = $getRoot().clear();
+        out.source = $createTestElementNode();
+        out.target = $createTestElementNode();
+        out.mover = $createParagraphNode();
+        const a2 = $createParagraphNode();
+        const a3 = $createParagraphNode();
+        out.inTarget = $createParagraphNode();
+        out.source.append(out.mover, a2, a3);
+        out.target.append(out.inTarget);
+        root.append(out.source, out.target);
+      };
+
+      test.for(methods)(
+        '$name shifts offset > removed index in source parent',
+        ({act}) => {
+          const {editor} = testEnv;
+          let sourceKey = '';
+          editor.update(
+            () => {
+              const refs = {} as Refs;
+              $setupTwoContainers(refs);
+              sourceKey = refs.source.__key;
+              // Collapsed at end of source. 3 > removedIndex (0), so the
+              // -1 shift must drive it to 2.
+              refs.source.select(3, 3);
+              act(refs.inTarget, refs.mover);
+            },
+            {discrete: true},
+          );
+          editor.read(() => {
+            const sel = $getSelection();
+            invariant($isRangeSelection(sel));
+            expect(sel.anchor.key).toBe(sourceKey);
+            expect(sel.anchor.type).toBe('element');
+            expect(sel.anchor.offset).toBe(2);
+            expect(sel.focus.offset).toBe(2);
+          });
+        },
+      );
+
+      test.for(methods)(
+        '$name does not shift offset at removed index (boundary)',
+        ({act}) => {
+          const {editor} = testEnv;
+          let sourceKey = '';
+          editor.update(
+            () => {
+              const refs = {} as Refs;
+              $setupTwoContainers(refs);
+              sourceKey = refs.source.__key;
+              // Collapsed at source offset 0. The helper uses
+              // `nodeOffset < selectionOffset` for negative shifts, so
+              // offset == removedIndex (both 0) must stay.
+              refs.source.select(0, 0);
+              act(refs.inTarget, refs.mover);
+            },
+            {discrete: true},
+          );
+          editor.read(() => {
+            const sel = $getSelection();
+            invariant($isRangeSelection(sel));
+            expect(sel.anchor.key).toBe(sourceKey);
+            expect(sel.anchor.offset).toBe(0);
+            expect(sel.focus.offset).toBe(0);
+          });
+        },
+      );
+
+      test.for(methods)(
+        '$name shifts only the past-boundary side of a non-collapsed selection',
+        ({act}) => {
+          const {editor} = testEnv;
+          let sourceKey = '';
+          editor.update(
+            () => {
+              const refs = {} as Refs;
+              $setupTwoContainers(refs);
+              sourceKey = refs.source.__key;
+              // Anchor at 0 (boundary), focus at 3 (past). After removing
+              // index 0: anchor stays at 0, focus shifts to 2.
+              refs.source.select(0, 3);
+              act(refs.inTarget, refs.mover);
+            },
+            {discrete: true},
+          );
+          editor.read(() => {
+            const sel = $getSelection();
+            invariant($isRangeSelection(sel));
+            expect(sel.anchor.key).toBe(sourceKey);
+            expect(sel.anchor.offset).toBe(0);
+            expect(sel.focus.key).toBe(sourceKey);
+            expect(sel.focus.offset).toBe(2);
+          });
+        },
+      );
+
+      test.for(methods)(
+        '$name leaves selection in an unrelated third parent untouched',
+        ({act}) => {
+          const {editor} = testEnv;
+          let sourceKey = '';
+          let otherKey = '';
+          editor.update(
+            () => {
+              const root = $getRoot().clear();
+              const source = $createTestElementNode();
+              const target = $createTestElementNode();
+              const other = $createTestElementNode();
+              const mover = $createParagraphNode();
+              const a2 = $createParagraphNode();
+              const a3 = $createParagraphNode();
+              const inTarget = $createParagraphNode();
+              const inOther = $createParagraphNode();
+              source.append(mover, a2, a3);
+              target.append(inTarget);
+              other.append(inOther);
+              root.append(source, target, other);
+              sourceKey = source.__key;
+              otherKey = other.__key;
+              // Cursor sits in `other`, which the move does not touch.
+              other.select(1, 1);
+              act(inTarget, mover);
+            },
+            {discrete: true},
+          );
+          editor.read(() => {
+            const sel = $getSelection();
+            invariant($isRangeSelection(sel));
+            expect(sel.anchor.key).toBe(otherKey);
+            expect(sel.anchor.offset).toBe(1);
+            expect(sel.focus.key).toBe(otherKey);
+            expect(sel.focus.offset).toBe(1);
+            expect(sourceKey).not.toBe(otherKey);
+          });
+        },
+      );
+
+      test.for(methodsWithRestoreFlag)(
+        '$name with restoreSelection=false skips the source-parent shift',
+        ({actNoRestore}) => {
+          const {editor} = testEnv;
+          let sourceKey = '';
+          editor.update(
+            () => {
+              const refs = {} as Refs;
+              $setupTwoContainers(refs);
+              sourceKey = refs.source.__key;
+              refs.source.select(3, 3);
+              actNoRestore(refs.inTarget, refs.mover);
+            },
+            {discrete: true},
+          );
+          editor.read(() => {
+            const sel = $getSelection();
+            invariant($isRangeSelection(sel));
+            expect(sel.anchor.key).toBe(sourceKey);
+            expect(sel.anchor.offset).toBe(3);
+            expect(sel.focus.offset).toBe(3);
+          });
+        },
+      );
+    });
+  });
+
+  describe('within-parent move', () => {
+    initializeUnitTest(testEnv => {
+      // For within-parent moves the source and target parents coincide.
+      // The pre-removal -1 shift and the post-insertion +1 shift compose
+      // so element-anchored offsets track the (unchanged) visual layout
+      // instead of going stale or out of range, which was the #6031 bug
+      // for callers that did not detect same-parent moves themselves.
+      const methodsForWithinParent = methodsWithRestoreFlag;
+
+      test.for(methodsForWithinParent)(
+        '$name keeps an end-of-parent cursor in range for a no-op move',
+        ({name, act}) => {
+          const {editor} = testEnv;
+          let parentKey = '';
+          editor.update(
+            () => {
+              const root = $getRoot().clear();
+              const parent = $createTestElementNode();
+              const a = $createParagraphNode();
+              const b = $createParagraphNode();
+              parent.append(a, b);
+              root.append(parent);
+              parentKey = parent.__key;
+              // Collapsed at offset 2 (end of [a, b]). Pre-fix this went
+              // out of range when the within-parent move's removeFromParent
+              // shrank `parent` without adjusting the offset.
+              parent.select(2, 2);
+              // Each method is invoked so the move is a layout no-op:
+              // insertBefore: b.insertBefore(a) → a stays before b
+              // insertAfter:  a.insertAfter(b)  → b stays after a
+              if (name === 'insertBefore') {
+                act(b, a);
+              } else {
+                act(a, b);
+              }
+            },
+            {discrete: true},
+          );
+
+          editor.read(() => {
+            const sel = $getSelection();
+            invariant($isRangeSelection(sel));
+            expect(sel.anchor.key).toBe(parentKey);
+            expect(sel.anchor.offset).toBe(2);
+            expect(sel.focus.offset).toBe(2);
+          });
+        },
+      );
+    });
+  });
 });
 
 // These are outside of the above suite because of the


### PR DESCRIPTION
## Description

`LexicalNode.prototype.replace`, `insertAfter`, and `insertBefore` move a node from one parent to another by calling the internal `removeFromParent` helper, then re-wiring the node into its new home. `removeFromParent` is a low-level pointer-only operation that does not touch the editor's selection, and the three callers also did not adjust element-anchored offsets in the old parent. An `{key: oldParentKey, type: 'element', offset: N}` selection with `N > removedIndex` was left pointing past the now-shrunk parent's last child, sometimes out of range entirely (e.g. cursor at end of source, mover at index 0).

Each caller now captures the moved node's old parent and index before `removeFromParent`, then calls `$updateElementSelectionOnCreateDeleteNode(selection, oldParent, oldIndex, -1)` so element-anchored offsets past the removed index shift by one. The existing post-insertion `+1` adjustment in `insertBefore`/`insertAfter` is unchanged, so within-parent moves stay in range throughout — previously the cursor at end of source went out of range while the parent was momentarily shrunk before the re-insertion.

The fix lives in the callers rather than `removeFromParent` because importing `$updateElementSelectionOnCreateDeleteNode` into `LexicalUtils.ts` creates a circular dependency with `LexicalSelection.ts` (fails at `TabNode extends TextNode` load with `Class extends value undefined`). `removeFromParent` keeps its signature; its JSDoc now documents the caller contract and points at the four call sites (`$removeNode`, `replace`, `insertBefore`, `insertAfter`) that follow the pattern.

Per review feedback (https://github.com/facebook/lexical/pull/8501#issuecomment-4432297688) the same selection-tracks-node-mutation pattern is also applied inside `replace`'s element-anchored case: instead of `$moveSelectionPointToEnd` relocating the point to the receiver's last descendant, the point now maps to `{key: other.__key, offset: prevSize + originalOffset, type: 'element'}` where `prevSize` is `other.getChildrenSize()` before the children transfer. Receivers with no pre-existing children (e.g. `$setBlocksType`'s freshly-created receivers) see `prevSize = 0` so the original offset is preserved end-to-end. `$moveSelectionPointToEnd` stays as the fallback for `!includeChildren` (children destroyed, no relative position to preserve) and non-element points (text-anchored selections inside transferred children follow their text node's key, preserved across the transfer).

### Breaking Change

Public methods now adjust the editor's selection differently after a node move:

- **Cross-parent moves via `replace` / `insertAfter` / `insertBefore`.** Previously, an element-anchored selection in the source parent with `offset > removedIndex` was left unadjusted, sometimes pointing past the parent's last child. Now the offset shifts by `-1`. Downstream code that read `$getSelection()` immediately after one of these calls and relied on the stale offset will observe a different value.
- **Within-parent moves via `insertBefore` / `insertAfter` / `replace`.** Previously the cursor at the end of the parent could briefly be left out of range while `removeFromParent` shrank the parent before the re-insertion grew it back. Now the pre-removal `-1` shift composes with the existing post-insertion `+1`, so element-anchored offsets stay in range. For `replace`, this also means a within-parent cursor past the removed slot now shifts by `-1` instead of staying put, matching the cross-parent case.
- **`replace(other, true)` with an element-anchored point on the replaced node.** Previously, `$moveSelectionPointToEnd` relocated the point to the receiver's last descendant, losing the relative position. Now the point maps to `{key: other.__key, offset: prevSize + originalOffset, type: 'element'}` where `prevSize = other.getChildrenSize()` before the children transfer. Receivers with no pre-existing children (e.g. `$setBlocksType`'s freshly-created receivers) see `prevSize = 0`, so the original offset is preserved. The legacy `$moveSelectionPointToEnd` fallback is kept for `!includeChildren` and non-element points (where there's no children-mapping to preserve).

Closes #6031

## Test plan

- [x] `pnpm vitest run --project unit` — 114 files / 2540 tests pass. Existing `Element-anchored selection on old parent (#6031)` block plus the new `replace(other, includeChildren) selection mapping` block in `LexicalNode.test.ts`:
  - **#6031 block** — `test.for` over the three methods covering: cross-parent past-boundary shift / boundary preservation / non-collapsed selection / unrelated-parent untouched / `restoreSelection: false` skip / within-parent no-op end-cursor preservation.
  - **`replace` selection mapping block** — element-anchored point maps to `prevSize + originalOffset` (etrepum's snippet) / non-collapsed anchor+focus both shift / text-anchored selection inside transferred children unaffected / `!includeChildren` falls back to legacy `$moveSelectionPointToEnd` / fresh-receiver (`prevSize=0`) preserves original offset.
- [x] `pnpm tsc --noEmit -p tsconfig.json` clean.
- [x] Prettier / eslint clean on the changed files.