### PR TITLE
[lexical-extension][lexical-playground] Feature: Insert paragraph on click after the last block

### DIFF
--- a/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
+++ b/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createParagraphNode,
+  $getRoot,
+  $isDecoratorNode,
+  $isElementNode,
+  defineExtension,
+  LexicalEditor,
+  LexicalNode,
+  safeCast,
+  stopLexicalPropagation,
+} from 'lexical';
+
+import {namedSignals} from './namedSignals';
+import {effect, type Signal} from './signals';
+
+/**
+ * @experimental
+ *
+ * Default predicate matches {@link DecoratorNode} and shadow-root
+ * `ElementNode`s (e.g. `TableNode`). Apps that want to also trigger on
+ * other node types — `CodeNode`, custom non-editable blocks — should
+ * compose this default in their own predicate rather than re-deriving
+ * the check:
+ *
+ * ```ts
+ * configExtension(ClickAfterLastBlockExtension, {
+ *   $shouldInsertAfter: (node) =>
+ *     $defaultShouldInsertAfter(node) || $isCodeNode(node),
+ * });
+ * ```
+ */
+export function $defaultShouldInsertAfter(node: LexicalNode): boolean {
+  if ($isDecoratorNode(node)) {
+    return true;
+  }
+  if ($isElementNode(node) && node.isShadowRoot()) {
+    return true;
+  }
+  return false;
+}
+
+export interface ClickAfterLastBlockConfig {
+  /** Set to `true` to disable this extension. */
+  disabled: boolean;
+  /**
+   * Called inside the editor update with the last child of the root when
+   * the user clicks the empty area below it. Return `true` to insert a
+   * new paragraph after that node and select it; return `false` to leave
+   * the click alone. Default is {@link $defaultShouldInsertAfter} — see
+   * its docs for composition patterns.
+   */
+  $shouldInsertAfter: (node: LexicalNode) => boolean;
+}
+
+export interface ClickAfterLastBlockOutput {
+  /** Set to `true` to disable this extension. */
+  disabled: Signal<boolean>;
+  /** Predicate signal — see {@link ClickAfterLastBlockConfig.$shouldInsertAfter}. */
+  $shouldInsertAfter: Signal<(node: LexicalNode) => boolean>;
+}
+
+/**
+ * Decide whether a click at `event` should be claimed by this extension.
+ * Used by both the mousedown listener (to call preventDefault on the
+ * browser's native caret pick) and the click listener (to actually
+ * insert the paragraph). Factored out so the two handlers stay in sync
+ * — they would otherwise share ~22 lines of byte-for-byte identical
+ * logic and have to be maintained together.
+ *
+ * Read-only because it is called outside an editor.update; mutation
+ * happens in the click handler's editor.update below.
+ */
+function shouldClaimClick(
+  editor: LexicalEditor,
+  rootElement: HTMLElement,
+  event: MouseEvent,
+  $shouldInsertAfter: (node: LexicalNode) => boolean,
+): boolean {
+  if (!editor.isEditable()) {
+    return false;
+  }
+  // Only react to clicks on the root container itself. A click inside
+  // an existing block is handled by the normal caret placement path.
+  if (event.target !== rootElement) {
+    return false;
+  }
+  return editor.getEditorState().read(
+    () => {
+      const lastChild = $getRoot().getLastChild();
+      if (lastChild === null) {
+        return false;
+      }
+      const lastChildDOM = editor.getElementByKey(lastChild.getKey());
+      if (lastChildDOM === null) {
+        return false;
+      }
+      // Exclusive lower edge — clicks at exactly the bottom pixel fall
+      // through to native handling, which is what users expect when
+      // they click on a block's visible bottom border.
+      if (event.clientY <= lastChildDOM.getBoundingClientRect().bottom) {
+        return false;
+      }
+      return $shouldInsertAfter(lastChild);
+    },
+    {editor},
+  );
+}
+
+/**
+ * Click handling for the empty area below the last block of the document.
+ *
+ * Without this extension, clicking the area below the last block when that
+ * block is a {@link DecoratorNode}, a shadow-root ElementNode (e.g.
+ * `TableNode`), or any other block that doesn't accept the click naturally
+ * leaves the selection in an awkward place — `null` for a bare decorator,
+ * or at the end of a table cell. Users typically expect a new paragraph
+ * to appear below the block with the caret in it, matching the behavior
+ * of editors like Notion.
+ *
+ * This extension intercepts clicks under those conditions, inserts a new
+ * empty paragraph after the last block, and selects it.
+ *
+ * Closes #8544.
+ */
+export const ClickAfterLastBlockExtension = defineExtension({
+  build: (_editor, config): ClickAfterLastBlockOutput => namedSignals(config),
+  config: safeCast<ClickAfterLastBlockConfig>({
+    $shouldInsertAfter: $defaultShouldInsertAfter,
+    disabled: false,
+  }),
+  name: '@lexical/ClickAfterLastBlock',
+  register: (editor, _config, _state) =>
+    effect(() => {
+      const output = _state.getOutput();
+      if (output.disabled.value) {
+        return;
+      }
+      return editor.registerRootListener(rootElement => {
+        if (rootElement === null) {
+          return;
+        }
+        // Two-phase: cancel native caret-pick at the earliest browser
+        // event (mousedown), then claim the click for our own paragraph
+        // insert. Without the mousedown leg the browser places a caret
+        // on the previous text block before our editor.update lands,
+        // visible as a one-frame cursor flicker.
+        //
+        // Side effect to be aware of: cancelling mousedown also cancels
+        // native focus on that click. The subsequent paragraph.select()
+        // inside editor.update DOM-focuses the root through the
+        // reconciler, so the net effect is the same focused root, but
+        // we are now responsible for the focus transition rather than
+        // the browser.
+        //
+        // lexical core has a `pointerdown` listener that flips a
+        // module-level `isSelectionChangeFromMouseDown` flag consumed
+        // on the next selectionchange (LexicalEvents.ts). preventing
+        // mousedown means no native selectionchange fires for this
+        // click, so the flag never gets a chance to be consumed in the
+        // wrong cycle. If you swap mousedown for pointerdown here you
+        // also have to revisit that interaction.
+        const onMouseDown = (event: MouseEvent) => {
+          if (
+            shouldClaimClick(
+              editor,
+              rootElement,
+              event,
+              output.$shouldInsertAfter.peek(),
+            )
+          ) {
+            event.preventDefault();
+          }
+        };
+
+        const onClick = (event: MouseEvent) => {
+          if (
+            !shouldClaimClick(
+              editor,
+              rootElement,
+              event,
+              output.$shouldInsertAfter.peek(),
+            )
+          ) {
+            return;
+          }
+          event.preventDefault();
+          // Tell lexical's root click handler to skip this event so the
+          // default caret-placement logic in LexicalEvents.onClick exits
+          // early. Without this the previous text block briefly receives
+          // the caret before our paragraph insert lands.
+          stopLexicalPropagation(event);
+          editor.update(() => {
+            const lastChild = $getRoot().getLastChild();
+            if (lastChild === null) {
+              return;
+            }
+            // Re-check inside the update — predicate may flip between
+            // read and update if external transforms run.
+            if (!output.$shouldInsertAfter.peek()(lastChild)) {
+              return;
+            }
+            const paragraph = $createParagraphNode();
+            lastChild.insertAfter(paragraph);
+            paragraph.select();
+          });
+        };
+
+        // Capture phase so the mousedown preventDefault runs before any
+        // bubble-phase handler can react, and so the click flag is set
+        // before lexical core's bubble-phase onClick reads it.
+        rootElement.addEventListener('mousedown', onMouseDown, true);
+        rootElement.addEventListener('click', onClick, true);
+        return () => {
+          rootElement.removeEventListener('mousedown', onMouseDown, true);
+          rootElement.removeEventListener('click', onClick, true);
+        };
+      });
+    }),
+});

