### PR TITLE
[lexical-extension] Bug Fix: Set the correct default `$canIndent`

### DIFF
--- a/packages/lexical-extension/src/TabIndentationExtension.ts
+++ b/packages/lexical-extension/src/TabIndentationExtension.ts
@@ -70,7 +70,7 @@ function $indentOverTab(selection: RangeSelection): boolean {
 export type CanIndentPredicate = (node: ElementNode) => boolean;
 
 function $defaultCanIndent(node: ElementNode) {
-  return node.canBeEmpty();
+  return node.canIndent();
 }
 
 export function registerTabIndentation(


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

It looks like it was an autocomplete error, so I'm fixing it to correctly use the default predicate for TabExtension

## Test plan

### Before



In the TabIndentationExtension and TabIndentationPlugin, the results of `canBeEmpty()` method was used by default for the `$canIndent` parameter


### After

The `$canIndent` option defaults to the result of the `canIndent()` method