### PR TITLE
[lexical-playground] Bug Fix: Build dev playground in development mode

### DIFF
--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host --port 3000",
-    "build-dev": "vite build",
+    "build-dev": "vite build --mode development",
     "build-prod": "vite build --mode production",
     "build-vercel": "(cd ../../ && node ./scripts/build.mjs) && pnpm run build-dev",
     "preview": "vite preview --port 4000 --host"

--- a/packages/lexical-playground/vite.config.ts
+++ b/packages/lexical-playground/vite.config.ts
@@ -26,15 +26,17 @@ export default defineConfig(({mode}) => ({
       },
     },
     target: 'es2022',
-    ...(mode === 'production' && {
-      minify: 'terser',
-      terserOptions: {
-        compress: {
-          toplevel: true,
-        },
-        keep_classnames: true,
-      },
-    }),
+    ...(mode === 'production'
+      ? {
+          minify: 'terser',
+          terserOptions: {
+            compress: {
+              toplevel: true,
+            },
+            keep_classnames: true,
+          },
+        }
+      : {minify: false}),
   },
   plugins: [
     viteMonorepoResolutionPlugin(),


### PR DESCRIPTION
## Description

I'm pretty sure we had playground building in dev a while ago, which made debugging and issue reports easier. This restores that.

`vite build` defaults to `--mode production`, so the `build-dev` script (used by `build-vercel` to deploy playground.lexical.dev) was actually producing a production build: terser-minified, with Lexical invariant messages replaced by "Minified Lexical error #NNN" codes and __DEV__ warnings stripped. This made the public playground's tracebacks unreadable despite being intended as the non-minified dev environment.

Pass `--mode development` so the playground resolves the development builds of the Lexical packages and keeps full error messages, and set `minify: false` for non-production builds (Vite's default minifier is esbuild, which would otherwise still minify the output).
