### PR TITLE
[lexical-table] Bug Fix: prevent crash when moving selection with arrow key outside of nested table

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -1902,6 +1902,7 @@ function $handleArrowKey(
 
   const selection = $getSelection();
 
+  // Handle arrow key into a table (including from a table into a nested table)
   if (!$isSelectionInTable(selection, tableNode)) {
     if ($isRangeSelection(selection)) {
       if (direction === 'backward') {
@@ -2200,7 +2201,10 @@ function $handleArrowKey(
       }
     }
   } else if ($isTableSelection(selection)) {
-    const {anchor, focus} = selection;
+    const {anchor, focus, tableKey} = selection;
+    if (tableKey !== tableNode.getKey()) {
+      return false;
+    }
     const anchorCellNode = $findMatchingParent(
       anchor.getNode(),
       $isTableCellNode,


### PR DESCRIPTION
## Description

Closes #8484

Problem: With a **table** selection on a nested table, the arrow key handler would fire for both the parent and the nested table, and this breaks one of the invariants (`LexicalTableObserver.$updateTableTableSelection`).

The problem is similar in nature to the mouse selection bugs that were fixed by refactoring selection to be registered once, and handle all of the tables. Ideally we would do the same for the arrow key handler, but for now, this prevents the editor crash.

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*

### After

*Insert relevant screenshots/recordings/automated-tests*