### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/packages/lexical-website/docusaurus.config.ts
+++ b/packages/lexical-website/docusaurus.config.ts
@@ -419,6 +419,7 @@ const config: Config = {
         ],
       },
     ],
+    'docusaurus-plugin-copy-page-button',
   ].filter(plugin => plugin != null),
   presets: [
     [

--- a/packages/lexical-website/package.json
+++ b/packages/lexical-website/package.json
@@ -37,6 +37,7 @@
     "@mermaid-js/layout-elk": "^0.2.1",
     "@radix-ui/react-tabs": "^1.1.13",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.7.0",
     "docusaurus-plugin-typedoc": "^1.4.2",
     "fs-extra": "^11.3.4",
     "lexical": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1001,6 +1001,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      docusaurus-plugin-copy-page-button:
+        specifier: ^0.7.0
+        version: 0.7.0(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7))(@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react@19.2.5)
       docusaurus-plugin-typedoc:
         specifier: ^1.4.2
         version: 1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)))
@@ -6896,6 +6899,13 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  docusaurus-plugin-copy-page-button@0.7.0:
+    resolution: {integrity: sha512-2YGcDHlgGjTuemVVqSBV7C7myT3aKo7PiNIPJH1zwy0ltE41qgS+wFHmEH8202SrQaszu9DYiAFEJ/TAGAL0WQ==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
+      react: 19.2.5
 
   docusaurus-plugin-typedoc@1.4.2:
     resolution: {integrity: sha512-1qerRejLSYxEWdyVPLDMMeKFPLA/37yZAsdwJy9ThHFQR78+v3b5spSbk67VHGLr2mAn4FVHu0aGJ6p7iWotSg==}
@@ -14706,7 +14716,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.2.5)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.15
       react: 19.2.5
 
   '@docusaurus/theme-classic@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.15)(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
@@ -19890,6 +19900,11 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  docusaurus-plugin-copy-page-button@0.7.0(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7))(@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react@19.2.5):
+    dependencies:
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7))(@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      react: 19.2.5
 
   docusaurus-plugin-typedoc@1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3))):
     dependencies:


### PR DESCRIPTION
## Summary

Adds [`docusaurus-plugin-copy-page-button`](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) to the Lexical docs site so readers can copy any page as clean markdown — useful when piping editor state, node types, or plugin architecture context into ChatGPT, Claude, Perplexity, or Gemini.

The plugin auto-injects a small "Copy page" button + dropdown into the doc page's table-of-contents area. The dropdown offers:

- Copy as markdown
- View as markdown
- Open in ChatGPT / Claude / Perplexity / Gemini

Live preview of the UI: https://portdeveloper.github.io/copy-page-button-showcase/

## Adoption

The plugin currently ships on docs sites for React Native (via facebook/react-native-website#5085), PlayCanvas, Puppeteer, Arbitrum, Cardano, Sui, Ethereum execution-apis, and others — full list in the [project README](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button#used-by).

## Changes

- Added `'docusaurus-plugin-copy-page-button'` to the `plugins` array in `packages/lexical-website/docusaurus.config.ts`
- Added `docusaurus-plugin-copy-page-button@^0.7.0` to `packages/lexical-website/dependencies`
- Resulting `pnpm-lock.yaml` updates

## Notes

I did not run the full `pnpm -C ../.. run build && docusaurus build` locally — that builds every workspace package first, which is expensive. The plugin add is a single string in the `plugins` array, matching the pattern landed in facebook/react-native-website#5085 and playcanvas/developer-site#991. Happy to provide a CI-friendly verification if useful.


I used my agents to generate this PR, please let me know if you have any further questions! I will be replying asap 🙏 