### PR TITLE
[lexical] Bug Fix: Cache last-child kind for trailing-<br> reconcile

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -252,6 +252,21 @@ export interface LexicalPrivateDOM {
    */
   __lexicalFirstTextKey?: NodeKey | null | undefined;
   __lexicalLineBreak?: HTMLBRElement | HTMLImageElement | undefined | null;
+  /**
+   * Kind of last child recorded for this element during the previous
+   * reconcile, used by `$reconcileElementTerminatingLineBreak` to decide
+   * whether the trailing-`<br>` shape needs to change without calling
+   * `isInline()` on the prev-state node reference (which would resolve
+   * to a detached node once the last child has been removed in this
+   * commit). Set alongside `setManagedLineBreak` / cleared alongside
+   * `removeManagedLineBreak`.
+   */
+  __lexicalLastChildKind?:
+    | 'line-break'
+    | 'decorator'
+    | 'empty'
+    | null
+    | undefined;
   __lexicalDir?: 'ltr' | 'rtl' | null | undefined;
   __lexicalUnmanaged?: boolean | undefined;
 }

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -561,18 +561,23 @@ function $reconcileElementTerminatingLineBreak(
   nextElement: ElementNode,
   dom: HTMLElement & LexicalPrivateDOM,
 ): void {
-  const prevLineBreak = isLastChildLineBreakOrDecorator(
-    prevElement,
-    activePrevNodeMap,
+  // Read previous render's last-child kind from the slot element's cache
+  // so the prev-state `DecoratorNode` reference's `isInline()` (which
+  // routes through `getLatest()` and would throw once the key is detached
+  // from the active node map) is never called.
+  const slot = activeEditorDOMRenderConfig.$getDOMSlot(
+    nextElement,
+    dom,
+    activeEditor,
   );
+  const slotElement = slot.element as HTMLElement & LexicalPrivateDOM;
+  const prevLineBreak = slotElement.__lexicalLastChildKind ?? null;
   const nextLineBreak = isLastChildLineBreakOrDecorator(
     nextElement,
     activeNextNodeMap,
   );
   if (prevLineBreak !== nextLineBreak) {
-    activeEditorDOMRenderConfig
-      .$getDOMSlot(nextElement, dom, activeEditor)
-      .setManagedLineBreak(nextLineBreak);
+    slot.setManagedLineBreak(nextLineBreak);
   }
 }
 

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -570,7 +570,7 @@ function $reconcileElementTerminatingLineBreak(
     dom,
     activeEditor,
   );
-  const slotElement = slot.element as HTMLElement & LexicalPrivateDOM;
+  const slotElement: HTMLElement & LexicalPrivateDOM = slot.element;
   const prevLineBreak = slotElement.__lexicalLastChildKind ?? null;
   const nextLineBreak = isLastChildLineBreakOrDecorator(
     nextElement,

--- a/packages/lexical/src/__tests__/unit/LexicalReconcilerStaleDecorator.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconcilerStaleDecorator.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createParagraphNode, $getNodeByKey, $getRoot, NodeKey} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import invariant from 'shared/invariant';
+import {describe, expect, test} from 'vitest';
+
+describe('LexicalReconciler — last-child decorator removal', () => {
+  test('does not throw when an inline DecoratorNode is removed as the last child of an element', () => {
+    const errors: Error[] = [];
+    let decoratorKey: NodeKey = '';
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const paragraph = $createParagraphNode();
+        const decorator = $createTestDecoratorNode();
+        paragraph.append(decorator);
+        $getRoot().append(paragraph);
+        decoratorKey = decorator.getKey();
+      },
+      name: 'lexical-reconciler-stale-decorator',
+      nodes: [TestDecoratorNode],
+      onError: error => {
+        errors.push(error);
+      },
+    });
+
+    editor.update(
+      () => {
+        const decorator = $getNodeByKey(decoratorKey);
+        invariant(
+          decorator !== null,
+          'decorator missing — initial state did not commit',
+        );
+        decorator.remove();
+      },
+      {discrete: true},
+    );
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -189,6 +189,8 @@ export class ElementDOMSlot<T extends HTMLElement = HTMLElement> {
   setManagedLineBreak(
     lineBreakType: null | 'empty' | 'line-break' | 'decorator',
   ): void {
+    const element: HTMLElement & LexicalPrivateDOM = this.element;
+    element.__lexicalLastChildKind = lineBreakType;
     if (lineBreakType === null) {
       this.removeManagedLineBreak();
     } else {


### PR DESCRIPTION
## Description

`$reconcileElementTerminatingLineBreak` decides whether an element's trailing-`<br>` shape needs to change by comparing the previous and next render's last-child kind (`line-break` / `decorator` / `empty` / `null`). Before this PR the "previous" answer came from `isLastChildLineBreakOrDecorator(prevElement, activePrevNodeMap)`, which calls `prevElement.getLastChild().isInline()`. For an inline `DecoratorNode` whose `isInline()` routes through `getLatest()` (the standard mutable-field idiom — see `EquationNode` in the playground), that call resolves the node against the active node map. Once the commit has already removed the decorator (the very case we're trying to reconcile), the key is gone and `getLatest()` throws the missing-node invariant.

This PR records the last-child kind on the slot DOM element (`__lexicalLastChildKind`) alongside every `setManagedLineBreak` call, then reads it on the next reconcile instead of recomputing from the prev node. The slot element is the single chokepoint for trailing `<br>` shape, so cache writes and reads stay paired by construction. No `isInline()` call on a prev-state decorator reference.

The DOM-cache shape follows the pattern already in `LexicalPrivateDOM` (`__lexicalLineBreak`, `__lexicalTextContent`, `__lexicalFirstTextKey`, `__lexicalDir`, `__lexicalUnmanaged`) and matches the maintainer's guidance on a related thread: "anything we need to know about the previous render could be cached in the DOM itself."

Follow-up to #8534 (Known limitation: stale `DecoratorNode` reference during trailing-`<br>` reconcile).

## Test plan

- [x] New unit test `LexicalReconcilerStaleDecorator.test.ts` — removes an inline `DecoratorNode` as the last child of a paragraph; before the fix, the reconciler threw the missing-node invariant; after, no errors.
- [x] `pnpm vitest run --project unit` — 2594 passed, 0 failed.
- [x] `pnpm tsc --noEmit -p tsconfig.json` clean.
- [x] `pnpm flow` clean.
- [x] `prettier --check` / `eslint` clean on changed files.
- [x] Playground manual: paste a KaTeX equation, delete it as the last child of a paragraph (the original repro path from #8534) — no console error.