### PR TITLE
[lexical-playground] Bug Fix: EquationNode click → NodeSelection + empty-input Backspace removes

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/EquationNode.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/EquationNode.spec.mjs
@@ -37,7 +37,7 @@ function equationHtml(inline = true) {
               height="0"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
               width="0" />
-            <span role="button" tabindex="-1">
+            <span>
               ${inline ? '' : `<span class="katex-display">`}
               <span class="katex">
                 <span class="katex-html" aria-hidden="true">

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -982,7 +982,7 @@ test.describe.parallel('Markdown', () => {
               height="0"
               src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
               width="0" />
-            <span role="button" tabindex="-1">
+            <span>
               <span class="katex">
                 <span class="katex-html" aria-hidden="true">
                   <span class="base">

--- a/packages/lexical-playground/__tests__/regression/6974-delete-character-backward.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/6974-delete-character-backward.spec.mjs
@@ -43,7 +43,7 @@ test.describe('Regression tests for #6974', () => {
             height="0"
             src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
             width="0" />
-          <span role="button" tabindex="-1">
+          <span>
             <span>
               <span aria-hidden="true">
                 <span>
@@ -77,7 +77,7 @@ test.describe('Regression tests for #6974', () => {
             height="0"
             src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
             width="0" />
-          <span role="button" tabindex="-1">
+          <span>
             <span>
               <span aria-hidden="true">
                 <span>

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -13,12 +13,16 @@ import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
+  $createParagraphNode,
   $getNodeByKey,
+  $getSelection,
   $isElementNode,
+  $isNodeSelection,
   $isTextNode,
   CLICK_COMMAND,
   COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
+  KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
   NodeKey,
   SELECTION_CHANGE_COMMAND,
@@ -88,6 +92,51 @@ export default function EquationComponent({
     }
     return editor.registerCommand(CLICK_COMMAND, onClick, COMMAND_PRIORITY_LOW);
   }, [editor, isEditable, onClick]);
+
+  // Pressing Enter while this equation is the lone NodeSelection
+  // inserts a fresh empty paragraph right after it and moves the caret
+  // into the new paragraph. Without this, the default rich-text path
+  // (lifted to a RangeSelection past the decorator via
+  // RichTextExtension's block-decorator branch) leaves the caret on a
+  // root-level element point that swallows further keystrokes — the
+  // user sees an editor that won't accept text after a fresh equation.
+  const $onEnter = useCallback(
+    (event: KeyboardEvent) => {
+      const latestSelection = $getSelection();
+      if (
+        !(
+          $isNodeSelection(latestSelection) &&
+          latestSelection.has(nodeKey) &&
+          latestSelection.getNodes().length === 1
+        )
+      ) {
+        return false;
+      }
+      event.preventDefault();
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if (!$isEquationNode(node)) {
+          return;
+        }
+        const paragraph = $createParagraphNode();
+        node.insertAfter(paragraph);
+        paragraph.select();
+      });
+      return true;
+    },
+    [editor, nodeKey],
+  );
+
+  useEffect(() => {
+    if (!isEditable) {
+      return undefined;
+    }
+    return editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      $onEnter,
+      COMMAND_PRIORITY_LOW,
+    );
+  }, [editor, isEditable, $onEnter]);
 
   // Remove this equation when the user presses Backspace inside an
   // already-empty `EquationEditor`. Without this, the LaTeX input

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -19,6 +19,7 @@ import {
   $isElementNode,
   $isNodeSelection,
   $isTextNode,
+  $setSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
@@ -68,9 +69,6 @@ export default function EquationComponent({
   // RangeSelection attempt that follows the native `selectionchange`.
   const onClick = useCallback(
     (event: MouseEvent) => {
-      if (!isEditable) {
-        return false;
-      }
       const dom = editor.getElementByKey(nodeKey);
       if (dom === null || !dom.contains(event.target as Node)) {
         return false;
@@ -83,15 +81,12 @@ export default function EquationComponent({
       }
       return true;
     },
-    [clearSelection, editor, isEditable, isSelected, nodeKey, setSelected],
+    [clearSelection, editor, isSelected, nodeKey, setSelected],
   );
 
   useEffect(() => {
-    if (!isEditable) {
-      return undefined;
-    }
     return editor.registerCommand(CLICK_COMMAND, onClick, COMMAND_PRIORITY_LOW);
-  }, [editor, isEditable, onClick]);
+  }, [editor, onClick]);
 
   // Pressing Enter while this equation is the lone NodeSelection
   // inserts a fresh empty paragraph right after it and moves the caret
@@ -112,19 +107,33 @@ export default function EquationComponent({
       ) {
         return false;
       }
-      event.preventDefault();
-      editor.update(() => {
-        const node = $getNodeByKey(nodeKey);
-        if (!$isEquationNode(node)) {
-          return;
+      const node = $getNodeByKey(nodeKey);
+      if (!$isEquationNode(node)) {
+        return false;
+      }
+      // The KEY_ENTER_COMMAND handler runs inside an active editor
+      // scope, so lexical state mutations happen directly here (no
+      // `editor.update` wrap — wrapping would defer the work to a
+      // microtask, and the surrounding `event.preventDefault() +
+      // return true` would fall through to the default rich-text
+      // path before our paragraph insertion lands).
+      if (node.isInline()) {
+        const parent = node.getParent();
+        if (!$isElementNode(parent)) {
+          return false;
         }
+        const paragraph = $createParagraphNode();
+        parent.insertAfter(paragraph);
+        paragraph.select();
+      } else {
         const paragraph = $createParagraphNode();
         node.insertAfter(paragraph);
         paragraph.select();
-      });
+      }
+      event.preventDefault();
       return true;
     },
-    [editor, nodeKey],
+    [nodeKey],
   );
 
   useEffect(() => {
@@ -149,11 +158,30 @@ export default function EquationComponent({
       if (!$isEquationNode(node)) {
         return;
       }
-      const prevSibling = node.getPreviousSibling();
-      node.remove();
-      if ($isElementNode(prevSibling) || $isTextNode(prevSibling)) {
-        prevSibling.selectEnd();
+      if (node.isInline()) {
+        // Clear lexical's selection first (avoid stale NodeSelection
+        // node refs surviving the remove) and preserve the wrapper
+        // paragraph (`remove(true)`) so lexical doesn't try to chain-
+        // delete a now-empty parent during commit.
+        $setSelection(null);
+        node.remove(true);
+        return;
       }
+      const prevSibling = node.getPreviousSibling();
+      if ($isElementNode(prevSibling) || $isTextNode(prevSibling)) {
+        node.remove();
+        prevSibling.selectEnd();
+        return;
+      }
+      // Block equation with no previous sibling — naive `node.remove()`
+      // here would leave the root with zero children and no parkable
+      // cursor (lexical's `EditorState.isEmpty()` accepts an empty
+      // root, and rich-text does not re-seed a paragraph), forcing
+      // the user to reload. Swap the equation for a fresh empty
+      // paragraph instead.
+      const paragraph = $createParagraphNode();
+      node.replace(paragraph);
+      paragraph.select();
     });
   }, [editor, nodeKey]);
 

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -10,12 +10,15 @@ import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
+import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
-  $getSelection,
-  $isNodeSelection,
+  $isElementNode,
+  $isTextNode,
+  CLICK_COMMAND,
   COMMAND_PRIORITY_HIGH,
+  COMMAND_PRIORITY_LOW,
   KEY_ESCAPE_COMMAND,
   NodeKey,
   SELECTION_CHANGE_COMMAND,
@@ -41,9 +44,86 @@ export default function EquationComponent({
 }: EquationComponentProps): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const isEditable = useLexicalEditable();
+  const [isSelected, setSelected, clearSelection] =
+    useLexicalNodeSelection(nodeKey);
   const [equationValue, setEquationValue] = useState(equation);
   const [showEquationEditor, setShowEquationEditor] = useState<boolean>(false);
   const inputRef = useRef<HTMLTextAreaElement | HTMLInputElement>(null);
+
+  // Promote a click on the rendered KaTeX into a NodeSelection on this
+  // EquationNode. Without this, an EquationNode that is the only root
+  // child has no way to receive a selection — lexical's generic click
+  // handler does not turn DecoratorNode clicks into NodeSelection, so
+  // `$getSelection()` would stay `null` and downstream commands
+  // (Backspace, copy, ...) have nothing to act on.
+  //
+  // Listening through `CLICK_COMMAND` (instead of a React DOM `onClick`)
+  // matches the ImageComponent pattern: the lexical command fires
+  // *after* lexical's own selection normalization for the click, so the
+  // NodeSelection we set here is not immediately overwritten by the
+  // RangeSelection attempt that follows the native `selectionchange`.
+  const onClick = useCallback(
+    (event: MouseEvent) => {
+      if (!isEditable) {
+        return false;
+      }
+      const dom = editor.getElementByKey(nodeKey);
+      if (dom === null || !dom.contains(event.target as Node)) {
+        return false;
+      }
+      if (event.shiftKey) {
+        setSelected(!isSelected);
+      } else {
+        clearSelection();
+        setSelected(true);
+      }
+      return true;
+    },
+    [clearSelection, editor, isEditable, isSelected, nodeKey, setSelected],
+  );
+
+  useEffect(() => {
+    if (!isEditable) {
+      return undefined;
+    }
+    return editor.registerCommand(CLICK_COMMAND, onClick, COMMAND_PRIORITY_LOW);
+  }, [editor, isEditable, onClick]);
+
+  // Remove this equation when the user presses Backspace inside an
+  // already-empty `EquationEditor`. Without this, the LaTeX input
+  // swallows the keystroke (its value is already empty so the browser
+  // does nothing), and lexical never sees the deletion attempt — the
+  // node would otherwise sit empty in the editor forever.
+  const onDeleteEmpty = useCallback(() => {
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+      if (!$isEquationNode(node)) {
+        return;
+      }
+      const prevSibling = node.getPreviousSibling();
+      node.remove();
+      if ($isElementNode(prevSibling) || $isTextNode(prevSibling)) {
+        prevSibling.selectEnd();
+      }
+    });
+  }, [editor, nodeKey]);
+
+  // Mirror `isSelected` onto the keyed `<div|span class="editor-equation">`
+  // (the element returned by `EquationNode.createDOM`) so the existing
+  // `.editor-equation.focused` CSS rule renders the outline. React owns
+  // the inner `KatexRenderer` subtree but not the keyed wrapper, so we
+  // toggle the class imperatively.
+  useEffect(() => {
+    const dom = editor.getElementByKey(nodeKey);
+    if (dom === null) {
+      return;
+    }
+    if (isSelected && isEditable) {
+      dom.classList.add('focused');
+    } else {
+      dom.classList.remove('focused');
+    }
+  }, [editor, nodeKey, isSelected, isEditable]);
 
   const onHide = useCallback(
     (restoreSelection?: boolean) => {
@@ -100,21 +180,14 @@ export default function EquationComponent({
           COMMAND_PRIORITY_HIGH,
         ),
       );
-    } else {
-      return editor.registerUpdateListener(({editorState}) => {
-        const isSelected = editorState.read(() => {
-          const selection = $getSelection();
-          return (
-            $isNodeSelection(selection) &&
-            selection.has(nodeKey) &&
-            selection.getNodes().length === 1
-          );
-        });
-        if (isSelected) {
-          setShowEquationEditor(true);
-        }
-      });
     }
+    // Previously this branch promoted any NodeSelection on this
+    // equation into the EquationEditor input automatically. That
+    // collides with the new single-click → NodeSelection flow (a click
+    // would immediately drop the user into the input). The double-click
+    // gesture (`KatexRenderer.onDoubleClick`) is now the only path into
+    // edit mode.
+    return undefined;
   }, [editor, nodeKey, onHide, showEquationEditor, isEditable]);
 
   return (
@@ -124,6 +197,7 @@ export default function EquationComponent({
           equation={equationValue}
           setEquation={setEquationValue}
           inline={inline}
+          onDeleteEmpty={onDeleteEmpty}
           ref={inputRef}
         />
       ) : (

--- a/packages/lexical-playground/src/ui/EquationEditor.tsx
+++ b/packages/lexical-playground/src/ui/EquationEditor.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import type {JSX, Ref, RefObject} from 'react';
+import type {JSX, KeyboardEvent, Ref, RefObject} from 'react';
 
 import './EquationEditor.css';
 
@@ -17,14 +17,27 @@ type BaseEquationEditorProps = {
   equation: string;
   inline: boolean;
   setEquation: (equation: string) => void;
+  onDeleteEmpty?: () => void;
 };
 
 function EquationEditor(
-  {equation, setEquation, inline}: BaseEquationEditorProps,
+  {equation, setEquation, inline, onDeleteEmpty}: BaseEquationEditorProps,
   forwardedRef: Ref<HTMLInputElement | HTMLTextAreaElement>,
 ): JSX.Element {
   const onChange = (event: ChangeEvent) => {
     setEquation((event.target as HTMLInputElement).value);
+  };
+
+  // Backspace inside an already-empty editor removes the host
+  // EquationNode entirely, mirroring how users normally collapse a
+  // node by pressing Backspace at its start.
+  const onKeyDown = (
+    event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    if (event.key === 'Backspace' && equation === '' && onDeleteEmpty) {
+      event.preventDefault();
+      onDeleteEmpty();
+    }
   };
 
   return inline && isHTMLElement(forwardedRef) ? (
@@ -34,6 +47,7 @@ function EquationEditor(
         className="EquationEditor_inlineEditor"
         value={equation}
         onChange={onChange}
+        onKeyDown={onKeyDown}
         autoFocus={true}
         ref={forwardedRef as RefObject<HTMLInputElement>}
       />
@@ -46,6 +60,7 @@ function EquationEditor(
         className="EquationEditor_blockEditor"
         value={equation}
         onChange={onChange}
+        onKeyDown={onKeyDown}
         ref={forwardedRef as RefObject<HTMLTextAreaElement>}
       />
       <span className="EquationEditor_dollarSign">{'\n$$'}</span>

--- a/packages/lexical-playground/src/ui/KatexRenderer.tsx
+++ b/packages/lexical-playground/src/ui/KatexRenderer.tsx
@@ -49,12 +49,7 @@ export default function KatexRenderer({
         height="0"
         alt=""
       />
-      <span
-        role="button"
-        tabIndex={-1}
-        onDoubleClick={onDoubleClick}
-        ref={katexElementRef}
-      />
+      <span onDoubleClick={onDoubleClick} ref={katexElementRef} />
       <img
         src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
         width="0"


### PR DESCRIPTION
## Description

`EquationNode` (playground's KaTeX wrapper, a `DecoratorNode`) had no path that turned a single click into a `NodeSelection`, so downstream commands (Backspace, copy, Enter, arrow keys) had nothing to act on. A block equation that ends up as the sole root child becomes uninteractive (no caret, no selection, no way to delete), and the inline LaTeX editor's empty-input Backspace was a dead end.

### Fix

Mirror the `ImageComponent` / `PollComponent` pattern:

- Register `CLICK_COMMAND` on `EquationComponent` (`COMMAND_PRIORITY_LOW`). A click inside the keyed `editor-equation` DOM sets a `NodeSelection`; shift+click toggles. The command-level hook fires after lexical's own selection normalization, so the `NodeSelection` survives the surrounding `selectionchange` flow.
- Mirror `isSelected` onto the keyed wrapper as a `focused` class so the existing `.editor-equation.focused` outline renders.
- Register `KEY_ENTER_COMMAND`: `NodeSelection` on a block equation inserts an empty paragraph after the equation and selects it. Inline equation inserts the paragraph after the wrapper (insertAfter on the inline equation itself would nest paragraph-in-paragraph).
- Drop `tabIndex={-1}` and `role="button"` from `KatexRenderer`. With `tabIndex`, focus stayed inside the decorator subtree on click and `KEY_BACKSPACE_COMMAND` short-circuited via `$isTargetWithinDecorator(event.target)`. Removing them matches `ImageComponent` — focus stays on the contenteditable root, Backspace routes through `DELETE_CHARACTER_COMMAND` → `NodeSelection.deleteNodes()`.
- Wire `EquationEditor`'s `onKeyDown` to an `onDeleteEmpty` callback: when the LaTeX input is already empty and Backspace fires, remove the host node. Block path selects the previous sibling's end (or replaces with an empty paragraph if none); inline path clears the selection and `node.remove(true)` to preserve the wrapper paragraph.
- Drop the previous "auto-open EquationEditor on lone NodeSelection" effect — it would now fire on every single click. Double-click remains the only entry into edit mode.

### Known limitation

Deleting an inline equation (from any path, including main on this branch's base) emits a console error: `Lexical node does not exist in active editor state. Avoid using the same node references between nested closures from editorState.read/editor.update.`

Rough debugging: the throw lands in `$commitPendingUpdates` → `triggerListeners('update', ...)` (`LexicalUpdates.ts:714`), i.e. after the equation has already been removed and the editor state is committing. One of the registered update listeners reads a node reference that is no longer in the active NodeMap. The trigger reproduces on plain main too, not just on this branch — the fix here doesn't add the bug, it surfaces it more often because the new flows reach this path.

Splitting it off as a follow-up because identifying which listener holds the stale reference means stepping through lexical's internal update / mutation listener chain, and reshaping that chain is well outside the playground change in this PR. Better as a focused follow-up against lexical core once the trigger is isolated.

Closes #8533.

## Test plan

- [x] `pnpm tsc --noEmit -p tsconfig.json` clean.
- [x] Manual on Chrome and Safari:
  - Block equation as sole root child: click → `NodeSelection`, outline appears. Backspace removes the equation and replaces it with an empty paragraph (caret in the paragraph).
  - Block equation between paragraphs: Enter on the `NodeSelection` inserts an empty paragraph after the equation, caret inside ready for typing.
  - Inline equation: click → `NodeSelection`, outline. Backspace removes the equation; caret stays in the surrounding paragraph.
  - Inline equation double-click → input → delete all LaTeX → Backspace removes the host node (wrapper paragraph survives).
  - Double-click remains the only entry into edit mode.