### PR TITLE
[lexical] Feature: Detect infinite recursion in update listeners

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -626,6 +626,7 @@ export function resetEditor(
   if (!options || !options.preserveUpdateQueue) {
     editor._updateTags = new Set();
     editor._updates = [];
+    editor._cascadeCount = 0;
   }
   editor._blockCursorElement = null;
 
@@ -946,6 +947,8 @@ export class LexicalEditor {
   /** @internal */
   _updating: boolean;
   /** @internal */
+  _cascadeCount: number;
+  /** @internal */
   _listeners: Listeners;
   /** @internal */
   _commands: Commands;
@@ -1012,6 +1015,7 @@ export class LexicalEditor {
     this._keyToDOMMap = new GenMap();
     this._updates = [];
     this._updating = false;
+    this._cascadeCount = 0;
     // Listeners
     this._listeners = {
       decorator: new Map(),

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -843,12 +843,29 @@ export function triggerCommandListeners<
 function $triggerEnqueuedUpdates(editor: LexicalEditor): void {
   const queuedUpdates = editor._updates;
 
-  if (queuedUpdates.length !== 0) {
-    const queuedUpdate = queuedUpdates.shift();
-    if (queuedUpdate) {
-      const [updateFn, options] = queuedUpdate;
-      $beginUpdate(editor, updateFn, options);
+  if (queuedUpdates.length === 0) {
+    editor._cascadeCount = 0;
+    return;
+  }
+  if (editor._cascadeCount++ > 99) {
+    editor._updates = [];
+    editor._cascadeCount = 0;
+    try {
+      invariant(
+        false,
+        'One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition.',
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        editor._onError(error);
+      }
     }
+    return;
+  }
+  const queuedUpdate = queuedUpdates.shift();
+  if (queuedUpdate) {
+    const [updateFn, options] = queuedUpdate;
+    $beginUpdate(editor, updateFn, options);
   }
 }
 

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1189,6 +1189,48 @@ describe('LexicalEditor tests', () => {
     boldListener();
   });
 
+  it('Detects infinite recursivity on update listeners', async () => {
+    const errorListener = vi.fn();
+    init(errorListener);
+
+    const unregisterListener = editor.registerUpdateListener(() => {
+      editor.update(() => {
+        $getRoot().markDirty();
+      });
+    });
+
+    expect(errorListener).toHaveBeenCalledTimes(0);
+
+    editor.update(() => {
+      $getRoot().markDirty();
+    });
+
+    // drain the microtask chain produced by the cascade
+    for (let i = 0; i < 200 && errorListener.mock.calls.length === 0; i++) {
+      await Promise.resolve();
+    }
+
+    expect(errorListener).toHaveBeenCalledTimes(1);
+    expect(errorListener.mock.calls[0][0].message).toMatch(
+      /endlessly enqueueing/,
+    );
+
+    unregisterListener();
+
+    // editor should be usable again after the cascade is cut
+    editor.update(
+      () => {
+        $getRoot().markDirty();
+      },
+      {discrete: true},
+    );
+    // drain any lingering microtask chain to confirm no further cascade
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+    expect(errorListener).toHaveBeenCalledTimes(1);
+  });
+
   it('Should be able to update an editor state without a root element', () => {
     const ref = createRef<HTMLDivElement>();
 


### PR DESCRIPTION
## Description

`editor.registerUpdateListener` is documented as something to "watch out for infinite loops" with, but there is no runtime detection. When a listener calls `editor.update()` and the resulting state change is dirty enough to fire the listener again, the chain runs synchronously through `$triggerEnqueuedUpdates` → `$beginUpdate` → commit → listener → `_updates.push` → `$triggerEnqueuedUpdates` ... until the browser hangs. The existing `infiniteTransformCount` counter resets per `$beginUpdate`, so it can't catch a cascade that crosses update lifecycles.

### Fix

Add a per-editor `_cascadeCount` counter that increments in `$triggerEnqueuedUpdates` when the queue is non-empty and resets when the chain naturally drains or the editor is reset. Once the counter exceeds the threshold, surface a cascade-specific `invariant` through `editor._onError` and clear the pending update queue so the chain is cut even if the user's `onError` swallows the throw. The counter is editor-instance state rather than module-level because a listener on editor A can synchronously call `editor.update()` on editor B; sharing the counter would let A's cascade exhaust B's budget.

Closes #3694

### Design notes

- The `try`/`catch` wraps only the cascade-detection `invariant`, not the surrounding `$beginUpdate` call, so it doesn't intercept the deliberate re-throw from `$commitPendingUpdates`'s reconciler-recovery path.
- Threshold matches the existing `infiniteTransformCount` (99).

## Test plan

- [x] `pnpm vitest run --project unit packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx` — 79 tests pass (new "Detects infinite recursivity on update listeners" alongside the existing transform-recursivity test)
- [x] `pnpm vitest run --project unit` — 2585 tests pass, no NestedEditor regression
- [x] `pnpm tsc --noEmit -p tsconfig.json` clean
- [x] `pnpm flow` clean
- [x] `npx prettier --check` clean on changed files