### PR TITLE
[ci] Chore: pin Windows e2e runners to windows-2022

### DIFF
--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -59,7 +59,7 @@ jobs:
   build-windows:
     env:
       node-version: 24.x
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-pnpm
@@ -123,7 +123,7 @@ jobs:
         editor-mode: ['rich-text', 'plain-text']
     uses: ./.github/workflows/call-e2e-test.yml
     with:
-      os: 'windows-latest'
+      os: 'windows-2022'
       node-version: ${{ matrix.node-version }}
       browser: ${{ matrix.browser }}
       editor-mode: ${{ matrix.editor-mode }}
@@ -162,7 +162,7 @@ jobs:
         browser: ['chromium', 'firefox']
     uses: ./.github/workflows/call-e2e-test.yml
     with:
-      os: 'windows-latest'
+      os: 'windows-2022'
       node-version: ${{ matrix.node-version }}
       browser: ${{ matrix.browser }}
       editor-mode: 'rich-text-with-collab'


### PR DESCRIPTION
## Description

windows-latest now resolves to Windows Server 2025, which has been producing intermittent STATUS_STACK_BUFFER_OVERRUN (exit 3221226505 / 0xC0000409) crashes in Node-spawning steps — including pnpm install and the Playwright test entrypoint — unrelated to anything in our code. Pin to windows-2022 until the 2025 image stabilizes.

## Test plan

Run e2e suite