### PR TITLE
[lexical] Bug Fix: Skip $reconcileChildren fast path during full reconcile

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -971,6 +971,19 @@ function $reconcileChildren(
   const sizeDelta = nextChildrenSize - prevChildrenSize;
   if (
     !__benchOnly.skipChildrenFastPath &&
+    // A FULL_RECONCILE (e.g. `setEditorState`, which backs history
+    // undo/redo) swaps the whole node map wholesale without routing
+    // structural changes through `getWritable()`, so `_cloneNotNeeded`
+    // is empty even when prev and next children differ by key. That
+    // breaks the `sizeDelta === 0` walk below, which starts at
+    // `prevElement.__first` but advances via the next map's `__next`
+    // pointers — assuming both lists hold the same keys in the same
+    // order. With a same-size key swap (undo replacing a CodeNode with
+    // the paragraphs it came from) the walk reaches a next-only key and
+    // `$reconcileNode` throws on the missing prev node (#8563). Dirty
+    // tracking is meaningless in this mode anyway, so fall through to the
+    // general key-diffing path.
+    !treatAllNodesAsDirty &&
     Math.abs(sizeDelta) <= 1 &&
     prevChildrenSize >= MIN_FAST_PATH_CHILDREN &&
     prevElement.__first === nextElement.__first &&

--- a/packages/lexical/src/__tests__/unit/Issue8563Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue8563Repro.test.ts
@@ -6,26 +6,10 @@
  *
  */
 
-import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {buildEditorFromExtensions} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import {describe, expect, test} from 'vitest';
-
-// Attaches a root element so DOM reconciliation runs, and returns a dispose
-// that detaches it. `buildEditorFromExtensions` disposal calls both this
-// cleanup and `editor.setRootElement(null)`, so a `using` editor tears the
-// whole thing down at end of scope.
-const TestRootElementExtension = defineExtension({
-  name: 'issue-8563-root',
-  register(editor) {
-    const root = document.createElement('div');
-    document.body.appendChild(root);
-    editor.setRootElement(root);
-    return () => {
-      document.body.removeChild(root);
-    };
-  },
-});
 
 // Regression test for https://github.com/facebook/lexical/issues/8563
 //
@@ -43,12 +27,16 @@ describe('Issue #8563: full reconcile with same-size child key swap', () => {
   test('undo (setEditorState) does not crash when a child is replaced by a different-key child of equal count', () => {
     const errors: Error[] = [];
     using editor = buildEditorFromExtensions({
-      dependencies: [RichTextExtension, TestRootElementExtension],
+      dependencies: [RichTextExtension],
       name: 'issue-8563-repro',
       onError: e => {
         errors.push(e);
       },
     });
+    // A root element makes DOM reconciliation run; the crash is in node-map
+    // lookups so the element does not need to be attached to the document.
+    // `using` disposal calls setRootElement(null).
+    editor.setRootElement(document.createElement('div'));
 
     // State A: enough children to engage the fast path (>= 4).
     editor.update(

--- a/packages/lexical/src/__tests__/unit/Issue8563Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue8563Repro.test.ts
@@ -6,10 +6,26 @@
  *
  */
 
-import {buildEditorFromExtensions} from '@lexical/extension';
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
-import {afterEach, describe, expect, test} from 'vitest';
+import {describe, expect, test} from 'vitest';
+
+// Attaches a root element so DOM reconciliation runs, and returns a dispose
+// that detaches it. `buildEditorFromExtensions` disposal calls both this
+// cleanup and `editor.setRootElement(null)`, so a `using` editor tears the
+// whole thing down at end of scope.
+const TestRootElementExtension = defineExtension({
+  name: 'issue-8563-root',
+  register(editor) {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    editor.setRootElement(root);
+    return () => {
+      document.body.removeChild(root);
+    };
+  },
+});
 
 // Regression test for https://github.com/facebook/lexical/issues/8563
 //
@@ -24,39 +40,25 @@ import {afterEach, describe, expect, test} from 'vitest';
 // pointers and reached a key that only exists in the next state, throwing
 // `reconcileNode: prevNode or nextNode does not exist in nodeMap`.
 describe('Issue #8563: full reconcile with same-size child key swap', () => {
-  let cleanup: (() => void) | null = null;
-  afterEach(() => {
-    if (cleanup) {
-      cleanup();
-      cleanup = null;
-    }
-  });
-
   test('undo (setEditorState) does not crash when a child is replaced by a different-key child of equal count', () => {
     const errors: Error[] = [];
-    const editor = buildEditorFromExtensions({
-      dependencies: [RichTextExtension],
+    using editor = buildEditorFromExtensions({
+      dependencies: [RichTextExtension, TestRootElementExtension],
       name: 'issue-8563-repro',
       onError: e => {
         errors.push(e);
       },
     });
-    const root = document.createElement('div');
-    document.body.appendChild(root);
-    editor.setRootElement(root);
-    cleanup = () => {
-      editor.setRootElement(null);
-      document.body.removeChild(root);
-      editor.dispose();
-    };
 
     // State A: enough children to engage the fast path (>= 4).
     editor.update(
       () => {
-        const r = $getRoot();
-        r.clear();
+        const root = $getRoot();
+        root.clear();
         for (let i = 0; i < 5; i++) {
-          r.append($createParagraphNode().append($createTextNode(`line ${i}`)));
+          root.append(
+            $createParagraphNode().append($createTextNode(`line ${i}`)),
+          );
         }
       },
       {discrete: true},

--- a/packages/lexical/src/__tests__/unit/Issue8563Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue8563Repro.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {afterEach, describe, expect, test} from 'vitest';
+
+// Regression test for https://github.com/facebook/lexical/issues/8563
+//
+// Undo applies the previous editor state via `setEditorState`, which runs a
+// FULL_RECONCILE without routing any structural change through
+// `getWritable()`. That leaves `_cloneNotNeeded` empty, which the
+// `sizeDelta === 0` children fast path used as its signal that the parent's
+// children were structurally unchanged (same keys in the same order). When a
+// child is replaced by a different-key child of equal count (e.g. undo turning
+// a code block back into the paragraphs it was made from), the fast path
+// walked from `prevElement.__first` while following the *next* map's `__next`
+// pointers and reached a key that only exists in the next state, throwing
+// `reconcileNode: prevNode or nextNode does not exist in nodeMap`.
+describe('Issue #8563: full reconcile with same-size child key swap', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    if (cleanup) {
+      cleanup();
+      cleanup = null;
+    }
+  });
+
+  test('undo (setEditorState) does not crash when a child is replaced by a different-key child of equal count', () => {
+    const errors: Error[] = [];
+    const editor = buildEditorFromExtensions({
+      dependencies: [RichTextExtension],
+      name: 'issue-8563-repro',
+      onError: e => {
+        errors.push(e);
+      },
+    });
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    editor.setRootElement(root);
+    cleanup = () => {
+      editor.setRootElement(null);
+      document.body.removeChild(root);
+      editor.dispose();
+    };
+
+    // State A: enough children to engage the fast path (>= 4).
+    editor.update(
+      () => {
+        const r = $getRoot();
+        r.clear();
+        for (let i = 0; i < 5; i++) {
+          r.append($createParagraphNode().append($createTextNode(`line ${i}`)));
+        }
+      },
+      {discrete: true},
+    );
+    const stateA = editor.getEditorState();
+
+    // State B: replace only the last child, keeping the count at 5 and the
+    // first child key unchanged. This is the shape an undo of a block
+    // transform produces (a same-size child swap at the end of root).
+    editor.update(
+      () => {
+        $getRoot()
+          .getLastChildOrThrow()
+          .replace($createParagraphNode().append($createTextNode('replaced')));
+      },
+      {discrete: true},
+    );
+
+    // Undo: restore state A. FULL_RECONCILE from B with a same-size,
+    // different-last-key children list — used to crash reconciliation.
+    editor.setEditorState(stateA);
+
+    expect(errors).toEqual([]);
+    expect(editor.read(() => $getRoot().getTextContent())).toBe(
+      'line 0\n\nline 1\n\nline 2\n\nline 3\n\nline 4',
+    );
+    expect(editor.getRootElement()!.textContent).toBe(
+      'line 0line 1line 2line 3line 4',
+    );
+  });
+});


### PR DESCRIPTION
## Description

The sizeDelta===0 children fast path walks from prevElement.__first while following the next node map's __next pointers, assuming prev and next children share the same keys in the same order. It gated that assumption on _cloneNotNeeded, but a FULL_RECONCILE (setEditorState, which backs history undo/redo) swaps the node map wholesale without routing changes through getWritable(), leaving _cloneNotNeeded empty even when children differ by key. Undoing a markdown code-block transform produces a same-size child key swap, so the walk reached a next-only key and threw "reconcileNode: prevNode or nextNode does not exist in nodeMap" during reconciliation.

Gate the fast path on !treatAllNodesAsDirty so full reconciles fall through to the general key-diffing path.

Closes #8563

## Test plan

New unit tests