### PR TITLE
[lexical-website] Bug Fix: Fix crash on /docs/error page from undefined process

### DIFF
--- a/packages/lexical-website/docusaurus.config.ts
+++ b/packages/lexical-website/docusaurus.config.ts
@@ -347,7 +347,7 @@ const config: Config = {
     './plugins/webpack-buffer',
     async function webpackLexicalModules() {
       return {
-        configureWebpack() {
+        configureWebpack(_config, _isServer, {currentBundler}) {
           const alias: Record<string, string | false | string[]> = {
             ...buildLexicalWebpackAliases(),
             '@examples/agent-example': path.resolve(
@@ -393,7 +393,19 @@ const config: Config = {
             'onnxruntime-node': false,
             sharp: false,
           };
-          return {resolve: {alias}};
+          return {
+            plugins: [
+              // FB_INTERNAL only exists in Meta's internal build. Define it for
+              // the browser bundle so client code (e.g. ErrorCodePage) can read
+              // process.env.FB_INTERNAL without a ReferenceError on `process`.
+              new currentBundler.instance.DefinePlugin({
+                'process.env.FB_INTERNAL': JSON.stringify(
+                  process.env.FB_INTERNAL ?? '',
+                ),
+              }),
+            ],
+            resolve: {alias},
+          };
         },
         name: 'webpack-lexical-modules',
       };

--- a/packages/lexical-website/src/components/ErrorCodePage.tsx
+++ b/packages/lexical-website/src/components/ErrorCodePage.tsx
@@ -42,7 +42,11 @@ function ErrorFinder() {
   const [codes, setCodes] = useState<ErrorCodes | null>(null);
 
   useEffect(() => {
-    if (!process.env.FB_INTERNAL) {
+    const isFBInternal =
+      typeof process !== 'undefined' &&
+      process.env != null &&
+      Boolean(process.env.FB_INTERNAL);
+    if (!isFBInternal) {
       import('../../../../scripts/error-codes/codes.json').then(module =>
         setCodes(module as unknown as ErrorCodes),
       );

--- a/packages/lexical-website/src/components/ErrorCodePage.tsx
+++ b/packages/lexical-website/src/components/ErrorCodePage.tsx
@@ -42,11 +42,7 @@ function ErrorFinder() {
   const [codes, setCodes] = useState<ErrorCodes | null>(null);
 
   useEffect(() => {
-    const isFBInternal =
-      typeof process !== 'undefined' &&
-      process.env != null &&
-      Boolean(process.env.FB_INTERNAL);
-    if (!isFBInternal) {
+    if (!process.env.FB_INTERNAL) {
       import('../../../../scripts/error-codes/codes.json').then(module =>
         setCodes(module as unknown as ErrorCodes),
       );


### PR DESCRIPTION
## Description

The minified production build of Lexical points users to
`https://lexical.dev/docs/error?code=N` for the full error text, but that
page crashes on load.

`ErrorCodePage` reads `process.env.FB_INTERNAL` in browser code to decide
whether to load `scripts/error-codes/codes.json`. The OSS Docusaurus build
never defines `process` for the client bundle (only `Buffer` is polyfilled,
and `customFields` doesn't expose it), so the access throws
`ReferenceError: process is not defined` and the page never renders.

This PR defines the token at build time via the bundler's `DefinePlugin` in
`docusaurus.config.ts`, so `process.env.FB_INTERNAL` is statically replaced
in the browser bundle (`""` in OSS, honoring the env var if it is set). The
`ErrorCodePage` source is left unchanged, matching what Meta's internal
bundler already expects.

Closes #8556

## Test plan

### Before

Visiting `/docs/error?code=94` crashes with
`Uncaught ReferenceError: process is not defined`. Workaround is running
`process = {env:{}}` in the console and clicking "try again".

### After

https://lexical-git-fork-etrepum-claude-lexical-web-fbcf0a-fbopensource.vercel.app/docs/error?code=94 does not crash

`pnpm -C packages/lexical-website run build` succeeds, and the compiled
error-page chunk contains no `process` reference and no `FB_INTERNAL`
string. The `useEffect` compiles to an unconditional dynamic import of the
codes chunk:

```js
useEffect(() => { t.e("3595").then(t.t.bind(t, 45078, 19)).then(e => r(e)) }, [])
```

The codes chunk builds and includes code `94`, so visiting
`/docs/error?code=94` now renders the full error message instead of
crashing.