### PR TITLE
[lexical][lexical-list][lexical-selection][lexical-link] Refactor: Centralize replace-area selection mapping + bulk splice

### DIFF
--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -814,9 +814,13 @@ export function $toggleLink(
           !$isAutoLinkNode(parent) && $isLinkNode(parent),
       );
       if (parentLink !== null) {
-        parentLink.getChildren().forEach(child => {
-          parentLink.insertBefore(child);
-        });
+        parentLink
+          .getParentOrThrow()
+          .splice(
+            parentLink.getIndexWithinParent(),
+            0,
+            parentLink.getChildren(),
+          );
         parentLink.remove();
       }
       return;

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -31,6 +31,7 @@ import {
   $applyNodeReplacement,
   $copyNode,
   $createParagraphNode,
+  $getSelection,
   $getSiblingCaret,
   $isElementNode,
   $isParagraphNode,
@@ -297,14 +298,38 @@ export class ListItemNode extends ElementNode {
       list.insertAfter(replaceWithNode);
       replaceWithNode.insertAfter(newList);
     }
+    const toReplaceKey = this.__key;
+    let prevSizeBeforeChildrenTransfer = 0;
     if (includeChildren) {
       invariant(
         $isElementNode(replaceWithNode),
         'includeChildren should only be true for ElementNodes',
       );
-      this.getChildren().forEach((child: LexicalNode) => {
-        replaceWithNode.append(child);
-      });
+      prevSizeBeforeChildrenTransfer = replaceWithNode.getChildrenSize();
+      replaceWithNode.splice(
+        prevSizeBeforeChildrenTransfer,
+        0,
+        this.getChildren(),
+      );
+    }
+    // The base LexicalNode.replace remaps element-anchored selection points
+    // from the replaced node to the replacement, but this override skips
+    // super and the trailing this.remove() would otherwise drop selection
+    // onto a sibling list item via moveSelectionPointToSibling. Mirror the
+    // base behavior here for the element-anchored case.
+    if (includeChildren && $isElementNode(replaceWithNode)) {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        for (const point of selection.getStartEndPoints()) {
+          if (point.key === toReplaceKey && point.type === 'element') {
+            point.set(
+              replaceWithNode.getKey(),
+              prevSizeBeforeChildrenTransfer + point.offset,
+              'element',
+            );
+          }
+        }
+      }
     }
     this.remove();
     if (list.getChildrenSize() === 0) {

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -71,12 +71,7 @@ export function $insertList(listType: ListType): void {
   if (selection !== null) {
     let nodes = selection.getNodes();
     if ($isRangeSelection(selection)) {
-      const anchorAndFocus = selection.getStartEndPoints();
-      invariant(
-        anchorAndFocus !== null,
-        'insertList: anchor should be defined',
-      );
-      const [anchor] = anchorAndFocus;
+      const [anchor] = selection.getStartEndPoints();
       const anchorNode = anchor.getNode();
       const anchorNodeParent = anchorNode.getParent();
 

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -19,11 +19,9 @@ import type {
 import {TableSelection} from '@lexical/table';
 import {
   $caretFromPoint,
-  $createRangeSelection,
   $extendCaretToRange,
   $findMatchingParent,
   $getPreviousSelection,
-  $getSelection,
   $hasAncestor,
   $isChildCaret,
   $isDecoratorNode,
@@ -76,12 +74,8 @@ export function $setBlocksType<T extends ElementNode>(
   // expand it here
   const anchorAndFocus = selection.getStartEndPoints();
   const blockMap = new Map<NodeKey, ElementNode>();
-  let newSelection: RangeSelection | null = null;
   if (anchorAndFocus) {
     const [anchor, focus] = anchorAndFocus;
-    newSelection = $createRangeSelection();
-    newSelection.anchor.set(anchor.key, anchor.offset, anchor.type);
-    newSelection.focus.set(focus.key, focus.offset, focus.type);
     const anchorBlock = $findMatchingParent(
       anchor.getNode(),
       INTERNAL_$isBlock,
@@ -104,29 +98,13 @@ export function $setBlocksType<T extends ElementNode>(
       }
     }
   }
-  for (const [key, prevNode] of blockMap) {
+  // Selection remapping is delegated to LexicalNode.replace (and the
+  // ListItemNode.replace override): both remap an element-anchored point
+  // on the replaced block to {key: replacement, offset: prevSize + offset}.
+  for (const [, prevNode] of blockMap) {
     const element = $createElement();
     $afterCreateElement(prevNode, element);
     prevNode.replace(element, true);
-    if (newSelection) {
-      if (key === newSelection.anchor.key) {
-        newSelection.anchor.set(
-          element.getKey(),
-          newSelection.anchor.offset,
-          newSelection.anchor.type,
-        );
-      }
-      if (key === newSelection.focus.key) {
-        newSelection.focus.set(
-          element.getKey(),
-          newSelection.focus.offset,
-          newSelection.focus.type,
-        );
-      }
-    }
-  }
-  if (newSelection && selection.is($getSelection())) {
-    $setSelection(newSelection);
   }
 }
 
@@ -326,14 +304,17 @@ export function $wrapNodesImpl(
         elementMapping.set(parentKey, targetElement);
         // Move node and its siblings to the new
         // element.
-        parent.getChildren().forEach(child => {
-          targetElement.append(child);
+        const children = parent.getChildren();
+        targetElement.splice(targetElement.getChildrenSize(), 0, children);
+        for (const child of children) {
           movedNodes.add(child.getKey());
           if ($isElementNode(child)) {
             // Skip nested leaf nodes if the parent has already been moved
-            child.getChildrenKeys().forEach(key => movedNodes.add(key));
+            for (const key of child.getChildrenKeys()) {
+              movedNodes.add(key);
+            }
           }
-        });
+        }
         $removeParentEmptyElements(parent);
       }
     } else if (emptyElements.has(node.getKey())) {

--- a/packages/lexical-utils/src/markSelection.ts
+++ b/packages/lexical-utils/src/markSelection.ts
@@ -25,7 +25,7 @@ import positionNodeOnRange from './positionNodeOnRange';
 import px from './px';
 
 function $getOrderedSelectionPoints(selection: RangeSelection): [Point, Point] {
-  const points = selection.getStartEndPoints()!;
+  const points = selection.getStartEndPoints();
   return selection.isBackward() ? [points[1], points[0]] : points;
 }
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -630,7 +630,7 @@ declare export class RangeSelection implements BaseSelection {
   getCachedNodes(): null | Array<LexicalNode>;
   setCachedNodes(nodes: null | Array<LexicalNode>): void;
   forwardDeletion(anchor: PointType, anchorNode: ElementNode | TextNode, isBackward: boolean): boolean;
-  getStartEndPoints(): null | [PointType, PointType];
+  getStartEndPoints(): [PointType, PointType];
 }
 export type TextPoint = TextPointType;
 type TextPointType = {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1332,9 +1332,11 @@ export class LexicalNode {
         'includeChildren should only be true for ElementNodes',
       );
       prevSizeBeforeChildrenTransfer = writableReplaceWith.getChildrenSize();
-      this.getChildren().forEach((child: LexicalNode) => {
-        writableReplaceWith.append(child);
-      });
+      writableReplaceWith.splice(
+        prevSizeBeforeChildrenTransfer,
+        0,
+        this.getChildren(),
+      );
     }
     if ($isRangeSelection(selection)) {
       $setSelection(selection);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2000,7 +2000,7 @@ export class RangeSelection implements BaseSelection {
     return isBackward;
   }
 
-  getStartEndPoints(): null | [PointType, PointType] {
+  getStartEndPoints(): [PointType, PointType] {
     return [this.anchor, this.focus];
   }
 }


### PR DESCRIPTION
## Description

Follow-up to #8501. PR #8501 taught `LexicalNode.replace` to map an element-anchored selection on the replaced node to `{key: replacement, offset: prevSize + originalOffset, type: 'element'}` and left two pieces for this PR: the same mapping in `ListItemNode.replace` (an override that bypasses `super.replace`), and removal of the `$setBlocksType` workaround that compensated for the lossy pre-#8501 behavior.

### What changed

- `ListItemNode.replace` mirrors the base `prevSize + offset` mapping in its `includeChildren` branch. The mapping runs before the trailing `this.remove()` so the subsequent `$removeNode → moveSelectionPointToSibling` sees anchor/focus already redirected to the replacement and is a no-op for those points. Text-anchored selections inside transferred children follow their text node's key across the children move, so no extra mapping is needed for that case. This catches the override up to the contract base `replace` started honoring in #8501.
- `$setBlocksType` drops the cloned-`newSelection` + per-iteration override + `selection.is($getSelection())` commit. With base and list-item `replace` paths both handling element-anchored mapping, the caller-side workaround is redundant. Unused `$createRangeSelection` and `$getSelection` imports removed.
- `getChildren().forEach(parent.append)` patterns collapse to a single `parent.splice(parent.getChildrenSize(), 0, getChildren())` call at the four sites in this area: base `LexicalNode.replace`, `ListItemNode.replace`, `$setBlocksType`'s wrap branch, and `$toggleLink`'s unlink branch. Since `append` is `splice`-of-1, this is one bookkeeping pass instead of N.
- `$toggleLink` unlink: the original `parentLink.getChildren().forEach(c => parentLink.insertBefore(c))` is a "promote children to siblings before self" shape. Splice equivalent: `parentLink.getParentOrThrow().splice(parentLink.getIndexWithinParent(), 0, parentLink.getChildren())`. `parentLink` was just located via `$findMatchingParent` on a descendant so its parent is guaranteed — `getParentOrThrow()` keeps that as a loud invariant rather than a silent skip.

### Note on `$toggleLink` selection adjustment

The `forEach(insertBefore)` → single `splice` substitution has a subtle semantic difference: each `insertBefore` calls `$updateElementSelectionOnCreateDeleteNode` (one selection shift per insert), while a single `splice` with `deleteCount=0` does not. In practice this path runs only when `selection.isCollapsed() && url === null` and the collapsed selection sits inside the link's text content, so no element-anchored selection in the grandparent at the link's index is reachable. Behavior unchanged for the documented entry conditions.

Closes the follow-up scope discussed at https://github.com/facebook/lexical/pull/8501#issuecomment-4433272460

## Test plan

- [x] `pnpm vitest run --project unit` — full unit suite (114 files, 2565 tests + 1 skipped) green.
- [x] Affected packages (lexical / lexical-list / lexical-selection / lexical-link / lexical-markdown) — 1361 tests pass. The existing `$setBlocksType` describe block in `LexicalSelection.test.tsx` covers the workaround-removal regression surface; the list-item regression that blocked the cleanup attempt during #8501 (the "Expected ListItemNode to have block ElementNode ancestor" invariant) does not reproduce on this branch.
- [x] tsc / prettier / eslint clean.