### PR TITLE
[lexical][lexical-rich-text][lexical-code-core] Bug Fix: Cursor stuck before leading inline DecoratorNode

### DIFF
--- a/packages/lexical-code-core/src/CodeIndentation.ts
+++ b/packages/lexical-code-core/src/CodeIndentation.ts
@@ -446,6 +446,14 @@ function $handleMoveTo(
   const direction = $getCodeLineDirection(focusLineNode);
   const moveToStart = direction === 'rtl' ? !isMoveToStart : isMoveToStart;
 
+  // Shift variant: let the non-shift branches resolve the target via
+  // framework helpers (`selectNext` / `selectStart` / `setTextNodeRange` /
+  // `node.select`), then restore the original anchor so we end up with an
+  // extended selection rather than a collapsed caret. This keeps point
+  // shapes (text vs. element) consistent between shift and non-shift.
+  const originalAnchorKey = anchor.key;
+  const originalAnchorOffset = anchor.offset;
+  const originalAnchorType = anchor.type;
   if (moveToStart) {
     const start = $getStartOfCodeInLine(focusLineNode, focus.offset);
     if (start !== null) {
@@ -461,6 +469,13 @@ function $handleMoveTo(
   } else {
     const node = $getEndOfCodeInLine(focusLineNode);
     node.select();
+  }
+  if (event.shiftKey) {
+    selection.anchor.set(
+      originalAnchorKey,
+      originalAnchorOffset,
+      originalAnchorType,
+    );
   }
 
   event.preventDefault();

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
@@ -579,6 +579,52 @@ describe('LexicalCodeNode tests', () => {
             );
           });
         });
