### PR TITLE
[lexical-website] Bug Fix: Remove embed=1 from non-iframe StackBlitz links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ Lexical version:
 Link to code example:
 
 <!--
-  Please provide a CodeSandbox (https://codesandbox.io/s/new) or (https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-plain-text?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview), a link to a
+  Please provide a CodeSandbox (https://codesandbox.io/s/new) or (https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-plain-text?file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview), a link to a
   repository on GitHub, or provide a minimal code example that reproduces the
   problem. You may provide a screenshot of the application if you think it is
   relevant to your bug report. Here are some tips for providing a minimal

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ function Editor() {
 ```
 
 Try it yourself:
-- [Plain Text Example](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-plain-text?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview)
-- [Rich Text Example](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview)
+- [Plain Text Example](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-plain-text?file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview)
+- [Rich Text Example](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview)
 
 ## Development
 

--- a/packages/lexical-react/README.md
+++ b/packages/lexical-react/README.md
@@ -10,7 +10,7 @@ Install `lexical` and `@lexical/react`:
 npm install --save lexical @lexical/react
 ```
 
-Below is an example of a basic plain text editor using `lexical` and `@lexical/react` ([try it yourself](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-plain-text?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview)).
+Below is an example of a basic plain text editor using `lexical` and `@lexical/react` ([try it yourself](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-plain-text?file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview)).
 
 ```jsx
 import {$getRoot, $getSelection} from 'lexical';

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -177,7 +177,7 @@ type HTMLConfig = {
 
 #### Example of a use case for the `html` Property for Import and Export Configuration:
 
-[Rich text sandbox](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview)
+[Rich text sandbox](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview)
 
 ### Handling extended HTML styling
 

--- a/packages/lexical-website/src/components/Gallery/galleryExamples.ts
+++ b/packages/lexical-website/src/components/Gallery/galleryExamples.ts
@@ -25,7 +25,7 @@ export interface GalleryExample {
   description: string;
   /** Filter tags (e.g. 'opensource', 'favorite') */
   tags: string[];
-  /** Query string appended to the StackBlitz embed URL */
+  /** Query string appended to the StackBlitz URL */
   stackblitzQuery: string;
   /**
    * CSS selector to wait for before taking a screenshot.
@@ -64,7 +64,7 @@ export const galleryExamples: GalleryExample[] = [
     description: 'Learn how to create an editor with Emojis',
     dir: 'vanilla-js-plugin',
     stackblitzQuery:
-      'embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=0&ctl=0',
+      'file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=0&ctl=0',
     tags: ['opensource', 'vanilla', 'emoji'],
     title: 'EmojiPlugin',
     waitForSelector: '[data-lexical-editor]',
@@ -72,7 +72,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Learn how to create an editor with Real Time Collaboration',
     dir: 'react-rich-collab',
-    stackblitzQuery: 'ctl=0&file=src%2Fmain.tsx&terminalHeight=0&embed=1',
+    stackblitzQuery: 'ctl=0&file=src%2Fmain.tsx&terminalHeight=0',
     tags: ['opensource', 'favorite', 'react', 'collab', 'toolbar'],
     title: 'Collab RichText',
     // Editor is inside iframes, so wait for the iframe elements instead
@@ -81,7 +81,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Learn how to create an editor with Tables',
     dir: 'react-table',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
     tags: ['opensource', 'react', 'tables', 'toolbar'],
     title: 'TablePlugin',
     waitForSelector: '[data-lexical-editor]',
@@ -89,7 +89,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Tables using the Extension architecture',
     dir: 'extension-react-table',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
     tags: ['opensource', 'extension', 'favorite', 'react', 'tables', 'toolbar'],
     title: 'Extension: React Table',
     waitForSelector: '[data-lexical-editor]',
@@ -98,7 +98,7 @@ export const galleryExamples: GalleryExample[] = [
     description: 'SSR and hydration with Svelte 5 and the Extension API',
     dir: 'extension-sveltekit-ssr-hydration',
     stackblitzQuery:
-      'embed=1&file=src%2Froutes%2F%2Bpage.svelte&terminalHeight=0&ctl=0',
+      'file=src%2Froutes%2F%2Bpage.svelte&terminalHeight=0&ctl=0',
     tags: ['opensource', 'svelte', 'ssr', 'extension', 'tailwind', 'simple'],
     title: 'Extension: SvelteKit SSR',
     viteConfig: 'vite.config.ts',
@@ -107,7 +107,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Mount React plugins into a vanilla JS Extension editor',
     dir: 'extension-vanilla-react-plugin-host',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.ts&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.ts&terminalHeight=0&ctl=0',
     tags: ['opensource', 'vanilla', 'react', 'extension', 'tailwind'],
     title: 'Extension: React Plugin Host',
     waitForSelector: '[data-lexical-editor]',
@@ -115,7 +115,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Split-view markdown WYSIWYG editor with live preview',
     dir: 'markdown-editor',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
     tags: [
       'opensource',
       'favorite',
@@ -132,7 +132,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Vanilla JS checklist editor with Extensions and Tailwind',
     dir: 'extension-vanilla-tailwind',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.ts&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.ts&terminalHeight=0&ctl=0',
     tags: ['opensource', 'vanilla', 'extension', 'tailwind', 'simple'],
     title: 'Extension: Vanilla Tailwind',
     waitForSelector: '[data-lexical-editor]',
@@ -141,7 +141,7 @@ export const galleryExamples: GalleryExample[] = [
     description:
       'AI-powered editor with paragraph generation and named entity recognition',
     dir: 'agent-example',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
     tags: [
       'opensource',
       'extension',
@@ -159,7 +159,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Chat interface with multiple rich text editor instances',
     dir: 'website-chat',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
     tags: [
       'opensource',
       'extension',
@@ -177,7 +177,7 @@ export const galleryExamples: GalleryExample[] = [
     description:
       'Notion-style editor with slash commands and drag-and-drop blocks',
     dir: 'website-notion',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
     tags: ['opensource', 'favorite', 'block', 'react', 'extension', 'tailwind'],
     title: 'Notion-style block editor',
     viteConfig: 'vite.config.ts',
@@ -186,7 +186,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Simple rich text input with hashtag support',
     dir: 'website-rich-input',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
     tags: [
       'opensource',
       'favorite',
@@ -202,7 +202,7 @@ export const galleryExamples: GalleryExample[] = [
   {
     description: 'Rich text editor with a formatting toolbar',
     dir: 'website-toolbar',
-    stackblitzQuery: 'embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
+    stackblitzQuery: 'file=src%2Fmain.tsx&terminalHeight=0&ctl=0',
     tags: [
       'opensource',
       'favorite',


### PR DESCRIPTION
## Description

The embed=1 query param only works when the StackBlitz URL is loaded inside an iframe. Links that open in a new window/tab (markdown links and gallery cards via target="_blank") fail to load with embed=1, so strip the param from those URLs while leaving the iframe src URLs untouched.

## Test plan

### Before

The preview doesn't load (reports a compatibility error when there isn't one) when clicking on a demo from https://lexical.dev/gallery

### After

The previews load