### PR TITLE
[lexical] Bug Fix: Correct children fast-path text size for cross-parent-moved elements

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -66,10 +66,12 @@ type IntentionallyMarkedAsDirtyElement = boolean;
  * so all instances share the same V8 hidden-class shape and the setter is
  * a stable inline cache hit instead of a per-instance shape transition.
  *
- * ElementNodes already carry their computed text content in
- * `dom.__lexicalTextContent` (written at the end of `$reconcileChildren`),
- * so we never set this on ElementNodes — `$cachedTextSize` routes them to
- * the DOM cache instead.
+ * ElementNodes are NOT stored here: an element can be dirty without being
+ * cloned (a descendant edit marks ancestors dirty via
+ * `internalMarkParentElementsAsDirty` but does not `getWritable()` them), so
+ * the same — DEV-frozen — instance would need its size rewritten when its
+ * text changes, which the skip-if-set guard cannot do. Element sizes come
+ * from `dom.__lexicalTextContent` instead (see `$cachedTextSize`).
  *
  * Leaf writes are skipped when the slot is already not `undefined`. The
  * setter is only re-entered for the same instance via cross-parent moves
@@ -90,17 +92,39 @@ type IntentionallyMarkedAsDirtyElement = boolean;
  */
 export const CACHED_TEXT_SIZE_KEY = Symbol.for('@lexical/CachedTextSize');
 