--- a/packages/lexical-extension/src/__tests__/unit/ClickAfterLastBlock.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/ClickAfterLastBlock.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  configExtension,
+  defineExtension,
+  type LexicalNode,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
+
+import {ClickAfterLastBlockExtension} from '../../ClickAfterLastBlockExtension';
+
+function setUpEditor(
+  options: {
+    disabled?: boolean;
+    $shouldInsertAfter?: (node: LexicalNode) => boolean;
+    withInitialChildren?: boolean;
+  } = {},
+) {
+  const {
+    disabled = false,
+    $shouldInsertAfter,
+    withInitialChildren = true,
+  } = options;
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: withInitialChildren
+        ? () => {
+            const root = $getRoot();
+            // Block-level TestDecoratorNode at the end of the document,
+            // to exercise the same path Equation / PageBreak hit in the
+            // playground.
+            const decorator = $createTestDecoratorNode().setIsInline(false);
+            root.append(
+              $createParagraphNode().append($createTextNode('hello')),
+              decorator,
+            );
+          }
+        : () => {},
+      dependencies: [
+        RichTextExtension,
+        configExtension(ClickAfterLastBlockExtension, {
+          disabled,
+          ...($shouldInsertAfter ? {$shouldInsertAfter} : {}),
+        }),
+      ],
+      name: 'click-after-last-block-test',
+      nodes: [TestDecoratorNode],
+      register: editor => {
+        const rootElement = document.createElement('div');
+        document.body.appendChild(rootElement);
+        editor.setRootElement(rootElement);
+        return () => rootElement.remove();
+      },
+    }),
+  );
+}
+
+function dispatchMouseEvent(
+  type: 'mousedown' | 'click',
+  rootElement: HTMLElement,
+  clientY: number,
+): MouseEvent {
+  // jsdom's getBoundingClientRect returns all-zero, so any positive
+  // clientY satisfies the "below the last block" check.
+  // dispatchEvent already sets event.target = rootElement.
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientY,
+  });
+  rootElement.dispatchEvent(event);
+  return event;
+}
+
+describe('ClickAfterLastBlockExtension', () => {
+  test('inserts a paragraph after the last block when the last child is a block decorator', () => {
+    using editor = setUpEditor();
+    const root = editor.getRootElement()!;
+    const initialChildren = editor.read(() => $getRoot().getChildrenSize());
+    expect(initialChildren).toBe(2);
+
+    dispatchMouseEvent('mousedown', root, 100);
+    dispatchMouseEvent('click', root, 100);
+
+    editor.read(() => {
+      const rootNode = $getRoot();
+      expect(rootNode.getChildrenSize()).toBe(3);
+      const lastChild: LexicalNode | null = rootNode.getLastChild();
+      assert(
+        lastChild !== null && $isParagraphNode(lastChild),
+        'last child after click should be an empty paragraph',
+      );
+      expect(lastChild.isEmpty()).toBe(true);
+    });
+  });
+
+  test('does nothing when the predicate rejects the last child', () => {
+    using editor = setUpEditor({$shouldInsertAfter: () => false});
+    const root = editor.getRootElement()!;
+
+    dispatchMouseEvent('mousedown', root, 100);
+    dispatchMouseEvent('click', root, 100);
+
+    editor.read(() => {
+      // Predicate refused → original 2 children stay.
+      expect($getRoot().getChildrenSize()).toBe(2);
+    });
+  });
+
+  test('respects disabled config', () => {
+    using editor = setUpEditor({disabled: true});
+    const root = editor.getRootElement()!;
+
+    dispatchMouseEvent('mousedown', root, 100);
+    dispatchMouseEvent('click', root, 100);
+
+    editor.read(() => {
+      // Disabled → original 2 children stay.
+      expect($getRoot().getChildrenSize()).toBe(2);
+    });
+  });
+
+  test('does nothing in read-only mode', () => {
+    using editor = setUpEditor();
+    const root = editor.getRootElement()!;
+    editor.setEditable(false);
+
+    dispatchMouseEvent('mousedown', root, 100);
+    dispatchMouseEvent('click', root, 100);
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(2);
+    });
+  });
+
+  test('does nothing on an empty root with no last child', () => {
+    using editor = setUpEditor({withInitialChildren: false});
+    const root = editor.getRootElement()!;
+
+    dispatchMouseEvent('mousedown', root, 100);
+    dispatchMouseEvent('click', root, 100);
+
+    editor.read(() => {
+      // No crash, no insertion.
+      expect($getRoot().getChildrenSize()).toBe(0);
+    });
+  });
+});

