### PR TITLE
[lexical] Feature: ElementNode import/export support for data-lexical-indent

### DIFF
--- a/packages/lexical-playground/__tests__/unit/docSerialization.test.ts
+++ b/packages/lexical-playground/__tests__/unit/docSerialization.test.ts
@@ -210,7 +210,7 @@ describe('docSerialization', () => {
           htmlString2 = $generateHtmlFromNodes(editor);
         });
         expect(htmlString2).toBe(
-          '<p><span style="white-space: pre-wrap;">paragraph</span></p><h1><span style="white-space: pre-wrap;">heading</span></h1><blockquote><span style="white-space: pre-wrap;">quote</span></blockquote><p style="padding-inline-start: 80px;"><span style="white-space: pre-wrap;">paragraph</span></p><h1 style="padding-inline-start: 80px;"><span style="white-space: pre-wrap;">heading</span></h1><blockquote style="padding-inline-start: 80px;"><span style="white-space: pre-wrap;">quote</span></blockquote>',
+          '<p><span style="white-space: pre-wrap;">paragraph</span></p><h1><span style="white-space: pre-wrap;">heading</span></h1><blockquote><span style="white-space: pre-wrap;">quote</span></blockquote><p style="padding-inline-start: 80px;" data-lexical-indent="2"><span style="white-space: pre-wrap;">paragraph</span></p><h1 style="padding-inline-start: 80px;" data-lexical-indent="2"><span style="white-space: pre-wrap;">heading</span></h1><blockquote style="padding-inline-start: 80px;" data-lexical-indent="2"><span style="white-space: pre-wrap;">quote</span></blockquote>',
         );
       });
     });

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -2098,6 +2098,17 @@ export function setNodeIndentFromDOM(
   elementDom: HTMLElement,
   elementNode: ElementNode,
 ) {
+  // Prefer the authoritative attribute Lexical writes in exportDOM, since the
+  // padding-inline-start fallback can't recover a custom
+  // `--lexical-indent-base-value` or the reconciler's `calc(...)` form.
+  const indentAttr = elementDom.getAttribute('data-lexical-indent');
+  if (indentAttr !== null) {
+    const parsed = parseInt(indentAttr, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      elementNode.setIndent(parsed);
+      return;
+    }
+  }
   const indentSize = parseInt(elementDom.style.paddingInlineStart, 10) || 0;
   const indent = Math.round(indentSize / 40);
   elementNode.setIndent(indent);

--- a/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
@@ -43,9 +43,9 @@ function $importHtml(html: string) {
 describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () => {
   test('exportDOM emits data-lexical-indent and importDOM round-trips', () => {
     using editor = setUpEditor(() => {
-      const para = $createParagraphNode().append($createTextNode('hi'));
-      para.setIndent(2);
-      $getRoot().append(para);
+      $getRoot().append(
+        $createParagraphNode().append($createTextNode('hi')).setIndent(2),
+      );
     });
 
     const html = editor.read(() => $generateHtmlFromNodes(editor));

--- a/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
@@ -48,10 +48,7 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
       $getRoot().append(para);
     });
 
-    let html = '';
-    editor.read(() => {
-      html = $generateHtmlFromNodes(editor);
-    });
+    const html = editor.read(() => $generateHtmlFromNodes(editor));
 
     expect(html).toContain('data-lexical-indent="2"');
     expect(html).toContain('padding-inline-start: 80px');

--- a/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
@@ -13,12 +13,12 @@ import {RichTextExtension} from '@lexical/rich-text';
 import {
   $createParagraphNode,
   $createTextNode,
+  $getEditor,
   $getRoot,
   $isParagraphNode,
-  LexicalEditor,
-  ParagraphNode,
+  $selectAll,
 } from 'lexical';
-import {describe, expect, test} from 'vitest';
+import {assert, describe, expect, test} from 'vitest';
 
 function setUpEditor($initialEditorState?: () => void) {
   const editor = buildEditorFromExtensions(
@@ -32,13 +32,12 @@ function setUpEditor($initialEditorState?: () => void) {
   return editor;
 }
 
-function $importHtml(editor: LexicalEditor, html: string) {
-  const root = $getRoot();
-  root.clear();
+function $importHtml(html: string) {
+  const editor = $getEditor();
   const parser = new DOMParser();
   const dom = parser.parseFromString(html, 'text/html');
   const nodes = $generateNodesFromDOM(editor, dom);
-  $insertGeneratedNodes(editor, nodes, root.select(0));
+  $insertGeneratedNodes(editor, nodes, $selectAll());
 }
 
 describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () => {
@@ -46,7 +45,7 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
     using editor = setUpEditor(() => {
       const para = $createParagraphNode().append($createTextNode('hi'));
       para.setIndent(2);
-      $getRoot().clear().append(para);
+      $getRoot().append(para);
     });
 
     let html = '';
@@ -57,11 +56,11 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
     expect(html).toContain('data-lexical-indent="2"');
     expect(html).toContain('padding-inline-start: 80px');
 
-    editor.update(() => $importHtml(editor, html), {discrete: true});
+    editor.update(() => $importHtml(html), {discrete: true});
 
     editor.read(() => {
-      const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
-      expect($isParagraphNode(para)).toBe(true);
+      const para = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(para), 'expected ParagraphNode as first child');
       expect(para.getIndent()).toBe(2);
     });
   });
@@ -74,15 +73,14 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
     editor.update(
       () =>
         $importHtml(
-          editor,
           '<p data-lexical-indent="2" style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px));">hi</p>',
         ),
       {discrete: true},
     );
 
     editor.read(() => {
-      const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
-      expect($isParagraphNode(para)).toBe(true);
+      const para = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(para), 'expected ParagraphNode as first child');
       expect(para.getIndent()).toBe(2);
     });
   });
@@ -95,15 +93,14 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
     editor.update(
       () =>
         $importHtml(
-          editor,
           '<p data-lexical-indent="2" style="padding-inline-start: 32px;">hi</p>',
         ),
       {discrete: true},
     );
 
     editor.read(() => {
-      const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
-      expect($isParagraphNode(para)).toBe(true);
+      const para = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(para), 'expected ParagraphNode as first child');
       expect(para.getIndent()).toBe(2);
     });
   });
