### PR TITLE
[lexical-playground] Chore: Drop FIXME #8348 Firefox ArrowDown workaround in Tables.spec.mjs

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1654,10 +1654,7 @@ test.describe.parallel('Tables', () => {
     await insertCollapsible(page);
 
     await page.keyboard.type('123');
-    await page.keyboard.press(
-      // FIXME #8348 firefox ArrowDown skips over the content block
-      browserName === 'firefox' ? 'ArrowRight' : 'ArrowDown',
-    );
+    await page.keyboard.press('ArrowDown');
     await page.keyboard.type('123');
     await page.keyboard.press('Enter');
     await page.keyboard.press('Enter');


### PR DESCRIPTION
## Summary

Issue #8348 (Firefox regression in up/down arrow key handling with collapsible) was fixed by #8349 (merged 2026-04-14). The same PR added `Selection.spec.mjs:703` *"Arrow keys navigate into/out of collapsible content in all browsers (#8348)"*, which asserts arrow-nav now works correctly in Firefox too.

The Firefox-only `ArrowRight` workaround in `Tables.spec.mjs` is now dead code — it masks any future regression and obscures the test's intent (this test is checking collapsible-newline behavior inside tables, not arrow-key navigation).

## Diff

```diff
     await page.keyboard.type('123');
-    await page.keyboard.press(
-      // FIXME #8348 firefox ArrowDown skips over the content block
-      browserName === 'firefox' ? 'ArrowRight' : 'ArrowDown',
-    );
+    await page.keyboard.press('ArrowDown');
     await page.keyboard.type('123');
```

`browserName` stays in the destructure — it's still used a few lines below for the Collapsible HTML-output check.

## Scope

One file, +1 / -4. No source / test-helper / CI changes.