-function $cachedTextSize(node: LexicalNode): number {
-  if ($isElementNode(node)) {
-    const keyedDom = activePrevKeyToDOMMap.get(node.__key);
-    const cached = keyedDom && keyedDom.__lexicalTextContent;
-    invariant(
-      typeof cached === 'string',
-      'cachedTextSize: missing __lexicalTextContent for ElementNode of type %s',
-      node.getType(),
-    );
-    return cached.length;
+// Previous-cycle text size of a node, computed entirely from the previous
+// node map. Used for an element that moved to a different parent this cycle:
+// its keyed `dom.__lexicalTextContent` is shared between prev and next and is
+// overwritten in place when the element is reconciled under its NEW parent —
+// which, if that parent reconciles first, happens before its OLD parent's
+// suffix walk reads it (see https://github.com/facebook/lexical/pull/8564 for
+// the sibling fast-path hazard). Walking the prev map avoids both that stale
+// read and the `getLatest()` -> next-state trap. Leaf sizes still come from
+// the per-instance cache on the previous-state leaf instances.
+function $prevTextContentSize(node: LexicalNode): number {
+  if (!$isElementNode(node)) {
+    return $leafCachedTextSize(node);
   }
+  let size = 0;
+  let childKey: NodeKey | null = node.__first;
+  let i = 0;
+  const lastIndex = node.__size - 1;
+  while (childKey !== null) {
+    const child = activePrevNodeMap.get(childKey);
+    if (child === undefined) {
+      break;
+    }
+    size += $prevTextContentSize(child);
+    if (i < lastIndex && $isElementNode(child) && !child.isInline()) {
+      size += DOUBLE_LINE_BREAK.length;
+    }
+    childKey = child.__next;
+    i++;
+  }
+  return size;
+}
+
+function $leafCachedTextSize(node: LexicalNode): number {
   const cached = node[CACHED_TEXT_SIZE_KEY];
   // $reconcileNode and $createNode set the size on every leaf they touch, so a
   // missing entry here means the invariant was broken upstream. Falling back to
@@ -113,6 +137,33 @@ function $cachedTextSize(node: LexicalNode): number {
     node.__key,
   );
   return cached;
+}
+
+function $cachedTextSize(node: LexicalNode): number {
+  if ($isElementNode(node)) {
+    // An element that moved to a different parent this cycle may have already
+    // been reconciled under its new parent, overwriting the shared keyed-DOM
+    // text cache with its NEW size. Recover the previous-cycle size from the
+    // prev node map instead. (`__parent === null` means detached/removed, not
+    // moved — its DOM cache is still its prev text.)
+    const nextNode = activeNextNodeMap.get(node.__key);
+    if (
+      nextNode !== undefined &&
+      $isElementNode(nextNode) &&
+      nextNode.__parent !== node.__parent
+    ) {
+      return $prevTextContentSize(node);
+    }
+    const keyedDom = activePrevKeyToDOMMap.get(node.__key);
+    const cached = keyedDom && keyedDom.__lexicalTextContent;
+    invariant(
+      typeof cached === 'string',
+      'cachedTextSize: missing __lexicalTextContent for ElementNode of type %s',
+      node.getType(),
+    );
+    return cached.length;
+  }
+  return $leafCachedTextSize(node);
 }
 
 function $setCachedTextSize(node: LexicalNode): void {

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -92,29 +92,31 @@ type IntentionallyMarkedAsDirtyElement = boolean;
  */
 export const CACHED_TEXT_SIZE_KEY = Symbol.for('@lexical/CachedTextSize');
 
+// Previous-cycle text size of a suffix child, for the `oldSuffixLength`
+// computation that decides how much of the parent's cached text to splice out.
+//
+// MUST run inside `activePrevEditorState.read(...)` (see `$prevSuffixTextSize`):
+// the moved-element branch and any `isInline()` the caller pairs with this call
+// resolve node methods through `getLatest()`, which is only safe against the
+// PREVIOUS node map. Reading the previous state there avoids both the
+// `getLatest()` -> next-state trap and the throw on a node that no longer
+// exists in the next state.
 function $cachedTextSize(node: LexicalNode): number {
   if ($isElementNode(node)) {
     // An element that moved to a different parent this cycle may have already
     // been reconciled under its new parent, overwriting the shared keyed-DOM
-    // text cache (`dom.__lexicalTextContent`) with its NEW size before this
-    // (old) parent's suffix walk reads it — the sibling fast-path hazard from
-    // https://github.com/facebook/lexical/pull/8564. Recover the previous size
-    // by reading it from the previous editor state, where `getChildren()` /
-    // `isInline()` resolve against the prev tree (so we neither read the
-    // forward-mutated DOM cache nor hit the `getLatest()` -> next-state trap
-    // that an `isInline()` call on a detached prev node would, cf. #8548).
-    // `ElementNode.getTextContentSize()` applies the same double-line-break
-    // rule as the reconciler's cache, so the value matches. (`__parent ===
-    // null` means detached/removed, not moved — its DOM cache is still valid.)
+    // text cache with its NEW size (see
+    // https://github.com/facebook/lexical/pull/8564 for the sibling fast-path
+    // hazard). Recompute its previous size from the previous editor state
+    // instead. (`__parent === null` means detached/removed, not moved — its DOM
+    // cache is still its prev text.)
     const nextNode = activeNextNodeMap.get(node.__key);
     if (
       nextNode !== undefined &&
       $isElementNode(nextNode) &&
       nextNode.__parent !== node.__parent
     ) {
-      return activePrevEditorState.read(() => node.getTextContentSize(), {
-        editor: activeEditor,
-      });
+      return node.getTextContentSize();
     }
     const keyedDom = activePrevKeyToDOMMap.get(node.__key);
     const cached = keyedDom && keyedDom.__lexicalTextContent;
@@ -137,6 +139,40 @@ function $cachedTextSize(node: LexicalNode): number {
     node.__key,
   );
   return cached;
+}
+
+// Total previous-render text length of the `count` suffix children starting at
+// `startKey` (in next-map order, which equals prev order across the size-0 and
+// size-±1 fast paths). This is the slice length removed from the parent's
+// cached text before the freshly reconciled suffix is appended.
+//
+// The whole walk runs inside `activePrevEditorState.read(...)` so that every
+// node method resolves against the PREVIOUS node map: `isInline()` returns the
+// node's previous-render value (a moved or re-typed node could answer
+// differently in the next state, and a node removed this cycle would throw),
+// and the moved-element branch of `$cachedTextSize` can recompute via
+// `getTextContentSize()`. Non-moved elements and leaves still read their O(1)
+// caches, so a large untouched suffix child is not re-walked.
+function $prevSuffixTextSize(startKey: NodeKey, count: number): number {
+  return activePrevEditorState.read(
+    () => {
+      let size = 0;
+      let cur: NodeKey | null = startKey;
+      for (let i = 0; i < count && cur !== null; i++) {
+        const prevNode = activePrevNodeMap.get(cur);
+        if (prevNode === undefined) {
+          break;
+        }
+        size += $cachedTextSize(prevNode);
+        if (i < count - 1 && $isElementNode(prevNode) && !prevNode.isInline()) {
+          size += DOUBLE_LINE_BREAK.length;
+        }
+        cur = prevNode.__next;
+      }
+      return size;
+    },
+    {editor: activeEditor},
+  );
 }
 
 function $setCachedTextSize(node: LexicalNode): void {
@@ -836,17 +872,10 @@ function $tryReconcileSuffixWithSizeDelta(
     ops.push({key: nextSuffixKeys[ni], kind: 'create', nextIndex: ni});
     ni++;
   }
-  let oldSuffixLength = 0;
-  for (let i = 0; i < kPrime; i++) {
-    const prevNode = activePrevNodeMap.get(prevSuffixKeys[i]);
-    if (prevNode === undefined) {
-      return false;
-    }
-    oldSuffixLength += $cachedTextSize(prevNode);
-    if (i < kPrime - 1 && $isElementNode(prevNode) && !prevNode.isInline()) {
-      oldSuffixLength += DOUBLE_LINE_BREAK.length;
-    }
-  }
+  // `prevSuffixKeys` was built above by walking the prev map from
+  // `prevSuffixStartKey`, so every key is present there and the helper
+  // reproduces the same `kPrime`-length traversal.
+  const oldSuffixLength = $prevSuffixTextSize(prevSuffixStartKey, kPrime);
   for (const op of ops) {
     const saved = $beginCaptureGuard();
     if (op.kind === 'reconcile') {
@@ -1043,25 +1072,12 @@ function $reconcileChildren(
       if (suffixStartKey !== null) {
         const k = dirtyChildren.size;
         if (sizeDelta === 0) {
-          let oldSuffixLength = 0;
+          // Same keys in the same order across prev and next (gated by
+          // `prevElement.__first === nextElement.__first`, no clone), so the
+          // prev-map walk visits exactly this suffix.
+          const oldSuffixLength = $prevSuffixTextSize(suffixStartKey, k);
           let cur: NodeKey | null = suffixStartKey;
           let i = 0;
-          while (cur !== null && i < k) {
-            const prevNode = activePrevNodeMap.get(cur);
-            if (prevNode === undefined) {
-              break;
-            }
-            oldSuffixLength += $cachedTextSize(prevNode);
-            if (i < k - 1 && $isElementNode(prevNode) && !prevNode.isInline()) {
-              oldSuffixLength += DOUBLE_LINE_BREAK.length;
-            }
-            const nextNodeForLink = activeNextNodeMap.get(cur);
-            cur = nextNodeForLink ? nextNodeForLink.__next : null;
-            i++;
-          }
-
-          cur = suffixStartKey;
-          i = 0;
           while (cur !== null && i < k) {
             const node = activeNextNodeMap.get(cur);
             if (node === undefined) {

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -92,39 +92,39 @@ type IntentionallyMarkedAsDirtyElement = boolean;
  */
 export const CACHED_TEXT_SIZE_KEY = Symbol.for('@lexical/CachedTextSize');
 
-// Previous-cycle text size of a node, computed entirely from the previous
-// node map. Used for an element that moved to a different parent this cycle:
-// its keyed `dom.__lexicalTextContent` is shared between prev and next and is
-// overwritten in place when the element is reconciled under its NEW parent —
-// which, if that parent reconciles first, happens before its OLD parent's
-// suffix walk reads it (see https://github.com/facebook/lexical/pull/8564 for
-// the sibling fast-path hazard). Walking the prev map avoids both that stale
-// read and the `getLatest()` -> next-state trap. Leaf sizes still come from
-// the per-instance cache on the previous-state leaf instances.
-function $prevTextContentSize(node: LexicalNode): number {
-  if (!$isElementNode(node)) {
-    return $leafCachedTextSize(node);
-  }
-  let size = 0;
-  let childKey: NodeKey | null = node.__first;
-  let i = 0;
-  const lastIndex = node.__size - 1;
-  while (childKey !== null) {
-    const child = activePrevNodeMap.get(childKey);
-    if (child === undefined) {
-      break;
+function $cachedTextSize(node: LexicalNode): number {
+  if ($isElementNode(node)) {
+    // An element that moved to a different parent this cycle may have already
+    // been reconciled under its new parent, overwriting the shared keyed-DOM
+    // text cache (`dom.__lexicalTextContent`) with its NEW size before this
+    // (old) parent's suffix walk reads it — the sibling fast-path hazard from
+    // https://github.com/facebook/lexical/pull/8564. Recover the previous size
+    // by reading it from the previous editor state, where `getChildren()` /
+    // `isInline()` resolve against the prev tree (so we neither read the
+    // forward-mutated DOM cache nor hit the `getLatest()` -> next-state trap
+    // that an `isInline()` call on a detached prev node would, cf. #8548).
+    // `ElementNode.getTextContentSize()` applies the same double-line-break
+    // rule as the reconciler's cache, so the value matches. (`__parent ===
+    // null` means detached/removed, not moved — its DOM cache is still valid.)
+    const nextNode = activeNextNodeMap.get(node.__key);
+    if (
+      nextNode !== undefined &&
+      $isElementNode(nextNode) &&
+      nextNode.__parent !== node.__parent
+    ) {
+      return activePrevEditorState.read(() => node.getTextContentSize(), {
+        editor: activeEditor,
+      });
     }
-    size += $prevTextContentSize(child);
-    if (i < lastIndex && $isElementNode(child) && !child.isInline()) {
-      size += DOUBLE_LINE_BREAK.length;
-    }
-    childKey = child.__next;
-    i++;
+    const keyedDom = activePrevKeyToDOMMap.get(node.__key);
+    const cached = keyedDom && keyedDom.__lexicalTextContent;
+    invariant(
+      typeof cached === 'string',
+      'cachedTextSize: missing __lexicalTextContent for ElementNode of type %s',
+      node.getType(),
+    );
+    return cached.length;
   }
-  return size;
-}
-
-function $leafCachedTextSize(node: LexicalNode): number {
   const cached = node[CACHED_TEXT_SIZE_KEY];
   // $reconcileNode and $createNode set the size on every leaf they touch, so a
   // missing entry here means the invariant was broken upstream. Falling back to
@@ -137,33 +137,6 @@ function $leafCachedTextSize(node: LexicalNode): number {
     node.__key,
   );
   return cached;
-}
-
-function $cachedTextSize(node: LexicalNode): number {
-  if ($isElementNode(node)) {
-    // An element that moved to a different parent this cycle may have already
-    // been reconciled under its new parent, overwriting the shared keyed-DOM
-    // text cache with its NEW size. Recover the previous-cycle size from the
-    // prev node map instead. (`__parent === null` means detached/removed, not
-    // moved — its DOM cache is still its prev text.)
-    const nextNode = activeNextNodeMap.get(node.__key);
-    if (
-      nextNode !== undefined &&
-      $isElementNode(nextNode) &&
-      nextNode.__parent !== node.__parent
-    ) {
-      return $prevTextContentSize(node);
-    }
-    const keyedDom = activePrevKeyToDOMMap.get(node.__key);
-    const cached = keyedDom && keyedDom.__lexicalTextContent;
-    invariant(
-      typeof cached === 'string',
-      'cachedTextSize: missing __lexicalTextContent for ElementNode of type %s',
-      node.getType(),
-    );
-    return cached.length;
-  }
-  return $leafCachedTextSize(node);
 }
 
 function $setCachedTextSize(node: LexicalNode): void {
@@ -283,6 +256,7 @@ let activeMutationListeners: MutationListeners;
 let activeDirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>;
 let activeDirtyLeaves: Set<NodeKey>;
 let activePrevNodeMap: NodeMap;
+let activePrevEditorState: EditorState;
 let activeNextNodeMap: NodeMap;
 let activePrevKeyToDOMMap: Map<NodeKey, HTMLElement & LexicalPrivateDOM>;
 let activeDirtyChildrenByParent: Map<NodeKey, Set<NodeKey>>;
@@ -1727,6 +1701,7 @@ export function $reconcileRoot(
   activeDirtyElements = dirtyElements;
   activeDirtyLeaves = dirtyLeaves;
   activePrevNodeMap = prevEditorState._nodeMap;
+  activePrevEditorState = prevEditorState;
   activeNextNodeMap = nextEditorState._nodeMap;
   activeEditorStateReadOnly = nextEditorState._readOnly;
   activePrevKeyToDOMMap = cloneMap(editor._keyToDOMMap);
@@ -1750,6 +1725,8 @@ export function $reconcileRoot(
   activeDirtyLeaves = undefined;
   // @ts-ignore
   activePrevNodeMap = undefined;
+  // @ts-ignore
+  activePrevEditorState = undefined;
   // @ts-ignore
   activeNextNodeMap = undefined;
   // @ts-ignore

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -71,7 +71,7 @@ type IntentionallyMarkedAsDirtyElement = boolean;
  * `internalMarkParentElementsAsDirty` but does not `getWritable()` them), so
  * the same — DEV-frozen — instance would need its size rewritten when its
  * text changes, which the skip-if-set guard cannot do. Element sizes come
- * from `dom.__lexicalTextContent` instead (see `$cachedTextSize`).
+ * from `dom.__lexicalTextContent` instead (see `$prevSuffixTextSize`).
  *
  * Leaf writes are skipped when the slot is already not `undefined`. The
  * setter is only re-entered for the same instance via cross-parent moves
@@ -92,67 +92,21 @@ type IntentionallyMarkedAsDirtyElement = boolean;
  */
 export const CACHED_TEXT_SIZE_KEY = Symbol.for('@lexical/CachedTextSize');
 
-// Previous-cycle text size of a suffix child, for the `oldSuffixLength`
-// computation that decides how much of the parent's cached text to splice out.
-//
-// MUST run inside `activePrevEditorState.read(...)` (see `$prevSuffixTextSize`):
-// the moved-element branch and any `isInline()` the caller pairs with this call
-// resolve node methods through `getLatest()`, which is only safe against the
-// PREVIOUS node map. Reading the previous state there avoids both the
-// `getLatest()` -> next-state trap and the throw on a node that no longer
-// exists in the next state.
-function $cachedTextSize(node: LexicalNode): number {
-  if ($isElementNode(node)) {
-    // An element that moved to a different parent this cycle may have already
-    // been reconciled under its new parent, overwriting the shared keyed-DOM
-    // text cache with its NEW size (see
-    // https://github.com/facebook/lexical/pull/8564 for the sibling fast-path
-    // hazard). Recompute its previous size from the previous editor state
-    // instead. (`__parent === null` means detached/removed, not moved — its DOM
-    // cache is still its prev text.)
-    const nextNode = activeNextNodeMap.get(node.__key);
-    if (
-      nextNode !== undefined &&
-      $isElementNode(nextNode) &&
-      nextNode.__parent !== node.__parent
-    ) {
-      return node.getTextContentSize();
-    }
-    const keyedDom = activePrevKeyToDOMMap.get(node.__key);
-    const cached = keyedDom && keyedDom.__lexicalTextContent;
-    invariant(
-      typeof cached === 'string',
-      'cachedTextSize: missing __lexicalTextContent for ElementNode of type %s',
-      node.getType(),
-    );
-    return cached.length;
-  }
-  const cached = node[CACHED_TEXT_SIZE_KEY];
-  // $reconcileNode and $createNode set the size on every leaf they touch, so a
-  // missing entry here means the invariant was broken upstream. Falling back to
-  // getTextContentSize() would resolve via getLatest() against the next state
-  // and silently miscompute prev sizes — fail loudly instead.
-  invariant(
-    cached !== undefined,
-    'cachedTextSize: missing entry for leaf %s key %s',
-    node.getType(),
-    node.__key,
-  );
-  return cached;
-}
-
 // Total previous-render text length of the `count` suffix children starting at
 // `startKey` (in next-map order, which equals prev order across the size-0 and
 // size-±1 fast paths). This is the slice length removed from the parent's
 // cached text before the freshly reconciled suffix is appended.
 //
 // The whole walk runs inside `activePrevEditorState.read(...)` so that every
-// node method resolves against the PREVIOUS node map: `isInline()` returns the
-// node's previous-render value (a moved or re-typed node could answer
-// differently in the next state, and a node removed this cycle would throw),
-// and the moved-element branch of `$cachedTextSize` can recompute via
-// `getTextContentSize()`. Non-moved elements and leaves still read their O(1)
-// caches, so a large untouched suffix child is not re-walked.
+// node method resolves against the PREVIOUS node map: a moved element recomputes
+// its size via `getTextContentSize()` (its shared keyed-DOM cache may already
+// hold the NEW size, cf. https://github.com/facebook/lexical/pull/8564), and the
+// inter-sibling `isInline()` returns the node's previous-render value (a moved
+// or re-typed node could answer differently in the next state, and a node
+// removed this cycle would throw). The per-child size logic is inlined here
+// rather than shared so it cannot be called outside this read. Non-moved
+// elements and leaves still read their O(1) caches, so a large untouched suffix
+// child is not re-walked.
 function $prevSuffixTextSize(startKey: NodeKey, count: number): number {
   return activePrevEditorState.read(
     () => {
@@ -160,12 +114,50 @@ function $prevSuffixTextSize(startKey: NodeKey, count: number): number {
       let cur: NodeKey | null = startKey;
       for (let i = 0; i < count && cur !== null; i++) {
         const prevNode = activePrevNodeMap.get(cur);
-        if (prevNode === undefined) {
-          break;
-        }
-        size += $cachedTextSize(prevNode);
-        if (i < count - 1 && $isElementNode(prevNode) && !prevNode.isInline()) {
-          size += DOUBLE_LINE_BREAK.length;
+        // Callers validate every suffix key is present in the prev map, so a
+        // miss means a broken upstream invariant. Fail loudly (the reconciler
+        // catch recovers via a full reconcile) rather than slice a partial sum.
+        invariant(
+          prevNode !== undefined,
+          'prevSuffixTextSize: missing prev node for key %s',
+          cur,
+        );
+        if ($isElementNode(prevNode)) {
+          const nextNode = activeNextNodeMap.get(cur);
+          if (
+            nextNode !== undefined &&
+            $isElementNode(nextNode) &&
+            nextNode.__parent !== prevNode.__parent
+          ) {
+            // Moved to a different parent this cycle: the shared keyed-DOM text
+            // cache may already hold its NEW size, so recompute from the prev
+            // tree. (`__parent === null` means detached/removed, not moved — its
+            // DOM cache is still its prev text.)
+            size += prevNode.getTextContentSize();
+          } else {
+            const keyedDom = activePrevKeyToDOMMap.get(cur);
+            const cached = keyedDom && keyedDom.__lexicalTextContent;
+            invariant(
+              typeof cached === 'string',
+              'prevSuffixTextSize: missing __lexicalTextContent for ElementNode of type %s',
+              prevNode.getType(),
+            );
+            size += cached.length;
+          }
+          if (i < count - 1 && !prevNode.isInline()) {
+            size += DOUBLE_LINE_BREAK.length;
+          }
+        } else {
+          // $reconcileNode / $createNode set the size on every leaf they touch,
+          // so a missing entry means the invariant was broken upstream.
+          const cached = prevNode[CACHED_TEXT_SIZE_KEY];
+          invariant(
+            cached !== undefined,
+            'prevSuffixTextSize: missing cached size for leaf %s key %s',
+            prevNode.getType(),
+            cur,
+          );
+          size += cached;
         }
         cur = prevNode.__next;
       }

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
@@ -167,10 +167,14 @@ function snapshot(editor: LexicalEditor): {
   text: string;
   dom: string;
 } {
+  // Read JSON and text from the SAME committed editor state so all three
+  // observations are one consistent snapshot. `editor.read` would flush any
+  // pending update first and could read a different state than `toJSON`.
+  const state = editor.getEditorState();
   return {
     dom: editor.getRootElement()!.innerHTML,
-    json: JSON.stringify(editor.getEditorState().toJSON()),
-    text: editor.read(() => $getRoot().getTextContent()),
+    json: JSON.stringify(state.toJSON()),
+    text: state.read(() => $getRoot().getTextContent(), {editor}),
   };
 }
 

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createLinkNode, LinkExtension} from '@lexical/link';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  $isTextNode,
+  type LexicalEditor,
+} from 'lexical';
+import {afterEach, describe, expect, test} from 'vitest';
+
+import {__benchOnly} from '../../LexicalReconciler';
+import {$createTestDecoratorNode, TestDecoratorNode} from '../utils';
+
+function makeEditor(): LexicalEditor {
+  const editor = buildEditorFromExtensions({
+    dependencies: [RichTextExtension, LinkExtension],
+    name: 'fast-path-cross-parent',
+    nodes: [TestDecoratorNode],
+    onError: e => {
+      throw e;
+    },
+  });
+  editor.setRootElement(document.createElement('div'));
+  return editor;
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick(rng: () => number, len: number): number {
+  return Math.floor(rng() * len);
+}
+
+// Two big paragraphs (>= 4 inline children each, engaging the fast path on
+// both), plus ops that MOVE children between them and wrap children in links —
+// stressing first-text-key cache transfer and cross-parent DOM reuse.
+function seedTwoParas(editor: LexicalEditor): void {
+  editor.update(
+    () => {
+      const root = $getRoot().clear();
+      for (let p = 0; p < 2; p++) {
+        const para = $createParagraphNode();
+        for (let i = 0; i < 5; i++) {
+          para.append($createTextNode(`p${p}w${i}`));
+        }
+        root.append(para);
+      }
+    },
+    {discrete: true},
+  );
+}
+
+const OPS: Array<(rng: () => number) => void> = [
+  // move a child from one paragraph to the end of the other
+  rng => {
+    const paras = $getRoot().getChildren();
+    if (paras.length < 2) {
+      return;
+    }
+    const fromIdx = pick(rng, paras.length);
+    const toIdx = (fromIdx + 1) % paras.length;
+    const from = paras[fromIdx];
+    const to = paras[toIdx];
+    if ($isElementNode(from) && $isElementNode(to)) {
+      const kids = from.getChildren();
+      if (kids.length > 0) {
+        to.append(kids[pick(rng, kids.length)]);
+      }
+    }
+  },
+  // move a child to the FRONT of the other paragraph (changes __first)
+  rng => {
+    const paras = $getRoot().getChildren();
+    if (paras.length < 2) {
+      return;
+    }
+    const fromIdx = pick(rng, paras.length);
+    const toIdx = (fromIdx + 1) % paras.length;
+    const from = paras[fromIdx];
+    const to = paras[toIdx];
+    if ($isElementNode(from) && $isElementNode(to)) {
+      const kids = from.getChildren();
+      const first = to.getFirstChild();
+      if (kids.length > 0 && first) {
+        first.insertBefore(kids[pick(rng, kids.length)]);
+      }
+    }
+  },
+  // wrap a child in a link (cross-parent move into a new inline element)
+  rng => {
+    const paras = $getRoot().getChildren();
+    const para = paras[pick(rng, paras.length)];
+    if ($isElementNode(para)) {
+      const kids = para.getChildren();
+      if (kids.length > 0) {
+        const target = kids[pick(rng, kids.length)];
+        const link = $createLinkNode('https://example.com');
+        target.insertBefore(link);
+        link.append(target);
+      }
+    }
+  },
+  // append text to a paragraph
+  rng => {
+    const paras = $getRoot().getChildren();
+    const para = paras[pick(rng, paras.length)];
+    if ($isElementNode(para)) {
+      para.append($createTextNode('x'));
+    }
+  },
+  // toggle format on the first child (stresses first-text-key)
+  rng => {
+    const paras = $getRoot().getChildren();
+    const para = paras[pick(rng, paras.length)];
+    if ($isElementNode(para)) {
+      const first = para.getFirstChild();
+      if ($isTextNode(first)) {
+        first.toggleFormat('bold');
+      }
+    }
+  },
+  // remove the first child (first-text key changes)
+  rng => {
+    const paras = $getRoot().getChildren();
+    const para = paras[pick(rng, paras.length)];
+    if ($isElementNode(para)) {
+      const first = para.getFirstChild();
+      if (first) {
+        first.remove();
+      }
+    }
+  },
+  // append a decorator / linebreak
+  rng => {
+    const paras = $getRoot().getChildren();
+    const para = paras[pick(rng, paras.length)];
+    if ($isElementNode(para)) {
+      para.append(
+        rng() < 0.5 ? $createTestDecoratorNode() : $createLineBreakNode(),
+      );
+    }
+  },
+];
+
+function snapshot(editor: LexicalEditor): {
+  json: string;
+  text: string;
+  dom: string;
+} {
+  return {
+    dom: editor.getRootElement()!.innerHTML,
+    json: JSON.stringify(editor.getEditorState().toJSON()),
+    text: editor.read(() => $getRoot().getTextContent()),
+  };
+}
+
+// Differential guard: a sequence of cross-parent moves (plus link-wrapping
+// and edits) applied to one editor with the children fast path live must
+// produce the same editor state, serialized JSON, and DOM as the same
+// sequence applied with the fast path disabled (the general walk).
+describe('fast path differential fuzz — cross-parent moves', () => {
+  afterEach(() => {
+    __benchOnly.skipChildrenFastPath = false;
+  });
+
+  test('fast path matches the general walk across cross-parent moves', () => {
+    const SEEDS = 100;
+    const OPS_PER_RUN = 20;
+    for (let s = 0; s < SEEDS; s++) {
+      const fast = makeEditor();
+      const slow = makeEditor();
+      try {
+        seedTwoParas(fast);
+        seedTwoParas(slow);
+        const rng = mulberry32(0x165667b1 ^ s);
+        for (let i = 0; i < OPS_PER_RUN; i++) {
+          const op = OPS[Math.floor(rng() * OPS.length)];
+          const localSeed = Math.floor(rng() * 0xffffffff);
+          __benchOnly.skipChildrenFastPath = false;
+          fast.update(() => op(mulberry32(localSeed)), {discrete: true});
+          __benchOnly.skipChildrenFastPath = true;
+          slow.update(() => op(mulberry32(localSeed)), {discrete: true});
+          __benchOnly.skipChildrenFastPath = false;
+          const f = snapshot(fast);
+          const sl = snapshot(slow);
+          expect(f.text, `seed ${s} step ${i}: text`).toBe(sl.text);
+          expect(f.json, `seed ${s} step ${i}: json`).toBe(sl.json);
+          expect(f.dom, `seed ${s} step ${i}: dom`).toBe(sl.dom);
+        }
+      } finally {
+        __benchOnly.skipChildrenFastPath = false;
+        fast.setRootElement(null);
+        slow.setRootElement(null);
+      }
+    }
+  });
+});

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
@@ -188,7 +188,7 @@ describe('fast path differential fuzz — cross-parent moves', () => {
   });
 
   test('fast path matches the general walk across cross-parent moves', () => {
-    const SEEDS = 200;
+    const SEEDS = 100;
     const OPS_PER_RUN = 20;
     for (let s = 0; s < SEEDS; s++) {
       const fast = makeEditor();

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
@@ -188,7 +188,7 @@ describe('fast path differential fuzz — cross-parent moves', () => {
   });
 
   test('fast path matches the general walk across cross-parent moves', () => {
-    const SEEDS = 100;
+    const SEEDS = 200;
     const OPS_PER_RUN = 20;
     for (let s = 0; s < SEEDS; s++) {
       const fast = makeEditor();

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createLinkNode, LinkExtension} from '@lexical/link';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+// Regression test for the $reconcileChildren suffix fast path computing a
+// wrong previous-suffix length when a dirty child of the reconciled element
+// moved to a *different* parent in the same update.
+//
+// `$cachedTextSize` reads an ElementNode's previous text size from its keyed
+// `dom.__lexicalTextContent`. That DOM node is shared between the previous and
+// next `keyToDOMMap`s and its cache is mutated in place during reconciliation.
+// When an inline element moves cross-parent and is reconciled (and grows)
+// under its new parent BEFORE its old parent's suffix walk runs, the old
+// parent reads the new, larger size as if it were the previous size and
+// slices too much off its cached text. The DOM stays correct, but the
+// `RootNode.__cachedText` that backs `getTextContent()` silently desyncs.
+describe('children fast path: cross-parent move and sibling text cache', () => {
+  test('getTextContent matches the live tree after moving + merging a trailing link', () => {
+    const errors: Error[] = [];
+    using editor = buildEditorFromExtensions({
+      dependencies: [RichTextExtension, LinkExtension],
+      name: 'cross-parent-text-cache',
+      onError: e => {
+        errors.push(e);
+      },
+    });
+    editor.setRootElement(document.createElement('div'));
+
+    const URL = 'https://example.com';
+
+    // P0 leads with a link of URL `URL`; P1 ends with another link of the same
+    // URL wrapping a line break. P1 has >= 4 children so its reconcile engages
+    // the children fast path. Root has 2 children (general path), so the bug
+    // surfaces inside P1's reconcile.
+    editor.update(
+      () => {
+        const root = $getRoot().clear();
+
+        const p0 = $createParagraphNode();
+        const leadingLink = $createLinkNode(URL);
+        leadingLink.append($createTextNode('P0TEXT'));
+        p0.append(leadingLink, $createTextNode('after'));
+
+        const p1 = $createParagraphNode();
+        const trailingLink = $createLinkNode(URL);
+        trailingLink.append($createLineBreakNode());
+        p1.append(
+          $createTextNode('x'),
+          $createLineBreakNode(),
+          $createTextNode('y'),
+          trailingLink,
+        );
+
+        root.append(p0, p1);
+      },
+      {discrete: true},
+    );
+
+    // Move P1's trailing link to the front of P0. It becomes adjacent to P0's
+    // leading link (same URL) and the link normalizer merges them, so the
+    // moved link grows from "\n" to "\nP0TEXT" under P0. P1 drops from 4 to 3
+    // children (the size-delta suffix path), and its reconcile reads the moved
+    // link's now-overwritten DOM text size.
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const p0 = root.getFirstChildOrThrow();
+        const p1 = root.getLastChildOrThrow();
+        if ($isElementNode(p0) && $isElementNode(p1)) {
+          const trailingLink = p1.getLastChildOrThrow();
+          p0.getFirstChildOrThrow().insertBefore(trailingLink);
+        }
+      },
+      {discrete: true},
+    );
+
+    expect(errors).toEqual([]);
+
+    // `getTextContent()` on the root reads `RootNode.__cachedText`, which the
+    // fast path maintains incrementally. Compare it against the text computed
+    // fresh from the children (ElementNode.getTextContent walks the tree and
+    // does not use the root cache).
+    const {cached, fresh} = editor.read(() => {
+      const root = $getRoot();
+      return {
+        cached: root.getTextContent(),
+        fresh: root
+          .getChildren()
+          .map(child => child.getTextContent())
+          .join('\n\n'),
+      };
+    });
+
+    expect(cached).toBe(fresh);
+  });
+});

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
@@ -95,17 +95,22 @@ describe('children fast path: cross-parent move and sibling text cache', () => {
     // `getTextContent()` on the root reads `RootNode.__cachedText`, which the
     // fast path maintains incrementally. Compare it against the text computed
     // fresh from the children (ElementNode.getTextContent walks the tree and
-    // does not use the root cache).
-    const {cached, fresh} = editor.read(() => {
-      const root = $getRoot();
-      return {
-        cached: root.getTextContent(),
-        fresh: root
-          .getChildren()
-          .map(child => child.getTextContent())
-          .join('\n\n'),
-      };
-    });
+    // does not use the root cache). Read from the committed editor state (not
+    // `editor.read`, which would flush any pending update first) so this
+    // observation is the same snapshot the reconcile just produced.
+    const {cached, fresh} = editor.getEditorState().read(
+      () => {
+        const root = $getRoot();
+        return {
+          cached: root.getTextContent(),
+          fresh: root
+            .getChildren()
+            .map(child => child.getTextContent())
+            .join('\n\n'),
+        };
+      },
+      {editor},
+    );
 
     expect(cached).toBe(fresh);
   });

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
@@ -16,6 +16,7 @@ import {
   $getRoot,
   $isElementNode,
 } from 'lexical';
+import invariant from 'shared/invariant';
 import {describe, expect, test} from 'vitest';
 
 // Regression test for the $reconcileChildren suffix fast path computing a
@@ -82,10 +83,10 @@ describe('children fast path: cross-parent move and sibling text cache', () => {
         const root = $getRoot();
         const p0 = root.getFirstChildOrThrow();
         const p1 = root.getLastChildOrThrow();
-        if ($isElementNode(p0) && $isElementNode(p1)) {
-          const trailingLink = p1.getLastChildOrThrow();
-          p0.getFirstChildOrThrow().insertBefore(trailingLink);
-        }
+        invariant($isElementNode(p0), 'p0 must be an ElementNode');
+        invariant($isElementNode(p1), 'p1 must be an ElementNode');
+        const trailingLink = p1.getLastChildOrThrow();
+        p0.getFirstChildOrThrow().insertBefore(trailingLink);
       },
       {discrete: true},
     );

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
@@ -15,9 +15,49 @@ import {
   $createTextNode,
   $getRoot,
   $isElementNode,
+  $isTextNode,
+  ElementNode,
+  type SerializedElementNode,
 } from 'lexical';
 import invariant from 'shared/invariant';
 import {describe, expect, test} from 'vitest';
+
+// An element whose inline-ness is mutable state read through `getLatest()`. A
+// non-last suffix sibling that flips block<->inline changes the double line
+// break that the suffix-length walk must subtract from the cached parent text;
+// reading `isInline()` against the next state (the flipped value) instead of
+// the previous one silently desyncs `RootNode.__cachedText`.
+class FlipInlineNode extends ElementNode {
+  __inline: boolean;
+  constructor(inline: boolean, key?: string) {
+    super(key);
+    this.__inline = inline;
+  }
+  static getType(): string {
+    return 'flip-inline';
+  }
+  static clone(node: FlipInlineNode): FlipInlineNode {
+    return new FlipInlineNode(node.__inline, node.__key);
+  }
+  static importJSON(serializedNode: SerializedElementNode): FlipInlineNode {
+    return new FlipInlineNode(false).updateFromJSON(serializedNode);
+  }
+  createDOM(): HTMLElement {
+    return document.createElement(this.__inline ? 'span' : 'div');
+  }
+  updateDOM(): false {
+    return false;
+  }
+  isInline(): boolean {
+    return this.getLatest().__inline;
+  }
+  setInline(inline: boolean): void {
+    this.getWritable().__inline = inline;
+  }
+  canBeEmpty(): boolean {
+    return false;
+  }
+}
 
 // Regression test for the $reconcileChildren suffix fast path computing a
 // wrong previous-suffix length when a dirty child of the reconciled element
@@ -99,6 +139,86 @@ describe('children fast path: cross-parent move and sibling text cache', () => {
     // does not use the root cache). Read from the committed editor state (not
     // `editor.read`, which would flush any pending update first) so this
     // observation is the same snapshot the reconcile just produced.
+    const {cached, fresh} = editor.getEditorState().read(
+      () => {
+        const root = $getRoot();
+        return {
+          cached: root.getTextContent(),
+          fresh: root
+            .getChildren()
+            .map(child => child.getTextContent())
+            .join('\n\n'),
+        };
+      },
+      {editor},
+    );
+
+    expect(cached).toBe(fresh);
+  });
+
+  // Regression test for the *other* `isInline()` in the suffix-length walk:
+  // the one deciding the double line break BETWEEN suffix siblings (not the one
+  // inside a moved element's `getTextContentSize()`). When a non-last suffix
+  // element's `isInline()` is state-dependent (routes through `getLatest()`)
+  // and flips between the previous and next states, the walk must read it
+  // against the *previous* state — otherwise it uses the next-state value,
+  // computes the wrong double-line-break length, and silently desyncs
+  // `RootNode.__cachedText`. (This call cannot throw — a removed sibling is
+  // always the last of the suffix, where `isInline()` is skipped — so the
+  // failure mode is a wrong cached value, not an error.)
+  test('flipping a non-last suffix element block<->inline keeps the cache in sync', () => {
+    const errors: Error[] = [];
+    using editor = buildEditorFromExtensions({
+      dependencies: [RichTextExtension],
+      name: 'suffix-sibling-isinline',
+      nodes: [FlipInlineNode],
+      onError: e => {
+        errors.push(e);
+      },
+    });
+    editor.setRootElement(document.createElement('div'));
+
+    // P: [text, lineBreak, E(block), text]. 4 children -> fast path. E is a
+    // non-last block element, so P's previous text carries a double line break
+    // after it. The line break keeps the text nodes from merging.
+    editor.update(
+      () => {
+        const root = $getRoot().clear();
+        const p = $createParagraphNode();
+        const e = new FlipInlineNode(false);
+        e.append($createTextNode('e'));
+        p.append(
+          $createTextNode('a'),
+          $createLineBreakNode(),
+          e,
+          $createTextNode('z'),
+        );
+        root.append(p);
+      },
+      {discrete: true},
+    );
+
+    // size-0 update: flip E to inline (dropping its trailing double line break)
+    // and dirty the last text node so [E, "z"] is the reconciled suffix. The
+    // suffix walk asks E.isInline() for the inter-sibling double line break;
+    // against the next state it answers "inline" (no break) while the cached
+    // parent text still holds the previous "block" break.
+    editor.update(
+      () => {
+        const p = $getRoot().getLastChildOrThrow();
+        invariant($isElementNode(p), 'p must be an ElementNode');
+        const e = p.getChildren()[2];
+        invariant(e instanceof FlipInlineNode, 'e must be a FlipInlineNode');
+        e.setInline(true);
+        const last = p.getLastChildOrThrow();
+        invariant($isTextNode(last), 'last child must be a text node');
+        last.toggleFormat('bold');
+      },
+      {discrete: true},
+    );
+
+    expect(errors).toEqual([]);
+
     const {cached, fresh} = editor.getEditorState().read(
       () => {
         const root = $getRoot();


### PR DESCRIPTION
## Description

The children fast path's `$cachedTextSize` read an ElementNode's previous text size from its keyed `dom.__lexicalTextContent`. That DOM node is shared between the previous and next `keyToDOMMap`s and is mutated in place during reconciliation. When an inline element moves to a different parent and is reconciled (growing) under its new parent before its old parent's suffix walk runs, the old parent read the new, larger size as if it were the previous size and sliced too much off its cached text. The DOM stayed correct, but `RootNode.__cachedText` (which backs `getTextContent()`) silently desynced.

Recover the previous-cycle size from the previous node map for an element whose next-state parent differs from its previous-state parent. This is in the same family as the full-reconcile hazard fixed in #8564.

## Test plan

New unit tests