### PR TITLE
[lexical-markdown] Chore: Cover bold italic markdown round trip

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -755,6 +755,10 @@ describe('Markdown', () => {
       md: '*text**text***',
     },
     {
+      html: '<p><b><strong style="white-space: pre-wrap;">text</strong></b><i><b><strong style="white-space: pre-wrap;">text</strong></b></i></p>',
+      md: '**text*text***',
+    },
+    {
       html: '<p><i><em style="white-space: pre-wrap;">foo**bar</em></i></p>',
       md: '*foo**bar*',
       mdAfterExport: '*foo\\*\\*bar*',


### PR DESCRIPTION
## Description

This PR adds regression coverage for markdown text that mixes adjacent bold and bold-italic formatting on the same line.

The reported case already round-trips correctly on current `main`, so this keeps that behavior covered in `lexical-markdown` and gives the issue a focused test case.

Closes #7974

## Test plan

### Before

There was no focused regression test for importing and exporting the reported `**text*text***` markdown shape.

### After

- `pnpm test-unit packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts`
