### PR TITLE
[lexical-clipboard] Feature: Add replaceContentWithRichText and $insertRichTextFromText helpers

### DIFF
--- a/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
+++ b/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
@@ -9,6 +9,7 @@
 
 import type {
   BaseSelection,
+  EditorUpdateOptions,
   LexicalEditor,
   RangeSelection,
   LexicalNode,
@@ -22,6 +23,17 @@ declare export function $insertDataTransferForRichText(
   dataTransfer: DataTransfer,
   selection: BaseSelection,
   editor: LexicalEditor,
+): void;
+
+declare export function $insertRichTextFromText(
+  text: string,
+  selection: BaseSelection,
+): void;
+
+declare export function replaceContentWithRichText(
+  editor: LexicalEditor,
+  text: string,
+  options?: EditorUpdateOptions,
 ): void;
 
 declare export function $getHtmlContent(

--- a/packages/lexical-clipboard/src/__tests__/unit/insertRichTextFromText.test.ts
+++ b/packages/lexical-clipboard/src/__tests__/unit/insertRichTextFromText.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $insertRichTextFromText,
+  replaceContentWithRichText,
+} from '@lexical/clipboard';
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  $isTabNode,
+  $isTextNode,
+  HISTORY_MERGE_TAG,
+  TextNode,
+} from 'lexical';
+import invariant from 'shared/invariant';
+import {describe, expect, it} from 'vitest';
+
+function createEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [RichTextExtension],
+      name: '[insert-rich-text-from-text-test]',
+    }),
+  );
+}
+
+function $paragraphTextAt(index: number): string {
+  const paragraph = $getRoot().getChildAtIndex(index);
+  invariant(
+    paragraph !== null && $isParagraphNode(paragraph),
+    'expected paragraph at index %s',
+    String(index),
+  );
+  return paragraph.getTextContent();
+}
+
+describe('$insertRichTextFromText', () => {
+  it('splits multi-line text into separate paragraphs', () => {
+    using editor = createEditor();
+    editor.update(
+      () =>
+        $insertRichTextFromText(
+          'first\nsecond\nthird',
+          $getRoot().clear().select(),
+        ),
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(3);
+      expect($paragraphTextAt(0)).toBe('first');
+      expect($paragraphTextAt(1)).toBe('second');
+      expect($paragraphTextAt(2)).toBe('third');
+    });
+  });
+
+  it('handles Windows-style CRLF newlines the same as LF', () => {
+    using editor = createEditor();
+    editor.update(
+      () => $insertRichTextFromText('a\r\nb', $getRoot().clear().select()),
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(2);
+      expect($paragraphTextAt(0)).toBe('a');
+      expect($paragraphTextAt(1)).toBe('b');
+    });
+  });
+
+  it('inserts a TabNode for tab characters', () => {
+    using editor = createEditor();
+    editor.update(
+      () => $insertRichTextFromText('a\tb', $getRoot().clear().select()),
+      {discrete: true},
+    );
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      invariant($isParagraphNode(paragraph), 'expected paragraph');
+      const children = paragraph.getChildren();
+      expect(children).toHaveLength(3);
+      invariant($isTextNode(children[0]), 'expected text');
+      invariant($isTabNode(children[1]), 'expected tab');
+      invariant($isTextNode(children[2]), 'expected text');
+      expect(children[0].getTextContent()).toBe('a');
+      expect(children[2].getTextContent()).toBe('b');
+    });
+  });
+
+  it('preserves $insertDataTransferForRichText behavior for trailing newline (paragraph break is honored)', () => {
+    using editor = createEditor();
+    editor.update(
+      () => $insertRichTextFromText('only\n', $getRoot().clear().select()),
+      {discrete: true},
+    );
+    editor.read(() => {
+      // Trailing newline yields a paragraph break; the helper does not
+      // collapse it. Matches the legacy plain-text paste path.
+      expect($getRoot().getChildrenSize()).toBe(2);
+      expect($paragraphTextAt(0)).toBe('only');
+      expect($paragraphTextAt(1)).toBe('');
+    });
+  });
+
+  it('inserts nothing for an empty string input', () => {
+    using editor = createEditor();
+    editor.update(
+      () => $insertRichTextFromText('', $getRoot().clear().select()),
+      {discrete: true},
+    );
+    editor.read(() => {
+      // After clear() the root has zero children; an empty input must not
+      // add any. The stronger assertion catches a future regression that
+      // would start inserting a paragraph on empty input.
+      expect($getRoot().getChildrenSize()).toBe(0);
+    });
+  });
+});
+
+describe('replaceContentWithRichText', () => {
+  it('clears existing content and inserts paragraphs', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createParagraphNode().append($createTextNode('previous')));
+      },
+      {discrete: true},
+    );
+
+    replaceContentWithRichText(editor, 'fresh\nlines');
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(2);
+      expect($paragraphTextAt(0)).toBe('fresh');
+      expect($paragraphTextAt(1)).toBe('lines');
+    });
+  });
+
+  it('runs node transforms on the inserted text', () => {
+    using editor = createEditor();
+    // Simulate the issue #7876 use case: a transform that rewrites a token.
+    // Unlike `setEditorState`, the insertText path the helper takes routes
+    // through the normal transform pipeline.
+    editor.registerNodeTransform(TextNode, node => {
+      const text = node.getTextContent();
+      if (text.includes('{{name}}')) {
+        node.setTextContent(text.replace('{{name}}', 'Ada'));
+      }
+    });
+
+    replaceContentWithRichText(editor, 'hello {{name}}');
+
+    editor.read(() => {
+      expect($paragraphTextAt(0)).toBe('hello Ada');
+    });
+  });
+
+  it('forwards update options to editor.update (HISTORY_MERGE_TAG case)', () => {
+    using editor = createEditor();
+    const tags: Set<string>[] = [];
+    editor.registerUpdateListener(({tags: updateTags}) => {
+      tags.push(new Set(updateTags));
+    });
+
+    replaceContentWithRichText(editor, 'restored', {
+      discrete: true,
+      tag: HISTORY_MERGE_TAG,
+    });
+
+    // The most recent update should carry the merge tag so history
+    // extensions can fold it into the previous entry on boot-time restore.
+    const last = tags[tags.length - 1];
+    expect(last.has(HISTORY_MERGE_TAG)).toBe(true);
+  });
+});

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -38,6 +38,7 @@ import {
   COMMAND_PRIORITY_CRITICAL,
   COPY_COMMAND,
   defineExtension,
+  EditorUpdateOptions,
   getDOMSelection,
   isSelectionWithinEditor,
   LexicalEditor,
@@ -138,6 +139,46 @@ export function $insertDataTransferForPlainText(
 }
 
 /**
+ * Inserts plain text into the editor at the provided selection, splitting on
+ * newlines and tabs so multi-line text becomes separate paragraphs (matching
+ * the rich-text paste behavior) rather than a single paragraph with line
+ * breaks (which is what {@link RangeSelection.insertRawText} produces).
+ *
+ * For non-range selections this falls back to `selection.insertRawText(text)`
+ * since paragraph splitting only makes sense inside a block context. Empty
+ * input is a no-op.
+ *
+ * @param text the plain text to insert
+ * @param selection the selection to use as the insertion point
+ */
+export function $insertRichTextFromText(
+  text: string,
+  selection: BaseSelection,
+): void {
+  if (!$isRangeSelection(selection)) {
+    selection.insertRawText(text);
+    return;
+  }
+  const parts = text.split(/(\r?\n|\t)/);
+  if (parts[parts.length - 1] === '') {
+    parts.pop();
+  }
+  for (let i = 0; i < parts.length; i++) {
+    const currentSelection = $getSelection();
+    if ($isRangeSelection(currentSelection)) {
+      const part = parts[i];
+      if (part === '\n' || part === '\r\n') {
+        currentSelection.insertParagraph();
+      } else if (part === '\t') {
+        currentSelection.insertNodes([$createTabNode()]);
+      } else {
+        currentSelection.insertText(part);
+      }
+    }
+  }
+}
+
+/**
  * Attempts to insert content of the mime-types application/x-lexical-editor, text/html,
  * text/plain, or text/uri-list (in descending order of priority) from the provided DataTransfer
  * object into the editor at the provided selection.
@@ -188,33 +229,38 @@ export function $insertDataTransferForRichText(
     }
   }
 
-  // Multi-line plain text in rich text mode pasted as separate paragraphs
-  // instead of single paragraph with linebreaks.
+  // Multi-line plain text in rich text mode is split into separate paragraphs
+  // rather than a single paragraph with linebreaks; see $insertRichTextFromText.
   // Webkit-specific: Supports read 'text/uri-list' in clipboard.
   const text = plainString || dataTransfer.getData('text/uri-list');
   if (text != null) {
-    if ($isRangeSelection(selection)) {
-      const parts = text.split(/(\r?\n|\t)/);
-      if (parts[parts.length - 1] === '') {
-        parts.pop();
-      }
-      for (let i = 0; i < parts.length; i++) {
-        const currentSelection = $getSelection();
-        if ($isRangeSelection(currentSelection)) {
-          const part = parts[i];
-          if (part === '\n' || part === '\r\n') {
-            currentSelection.insertParagraph();
-          } else if (part === '\t') {
-            currentSelection.insertNodes([$createTabNode()]);
-          } else {
-            currentSelection.insertText(part);
-          }
-        }
-      }
-    } else {
-      selection.insertRawText(text);
-    }
+    $insertRichTextFromText(text, selection);
   }
+}
+
+/**
+ * Replaces all content in the editor's root with the given plain text, split
+ * on newlines and tabs so each line becomes its own paragraph (with tab nodes
+ * preserved). Use this — instead of `editor.setEditorState` — when restoring
+ * from a plain-text store and you want node transforms (e.g. mention/variable
+ * detection) to run on the inserted text. The trade-off vs `setEditorState`
+ * is that each line is inserted through the normal pipeline (per-paragraph
+ * insert + transforms) rather than a single state reconciliation.
+ *
+ * @param editor the LexicalEditor whose root content is being replaced
+ * @param text the plain text to insert in place of the existing content
+ * @param options forwarded to the underlying `editor.update` (e.g. pass
+ *   `{tag: HISTORY_MERGE_TAG}` to avoid creating a separate history entry
+ *   when restoring on boot)
+ */
+export function replaceContentWithRichText(
+  editor: LexicalEditor,
+  text: string,
+  options?: EditorUpdateOptions,
+): void {
+  editor.update(() => {
+    $insertRichTextFromText(text, $getRoot().clear().select());
+  }, options);
 }
 
 const LEXICAL_DRAG_MIME_TYPE = 'application/x-lexical-drag';

--- a/packages/lexical-clipboard/src/index.ts
+++ b/packages/lexical-clipboard/src/index.ts
@@ -18,6 +18,7 @@ export {
   $insertDataTransferForPlainText,
   $insertDataTransferForRichText,
   $insertGeneratedNodes,
+  $insertRichTextFromText,
   $writeDragSourceToDataTransfer,
   copyToClipboard,
   type ExportMimeTypeConfig,
@@ -25,5 +26,6 @@ export {
   type GetClipboardDataConfig,
   GetClipboardDataExtension,
   type LexicalClipboardData,
+  replaceContentWithRichText,
   setLexicalClipboardDataTransfer,
 } from './clipboard';


### PR DESCRIPTION
## Description

Adds two helpers to `@lexical/clipboard` for inserting plain text as paragraph-aware rich text, addressing issue #7876.

`$insertRichTextFromText(text, selection)` is the low-level primitive — it splits multi-line text on newlines and tabs so each line becomes its own paragraph (with `TabNode` for `\t`), mirroring the paragraph-aware behavior already buried in the `$insertDataTransferForRichText` plain-text branch. Non-`RangeSelection` falls back to `selection.insertRawText(text)` since paragraph splitting only makes sense inside a block context.

`replaceContentWithRichText(editor, text, options?)` is the high-level wrapper — it clears the root and inserts the text via the low-level helper. The `options` arg forwards to `editor.update` so callers restoring from a plain-text store on boot can pass `{tag: HISTORY_MERGE_TAG}` to fold the restore into existing history rather than creating a new entry. The signature mirrors `editor.setEditorState(state, options)` for that reason; `InitialStateExtension.ts` uses the same `HISTORY_MERGE_OPTIONS = {tag: HISTORY_MERGE_TAG}` shape for the equivalent boot-time path.

The use case from #7876: a Vue app stores plain text in the DB and restores by calling `setEditorState` with a manually constructed `EditorState`. The transform path (e.g. `{{varName}}` → `VariableNode`) is skipped because `setEditorState` is a state replace, not a content insert. Routing the restore through `replaceContentWithRichText` instead runs the inserted text through the normal insert pipeline and transforms fire.

### Notes

- The paragraph-aware split logic already existed inline in `$insertDataTransferForRichText`'s plain-text branch. With the same primitive now publicly exported, that branch calls the helper to avoid duplicating the implementation.
- Your snippet on the issue thread (`replaceStateWithText`) was marked untested, so I took the API as a sketch rather than the literal target signature. The `options` arg falls out of the `editor.setEditorState(state, options)` precedent — drop it if you'd rather keep the minimum surface.

Closes #7876

## Test plan

- [x] `pnpm vitest run --project unit` — 2605/2605 pass, 1 skipped.
- [x] New unit tests at `packages/lexical-clipboard/src/__tests__/unit/insertRichTextFromText.test.ts` (8 cases):
  - multi-line LF split, CRLF parity, tab → `TabNode`
  - trailing-newline behavior preserved from the original branch
  - empty-string input no-ops (children count stays 0)
  - `replaceContentWithRichText` clears existing content
  - transform pipeline runs on inserted text (the #7876 case, verified end-to-end)
  - `options` arg forwards to `editor.update` (`HISTORY_MERGE_TAG` in the update listener's tags)
- [x] tsc / eslint / prettier clean.
- [x] Flow couldn't run locally (env version 0.312 vs config 0.314, also fails on main). The flow declarations follow the existing pattern in the file.