### PR TITLE
[lexical-yjs] Chore: Fix RenderSnapshot comment typo

### DIFF
--- a/packages/lexical-yjs/src/RenderSnapshot.ts
+++ b/packages/lexical-yjs/src/RenderSnapshot.ts
@@ -60,7 +60,7 @@ export const renderSnapshot__EXPERIMENTAL = (
 
   doc.transact(transaction => {
     // Before rendering, we are going to sanitize ops and split deleted ops
-    // if they were deleted by seperate users.
+    // if they were deleted by separate users.
     const pud = new PermanentUserData(doc);
     if (pud) {
       pud.dss.forEach(ds => {


### PR DESCRIPTION
## Summary

Fixes a spelling typo in a `RenderSnapshot` source comment.

## Files changed

- `packages/lexical-yjs/src/RenderSnapshot.ts`: `seperate` -> `separate`

## Before / after

Before, the comment describing deleted ops used a misspelling. After, the comment is corrected with no behavior change.

## Verification

- Inspected the diff to confirm this is a comment-only change.
- Ran `rg "seperate" packages/lexical-yjs/src/RenderSnapshot.ts` and confirmed no matches.

## Competing PR check

Checked for existing PRs with:

- `gh pr list --repo facebook/lexical --search "seperate RenderSnapshot" --state all --limit 10`
- `gh pr list --repo facebook/lexical --search "deleted by seperate users" --state all --limit 10`

No relevant matching PRs were returned.