### PR TITLE
[lexical-history] Feature: Add maxDepth option to HistoryExtension

### DIFF
--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -674,6 +674,62 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   });
 });
 
+describe('HistoryExtension maxDepth', () => {
+  function buildEditorWithMaxDepth(maxDepth: number | null) {
+    return buildEditorFromExtensions({
+      dependencies: [configExtension(HistoryExtension, {delay: 0, maxDepth})],
+      name: 'test',
+    });
+  }
+
+  function $appendParagraph(text: string) {
+    $getRoot().append($createParagraphNode().append($createTextNode(text)));
+  }
+
+  function pushNHistoryEvents(editor: LexicalEditor, n: number) {
+    // Each editor.update with discrete: true is a separate history event when
+    // delay is 0 — the merge window is closed.  The first update populates
+    // historyState.current; the second pushes it onto undoStack; from then
+    // on every additional update adds one entry.  So `n` updates produce
+    // `n - 1` undoStack entries.
+    for (let i = 0; i < n; i++) {
+      editor.update(() => $appendParagraph(`p${i}`), {discrete: true});
+    }
+  }
+
+  test('defaults to null (unbounded) and matches the historical behavior', () => {
+    using editor = buildEditorWithMaxDepth(null);
+    pushNHistoryEvents(editor, 25);
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    expect(output.maxDepth.peek()).toBe(null);
+    expect(output.historyState.peek().undoStack.length).toBe(24);
+  });
+
+  test('caps the undoStack to maxDepth via FIFO eviction', () => {
+    using editor = buildEditorWithMaxDepth(5);
+    pushNHistoryEvents(editor, 20);
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    expect(output.historyState.peek().undoStack.length).toBe(5);
+    // canUndo stays true once any entry exists.
+    expect(output.canUndo.peek()).toBe(true);
+  });
+
+  test('reactively respects a maxDepth signal update for future events', () => {
+    using editor = buildEditorWithMaxDepth(null);
+    pushNHistoryEvents(editor, 8); // 7 entries
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+    expect(output.historyState.peek().undoStack.length).toBe(7);
+
+    // Lowering maxDepth does not retroactively trim — only future pushes
+    // observe the new cap, at which point the stack settles to that length.
+    output.maxDepth.value = 3;
+    expect(output.historyState.peek().undoStack.length).toBe(7);
+
+    pushNHistoryEvents(editor, 5); // 5 more events trigger trimming
+    expect(output.historyState.peek().undoStack.length).toBe(3);
+  });
+});
+
 describe('SharedHistoryExtension', () => {
   test('can create a parent editor', async () => {
     const clock = Date.now();

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -452,6 +452,12 @@ function clearHistory(
  * NOT invoked when a candidate update is discarded without changing the
  * stacks. Useful for keeping derived values (e.g. signals) in sync with the
  * current `HistoryState`.
+ * @param maxDepth - The maximum number of entries the undo stack may hold.
+ * When the cap is exceeded a new history event has been pushed the oldest
+ * entries are dropped from the front of the stack until the stack length is
+ * `maxDepth`. Pass `null` (the default) to keep the stack unbounded — the
+ * historical behavior. May be a plain number or a `ReadonlySignal<number | null>`
+ * for reactive reconfiguration.
  * @returns The listeners cleanup callback function.
  */
 export function registerHistory(
@@ -460,8 +466,13 @@ export function registerHistory(
   delay: number | ReadonlySignal<number>,
   dateNow: () => number = Date.now,
   onHistoryStateChange?: (state: HistoryState) => void,
+  maxDepth: number | null | ReadonlySignal<number | null> = null,
 ): () => void {
   const getMergeAction = createMergeActionGetter(editor, delay, dateNow);
+  const readMaxDepth = (): number | null =>
+    typeof maxDepth === 'number' || maxDepth === null
+      ? maxDepth
+      : maxDepth.peek();
 
   const notifyChange = () => {
     if (onHistoryStateChange) {
@@ -510,6 +521,14 @@ export function registerHistory(
         undoStack.push({
           ...current,
         });
+        const cap = readMaxDepth();
+        if (cap !== null && undoStack.length > cap) {
+          // FIFO-evict the oldest entries so the stack stays at `cap`.
+          // Editing the array in place keeps the same `historyState.undoStack`
+          // reference that callers (e.g. SharedHistoryExtension) may hold on
+          // to.
+          undoStack.splice(0, undoStack.length - cap);
+        }
         editor.dispatchCommand(CAN_UNDO_COMMAND, true);
       }
     } else if (mergeAction === DISCARD_HISTORY_CANDIDATE) {
@@ -597,6 +616,18 @@ export interface HistoryConfig {
    * The now() function, defaults to Date.now.
    */
   now: () => number;
+  /**
+   * The maximum number of entries the undo stack may hold. When the cap is
+   * exceeded the oldest entries are dropped (FIFO) so the stack stays at this
+   * length. Defaults to `null`, which keeps the stack unbounded — the
+   * historical behavior. Setting a finite cap is recommended for editors that
+   * may receive a very large number of distinct history events (long writing
+   * sessions, automated input, etc.) since each entry retains a full
+   * `EditorState` snapshot.
+   *
+   * For reference, ProseMirror's `history()` plugin defaults to `depth: 100`.
+   */
+  maxDepth: number | null;
 }
 
 /** Internal writable signals created during the init phase. */
@@ -631,6 +662,12 @@ export interface HistoryExtensionOutput {
   disabled: Signal<boolean>;
   /** The active {@link HistoryState} instance. */
   historyState: Signal<HistoryState>;
+  /**
+   * Maximum number of entries the undo stack may hold. `null` disables the
+   * cap. Changes apply to the next history event — the current undo stack is
+   * not retroactively trimmed when the value is lowered.
+   */
+  maxDepth: Signal<number | null>;
   /** The clock function forwarded to {@link registerHistory}. */
   now: Signal<() => number>;
 }
@@ -642,7 +679,7 @@ export interface HistoryExtensionOutput {
 export const HistoryExtension = defineExtension({
   build: (
     editor,
-    {delay, createInitialHistoryState, disabled, now},
+    {delay, createInitialHistoryState, disabled, maxDepth, now},
     state,
   ): HistoryExtensionOutput => {
     // The init phase already created writable Signal<boolean> instances for
@@ -655,6 +692,7 @@ export const HistoryExtension = defineExtension({
         delay,
         disabled,
         historyState: createInitialHistoryState(editor),
+        maxDepth,
         now,
       }),
       ...state.getInitResult(),
@@ -664,6 +702,7 @@ export const HistoryExtension = defineExtension({
     createInitialHistoryState: createEmptyHistoryState,
     delay: 300,
     disabled: typeof window === 'undefined',
+    maxDepth: null,
     now: Date.now,
   }),
   init: (): HistoryExtensionInit => ({
@@ -696,6 +735,7 @@ export const HistoryExtension = defineExtension({
         stores.delay,
         () => stores.now.peek()(),
         syncFromHistoryState,
+        stores.maxDepth,
       );
     });
   },


### PR DESCRIPTION
## Description

Adds a `maxDepth: number | null` config option (and matching output Signal) to `HistoryExtension`. When non-null, the undo stack is FIFO-evicted to that length on each push. Defaults to null, preserving the historical unbounded behavior — existing consumers are unchanged.

This is intentionally a per-event check rather than a periodic prune so the cap is enforced exactly when entries are appended; the trim does shape the array referenced by `historyState.undoStack` (in place via splice) so peer extensions such as `SharedHistoryExtension` that hold a reference to it continue to see the trimmed stack.

## Test plan

New unit tests cover three cases: the unbounded default, a finite cap evicting older entries, and reactive lowering of the cap via the output Signal.
