### PR TITLE
[lexical-markdown] Bug Fix: Fix Markdown import with Unicode whitespace

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -385,6 +385,11 @@ describe('Markdown', () => {
       md: '**Hello** world',
     },
     {
+      html: '<p><b><strong style="white-space: pre-wrap;">Bold label:</strong></b><span style="white-space: pre-wrap;">&nbsp;Following paragraph text.</span></p>',
+      md: '**Bold label:**\u00A0Following paragraph text.',
+      skipExport: true,
+    },
+    {
       html: '<p><i><b><strong style="white-space: pre-wrap;">Hello</strong></b></i><span style="white-space: pre-wrap;"> world</span></p>',
       md: '***Hello*** world',
     },

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -444,7 +444,7 @@ export function transformersByType(transformers: Array<Transformer>): Readonly<{
 }
 
 export const PUNCTUATION_OR_SPACE = /[!-/:-@[-`{-~\s]/;
-export const WHITESPACE = /[ \t\n\r\f]/;
+export const WHITESPACE = /\s/;
 export const PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~]/;
 
 const MARKDOWN_EMPTY_LINE_REG_EXP = /^\s{0,3}$/;


### PR DESCRIPTION
## Description

Fixes markdown import for bold/italic when the character after the closing delimiter is Unicode whitespace (e.g. U+00A0 NBSP), which is common in pasted content from email clients and word processors.
- Broaden `WHITESPACE` in `@lexical/markdown` to use `\s` so emphasis flanking matches `PUNCTUATION_OR_SPACE`
- Add regression test for `**Bold label:**` + NBSP + following text

Fixes #8529

## Test plan

- [x] `pnpm run test-unit -- packages/lexical-markdown`
- [x] Manual: playground → Convert To Markdown → paste `**Bold label:**` + Option+Space (NBSP) + `Following...` → Convert From Markdown → text is bold

### Before

https://github.com/user-attachments/assets/d7276db0-fd5a-4c85-b9a0-b63c1cbd61ca

### After

https://github.com/user-attachments/assets/8da0f197-4b8a-467a-8e0f-b5042c2877df

<img width="1215" height="461" alt="Screenshot 2026-05-21 at 11 19 02 AM" src="https://github.com/user-attachments/assets/0bd02712-33c9-4d3a-8487-cffa6a477eda" />