--- a/packages/lexical-extension/src/index.ts
+++ b/packages/lexical-extension/src/index.ts
@@ -12,6 +12,12 @@ export {
   ClearEditorExtension,
   registerClearEditor,
 } from './ClearEditorExtension';
+export {
+  $defaultShouldInsertAfter,
+  type ClickAfterLastBlockConfig,
+  ClickAfterLastBlockExtension,
+  type ClickAfterLastBlockOutput,
+} from './ClickAfterLastBlockExtension';
 export {getKnownTypesAndNodes, type KnownTypesAndNodes} from './config';
 export {
   $isDecoratorTextNode,

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -6,9 +6,12 @@
  *
  */
 
+import {$isCodeNode} from '@lexical/code';
 import {
+  $defaultShouldInsertAfter,
   AutoFocusExtension,
   ClearEditorExtension,
+  ClickAfterLastBlockExtension,
   DecoratorTextExtension,
   HorizontalRuleExtension,
   SelectionAlwaysOnDisplayExtension,
@@ -205,6 +208,10 @@ const AppExtension = defineExtension({
     ClickableLinkExtension,
     SelectionAlwaysOnDisplayExtension,
     TerseExportExtension,
+    configExtension(ClickAfterLastBlockExtension, {
+      $shouldInsertAfter: node =>
+        $defaultShouldInsertAfter(node) || $isCodeNode(node),
+    }),
   ],
   html: buildHTMLConfig(),
   name: '@lexical/playground',

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -978,6 +978,7 @@ declare export function $isParagraphNode(
  * LexicalUtils
  */
 export type EventHandler = (event: Event, editor: LexicalEditor) => void;
+declare export function stopLexicalPropagation(event: Event): void;
 declare export function $hasUpdateTag(tag: UpdateTag): boolean;
 declare export function $addUpdateTag(tag: UpdateTag): void;
 declare export function $onUpdate(updateFn: () => void): void;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1508,7 +1508,8 @@ function onDocumentSelectionChange(event: Event): void {
   }
 }
 
-function stopLexicalPropagation(event: Event): void {
+/** @internal */
+export function stopLexicalPropagation(event: Event): void {
   // We attach a special property to ensure the same event doesn't re-fire
   // for parent editors.
   // @ts-ignore

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -183,6 +183,7 @@ export type {
 } from './LexicalEditorState';
 export {$isEditorState} from './LexicalEditorState';
 export type {EventHandler} from './LexicalEvents';
+export {stopLexicalPropagation} from './LexicalEvents';
 export type {
   BaseStaticNodeConfig,
   DOMChildConversion,


### PR DESCRIPTION
## Description

Closes #8544. When a `DecoratorNode`, a shadow-root `ElementNode` like `TableNode`, or a `CodeNode` sits at the end of the document, clicking the empty area below it currently puts the selection somewhere unexpected — `null` for a bare decorator, the end of a cell for a table, the end of the last line for a code block. Most editors (Notion, etc.) interpret that gesture as "make a paragraph here and let me type", and that's what this PR ships.

`ClickAfterLastBlockExtension` intercepts the click — both mousedown (to cancel the browser's native caret placement before it picks the previous text block) and click (to mark `_lexicalHandled` so lexical core skips its default onClick, then run `editor.update` to insert and select an empty paragraph). The two-phase shape was the only way to eliminate a one-frame cursor flicker on the previous text block; comments at the listener spot out the side effects to be aware of — focus transition ownership now lives with the extension, and lexical core's `isSelectionChangeFromMouseDown` flag never gets set for these clicks.

The trigger condition lives in a `$shouldInsertAfter` config callback, defaulting to `$defaultShouldInsertAfter` which matches `DecoratorNode` and shadow-root `ElementNode`. The default is exported so consumers extending the behavior — the playground composes it with `$isCodeNode` to cover the third type listed in the issue — don't re-derive the check. `@lexical/code-core` is intentionally kept out of `@lexical/extension`'s dependencies; the composition lives at the call site.

## Test plan

- [x] `pnpm vitest run --project unit -t ClickAfterLastBlock` — 5 unit tests: positive insertion, predicate-false skip, `disabled: true`, read-only mode, empty-root no-op.
- [x] `pnpm tsc --noEmit -p tsconfig.json` clean.
- [x] `pnpm flow` clean.
- [x] `prettier --check` / `eslint` clean on changed files.
- [x] Manual on Chrome and Safari playground:
  - Equation (block) / Table / Code / PageBreak at end-of-doc — clicking below inserts a paragraph and the caret lands there with no flicker on the previous block.
  - Plain paragraph / heading / list at end-of-doc — extension stays out of the way, native caret placement runs.
  - Read-only mode — no insertion.
  - Click directly on the last block or its content area — no insertion (target check).
  - After the extension inserts a paragraph, clicking below it again does nothing (last child is a paragraph, predicate rejects).
  - Typing in the inserted paragraph works normally.