### PR TITLE
[lexical-rich-text] Bug Fix: Insert paragraph on Enter for a block DecoratorNode NodeSelection

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionEnter.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionEnter.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createNodeSelection,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $setSelection,
+  KEY_ENTER_COMMAND,
+  ParagraphNode,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
+
+function createEditor(inline: boolean) {
+  return buildEditorFromExtensions({
+    $initialEditorState: () => {
+      const decorator = $createTestDecoratorNode().setIsInline(inline);
+      $getRoot().append(decorator);
+      const selection = $createNodeSelection();
+      selection.add(decorator.getKey());
+      $setSelection(selection);
+    },
+    dependencies: [RichTextExtension],
+    name: 'test',
+    nodes: [TestDecoratorNode],
+  });
+}
+
+describe('KEY_ENTER_COMMAND on a single-decorator NodeSelection', () => {
+  test('block decorator: inserts a paragraph after it and moves the caret', () => {
+    using editor = createEditor(false);
+
+    editor.dispatchCommand(KEY_ENTER_COMMAND, null);
+
+    editor.read(() => {
+      const root = $getRoot();
+      expect(root.getChildrenSize()).toBe(2);
+      const children = root.getChildren();
+      expect(children[0]).toBeInstanceOf(TestDecoratorNode);
+      expect(children[1]).toBeInstanceOf(ParagraphNode);
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.anchor.key).toBe(children[1].getKey());
+    });
+  });
+
+  test('inline decorator: no-op', () => {
+    using editor = createEditor(true);
+
+    editor.dispatchCommand(KEY_ENTER_COMMAND, null);
+
+    editor.read(() => {
+      const root = $getRoot();
+      expect(root.getChildrenSize()).toBe(1);
+      expect(root.getChildren()[0]).toBeInstanceOf(TestDecoratorNode);
+    });
+  });
+});

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1119,13 +1119,14 @@ export function registerRichText(
     editor.registerCommand<KeyboardEvent | null>(
       KEY_ENTER_COMMAND,
       event => {
-        const selection = $getSelection();
+        let selection = $getSelection();
         // When a block-level DecoratorNode is selected as a NodeSelection
         // (e.g. it is the only root child after the user removed all
         // surrounding paragraphs), Enter has no RangeSelection to act on
         // and the default handler bails out, leaving the editor stuck.
-        // Insert an empty paragraph after the decorator and place the
-        // caret in it so the user can keep typing.
+        // Convert to a RangeSelection past the decorator so the default
+        // RangeSelection handler below inserts a paragraph and places
+        // the caret.
         if ($isNodeSelection(selection)) {
           const nodes = selection.getNodes();
           if (
@@ -1133,15 +1134,8 @@ export function registerRichText(
             $isDecoratorNode(nodes[0]) &&
             !nodes[0].isInline()
           ) {
-            const newParagraph = $createParagraphNode();
-            nodes[0].insertAfter(newParagraph);
-            newParagraph.select();
-            if (event !== null) {
-              event.preventDefault();
-            }
-            return true;
+            selection = nodes[0].selectNext();
           }
-          return false;
         }
         if (!$isRangeSelection(selection)) {
           return false;

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1120,6 +1120,29 @@ export function registerRichText(
       KEY_ENTER_COMMAND,
       event => {
         const selection = $getSelection();
+        // When a block-level DecoratorNode is selected as a NodeSelection
+        // (e.g. it is the only root child after the user removed all
+        // surrounding paragraphs), Enter has no RangeSelection to act on
+        // and the default handler bails out, leaving the editor stuck.
+        // Insert an empty paragraph after the decorator and place the
+        // caret in it so the user can keep typing.
+        if ($isNodeSelection(selection)) {
+          const nodes = selection.getNodes();
+          if (
+            nodes.length === 1 &&
+            $isDecoratorNode(nodes[0]) &&
+            !nodes[0].isInline()
+          ) {
+            const newParagraph = $createParagraphNode();
+            nodes[0].insertAfter(newParagraph);
+            newParagraph.select();
+            if (event !== null) {
+              event.preventDefault();
+            }
+            return true;
+          }
+          return false;
+        }
         if (!$isRangeSelection(selection)) {
           return false;
         }


### PR DESCRIPTION
## Description

When a block-level `DecoratorNode` is selected as a `NodeSelection` (e.g. the user clicked on a YouTube embed), pressing Enter has no effect — `KEY_ENTER_COMMAND` registered by `registerRichText` bails out at the `$isRangeSelection(selection)` guard. The most visible case is when the decorator is the only root child (after the user removed all surrounding paragraphs), where the editor becomes uneditable from the keyboard, but the same no-op fires for any block-decorator NodeSelection — e.g. between paragraphs in the middle of the document.

### Fix

Add a NodeSelection branch in the rich-text Enter handler: if the selection holds a single block `DecoratorNode` (`!isInline()`), insert a new empty paragraph after the decorator via `insertAfter($createParagraphNode())` and move the caret in. Inline DecoratorNodes and other NodeSelection shapes still fall through to `return false`, preserving current behaviour. RangeSelection / null selection paths are untouched.

Closes #8525

## Note

Decorators that don't go through `BlockWithAlignableContents` / `useLexicalNodeSelection` (e.g. `EquationNode` in the playground manages selection inside its React component without producing a lexical NodeSelection) aren't covered here — the rich-text Enter handler never sees them. That's a separate node-side fix.

## Test plan

- [x] `pnpm vitest run --project unit packages/lexical-rich-text` — 5 files / 53 tests pass (new `RichTextNodeSelectionEnter.test.ts`: 2 tests via `$initialEditorState` factory + `buildEditorFromExtensions`)
- [x] `pnpm tsc --noEmit -p tsconfig.json` clean
- [x] `pnpm flow` clean
- [x] `npx prettier --check` clean on changed files
- [x] Manual playground:
  - `[YouTube]` only root state → Enter → empty paragraph appended, caret moves in
  - `[paragraph, YouTube, paragraph]` → YouTube NodeSelection + Enter → new empty paragraph between YouTube and next paragraph
  - Regular RangeSelection + Enter → unchanged (paragraph split)
  - Inline DecoratorNode NodeSelection + Enter → unchanged