### PR TITLE
[Breaking Change][lexical-markdown] Bug Fix: Apply markdown shortcuts on composition-committed triggers

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -452,7 +452,7 @@ export function registerMarkdownShortcuts(
   // `- `, ...) and text-match triggers carry their own single-character triggers.
   const compositionEndTriggerChars = new Set<string>([' ']);
   for (const t of byType.textFormat) {
-    compositionEndTriggerChars.add(t.tag[t.tag.length - 1]);
+    compositionEndTriggerChars.add(t.tag.slice(-1));
   }
   for (const t of byType.textMatch) {
     if (t.trigger !== undefined) {

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -27,6 +27,7 @@ import {
   $setSelection,
   COLLABORATION_TAG,
   COMMAND_PRIORITY_LOW,
+  COMPOSITION_END_TAG,
   HISTORIC_TAG,
   HISTORY_PUSH_TAG,
   KEY_ENTER_COMMAND,
@@ -444,6 +445,20 @@ export function registerMarkdownShortcuts(
     byType.textMatch,
     ({trigger}) => trigger,
   );
+  // Composition end fires per IME commit (every CJK syllable, German dead-key
+  // resolve, etc.). Most of those have nothing to do with markdown, so only
+  // enter the transformer pass when the just-committed character can plausibly
+  // close a trigger. Space covers element/multilineElement triggers (`# `,
+  // `- `, ...) and text-match triggers carry their own single-character triggers.
+  const compositionEndTriggerChars = new Set<string>([' ']);
+  for (const t of byType.textFormat) {
+    compositionEndTriggerChars.add(t.tag[t.tag.length - 1]);
+  }
+  for (const t of byType.textMatch) {
+    if (t.trigger !== undefined) {
+      compositionEndTriggerChars.add(t.trigger);
+    }
+  }
 
   for (const transformer of transformers) {
     const type = transformer.type;
@@ -528,6 +543,13 @@ export function registerMarkdownShortcuts(
           return;
         }
 
+        // composition end commits the composed text without moving the
+        // selection (compositionupdate already did) and may jump the anchor by
+        // more than one when multi-character commits land at once. Skip the
+        // typed-character heuristics so a trailing trigger character can still
+        // fire its transform.
+        const isCompositionEnd = tags.has(COMPOSITION_END_TAG);
+
         const selection = editorState.read($getSelection);
         const prevSelection = prevEditorState.read($getSelection);
 
@@ -537,7 +559,7 @@ export function registerMarkdownShortcuts(
           !$isRangeSelection(prevSelection) ||
           !$isRangeSelection(selection) ||
           !selection.isCollapsed() ||
-          selection.is(prevSelection)
+          (selection.is(prevSelection) && !isCompositionEnd)
         ) {
           return;
         }
@@ -550,9 +572,20 @@ export function registerMarkdownShortcuts(
         if (
           !$isTextNode(anchorNode) ||
           !dirtyLeaves.has(anchorKey) ||
-          (anchorOffset !== 1 && anchorOffset > prevSelection.anchor.offset + 1)
+          (!isCompositionEnd &&
+            anchorOffset !== 1 &&
+            anchorOffset > prevSelection.anchor.offset + 1)
         ) {
           return;
+        }
+
+        if (isCompositionEnd) {
+          const closeChar = editorState.read(() => anchorNode.getTextContent())[
+            anchorOffset - 1
+          ];
+          if (!compositionEndTriggerChars.has(closeChar)) {
+            return;
+          }
         }
 
         editor.update(() => {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -18,6 +18,7 @@ import {
 } from '@lexical/list';
 import {$createQuoteNode, HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {
+  $addUpdateTag,
   $copyNode,
   $createLineBreakNode,
   $createParagraphNode,
@@ -30,12 +31,17 @@ import {
   $insertNodes,
   $isElementNode,
   $isLineBreakNode,
+  $isParagraphNode,
   $isRangeSelection,
   $isTextNode,
+  $setCompositionKey,
   $setSelectionFromCaretRange,
   $setState,
+  COMPOSITION_END_TAG,
   KEY_ENTER_COMMAND,
+  type TextNode,
 } from 'lexical';
+import invariant from 'shared/invariant';
 import {assert, describe, expect, it} from 'vitest';
 
 import {
@@ -1389,6 +1395,126 @@ describe('Markdown', () => {
 
       expect(editor.read(() => $generateHtmlFromNodes(editor))).toBe(
         '<p><span style="white-space: pre-wrap;">```</span></p>',
+      );
+    });
+  });
+
+  describe('composition-end trigger characters (#7026)', () => {
+    function buildEditor() {
+      const editor = createHeadlessEditor({
+        nodes: [
+          HeadingNode,
+          ListNode,
+          ListItemNode,
+          QuoteNode,
+          CodeNode,
+          LinkNode,
+        ],
+      });
+      registerMarkdownShortcuts(editor, TRANSFORMERS);
+      return editor;
+    }
+
+    function $getTextNode(): TextNode {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      invariant(
+        $isParagraphNode(paragraph),
+        'expected ParagraphNode at root[0]',
+      );
+      const textNode = paragraph.getFirstChildOrThrow();
+      invariant($isTextNode(textNode), 'expected TextNode at paragraph[0]');
+      return textNode;
+    }
+
+    it('applies inline code when the closing backtick is committed via compositionend', () => {
+      const editor = buildEditor();
+
+      // Set up "`hello" with the caret at offset 6. The first backtick was
+      // typed normally, the rest mirrors what is in the editor once the
+      // German dead-key sequence "` h e l l o" has resolved.
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          $getRoot().append(paragraph);
+          const textNode = $createTextNode('`hello');
+          paragraph.append(textNode);
+          paragraph.selectEnd();
+        },
+        {discrete: true},
+      );
+
+      // Pretend compositionupdate is in progress: the backtick is pushed into
+      // the text node, the caret advances to the trailing position (collapsed,
+      // matching what a real compositionupdate leaves behind), and the editor
+      // is marked composing so the markdown listener short-circuits on
+      // `editor.isComposing()`.
+      editor.update(
+        () => {
+          const textNode = $getTextNode();
+          $setCompositionKey(textNode.getKey());
+          textNode.setTextContent('`hello`');
+          textNode.select(7, 7);
+        },
+        {discrete: true},
+      );
+
+      // compositionend flush: the text is already in place, the caret stays
+      // where it is, and the COMPOSITION_END_TAG is added. Without the
+      // bypass the listener would bail on `selection.is(prevSelection)`.
+      editor.update(
+        () => {
+          $setCompositionKey(null);
+          $addUpdateTag(COMPOSITION_END_TAG);
+          $getTextNode().markDirty();
+        },
+        {discrete: true},
+      );
+
+      expect(editor.read(() => $generateHtmlFromNodes(editor))).toBe(
+        '<p><code spellcheck="false" style="white-space: pre-wrap;"><span>hello</span></code></p>',
+      );
+    });
+
+    it('applies inline code when compositionend commits the trigger as a multi-character chunk', () => {
+      const editor = buildEditor();
+
+      // Some IMEs (and synthetic event sources) skip compositionupdate and
+      // land the entire composed run on compositionend. Model that here:
+      // the caret stays at offset 6 across the composition, then jumps to 8
+      // when compositionend commits "a`". The transform should still fire,
+      // which requires the offset-jump bypass (the selection-equality bypass
+      // alone is not enough here).
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          $getRoot().append(paragraph);
+          const textNode = $createTextNode('`hello');
+          paragraph.append(textNode);
+          paragraph.selectEnd();
+        },
+        {discrete: true},
+      );
+
+      editor.update(
+        () => {
+          $setCompositionKey($getTextNode().getKey());
+        },
+        {discrete: true},
+      );
+
+      editor.update(
+        () => {
+          $setCompositionKey(null);
+          $addUpdateTag(COMPOSITION_END_TAG);
+          const textNode = $getTextNode();
+          textNode.setTextContent('`helloa`');
+          textNode.select(8, 8);
+        },
+        {discrete: true},
+      );
+
+      expect(editor.read(() => $generateHtmlFromNodes(editor))).toBe(
+        '<p><code spellcheck="false" style="white-space: pre-wrap;"><span>helloa</span></code></p>',
       );
     });
   });


### PR DESCRIPTION
## Description

`registerMarkdownShortcuts` runs as an update listener that bails when the typing heuristics say "this update isn't a user typing one character". Two of those guards (`selection.is(prevSelection)` and the anchor-offset jump) interpret typed input as a forward selection move by one. That doesn't match what composition-driven input looks like: a compositionupdate flush has already advanced the caret during composition, so by the time compositionend arrives the selection looks unchanged, and a multi-character commit makes the anchor jump by more than one in a single flush. The result is that markdown trigger characters committed via composition (German/Spanish dead-key `, IME compose-then-commit, etc.) silently skip the transform until something else nudges the caret.

The fix detects `COMPOSITION_END_TAG` on the update (added by lexical core in `$onCompositionEndImpl`) and skips both heuristic guards in that case. A second `compositionEndTriggerChars` gate keeps the listener cheap on CJK typing: only enter the transformer pass when the just-committed character could close a real transformer trigger. Element / multilineElement transformers stay covered because their effective trigger is the space that follows their pattern, and space is in the trigger set.

### Backwards compatibility

Composition-committed trigger characters now fire their TextFormat / TextMatch transform on the compositionend update instead of waiting for a subsequent insert/backspace. Previously the only way to land inline code from a German dead-key (or analogous patterns under CJK IMEs) was the space + space + backspace sequence noted in the issue.

Closes #7026

## Test plan

- [x] `pnpm vitest run --project unit packages/lexical-markdown/src/__tests__/unit/` — 378 markdown tests pass, including two new `composition-end trigger characters (#7026)` cases:
  - single-character commit (the German dead-key shape: `` ` `` `h e l l o ` `` SPACE)
  - multi-character commit (compositionend lands the closing trigger atomically, exercising the offset-jump bypass)
- [x] `pnpm vitest run --project unit` — full unit suite (114 files, 2567 tests) green.
- [x] tsc / prettier / eslint clean.
- [x] Manual playground: macOS + German keyboard layout. Sequence that previously needed space + space + backspace now transforms on the first space.