### PR TITLE
ci: declare empty permissions on devtools-extension-publish workflow

### DIFF
--- a/.github/workflows/devtools-extension-publish.yml
+++ b/.github/workflows/devtools-extension-publish.yml
@@ -9,6 +9,8 @@ on:
         default: 0
         type: number
 
+permissions: {}
+
 jobs:
   release:
     if: github.repository_owner == 'facebook'


### PR DESCRIPTION
The DevTools extension publish workflow only uses external store credentials (Edge, Firefox, Chrome) to upload the packaged extension. Nothing in the job calls the GitHub API beyond `actions/checkout`, which on a public repo works without a scoped `GITHUB_TOKEN`.

This patch declares `permissions: {}` at workflow scope, matching the empty-by-default block already used in `call-core-tests.yml`, `call-e2e-all-tests.yml`, `call-e2e-canary-tests.yml`, and `call-e2e-test.yml`. With it set, the workflow token can no longer be widened by a future change to the repository default.

Out of scope for this PR (left untouched on purpose):

- `nightly-release.yml`, `pre-release.yml`, `version.yml` -- each calls `./.github/workflows/call-increment-version.yml`, which declares `permissions: contents: write` per job (it pushes the version bump). Tightening the caller would intersect the callee's grant down to read, breaking the bump. Worth a separate look once the right per-job pattern is settled.

No behavioural change here.