### PR TITLE
[lexical] Bug Fix: handle triple-click overselection in `$setBlocksType`

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -3158,6 +3158,61 @@ describe('LexicalSelection tests', () => {
       );
     });
 
+    test('Triple-click overselection: focus at element offset 0 of non-empty next block is skipped', () => {
+      using testEditor = buildEditorFromExtensions({
+        $initialEditorState: () => {
+          const text1 = $createTextNode('text 1');
+          const paragraph2 = $createParagraphNode();
+          $getRoot().append(
+            $createParagraphNode().append(text1),
+            paragraph2.append($createLineBreakNode()),
+          );
+
+          // Browser triple-click: focus lands on the text node of the
+          // following block at offset 0, even though visually only
+          // paragraph1's content is selected.
+          const selection = text1.selectStart();
+          selection.focus.set(paragraph2.getKey(), 0, 'element');
+
+          $setBlocksType(selection, () => $createHeadingNode('h1'));
+        },
+        dependencies: [RichTextExtension],
+        name: '@test',
+      });
+      testEditor.read(() => {
+        const rootChildren = $getRoot().getChildren();
+        expect($isHeadingNode(rootChildren[0])).toBe(true);
+        expect($isParagraphNode(rootChildren[1])).toBe(true);
+        expect(rootChildren.length).toBe(2);
+      });
+    });
+
+    test('Triple-click overselection: focus at element offset 0 of empty next block is converted', () => {
+      using testEditor = buildEditorFromExtensions({
+        $initialEditorState: () => {
+          const text1 = $createTextNode('text 1');
+          const paragraph2 = $createParagraphNode();
+          $getRoot().append($createParagraphNode().append(text1), paragraph2);
+
+          // Browser triple-click: focus lands on the text node of the
+          // following block at offset 0, even though visually only
+          // paragraph1's content is selected.
+          const selection = text1.selectStart();
+          selection.focus.set(paragraph2.getKey(), 0, 'element');
+
+          $setBlocksType(selection, () => $createHeadingNode('h1'));
+        },
+        dependencies: [RichTextExtension],
+        name: '@test',
+      });
+      testEditor.read(() => {
+        const rootChildren = $getRoot().getChildren();
+        expect($isHeadingNode(rootChildren[0])).toBe(true);
+        expect($isHeadingNode(rootChildren[1])).toBe(true);
+        expect(rootChildren.length).toBe(2);
+      });
+    });
+
     test('Triple-click overselection: focus at offset 0 of next block is skipped', () => {
       using testEditor = buildEditorFromExtensions({
         $initialEditorState: () => {

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -3152,6 +3152,214 @@ describe('LexicalSelection tests', () => {
       );
     });
 
+    test('Triple-click overselection: focus at offset 0 of next block is skipped', async () => {
+      const testEditor = createTestEditor();
+      const element = document.createElement('div');
+      testEditor.setRootElement(element);
+
+      await testEditor.update(() => {
+        const root = $getRoot();
+        const paragraph1 = $createParagraphNode();
+        const text1 = $createTextNode('text 1');
+        const paragraph2 = $createParagraphNode();
+        const text2 = $createTextNode('text 2');
+        root.append(paragraph1, paragraph2);
+        paragraph1.append(text1);
+        paragraph2.append(text2);
+
+        const selection = $createRangeSelection();
+        $setSelection(selection);
+        // Browser triple-click: focus lands on the text node of the
+        // following block at offset 0, even though visually only
+        // paragraph1's content is selected.
+        $setAnchorPoint({
+          key: text1.__key,
+          offset: 0,
+          type: 'text',
+        });
+        $setFocusPoint({
+          key: text2.__key,
+          offset: 0,
+          type: 'text',
+        });
+
+        $setBlocksType(selection, () => {
+          return $createHeadingNode('h1');
+        });
+
+        const rootChildren = root.getChildren();
+        expect(rootChildren[0].__type).toBe('heading');
+        expect(rootChildren[1].__type).toBe('paragraph');
+        expect(rootChildren.length).toBe(2);
+      });
+    });
+
+    test('Triple-click overselection: focus inside nested inline at offset 0 is skipped', async () => {
+      const testEditor = createTestEditor();
+      const element = document.createElement('div');
+      testEditor.setRootElement(element);
+
+      await testEditor.update(() => {
+        const root = $getRoot();
+        const paragraph1 = $createParagraphNode();
+        const text1 = $createTextNode('text 1');
+        const paragraph2 = $createParagraphNode();
+        const link2 = $createLinkNode('https://lexical.dev');
+        const text2 = $createTextNode('link');
+        root.append(paragraph1, paragraph2);
+        paragraph1.append(text1);
+        paragraph2.append(link2.append(text2));
+
+        const selection = $createRangeSelection();
+        $setSelection(selection);
+        $setAnchorPoint({
+          key: text1.__key,
+          offset: 0,
+          type: 'text',
+        });
+        // Focus on a text node nested inside an inline element that
+        // is the first descendant of paragraph2.
+        $setFocusPoint({
+          key: text2.__key,
+          offset: 0,
+          type: 'text',
+        });
+
+        $setBlocksType(selection, () => {
+          return $createHeadingNode('h1');
+        });
+
+        const rootChildren = root.getChildren();
+        expect(rootChildren[0].__type).toBe('heading');
+        expect(rootChildren[1].__type).toBe('paragraph');
+        expect(rootChildren.length).toBe(2);
+      });
+    });
+
+    test('Non-zero focus offset in next block still converts both blocks', async () => {
+      const testEditor = createTestEditor();
+      const element = document.createElement('div');
+      testEditor.setRootElement(element);
+
+      await testEditor.update(() => {
+        const root = $getRoot();
+        const paragraph1 = $createParagraphNode();
+        const text1 = $createTextNode('text 1');
+        const paragraph2 = $createParagraphNode();
+        const text2 = $createTextNode('text 2');
+        root.append(paragraph1, paragraph2);
+        paragraph1.append(text1);
+        paragraph2.append(text2);
+
+        const selection = $createRangeSelection();
+        $setSelection(selection);
+        $setAnchorPoint({
+          key: text1.__key,
+          offset: 0,
+          type: 'text',
+        });
+        $setFocusPoint({
+          key: text2.__key,
+          offset: 1,
+          type: 'text',
+        });
+
+        $setBlocksType(selection, () => {
+          return $createHeadingNode('h1');
+        });
+
+        const rootChildren = root.getChildren();
+        expect(rootChildren[0].__type).toBe('heading');
+        expect(rootChildren[1].__type).toBe('heading');
+        expect(rootChildren.length).toBe(2);
+      });
+    });
+
+    test('Triple-click overselection spanning multiple blocks skips only the focus block', async () => {
+      const testEditor = createTestEditor();
+      const element = document.createElement('div');
+      testEditor.setRootElement(element);
+
+      await testEditor.update(() => {
+        const root = $getRoot();
+        const paragraph1 = $createParagraphNode();
+        const text1 = $createTextNode('text 1');
+        const paragraph2 = $createParagraphNode();
+        const text2 = $createTextNode('text 2');
+        const paragraph3 = $createParagraphNode();
+        const text3 = $createTextNode('text 3');
+        root.append(paragraph1, paragraph2, paragraph3);
+        paragraph1.append(text1);
+        paragraph2.append(text2);
+        paragraph3.append(text3);
+
+        const selection = $createRangeSelection();
+        $setSelection(selection);
+        $setAnchorPoint({
+          key: text1.__key,
+          offset: 0,
+          type: 'text',
+        });
+        $setFocusPoint({
+          key: text3.__key,
+          offset: 0,
+          type: 'text',
+        });
+
+        $setBlocksType(selection, () => {
+          return $createHeadingNode('h1');
+        });
+
+        const rootChildren = root.getChildren();
+        expect(rootChildren[0].__type).toBe('heading');
+        expect(rootChildren[1].__type).toBe('heading');
+        expect(rootChildren[2].__type).toBe('paragraph');
+        expect(rootChildren.length).toBe(3);
+      });
+    });
+
+    test('Focus at offset 0 in next block whose first descendant has a prior sibling still converts focus block', async () => {
+      const testEditor = createTestEditor();
+      const element = document.createElement('div');
+      testEditor.setRootElement(element);
+
+      await testEditor.update(() => {
+        const root = $getRoot();
+        const paragraph1 = $createParagraphNode();
+        const text1 = $createTextNode('text 1');
+        const paragraph2 = $createParagraphNode();
+        const text2a = $createTextNode('foo');
+        const text2b = $createTextNode('bar');
+        root.append(paragraph1, paragraph2);
+        paragraph1.append(text1);
+        // text2b is the second child; offset 0 of text2b is NOT at
+        // the start of paragraph2 (text2a precedes it).
+        paragraph2.append(text2a, text2b);
+
+        const selection = $createRangeSelection();
+        $setSelection(selection);
+        $setAnchorPoint({
+          key: text1.__key,
+          offset: 0,
+          type: 'text',
+        });
+        $setFocusPoint({
+          key: text2b.__key,
+          offset: 0,
+          type: 'text',
+        });
+
+        $setBlocksType(selection, () => {
+          return $createHeadingNode('h1');
+        });
+
+        const rootChildren = root.getChildren();
+        expect(rootChildren[0].__type).toBe('heading');
+        expect(rootChildren[1].__type).toBe('heading');
+        expect(rootChildren.length).toBe(2);
+      });
+    });
+
     test('Nested list with listItem twice indented from its parent', async () => {
       const testEditor = createTestEditor();
       const element = document.createElement('div');

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -6,7 +6,8 @@
  *
  */
 
-import {$createLinkNode} from '@lexical/link';
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createLinkNode, LinkExtension} from '@lexical/link';
 import {
   $createListItemNode,
   $createListNode,
@@ -22,7 +23,11 @@ import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import {MarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
-import {$createHeadingNode} from '@lexical/rich-text';
+import {
+  $createHeadingNode,
+  $isHeadingNode,
+  RichTextExtension,
+} from '@lexical/rich-text';
 import {
   $getSelectionStyleValueForProperty,
   $patchStyleText,
@@ -38,6 +43,7 @@ import {
   $getSelection,
   $isElementNode,
   $isLineBreakNode,
+  $isParagraphNode,
   $isRangeSelection,
   $isTextNode,
   $setSelection,
@@ -3152,210 +3158,143 @@ describe('LexicalSelection tests', () => {
       );
     });
 
-    test('Triple-click overselection: focus at offset 0 of next block is skipped', async () => {
-      const testEditor = createTestEditor();
-      const element = document.createElement('div');
-      testEditor.setRootElement(element);
+    test('Triple-click overselection: focus at offset 0 of next block is skipped', () => {
+      using testEditor = buildEditorFromExtensions({
+        $initialEditorState: () => {
+          const text1 = $createTextNode('text 1');
+          const text2 = $createTextNode('text 2');
+          $getRoot().append(
+            $createParagraphNode().append(text1),
+            $createParagraphNode().append(text2),
+          );
 
-      await testEditor.update(() => {
-        const root = $getRoot();
-        const paragraph1 = $createParagraphNode();
-        const text1 = $createTextNode('text 1');
-        const paragraph2 = $createParagraphNode();
-        const text2 = $createTextNode('text 2');
-        root.append(paragraph1, paragraph2);
-        paragraph1.append(text1);
-        paragraph2.append(text2);
+          // Browser triple-click: focus lands on the text node of the
+          // following block at offset 0, even though visually only
+          // paragraph1's content is selected.
+          const selection = text1.select().setTextNodeRange(text1, 0, text2, 0);
 
-        const selection = $createRangeSelection();
-        $setSelection(selection);
-        // Browser triple-click: focus lands on the text node of the
-        // following block at offset 0, even though visually only
-        // paragraph1's content is selected.
-        $setAnchorPoint({
-          key: text1.__key,
-          offset: 0,
-          type: 'text',
-        });
-        $setFocusPoint({
-          key: text2.__key,
-          offset: 0,
-          type: 'text',
-        });
-
-        $setBlocksType(selection, () => {
-          return $createHeadingNode('h1');
-        });
-
-        const rootChildren = root.getChildren();
-        expect(rootChildren[0].__type).toBe('heading');
-        expect(rootChildren[1].__type).toBe('paragraph');
+          $setBlocksType(selection, () => $createHeadingNode('h1'));
+        },
+        dependencies: [RichTextExtension],
+        name: '@test',
+      });
+      testEditor.read(() => {
+        const rootChildren = $getRoot().getChildren();
+        expect($isHeadingNode(rootChildren[0])).toBe(true);
+        expect($isParagraphNode(rootChildren[1])).toBe(true);
         expect(rootChildren.length).toBe(2);
       });
     });
 
-    test('Triple-click overselection: focus inside nested inline at offset 0 is skipped', async () => {
-      const testEditor = createTestEditor();
-      const element = document.createElement('div');
-      testEditor.setRootElement(element);
+    test('Triple-click overselection: focus inside nested inline at offset 0 is skipped', () => {
+      using testEditor = buildEditorFromExtensions({
+        $initialEditorState: () => {
+          const text1 = $createTextNode('text 1');
+          const text2 = $createTextNode('text 2');
+          $getRoot().append(
+            $createParagraphNode().append(text1),
+            $createParagraphNode().append(
+              $createLinkNode('https://lexical.dev').append(text2),
+            ),
+          );
 
-      await testEditor.update(() => {
-        const root = $getRoot();
-        const paragraph1 = $createParagraphNode();
-        const text1 = $createTextNode('text 1');
-        const paragraph2 = $createParagraphNode();
-        const link2 = $createLinkNode('https://lexical.dev');
-        const text2 = $createTextNode('link');
-        root.append(paragraph1, paragraph2);
-        paragraph1.append(text1);
-        paragraph2.append(link2.append(text2));
+          // Browser triple-click: focus lands on the text node of the
+          // following block at offset 0, even though visually only
+          // paragraph1's content is selected.
+          const selection = text1.select().setTextNodeRange(text1, 0, text2, 0);
 
-        const selection = $createRangeSelection();
-        $setSelection(selection);
-        $setAnchorPoint({
-          key: text1.__key,
-          offset: 0,
-          type: 'text',
-        });
-        // Focus on a text node nested inside an inline element that
-        // is the first descendant of paragraph2.
-        $setFocusPoint({
-          key: text2.__key,
-          offset: 0,
-          type: 'text',
-        });
-
-        $setBlocksType(selection, () => {
-          return $createHeadingNode('h1');
-        });
-
-        const rootChildren = root.getChildren();
-        expect(rootChildren[0].__type).toBe('heading');
-        expect(rootChildren[1].__type).toBe('paragraph');
+          $setBlocksType(selection, () => $createHeadingNode('h1'));
+        },
+        dependencies: [RichTextExtension, LinkExtension],
+        name: '@test',
+      });
+      testEditor.read(() => {
+        const rootChildren = $getRoot().getChildren();
+        expect($isHeadingNode(rootChildren[0])).toBe(true);
+        expect($isParagraphNode(rootChildren[1])).toBe(true);
         expect(rootChildren.length).toBe(2);
       });
     });
 
-    test('Non-zero focus offset in next block still converts both blocks', async () => {
-      const testEditor = createTestEditor();
-      const element = document.createElement('div');
-      testEditor.setRootElement(element);
+    test('Non-zero focus offset in next block still converts both blocks', () => {
+      using testEditor = buildEditorFromExtensions({
+        $initialEditorState: () => {
+          const text1 = $createTextNode('text 1');
+          const text2 = $createTextNode('text 2');
+          $getRoot().append(
+            $createParagraphNode().append(text1),
+            $createParagraphNode().append(text2),
+          );
 
-      await testEditor.update(() => {
-        const root = $getRoot();
-        const paragraph1 = $createParagraphNode();
-        const text1 = $createTextNode('text 1');
-        const paragraph2 = $createParagraphNode();
-        const text2 = $createTextNode('text 2');
-        root.append(paragraph1, paragraph2);
-        paragraph1.append(text1);
-        paragraph2.append(text2);
+          const selection = text1.select().setTextNodeRange(text1, 0, text2, 1);
 
-        const selection = $createRangeSelection();
-        $setSelection(selection);
-        $setAnchorPoint({
-          key: text1.__key,
-          offset: 0,
-          type: 'text',
-        });
-        $setFocusPoint({
-          key: text2.__key,
-          offset: 1,
-          type: 'text',
-        });
-
-        $setBlocksType(selection, () => {
-          return $createHeadingNode('h1');
-        });
-
-        const rootChildren = root.getChildren();
-        expect(rootChildren[0].__type).toBe('heading');
-        expect(rootChildren[1].__type).toBe('heading');
+          $setBlocksType(selection, () => $createHeadingNode('h1'));
+        },
+        dependencies: [RichTextExtension],
+        name: '@test',
+      });
+      testEditor.read(() => {
+        const rootChildren = $getRoot().getChildren();
+        expect($isHeadingNode(rootChildren[0])).toBe(true);
+        expect($isHeadingNode(rootChildren[1])).toBe(true);
         expect(rootChildren.length).toBe(2);
       });
     });
 
-    test('Triple-click overselection spanning multiple blocks skips only the focus block', async () => {
-      const testEditor = createTestEditor();
-      const element = document.createElement('div');
-      testEditor.setRootElement(element);
+    test('Triple-click overselection spanning multiple blocks skips only the focus block', () => {
+      using testEditor = buildEditorFromExtensions({
+        $initialEditorState: () => {
+          const text1 = $createTextNode('text 1');
+          const text2 = $createTextNode('text 2');
+          const text3 = $createTextNode('text 3');
+          $getRoot().append(
+            $createParagraphNode().append(text1),
+            $createParagraphNode().append(text2),
+            $createParagraphNode().append(text3),
+          );
 
-      await testEditor.update(() => {
-        const root = $getRoot();
-        const paragraph1 = $createParagraphNode();
-        const text1 = $createTextNode('text 1');
-        const paragraph2 = $createParagraphNode();
-        const text2 = $createTextNode('text 2');
-        const paragraph3 = $createParagraphNode();
-        const text3 = $createTextNode('text 3');
-        root.append(paragraph1, paragraph2, paragraph3);
-        paragraph1.append(text1);
-        paragraph2.append(text2);
-        paragraph3.append(text3);
+          const selection = text1.select().setTextNodeRange(text1, 0, text3, 0);
 
-        const selection = $createRangeSelection();
-        $setSelection(selection);
-        $setAnchorPoint({
-          key: text1.__key,
-          offset: 0,
-          type: 'text',
-        });
-        $setFocusPoint({
-          key: text3.__key,
-          offset: 0,
-          type: 'text',
-        });
-
-        $setBlocksType(selection, () => {
-          return $createHeadingNode('h1');
-        });
-
-        const rootChildren = root.getChildren();
-        expect(rootChildren[0].__type).toBe('heading');
-        expect(rootChildren[1].__type).toBe('heading');
-        expect(rootChildren[2].__type).toBe('paragraph');
+          $setBlocksType(selection, () => $createHeadingNode('h1'));
+        },
+        dependencies: [RichTextExtension],
+        name: '@test',
+      });
+      testEditor.read(() => {
+        const rootChildren = $getRoot().getChildren();
+        expect($isHeadingNode(rootChildren[0])).toBe(true);
+        expect($isHeadingNode(rootChildren[1])).toBe(true);
+        expect($isParagraphNode(rootChildren[2])).toBe(true);
         expect(rootChildren.length).toBe(3);
       });
     });
 
-    test('Focus at offset 0 in next block whose first descendant has a prior sibling still converts focus block', async () => {
-      const testEditor = createTestEditor();
-      const element = document.createElement('div');
-      testEditor.setRootElement(element);
+    test('Focus at offset 0 in next block whose first descendant has a prior sibling still converts focus block', () => {
+      using testEditor = buildEditorFromExtensions({
+        $initialEditorState: () => {
+          const text1 = $createTextNode('text 1');
+          const text2a = $createTextNode('foo');
+          const text2b = $createTextNode('bar').setFormat('bold');
+          $getRoot().append(
+            $createParagraphNode().append(text1),
+            // text2b is the second child; offset 0 of text2b is NOT at
+            // the start of paragraph2 (text2a precedes it).
+            $createParagraphNode().append(text2a, text2b),
+          );
 
-      await testEditor.update(() => {
-        const root = $getRoot();
-        const paragraph1 = $createParagraphNode();
-        const text1 = $createTextNode('text 1');
-        const paragraph2 = $createParagraphNode();
-        const text2a = $createTextNode('foo');
-        const text2b = $createTextNode('bar');
-        root.append(paragraph1, paragraph2);
-        paragraph1.append(text1);
-        // text2b is the second child; offset 0 of text2b is NOT at
-        // the start of paragraph2 (text2a precedes it).
-        paragraph2.append(text2a, text2b);
+          const selection = text1
+            .select()
+            .setTextNodeRange(text1, 0, text2b, 0);
 
-        const selection = $createRangeSelection();
-        $setSelection(selection);
-        $setAnchorPoint({
-          key: text1.__key,
-          offset: 0,
-          type: 'text',
-        });
-        $setFocusPoint({
-          key: text2b.__key,
-          offset: 0,
-          type: 'text',
-        });
-
-        $setBlocksType(selection, () => {
-          return $createHeadingNode('h1');
-        });
-
-        const rootChildren = root.getChildren();
-        expect(rootChildren[0].__type).toBe('heading');
-        expect(rootChildren[1].__type).toBe('heading');
+          $setBlocksType(selection, () => $createHeadingNode('h1'));
+        },
+        dependencies: [RichTextExtension],
+        name: '@test',
+      });
+      testEditor.read(() => {
+        const rootChildren = $getRoot().getChildren();
+        expect($isHeadingNode(rootChildren[0])).toBe(true);
+        expect($isHeadingNode(rootChildren[1])).toBe(true);
         expect(rootChildren.length).toBe(2);
       });
     });

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -53,6 +53,24 @@ export function $copyBlockFormatIndent(
   }
 }
 
+function $isPointAtBlockStart(point: Point, block: ElementNode): boolean {
+  if (point.type !== 'text' || point.offset !== 0) {
+    return false;
+  }
+  let node: LexicalNode = point.getNode();
+  while (node !== block) {
+    if (node.getPreviousSibling() !== null) {
+      return false;
+    }
+    const parent: LexicalNode | null = node.getParent();
+    if (parent === null) {
+      return false;
+    }
+    node = parent;
+  }
+  return true;
+}
+
 /**
  * Converts all nodes in the selection that are of one block type to another.
  * @param selection - The selected blocks to be converted.
@@ -81,15 +99,31 @@ export function $setBlocksType<T extends ElementNode>(
       INTERNAL_$isBlock,
     );
     const focusBlock = $findMatchingParent(focus.getNode(), INTERNAL_$isBlock);
+    const focusAtBlockStart =
+      $isElementNode(focusBlock) &&
+      anchorBlock !== focusBlock &&
+      $isPointAtBlockStart(focus, focusBlock);
     if ($isElementNode(anchorBlock)) {
       blockMap.set(anchorBlock.getKey(), anchorBlock);
     }
-    if ($isElementNode(focusBlock)) {
+    if ($isElementNode(focusBlock) && !focusAtBlockStart) {
       blockMap.set(focusBlock.getKey(), focusBlock);
     }
   }
   for (const node of selection.getNodes()) {
     if ($isElementNode(node) && INTERNAL_$isBlock(node)) {
+      if (
+        anchorAndFocus &&
+        node.is(
+          $findMatchingParent(anchorAndFocus[1].getNode(), INTERNAL_$isBlock),
+        ) &&
+        !node.is(
+          $findMatchingParent(anchorAndFocus[0].getNode(), INTERNAL_$isBlock),
+        ) &&
+        $isPointAtBlockStart(anchorAndFocus[1], node)
+      ) {
+        continue;
+      }
       blockMap.set(node.getKey(), node);
     } else if (anchorAndFocus === null) {
       const ancestorBlock = $findMatchingParent(node, INTERNAL_$isBlock);

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -54,7 +54,7 @@ export function $copyBlockFormatIndent(
 }
 
 function $isPointAtBlockStart(point: Point, block: ElementNode): boolean {
-  if (point.offset !== 0) {
+  if (point.type !== 'text' || point.offset !== 0) {
     return false;
   }
   let node: LexicalNode = point.getNode();

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -54,15 +54,15 @@ export function $copyBlockFormatIndent(
 }
 
 function $isPointAtBlockStart(point: Point, block: ElementNode): boolean {
-  if (point.type !== 'text' || point.offset !== 0) {
+  if (point.offset !== 0) {
     return false;
   }
   let node: LexicalNode = point.getNode();
-  while (node !== block) {
+  while (!node.is(block)) {
     if (node.getPreviousSibling() !== null) {
       return false;
     }
-    const parent: LexicalNode | null = node.getParent();
+    const parent = node.getParent();
     if (parent === null) {
       return false;
     }

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -85,7 +85,7 @@ export function $setBlocksType<T extends ElementNode>(
     newNodeDest: T,
   ) => void = $copyBlockFormatIndent,
 ): void {
-  if (selection === null) {
+  if (!selection) {
     return;
   }
   // Selections tend to not include their containing blocks so we effectively
@@ -135,7 +135,7 @@ export function $setBlocksType<T extends ElementNode>(
   // Selection remapping is delegated to LexicalNode.replace (and the
   // ListItemNode.replace override): both remap an element-anchored point
   // on the replaced block to {key: replacement, offset: prevSize + offset}.
-  for (const [, prevNode] of blockMap) {
+  for (const prevNode of blockMap.values()) {
     const element = $createElement();
     $afterCreateElement(prevNode, element);
     prevNode.replace(element, true);

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -8,6 +8,7 @@
 
 import type {
   BaseSelection,
+  DecoratorNode,
   ElementNode,
   LexicalNode,
   NodeKey,
@@ -54,10 +55,16 @@ export function $copyBlockFormatIndent(
 }
 
 function $isPointAtBlockStart(point: Point, block: ElementNode): boolean {
-  if (point.type !== 'text' || point.offset !== 0) {
+  if (point.offset !== 0) {
     return false;
   }
   let node: LexicalNode = point.getNode();
+  // When an ElementNode is empty it's not possible to distinguish if
+  // the selection's intent is the entire block or the edge so we consider
+  // it to be the entire block
+  if ($isElementNode(node) && node.isEmpty()) {
+    return false;
+  }
   while (!node.is(block)) {
     if (node.getPreviousSibling() !== null) {
       return false;
@@ -91,6 +98,8 @@ export function $setBlocksType<T extends ElementNode>(
   // Selections tend to not include their containing blocks so we effectively
   // expand it here
   const anchorAndFocus = selection.getStartEndPoints();
+  let skipFocusAtBlockStart = false;
+  let focusBlock: ElementNode | DecoratorNode<unknown> | null = null;
   const blockMap = new Map<NodeKey, ElementNode>();
   if (anchorAndFocus) {
     const [anchor, focus] = anchorAndFocus;
@@ -98,34 +107,25 @@ export function $setBlocksType<T extends ElementNode>(
       anchor.getNode(),
       INTERNAL_$isBlock,
     );
-    const focusBlock = $findMatchingParent(focus.getNode(), INTERNAL_$isBlock);
-    const focusAtBlockStart =
+    focusBlock = $findMatchingParent(focus.getNode(), INTERNAL_$isBlock);
+    skipFocusAtBlockStart =
       $isElementNode(focusBlock) &&
-      anchorBlock !== focusBlock &&
+      !focusBlock.is(anchorBlock) &&
       $isPointAtBlockStart(focus, focusBlock);
     if ($isElementNode(anchorBlock)) {
       blockMap.set(anchorBlock.getKey(), anchorBlock);
     }
-    if ($isElementNode(focusBlock) && !focusAtBlockStart) {
+    if ($isElementNode(focusBlock) && !skipFocusAtBlockStart) {
       blockMap.set(focusBlock.getKey(), focusBlock);
     }
   }
   for (const node of selection.getNodes()) {
     if ($isElementNode(node) && INTERNAL_$isBlock(node)) {
-      if (
-        anchorAndFocus &&
-        node.is(
-          $findMatchingParent(anchorAndFocus[1].getNode(), INTERNAL_$isBlock),
-        ) &&
-        !node.is(
-          $findMatchingParent(anchorAndFocus[0].getNode(), INTERNAL_$isBlock),
-        ) &&
-        $isPointAtBlockStart(anchorAndFocus[1], node)
-      ) {
+      if (skipFocusAtBlockStart && node.is(focusBlock)) {
         continue;
       }
       blockMap.set(node.getKey(), node);
-    } else if (anchorAndFocus === null) {
+    } else if (!anchorAndFocus) {
       const ancestorBlock = $findMatchingParent(node, INTERNAL_$isBlock);
       if ($isElementNode(ancestorBlock)) {
         blockMap.set(ancestorBlock.getKey(), ancestorBlock);

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -521,22 +521,6 @@ function onClick(event: PointerEvent, editor: LexicalEditor): void {
         ) {
           domSelection.removeAllRanges();
           selection.dirty = true;
-        } else if (event.detail === 3 && !selection.isCollapsed()) {
-          // Triple click causing selection to overflow into the nearest element. In that
-          // case visually it looks like a single element content is selected, focus node
-          // is actually at the beginning of the next element (if present) and any manipulations
-          // with selection (formatting) are affecting second element as well
-          const focus = selection.focus;
-          const focusNode = focus.getNode();
-          if (anchorNode !== focusNode) {
-            const parentNode = $findMatchingParent(
-              anchorNode,
-              node => $isElementNode(node) && !node.isInline(),
-            );
-            if ($isElementNode(parentNode)) {
-              parentNode.select(0);
-            }
-          }
         }
       } else if (event.pointerType === 'touch' || event.pointerType === 'pen') {
         // This is used to update the selection on touch devices (including Apple Pencil) when the user clicks on text after a

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -580,9 +580,10 @@ export class RangeSelection implements BaseSelection {
     anchorOffset: number,
     focusNode: TextNode,
     focusOffset: number,
-  ): void {
+  ): this {
     this.anchor.set(anchorNode.__key, anchorOffset, 'text');
     this.focus.set(focusNode.__key, focusOffset, 'text');
+    return this;
   }
 
   /**

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1942,6 +1942,8 @@ export function isBlockDomNode(
     : BLOCK_TAG_RE.test(node.nodeName);
 }
 
+const BlockNodeBrand: unique symbol = Symbol.for('@lexical/BlockNodeBrand');
+
 /**
  * @internal
  *
@@ -1957,7 +1959,7 @@ export function isBlockDomNode(
  */
 export function INTERNAL_$isBlock(
   node: LexicalNode,
-): node is ElementNode | DecoratorNode<unknown> {
+): node is (ElementNode | DecoratorNode<unknown>) & {[BlockNodeBrand]: never} {
   if ($isDecoratorNode(node) && !node.isInline()) {
     return true;
   }


### PR DESCRIPTION
Fixes facebook/lexical#7592. Alternative to #8490.

## Context

Browsers expand triple-click selections to cover an entire block, but leave the focus point at offset 0 of the *next* block. The selection visually looks like one paragraph is selected, but actually extends one position into the following block.

Historically, this selection behavior caused some issues, including:

- https://github.com/facebook/lexical/issues/2648 Converting to other blocks after selection (e.g. Heading)
- https://github.com/facebook/lexical/issues/2660 Over-selection
- https://github.com/facebook/lexical/issues/3784 Selections have incorrect format
- and another bug with table cell select-and-deletion mentioned in #4512

PR #4512 worked around these bugs in `onClick` (`LexicalEvents.ts`) by detecting `event.detail === 3` and forcibly re-selecting the parent block..

The `onClick` workaround is a poor fit, however, because it mutates the user's selection on *every* triple-click — breaking common cases like triple-clicking a paragraph with soft line breaks:(`<br>`), or triple-click-and-drag to select multiple lines, leading to issues like the one described in https://github.com/facebook/lexical/issues/7592

## Status of the original motivations

A lot has changed since #4512!

- Table cell deletion was fixed independently in #7213; the tables no longer rely on the `onClick` workaround.
- #2660 No longer manifests without the triple-click handler
- #3784 No longer manifests without the triple-click handler
- #2648 The heading format tool (and related tools — paragraph, quote, code block — all routed through `$setBlocksType`) is the only remaining caller depending on the workaround.

Which means the triple-click handler can be removed if `$setBlocksType` is updated to handle overselection.

## This change

Fix `$setBlocksType` (`@lexical/selection`) to skip converting the focus's block when no content of that block is actually selected — specifically, when the focus is a text-type point at offset 0 of the block's first descendant and the block differs from the anchor's block. This matches the visual semantics users expect, and covers both triple-click overselection and deliberate drag-select-to-start-of-next-block.

With that root cause fixed, the `onClick` triple-click workaround is removed.

## Tests

- Existing e2e tests for triple-click + heading conversion continue to pass without the `onClick` workaround (`Selection.spec.mjs`, `TextFormatting.spec.mjs`).
- `$setBlocksType` unit tests in `packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx` continue to pass; the fix only affects text-type focus points, so the existing element-point-based tests are unchanged.


### Before

I will add screencaps this evening.

### After

I will add screencaps this evening.