+
+        test('Shift+MOVE_TO_END preserves anchor and extends focus', async () => {
+          const {editor} = testEnv;
+          await setupRTLCode(editor);
+          const event = new KeyboardEventMock('keydown');
+          event.shiftKey = true;
+
+          const before = editor.read(() => {
+            const s = $getSelection();
+            invariant($isRangeSelection(s));
+            return {key: s.anchor.key, offset: s.anchor.offset};
+          });
+
+          editor.dispatchCommand(MOVE_TO_END, event);
+
+          editor.read(() => {
+            const selection = $getSelection();
+            invariant($isRangeSelection(selection));
+            expect(selection.isCollapsed()).toBe(false);
+            expect(selection.anchor.key).toBe(before.key);
+            expect(selection.anchor.offset).toBe(before.offset);
+          });
+        });
+
+        test('Shift+MOVE_TO_START preserves anchor and extends focus', async () => {
+          const {editor} = testEnv;
+          await setupRTLCode(editor);
+          const event = new KeyboardEventMock('keydown');
+          event.shiftKey = true;
+
+          const before = editor.read(() => {
+            const s = $getSelection();
+            invariant($isRangeSelection(s));
+            return {key: s.anchor.key, offset: s.anchor.offset};
+          });
+
+          editor.dispatchCommand(MOVE_TO_START, event);
+
+          editor.read(() => {
+            const selection = $getSelection();
+            invariant($isRangeSelection(selection));
+            expect(selection.isCollapsed()).toBe(false);
+            expect(selection.anchor.key).toBe(before.key);
+            expect(selection.anchor.offset).toBe(before.offset);
+          });
+        });
       });
 
       for (const moveTo of ['start', 'end']) {

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createHeadingNode, RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  LexicalEditor,
+  MOVE_TO_END,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
+
+function dispatchMoveToEnd(editor: LexicalEditor, shiftKey: boolean) {
+  editor.dispatchCommand(
+    MOVE_TO_END,
+    new KeyboardEvent('keydown', {ctrlKey: true, key: 'ArrowRight', shiftKey}),
+  );
+}
+
+function snapshotSelection(editor: LexicalEditor) {
+  return editor.read(() => {
+    const s = $getSelection();
+    if (!$isRangeSelection(s)) {
+      return null;
+    }
+    return {
+      anchor: [s.anchor.type, s.anchor.key, s.anchor.offset],
+      focus: [s.focus.type, s.focus.key, s.focus.offset],
+    };
+  });
+}
+
+describe('MOVE_TO_END on a leading inline DecoratorNode (Issue #8555)', () => {
+  test('Cmd+ArrowRight at offset 0 moves caret past the inline decorator', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToEnd(editor, false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.focus.type).toBe('text');
+      expect(selection.focus.offset).toBe('hello'.length);
+    });
+  });
+
+  test('Shift+Cmd+ArrowRight at offset 0 selects to end of element', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToEnd(editor, true);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.isCollapsed()).toBe(false);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.offset).toBe(0);
+      expect(selection.focus.offset).toBe('hello'.length);
+    });
+  });
+
+  test('Same fix applies inside HeadingNode', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('world');
+        const heading = $createHeadingNode('h1').append(decorator, text);
+        $getRoot().clear().append(heading);
+        heading.select(0, 0);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToEnd(editor, false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.focus.offset).toBe('world'.length);
+    });
+  });
+});
+
+describe('MOVE_TO_END no-op cases (Issue #8555)', () => {
+  test.for([
+    {
+      label: 'first child is text, not a decorator',
+      setup: () => {
+        const text = $createTextNode('plain');
+        const paragraph = $createParagraphNode().append(text);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+    },
+    {
+      label: 'first child is a block (non-inline) decorator',
+      setup: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(false);
+        const text = $createTextNode('after');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+    },
+    {
+      label: 'caret is past offset 0',
+      setup: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(1, 1);
+      },
+    },
+  ])('no-op: $label', ({setup}) => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: setup,
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    const before = snapshotSelection(editor);
+
+    dispatchMoveToEnd(editor, false);
+
+    expect(snapshotSelection(editor)).toEqual(before);
+  });
+});

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createHeadingNode, RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  LexicalEditor,
+  MOVE_TO_START,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
+
+function dispatchMoveToStart(editor: LexicalEditor, shiftKey: boolean) {
+  editor.dispatchCommand(
+    MOVE_TO_START,
+    new KeyboardEvent('keydown', {ctrlKey: true, key: 'ArrowLeft', shiftKey}),
+  );
+}
+
+function snapshotSelection(editor: LexicalEditor) {
+  return editor.read(() => {
+    const s = $getSelection();
+    if (!$isRangeSelection(s)) {
+      return null;
+    }
+    return {
+      anchor: [s.anchor.type, s.anchor.key, s.anchor.offset],
+      focus: [s.focus.type, s.focus.key, s.focus.offset],
+    };
+  });
+}
+
+describe('MOVE_TO_START on a leading inline DecoratorNode (Issue #8555)', () => {
+  test('Cmd+ArrowLeft from text caret moves caret before the inline decorator', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        text.select(3, 3);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToStart(editor, false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.offset).toBe(0);
+    });
+  });
+
+  test('Shift+Cmd+ArrowLeft selects from text caret back to element start', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        text.select(5, 5);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToStart(editor, true);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.isCollapsed()).toBe(false);
+      expect(selection.anchor.type).toBe('text');
+      expect(selection.anchor.offset).toBe(5);
+      expect(selection.focus.type).toBe('element');
+      expect(selection.focus.offset).toBe(0);
+    });
+  });
+
+  test('Same fix applies inside HeadingNode', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('world');
+        const heading = $createHeadingNode('h1').append(decorator, text);
+        $getRoot().clear().append(heading);
+        text.select(2, 2);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToStart(editor, false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.offset).toBe(0);
+    });
+  });
+});
+
+describe('MOVE_TO_START no-op cases (Issue #8555)', () => {
+  test.for([
+    {
+      label: 'first child is text, not a decorator',
+      setup: () => {
+        const text = $createTextNode('plain');
+        const paragraph = $createParagraphNode().append(text);
+        $getRoot().clear().append(paragraph);
+        text.select(3, 3);
+      },
+    },
+    {
+      label: 'first child is a block (non-inline) decorator',
+      setup: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(false);
+        const text = $createTextNode('after');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        text.select(2, 2);
+      },
+    },
+    {
+      label: 'caret already at element offset 0',
+      setup: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+    },
+  ])('no-op: $label', ({setup}) => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: setup,
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    const before = snapshotSelection(editor);
+
+    dispatchMoveToStart(editor, false);
+
+    expect(snapshotSelection(editor)).toEqual(before);
+  });
+});

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -110,6 +110,8 @@ import {
   KEY_ESCAPE_COMMAND,
   KEY_SPACE_COMMAND,
   KEY_TAB_COMMAND,
+  MOVE_TO_END,
+  MOVE_TO_START,
   OUTDENT_CONTENT_COMMAND,
   PASTE_COMMAND,
   PASTE_TAG,
@@ -1359,6 +1361,91 @@ export function registerRichText(
         }
 
         return false;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand<KeyboardEvent>(
+      MOVE_TO_END,
+      event => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          return false;
+        }
+        const {anchor} = selection;
+        if (anchor.type !== 'element' || anchor.offset !== 0) {
+          return false;
+        }
+        const element = anchor.getNode();
+        if (!$isElementNode(element)) {
+          return false;
+        }
+        const firstChild = element.getFirstChild();
+        if (!$isDecoratorNode(firstChild) || !firstChild.isInline()) {
+          return false;
+        }
+        // Native browser cursor traversal stops at the inline decorator's
+        // contenteditable=false boundary when the caret starts at element
+        // offset 0, so MOVE_TO_END leaves the caret stuck. Move it ourselves.
+        const elementKey = element.getKey();
+        const ending = element.selectEnd();
+        if (event.shiftKey) {
+          ending.anchor.set(elementKey, 0, 'element');
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand<KeyboardEvent>(
+      MOVE_TO_START,
+      event => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          return false;
+        }
+        const {anchor, focus} = selection;
+        const focusBlock = $findMatchingParent(
+          focus.getNode(),
+          (node): node is ElementNode =>
+            $isElementNode(node) && !node.isInline(),
+        );
+        if (focusBlock === null) {
+          return false;
+        }
+        const firstChild = focusBlock.getFirstChild();
+        if (!$isDecoratorNode(firstChild) || !firstChild.isInline()) {
+          return false;
+        }
+        // Cross-block selections fall through to native handling. The
+        // Chromium boundary bug only matters when both endpoints sit
+        // inside the block whose first child is the inline decorator.
+        const anchorBlock = $findMatchingParent(
+          anchor.getNode(),
+          (node): node is ElementNode =>
+            $isElementNode(node) && !node.isInline(),
+        );
+        if (anchorBlock !== focusBlock) {
+          return false;
+        }
+        const blockKey = focusBlock.getKey();
+        if (
+          focus.type === 'element' &&
+          focus.key === blockKey &&
+          focus.offset === 0
+        ) {
+          return false;
+        }
+        // Symmetric to the MOVE_TO_END case: Chromium stops the native
+        // caret at the inline decorator's contenteditable=false boundary
+        // when moving backwards, so element offset 0 is unreachable.
+        selection.focus.set(blockKey, 0, 'element');
+        if (!event.shiftKey) {
+          selection.anchor.set(blockKey, 0, 'element');
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        return true;
       },
       COMMAND_PRIORITY_EDITOR,
     ),

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1148,7 +1148,10 @@ export function isMoveBackward(event: KeyboardEventModifiers): boolean {
 }
 
 export function isMoveToStart(event: KeyboardEventModifiers): boolean {
-  return isExactShortcutMatch(event, 'ArrowLeft', CONTROL_OR_META);
+  return isExactShortcutMatch(event, 'ArrowLeft', {
+    ...CONTROL_OR_META,
+    shiftKey: 'any',
+  });
 }
 
 export function isMoveForward(event: KeyboardEventModifiers): boolean {
@@ -1158,7 +1161,10 @@ export function isMoveForward(event: KeyboardEventModifiers): boolean {
 }
 
 export function isMoveToEnd(event: KeyboardEventModifiers): boolean {
-  return isExactShortcutMatch(event, 'ArrowRight', CONTROL_OR_META);
+  return isExactShortcutMatch(event, 'ArrowRight', {
+    ...CONTROL_OR_META,
+    shiftKey: 'any',
+  });
 }
 
 export function isMoveUp(event: KeyboardEventModifiers): boolean {

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -27,6 +27,7 @@ import {
   SerializedTextNode,
   TextNode,
 } from 'lexical';
+import {IS_APPLE} from 'shared/environment';
 import {describe, expect, test, vi} from 'vitest';
 
 import {
@@ -36,6 +37,8 @@ import {
   getTextDirection,
   isArray,
   isExactShortcutMatch,
+  isMoveToEnd,
+  isMoveToStart,
   scheduleMicroTask,
   scrollIntoViewIfNeeded,
 } from '../../LexicalUtils';
@@ -318,6 +321,46 @@ describe('LexicalUtils tests', () => {
       expect(isExactShortcutMatch(eventWithoutCtrl, 'a', {ctrlKey: true})).toBe(
         false,
       );
+    });
+
+    test('isMoveToEnd() / isMoveToStart() accept Shift modifier', () => {
+      const modifier = IS_APPLE ? {metaKey: true} : {ctrlKey: true};
+
+      const rightWithoutShift = new KeyboardEvent('keydown', {
+        ...modifier,
+        key: 'ArrowRight',
+      });
+      const rightWithShift = new KeyboardEvent('keydown', {
+        ...modifier,
+        key: 'ArrowRight',
+        shiftKey: true,
+      });
+      const leftWithoutShift = new KeyboardEvent('keydown', {
+        ...modifier,
+        key: 'ArrowLeft',
+      });
+      const leftWithShift = new KeyboardEvent('keydown', {
+        ...modifier,
+        key: 'ArrowLeft',
+        shiftKey: true,
+      });
+
+      expect(isMoveToEnd(rightWithoutShift)).toBe(true);
+      expect(isMoveToEnd(rightWithShift)).toBe(true);
+      expect(isMoveToStart(leftWithoutShift)).toBe(true);
+      expect(isMoveToStart(leftWithShift)).toBe(true);
+
+      // Wrong direction rejected
+      expect(isMoveToEnd(leftWithoutShift)).toBe(false);
+      expect(isMoveToStart(rightWithoutShift)).toBe(false);
+
+      // Extra Alt modifier rejected
+      const rightWithAlt = new KeyboardEvent('keydown', {
+        ...modifier,
+        altKey: true,
+        key: 'ArrowRight',
+      });
+      expect(isMoveToEnd(rightWithAlt)).toBe(false);
     });
 
     test('isTokenOrSegmented()', async () => {


### PR DESCRIPTION
## Description

When a paragraph (or heading) starts with an inline `DecoratorNode` and the caret is at element offset 0, pressing Cmd/Ctrl+ArrowRight leaves the caret stuck in front of the decorator. The Shift variant is also stuck — selection never extends past the decorator boundary. The symmetric backwards case is also broken in Chromium: with the caret inside the trailing text, Cmd/Ctrl+ArrowLeft stops at the decorator's right edge instead of reaching element offset 0. Safari handles the backwards case correctly.

Root cause: the decorator renders as `contenteditable=false`, so the native caret can't move past its boundary. And the Shift variants don't even reach the relevant lexical commands because `isMoveToEnd` / `isMoveToStart` matching masks omit `shiftKey: 'any'`.

### What changed

- `packages/lexical/src/LexicalUtils.ts` — `isMoveToEnd` / `isMoveToStart` masks now include `shiftKey: 'any'`, aligning them with `isMoveForward` / `isMoveBackward`. Shift variants now dispatch `MOVE_TO_END` / `MOVE_TO_START` instead of being dropped at the matcher.
- `packages/lexical-rich-text/src/index.ts` — registers two `COMMAND_PRIORITY_EDITOR` listeners. `MOVE_TO_END` fires when anchor sits at element offset 0 and the block's first child is an inline `DecoratorNode`; it moves selection to the element end, with the Shift variant pinning anchor at element offset 0. `MOVE_TO_START` fires when the block's first child is an inline `DecoratorNode` and selection endpoints are within the same block; it moves focus to element offset 0, with the Shift variant preserving anchor. Cross-block selections fall through to native handling.
- `packages/lexical-code-core/src/CodeIndentation.ts` — `$handleMoveTo` now resolves the target via the existing framework helpers (`selectNext` / `selectStart` / `setTextNodeRange` / `node.select`), then restores the original anchor when `event.shiftKey` is set. Without this, the mask change would regress Shift+Cmd+Home/End inside code blocks to a collapsed caret.

### Backwards compatibility

`isMoveToEnd` / `isMoveToStart` are exported. Any external listener registered on `MOVE_TO_END` / `MOVE_TO_START` will now also receive Shift events; collapse-only handlers may need to branch on `event.shiftKey`. Matches the pre-existing shape of `isMoveForward` / `isMoveBackward`, so the omission looks unintentional, not deliberate.

### Known limitation

For a leading-inline-`DecoratorNode` paragraph that soft-wraps to a second visual line, the `MOVE_TO_START` handler unconditionally targets element offset 0 (block start) rather than the visual line start. Lexical state doesn't track visual lines, so the handler can't tell them apart. Out of scope for #8555 (single-line caret case); leaving as-is unless it surfaces in practice.

### Open question

The non-Shift `MOVE_TO_START` caret lands as an element-type point (`block`, offset 0), because no text node exists before the inline decorator to anchor on. `MOVE_TO_END` non-Shift caret stays text-type via `element.selectEnd()` since the last descendant is a text node. The asymmetry is intentional — each shape is the natural representation of its target. If one type is preferred, `MOVE_TO_END` can be flipped to element-type to match.

Closes #8555

## Test plan

- [x] `pnpm test-unit -- packages/lexical packages/lexical-rich-text packages/lexical-code packages/lexical-code-core` — all green (3231 passed, +10 new tests covering Shift / no-op / heading / mask matching / code-block regression).
- [x] `pnpm tsc` clean.
- [x] Manual on Chrome:
  - `<inline equation><text>` paragraph, caret at element offset 0 → Cmd+ArrowRight moves caret to text end; Cmd+Shift+ArrowRight selects equation + text.
  - Same paragraph, caret inside text → Cmd+ArrowLeft moves caret to element offset 0 (before equation); Cmd+Shift+ArrowLeft extends selection from text back to element offset 0.
  - Heading with same structure → same behaviors.
  - Two-paragraph mouse drag (P1 with leading inline decorator, P2 plain) → Cmd+(Shift+)ArrowLeft falls through to native, not overridden.
  - Code block, caret mid-line → Cmd+Shift+End / Shift+Home extend selection to line end / start.
- [x] Manual on Safari:
  - Same scenarios above — no regression. Cmd+ArrowLeft was already correct on Safari without this fix; the new handler produces the same result.