### PR TITLE
[lexical-playground] Bug Fix: Read __inline directly in EquationNode.isInline

### DIFF
--- a/packages/lexical-playground/__tests__/unit/EquationNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/EquationNode.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createParagraphNode, $getRoot} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
+
+import {$createEquationNode, EquationNode} from '../../src/nodes/EquationNode';
+
+describe('Issue #8534 follow-up: EquationNode.isInline on stale node ref', () => {
+  it('does not throw when called on a detached node reference', () => {
+    const editor = createTestEditor({
+      nodes: [EquationNode],
+      onError: error => {
+        throw error;
+      },
+    });
+
+    let equationRef: EquationNode | null = null;
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const equation = $createEquationNode('x^2', true);
+        paragraph.append(equation);
+        $getRoot().append(paragraph);
+        equationRef = equation;
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        equationRef!.remove();
+      },
+      {discrete: true},
+    );
+
+    // After removal, the prev-state reference's __key is no longer in
+    // the active node map. Calling isInline() on it must read __inline
+    // directly instead of routing through getLatest() (which would
+    // throw via invariant on null lookup).
+    editor.read(() => {
+      expect(() => equationRef!.isInline()).not.toThrow();
+      expect(equationRef!.isInline()).toBe(true);
+    });
+  });
+});

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -142,7 +142,13 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
   }
 
   isInline(): boolean {
-    return this.getLatest().__inline;
+    // `__inline` is fixed at construction (no setter, `clone` and
+    // `updateFromJSON` copy the same value). Reading it directly keeps
+    // `isInline()` safe to call on prev-state node references that the
+    // reconciler hands to `isLastChildLineBreakOrDecorator` while
+    // committing a removal — those references resolve to `null` under
+    // `getLatest()` once the node is dropped from the active node map.
+    return this.__inline;
   }
 
   getEquation(): string {


### PR DESCRIPTION
## Description

`EquationNode.isInline()` reads `this.getLatest().__inline`, which throws via the standard `getLatest()` invariant when called on a node reference whose key is no longer in the active node map. The reconciler hits this on every inline-equation removal: `isLastChildLineBreakOrDecorator` runs against `activePrevNodeMap` and calls `node.isInline()` on the prev-state `EquationNode` while the active state is the post-removal one. PR #8534 mentions this as a known limitation and a follow-up against lexical core.

**Reproduction**: insert an inline equation between two text runs (or any inline equation that ends up as a paragraph's last child). Click it to select, press Backspace. The equation removes correctly, but DevTools shows `Lexical node does not exist in active editor state. Avoid using the same node references between nested closures from editorState.read/editor.update.`. Same throw on the empty-LaTeX-input Backspace path inside the editor.

### Fix

Read `__inline` directly. The field is fixed at construction — the constructor sets it once from the `inline ?? false` argument, `clone` and `updateFromJSON` both copy the prev value through, and the class exposes no `setInline` (or equivalent) setter. So routing through `getLatest()` adds no correctness guarantee for this field; dropping it makes `isInline()` safe to call from prev-state node references the reconciler is holding mid-commit.

### Design notes

The root cause is on the lexical-core side: `isLastChildLineBreakOrDecorator` calling a method on a prev-state `DecoratorNode` reference is brittle for any `isInline()` override that does its own `getLatest()` (the lexical idiom for mutable fields). A few core-side directions I looked at:

- **Swap the `prevElement` lookup to use `activeNextNodeMap`.** Single-line change. Tried locally: the diff-comparison semantics shift — a removed last-child decorator collapses to `'empty'` on the prev arm in some cases — and the unit suite surfaced regressions in `LexicalNode.remove`, `LexicalTableNode` Cut-range, Collaboration text deletion, and `LexicalElementNode.getDOMSlot` (11 failures total). Not a drop-in.
- **Two `nodeMap` arguments (type from prev, method from active).** Cleaner in shape, but the prev-detached arm still needs a fallback for `isInline()` it cannot call, which puts you back to guessing inline vs block from prev type alone.
- **Temporary `activeEditorState` swap inside the prev arm.** Method calls would resolve correctly against the prev state. The variable is `LexicalUpdates.ts`-private, so this needs new internal API surface (a `withActiveEditorState(state, callback)` helper or equivalent) — broader surface change than the bug needs on its own.

The application-side change here resolves the EquationNode trigger without committing to one of those core directions. Two caveats. The fix is scoped to EquationNode — a future `DecoratorNode` subclass with mutable inline state and a `getLatest()`-based `isInline()` would hit the same reconciler path. And sidestepping `getLatest()` here goes against lexical's field-accessor idiom, so if `EquationNode.__inline` ever gains a setter the accessor needs to switch back.

## Test plan

- [x] New unit test `packages/lexical-playground/__tests__/unit/EquationNode.test.ts` — detached `EquationNode` reference's `isInline()` no longer throws (regression for the reconciler call site). Verified to fail on the pre-fix `return this.getLatest().__inline` baseline.
- [x] `corepack pnpm exec vitest --project unit --run` — 2594 tests pass / 1 skipped.
- [x] Manual playground:
  - Inline equation between text: click → NodeSelection → Backspace removes the equation, no console error.
  - Inline equation in edit mode: double-click → clear LaTeX → Backspace removes the host node, no console error.
  - Block equation as sole root child: same removal flows, no console error.