@@ -112,14 +109,13 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
     using editor = setUpEditor();
     // HTML from non-Lexical sources still uses the legacy padding heuristic.
     editor.update(
-      () =>
-        $importHtml(editor, '<p style="padding-inline-start: 80px;">hi</p>'),
+      () => $importHtml('<p style="padding-inline-start: 80px;">hi</p>'),
       {discrete: true},
     );
 
     editor.read(() => {
-      const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
-      expect($isParagraphNode(para)).toBe(true);
+      const para = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(para), 'expected ParagraphNode as first child');
       expect(para.getIndent()).toBe(2);
     });
   });

--- a/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
@@ -15,47 +15,39 @@ import {
   $createTextNode,
   $getRoot,
   $isParagraphNode,
+  LexicalEditor,
   ParagraphNode,
 } from 'lexical';
 import {describe, expect, test} from 'vitest';
 
-function setUpEditor() {
+function setUpEditor($initialEditorState?: () => void) {
   const editor = buildEditorFromExtensions(
-    RichTextExtension,
-    defineExtension({name: 'issue-7729-repro'}),
+    defineExtension({
+      $initialEditorState,
+      dependencies: [RichTextExtension],
+      name: 'issue-7729-repro',
+    }),
   );
   editor.setRootElement(document.createElement('div'));
   return editor;
 }
 
-function $importHtml(editor: ReturnType<typeof setUpEditor>, html: string) {
-  editor.update(
-    () => {
-      const root = $getRoot();
-      root.clear();
-      const parser = new DOMParser();
-      const dom = parser.parseFromString(html, 'text/html');
-      const nodes = $generateNodesFromDOM(editor, dom);
-      $insertGeneratedNodes(editor, nodes, root.select(0));
-    },
-    {discrete: true},
-  );
+function $importHtml(editor: LexicalEditor, html: string) {
+  const root = $getRoot();
+  root.clear();
+  const parser = new DOMParser();
+  const dom = parser.parseFromString(html, 'text/html');
+  const nodes = $generateNodesFromDOM(editor, dom);
+  $insertGeneratedNodes(editor, nodes, root.select(0));
 }
 
 describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () => {
   test('exportDOM emits data-lexical-indent and importDOM round-trips', () => {
-    using editor = buildEditorFromExtensions(
-      RichTextExtension,
-      defineExtension({
-        $initialEditorState: () => {
-          const para = $createParagraphNode().append($createTextNode('hi'));
-          para.setIndent(2);
-          $getRoot().clear().append(para);
-        },
-        name: 'issue-7729-export',
-      }),
-    );
-    editor.setRootElement(document.createElement('div'));
+    using editor = setUpEditor(() => {
+      const para = $createParagraphNode().append($createTextNode('hi'));
+      para.setIndent(2);
+      $getRoot().clear().append(para);
+    });
 
     let html = '';
     editor.read(() => {
@@ -65,7 +57,7 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
     expect(html).toContain('data-lexical-indent="2"');
     expect(html).toContain('padding-inline-start: 80px');
 
-    $importHtml(editor, html);
+    editor.update(() => $importHtml(editor, html), {discrete: true});
 
     editor.read(() => {
       const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
@@ -79,9 +71,13 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
     // What live-DOM copy/paste produces: the reconciler writes a calc(...)
     // expression that parseInt cannot recover. The data attribute makes
     // this unambiguous.
-    $importHtml(
-      editor,
-      '<p data-lexical-indent="2" style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px));">hi</p>',
+    editor.update(
+      () =>
+        $importHtml(
+          editor,
+          '<p data-lexical-indent="2" style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px));">hi</p>',
+        ),
+      {discrete: true},
     );
 
     editor.read(() => {
@@ -96,9 +92,13 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
     // Simulates a custom --lexical-indent-base-value (e.g. 16px): the
     // padding value (32px) would round to indent=1 with the old heuristic;
     // the data attribute restores the true value.
-    $importHtml(
-      editor,
-      '<p data-lexical-indent="2" style="padding-inline-start: 32px;">hi</p>',
+    editor.update(
+      () =>
+        $importHtml(
+          editor,
+          '<p data-lexical-indent="2" style="padding-inline-start: 32px;">hi</p>',
+        ),
+      {discrete: true},
     );
 
     editor.read(() => {
@@ -111,7 +111,11 @@ describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () 
   test('falls back to padding heuristic when data-lexical-indent is absent', () => {
     using editor = setUpEditor();
     // HTML from non-Lexical sources still uses the legacy padding heuristic.
-    $importHtml(editor, '<p style="padding-inline-start: 80px;">hi</p>');
+    editor.update(
+      () =>
+        $importHtml(editor, '<p style="padding-inline-start: 80px;">hi</p>'),
+      {discrete: true},
+    );
 
     editor.read(() => {
       const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();

--- a/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+import {initializeUnitTest} from '../utils';
+
+describe('Issue #7729: paragraph indent lost on DOM round-trip', () => {
+  initializeUnitTest(testEnv => {
+    test('exportDOM -> importDOM preserves indent (literal Npx case)', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const para = $createParagraphNode().append($createTextNode('hi'));
+          para.setIndent(2);
+          $getRoot().clear().append(para);
+        },
+        {discrete: true},
+      );
+
+      let html = '';
+      editor.read(() => {
+        html = $generateHtmlFromNodes(editor);
+      });
+
+      // exportDOM writes `${indent * 40}px` literally, so this should be 80px.
+      expect(html).toContain('padding-inline-start: 80px');
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(html, 'text/html');
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().clear();
+          nodes.forEach(n => $getRoot().append(n));
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const para = $getRoot().getFirstChildOrThrow();
+        expect($isParagraphNode(para)).toBe(true);
+        expect(para.getIndent()).toBe(2); // baseline round-trip
+      });
+    });
+
+    test('importDOM fails when style uses calc(var(--lexical-indent-base-value))', () => {
+      const {editor} = testEnv;
+      const reconcilerLikeHtml =
+        '<p style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px));">hi</p>';
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(reconcilerLikeHtml, 'text/html');
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().clear();
+          nodes.forEach(n => $getRoot().append(n));
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const para = $getRoot().getFirstChildOrThrow();
+        expect($isParagraphNode(para)).toBe(true);
+        // BUG: parseInt('calc(2 * var(...))') is NaN, so indent collapses to 0.
+        expect(para.getIndent()).toBe(2);
+      });
+    });
+
+    test('importDOM fails when custom base value yields non-40-multiple px', () => {
+      const {editor} = testEnv;
+      // Simulates --lexical-indent-base-value: 2em rendered to inline px,
+      // e.g. copy/paste of computed style: 2 levels * 2em = 4em which a
+      // browser may serialize as e.g. 32px (with default 16px font).
+      const html = '<p style="padding-inline-start: 32px;">hi</p>';
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(html, 'text/html');
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().clear();
+          nodes.forEach(n => $getRoot().append(n));
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const para = $getRoot().getFirstChildOrThrow();
+        expect($isParagraphNode(para)).toBe(true);
+        // With hardcoded /40 divisor: round(32/40) = 1 instead of 2.
+        // This documents that the divisor doesn't honour
+        // --lexical-indent-base-value.
+        expect(para.getIndent()).toBe(2);
+      });
+    });
+  });
+});

--- a/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
@@ -17,9 +17,9 @@ import {describe, expect, test} from 'vitest';
 
 import {initializeUnitTest} from '../utils';
 
-describe('Issue #7729: paragraph indent lost on DOM round-trip', () => {
+describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () => {
   initializeUnitTest(testEnv => {
-    test('exportDOM -> importDOM preserves indent (literal Npx case)', () => {
+    test('exportDOM emits data-lexical-indent and importDOM round-trips', () => {
       const {editor} = testEnv;
       editor.update(
         () => {
@@ -35,7 +35,7 @@ describe('Issue #7729: paragraph indent lost on DOM round-trip', () => {
         html = $generateHtmlFromNodes(editor);
       });
 
-      // exportDOM writes `${indent * 40}px` literally, so this should be 80px.
+      expect(html).toContain('data-lexical-indent="2"');
       expect(html).toContain('padding-inline-start: 80px');
 
       editor.update(
@@ -51,41 +51,20 @@ describe('Issue #7729: paragraph indent lost on DOM round-trip', () => {
 
       editor.read(() => {
         const para = $getRoot().getFirstChildOrThrow();
-        expect($isParagraphNode(para)).toBe(true);
-        expect(para.getIndent()).toBe(2); // baseline round-trip
-      });
-    });
-
-    test('importDOM fails when style uses calc(var(--lexical-indent-base-value))', () => {
-      const {editor} = testEnv;
-      const reconcilerLikeHtml =
-        '<p style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px));">hi</p>';
-
-      editor.update(
-        () => {
-          const parser = new DOMParser();
-          const dom = parser.parseFromString(reconcilerLikeHtml, 'text/html');
-          const nodes = $generateNodesFromDOM(editor, dom);
-          $getRoot().clear();
-          nodes.forEach(n => $getRoot().append(n));
-        },
-        {discrete: true},
-      );
-
-      editor.read(() => {
-        const para = $getRoot().getFirstChildOrThrow();
-        expect($isParagraphNode(para)).toBe(true);
-        // BUG: parseInt('calc(2 * var(...))') is NaN, so indent collapses to 0.
+        if (!$isParagraphNode(para)) {
+          throw new Error('expected paragraph node');
+        }
         expect(para.getIndent()).toBe(2);
       });
     });
 
-    test('importDOM fails when custom base value yields non-40-multiple px', () => {
+    test('data-lexical-indent wins over a calc(...) padding-inline-start', () => {
       const {editor} = testEnv;
-      // Simulates --lexical-indent-base-value: 2em rendered to inline px,
-      // e.g. copy/paste of computed style: 2 levels * 2em = 4em which a
-      // browser may serialize as e.g. 32px (with default 16px font).
-      const html = '<p style="padding-inline-start: 32px;">hi</p>';
+      // What live-DOM copy/paste produces: the reconciler writes a calc(...)
+      // expression that parseInt cannot recover. The data attribute makes
+      // this unambiguous.
+      const html =
+        '<p data-lexical-indent="2" style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px));">hi</p>';
 
       editor.update(
         () => {
@@ -100,10 +79,62 @@ describe('Issue #7729: paragraph indent lost on DOM round-trip', () => {
 
       editor.read(() => {
         const para = $getRoot().getFirstChildOrThrow();
-        expect($isParagraphNode(para)).toBe(true);
-        // With hardcoded /40 divisor: round(32/40) = 1 instead of 2.
-        // This documents that the divisor doesn't honour
-        // --lexical-indent-base-value.
+        if (!$isParagraphNode(para)) {
+          throw new Error('expected paragraph node');
+        }
+        expect(para.getIndent()).toBe(2);
+      });
+    });
+
+    test('data-lexical-indent wins over a non-40-multiple padding-inline-start', () => {
+      const {editor} = testEnv;
+      // Simulates a custom --lexical-indent-base-value (e.g. 16px): the
+      // padding value (32px) would round to indent=1 with the old heuristic;
+      // the data attribute restores the true value.
+      const html =
+        '<p data-lexical-indent="2" style="padding-inline-start: 32px;">hi</p>';
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(html, 'text/html');
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().clear();
+          nodes.forEach(n => $getRoot().append(n));
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const para = $getRoot().getFirstChildOrThrow();
+        if (!$isParagraphNode(para)) {
+          throw new Error('expected paragraph node');
+        }
+        expect(para.getIndent()).toBe(2);
+      });
+    });
+
+    test('falls back to padding heuristic when data-lexical-indent is absent', () => {
+      const {editor} = testEnv;
+      // HTML from non-Lexical sources still uses the legacy padding heuristic.
+      const html = '<p style="padding-inline-start: 80px;">hi</p>';
+
+      editor.update(
+        () => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(html, 'text/html');
+          const nodes = $generateNodesFromDOM(editor, dom);
+          $getRoot().clear();
+          nodes.forEach(n => $getRoot().append(n));
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const para = $getRoot().getFirstChildOrThrow();
+        if (!$isParagraphNode(para)) {
+          throw new Error('expected paragraph node');
+        }
         expect(para.getIndent()).toBe(2);
       });
     });

--- a/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
@@ -6,137 +6,117 @@
  *
  */
 
+import {$insertGeneratedNodes} from '@lexical/clipboard';
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {RichTextExtension} from '@lexical/rich-text';
 import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
   $isParagraphNode,
+  ParagraphNode,
 } from 'lexical';
 import {describe, expect, test} from 'vitest';
 
-import {initializeUnitTest} from '../utils';
+function setUpEditor() {
+  const editor = buildEditorFromExtensions(
+    RichTextExtension,
+    defineExtension({name: 'issue-7729-repro'}),
+  );
+  editor.setRootElement(document.createElement('div'));
+  return editor;
+}
+
+function $importHtml(editor: ReturnType<typeof setUpEditor>, html: string) {
+  editor.update(
+    () => {
+      const root = $getRoot();
+      root.clear();
+      const parser = new DOMParser();
+      const dom = parser.parseFromString(html, 'text/html');
+      const nodes = $generateNodesFromDOM(editor, dom);
+      $insertGeneratedNodes(editor, nodes, root.select(0));
+    },
+    {discrete: true},
+  );
+}
 
 describe('Issue #7729: paragraph indent round-trip via data-lexical-indent', () => {
-  initializeUnitTest(testEnv => {
-    test('exportDOM emits data-lexical-indent and importDOM round-trips', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
+  test('exportDOM emits data-lexical-indent and importDOM round-trips', () => {
+    using editor = buildEditorFromExtensions(
+      RichTextExtension,
+      defineExtension({
+        $initialEditorState: () => {
           const para = $createParagraphNode().append($createTextNode('hi'));
           para.setIndent(2);
           $getRoot().clear().append(para);
         },
-        {discrete: true},
-      );
+        name: 'issue-7729-export',
+      }),
+    );
+    editor.setRootElement(document.createElement('div'));
 
-      let html = '';
-      editor.read(() => {
-        html = $generateHtmlFromNodes(editor);
-      });
-
-      expect(html).toContain('data-lexical-indent="2"');
-      expect(html).toContain('padding-inline-start: 80px');
-
-      editor.update(
-        () => {
-          const parser = new DOMParser();
-          const dom = parser.parseFromString(html, 'text/html');
-          const nodes = $generateNodesFromDOM(editor, dom);
-          $getRoot().clear();
-          nodes.forEach(n => $getRoot().append(n));
-        },
-        {discrete: true},
-      );
-
-      editor.read(() => {
-        const para = $getRoot().getFirstChildOrThrow();
-        if (!$isParagraphNode(para)) {
-          throw new Error('expected paragraph node');
-        }
-        expect(para.getIndent()).toBe(2);
-      });
+    let html = '';
+    editor.read(() => {
+      html = $generateHtmlFromNodes(editor);
     });
 
-    test('data-lexical-indent wins over a calc(...) padding-inline-start', () => {
-      const {editor} = testEnv;
-      // What live-DOM copy/paste produces: the reconciler writes a calc(...)
-      // expression that parseInt cannot recover. The data attribute makes
-      // this unambiguous.
-      const html =
-        '<p data-lexical-indent="2" style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px));">hi</p>';
+    expect(html).toContain('data-lexical-indent="2"');
+    expect(html).toContain('padding-inline-start: 80px');
 
-      editor.update(
-        () => {
-          const parser = new DOMParser();
-          const dom = parser.parseFromString(html, 'text/html');
-          const nodes = $generateNodesFromDOM(editor, dom);
-          $getRoot().clear();
-          nodes.forEach(n => $getRoot().append(n));
-        },
-        {discrete: true},
-      );
+    $importHtml(editor, html);
 
-      editor.read(() => {
-        const para = $getRoot().getFirstChildOrThrow();
-        if (!$isParagraphNode(para)) {
-          throw new Error('expected paragraph node');
-        }
-        expect(para.getIndent()).toBe(2);
-      });
+    editor.read(() => {
+      const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+      expect($isParagraphNode(para)).toBe(true);
+      expect(para.getIndent()).toBe(2);
     });
+  });
 
-    test('data-lexical-indent wins over a non-40-multiple padding-inline-start', () => {
-      const {editor} = testEnv;
-      // Simulates a custom --lexical-indent-base-value (e.g. 16px): the
-      // padding value (32px) would round to indent=1 with the old heuristic;
-      // the data attribute restores the true value.
-      const html =
-        '<p data-lexical-indent="2" style="padding-inline-start: 32px;">hi</p>';
+  test('data-lexical-indent wins over a calc(...) padding-inline-start', () => {
+    using editor = setUpEditor();
+    // What live-DOM copy/paste produces: the reconciler writes a calc(...)
+    // expression that parseInt cannot recover. The data attribute makes
+    // this unambiguous.
+    $importHtml(
+      editor,
+      '<p data-lexical-indent="2" style="padding-inline-start: calc(2 * var(--lexical-indent-base-value, 40px));">hi</p>',
+    );
 
-      editor.update(
-        () => {
-          const parser = new DOMParser();
-          const dom = parser.parseFromString(html, 'text/html');
-          const nodes = $generateNodesFromDOM(editor, dom);
-          $getRoot().clear();
-          nodes.forEach(n => $getRoot().append(n));
-        },
-        {discrete: true},
-      );
-
-      editor.read(() => {
-        const para = $getRoot().getFirstChildOrThrow();
-        if (!$isParagraphNode(para)) {
-          throw new Error('expected paragraph node');
-        }
-        expect(para.getIndent()).toBe(2);
-      });
+    editor.read(() => {
+      const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+      expect($isParagraphNode(para)).toBe(true);
+      expect(para.getIndent()).toBe(2);
     });
+  });
 
-    test('falls back to padding heuristic when data-lexical-indent is absent', () => {
-      const {editor} = testEnv;
-      // HTML from non-Lexical sources still uses the legacy padding heuristic.
-      const html = '<p style="padding-inline-start: 80px;">hi</p>';
+  test('data-lexical-indent wins over a non-40-multiple padding-inline-start', () => {
+    using editor = setUpEditor();
+    // Simulates a custom --lexical-indent-base-value (e.g. 16px): the
+    // padding value (32px) would round to indent=1 with the old heuristic;
+    // the data attribute restores the true value.
+    $importHtml(
+      editor,
+      '<p data-lexical-indent="2" style="padding-inline-start: 32px;">hi</p>',
+    );
 
-      editor.update(
-        () => {
-          const parser = new DOMParser();
-          const dom = parser.parseFromString(html, 'text/html');
-          const nodes = $generateNodesFromDOM(editor, dom);
-          $getRoot().clear();
-          nodes.forEach(n => $getRoot().append(n));
-        },
-        {discrete: true},
-      );
+    editor.read(() => {
+      const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+      expect($isParagraphNode(para)).toBe(true);
+      expect(para.getIndent()).toBe(2);
+    });
+  });
 
-      editor.read(() => {
-        const para = $getRoot().getFirstChildOrThrow();
-        if (!$isParagraphNode(para)) {
-          throw new Error('expected paragraph node');
-        }
-        expect(para.getIndent()).toBe(2);
-      });
+  test('falls back to padding heuristic when data-lexical-indent is absent', () => {
+    using editor = setUpEditor();
+    // HTML from non-Lexical sources still uses the legacy padding heuristic.
+    $importHtml(editor, '<p style="padding-inline-start: 80px;">hi</p>');
+
+    editor.read(() => {
+      const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+      expect($isParagraphNode(para)).toBe(true);
+      expect(para.getIndent()).toBe(2);
     });
   });
 });

--- a/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7729Repro.test.ts
@@ -21,15 +21,13 @@ import {
 import {assert, describe, expect, test} from 'vitest';
 
 function setUpEditor($initialEditorState?: () => void) {
-  const editor = buildEditorFromExtensions(
+  return buildEditorFromExtensions(
     defineExtension({
       $initialEditorState,
       dependencies: [RichTextExtension],
       name: 'issue-7729-repro',
     }),
   );
-  editor.setRootElement(document.createElement('div'));
-  return editor;
 }
 
 function $importHtml(html: string) {

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -849,6 +849,11 @@ export class ElementNode extends LexicalNode {
         // We recommend keeping multiples of 40px to maintain consistency with list-items
         // (see https://github.com/facebook/lexical/pull/4025)
         element.style.paddingInlineStart = `${indent * 40}px`;
+        // Authoritative round-trip signal. padding-inline-start can be a
+        // non-40px multiple (custom `--lexical-indent-base-value`) or a
+        // `calc(...)` expression on the live DOM, neither of which the
+        // padding-based heuristic in setNodeIndentFromDOM can recover.
+        element.setAttribute('data-lexical-indent', String(indent));
       }
       const direction = this.getDirection();
       if (direction) {


### PR DESCRIPTION
## Description

Lexical currently only uses the padding-inline-start style to represent its indentation, but using it as a signal for the actual indentation is fragile if customized because it is based on display.

This changes the representation to use a data attribute on export so that the indentation can be reliably recovered on import regardless of CSS, with a fallback to the padding-inline-start heuristic.

Closes #7729

## Test plan

New unit tests