### PR TITLE
[lexical-website] Feature: Server-rendered "Copy page" Markdown button

### DIFF
--- a/packages/lexical-website/.gitignore
+++ b/packages/lexical-website/.gitignore
@@ -9,6 +9,7 @@
 .cache-loader
 /docs/api
 /docs/packages
+/static/llms
 
 # Misc
 .DS_Store

--- a/packages/lexical-website/docusaurus.config.ts
+++ b/packages/lexical-website/docusaurus.config.ts
@@ -17,6 +17,7 @@ import {fileURLToPath} from 'node:url';
 import {themes} from 'prism-react-renderer';
 
 import {packagesManager} from '../../scripts/shared/packagesManager.mjs';
+import copyPageButtonPlugin from './plugins/copy-page-button/index.mjs';
 import packageDocsPlugin from './plugins/package-docs/index.mjs';
 import slugifyPlugin from './src/plugins/lexical-remark-slugify-anchors/index.js';
 
@@ -345,11 +346,27 @@ const config: Config = {
           },
         ],
     './plugins/webpack-buffer',
+    copyPageButtonPlugin,
     async function webpackLexicalModules() {
       return {
         configureWebpack() {
           const alias: Record<string, string | false | string[]> = {
             ...buildLexicalWebpackAliases(),
+            // Dedupe the docs client module so swizzled theme components under
+            // src/theme share the same DocProvider React context as
+            // @docusaurus/theme-classic. pnpm can otherwise resolve a second
+            // copy of @docusaurus/plugin-content-docs, which would make
+            // useDoc() throw a ReactContextError during SSG.
+            '@docusaurus/plugin-content-docs/client$': require.resolve(
+              '@docusaurus/plugin-content-docs/client',
+              {
+                paths: [
+                  path.dirname(
+                    require.resolve('@docusaurus/theme-classic/package.json'),
+                  ),
+                ],
+              },
+            ),
             '@examples/agent-example': path.resolve(
               __dirname,
               '../../examples/agent-example/src',

--- a/packages/lexical-website/docusaurus.config.ts
+++ b/packages/lexical-website/docusaurus.config.ts
@@ -352,21 +352,6 @@ const config: Config = {
         configureWebpack() {
           const alias: Record<string, string | false | string[]> = {
             ...buildLexicalWebpackAliases(),
-            // Dedupe the docs client module so swizzled theme components under
-            // src/theme share the same DocProvider React context as
-            // @docusaurus/theme-classic. pnpm can otherwise resolve a second
-            // copy of @docusaurus/plugin-content-docs, which would make
-            // useDoc() throw a ReactContextError during SSG.
-            '@docusaurus/plugin-content-docs/client$': require.resolve(
-              '@docusaurus/plugin-content-docs/client',
-              {
-                paths: [
-                  path.dirname(
-                    require.resolve('@docusaurus/theme-classic/package.json'),
-                  ),
-                ],
-              },
-            ),
             '@examples/agent-example': path.resolve(
               __dirname,
               '../../examples/agent-example/src',

--- a/packages/lexical-website/package.json
+++ b/packages/lexical-website/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/faster": "^3.10.1",
     "@docusaurus/plugin-client-redirects": "^3.10.1",
+    "@docusaurus/plugin-content-docs": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/theme-common": "^3.10.1",
     "@docusaurus/theme-mermaid": "^3.10.1",

--- a/packages/lexical-website/plugins/copy-page-button/index.mjs
+++ b/packages/lexical-website/plugins/copy-page-button/index.mjs
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SITE_ALIAS = '@site';
+
+/**
+ * Path namespace (under `static/`) where a Markdown copy of every doc page is
+ * emitted, e.g. the page `/docs/intro` is written to `static/llms/docs/intro.md`
+ * and served at `/llms/docs/intro.md`. Must stay in sync with the
+ * `MARKDOWN_NAMESPACE` constant in `src/theme/CopyPageButton/index.tsx`.
+ */
+const OUTPUT_NAMESPACE = 'llms';
+
+function stripFrontMatter(raw) {
+  return raw.replace(/^\uFEFF?---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+}
+
+/**
+ * Drop the leading block of MDX `import`/`export` statements (and blank lines)
+ * that appear before the first piece of real content. Only the leading block is
+ * removed so `import`/`export` lines inside code fences are left untouched.
+ */
+function stripLeadingMdxStatements(body) {
+  const lines = body.split('\n');
+  let index = 0;
+  for (; index < lines.length; index++) {
+    const trimmed = lines[index].trim();
+    if (trimmed === '' || /^(?:import|export)\b/.test(trimmed)) {
+      continue;
+    }
+    break;
+  }
+  return lines.slice(index).join('\n');
+}
+
+function relativePermalink(permalink, baseUrl) {
+  let rel = permalink;
+  if (baseUrl && rel.startsWith(baseUrl)) {
+    rel = rel.slice(baseUrl.length);
+  }
+  rel = rel.replace(/^\/+/, '').replace(/\/+$/, '');
+  return rel || 'index';
+}
+
+/**
+ * Emit a clean Markdown copy of every doc page at build time so the
+ * server-rendered CopyPageButton can link to / copy / hand off real Markdown
+ * without any client-side DOM scraping.
+ *
+ * @type {import('@docusaurus/types').PluginModule}
+ */
+const copyPageButtonPlugin = async function (context) {
+  const {siteDir, siteConfig} = context;
+  const {baseUrl, url: siteUrl} = siteConfig;
+  const outputRoot = path.join(siteDir, 'static', OUTPUT_NAMESPACE);
+
+  const resolveSource = source => {
+    if (source.startsWith(SITE_ALIAS)) {
+      return path.join(siteDir, source.slice(SITE_ALIAS.length));
+    }
+    return path.isAbsolute(source) ? source : path.join(siteDir, source);
+  };
+
+  return {
+    // Runs in both dev and production, after every plugin has loaded its
+    // content, so we have the authoritative permalink -> source mapping for
+    // every doc (including the generated API reference).
+    allContentLoaded({allContent}) {
+      const docsContent = allContent['docusaurus-plugin-content-docs'];
+      if (!docsContent) {
+        return;
+      }
+
+      // Regenerate from scratch so renamed/removed pages don't leave orphans.
+      fs.rmSync(outputRoot, {force: true, recursive: true});
+
+      const normalizedSiteUrl = String(siteUrl || '').replace(/\/$/, '');
+
+      for (const instance of Object.values(docsContent)) {
+        const loadedVersions = (instance && instance.loadedVersions) || [];
+        for (const version of loadedVersions) {
+          for (const doc of version.docs || []) {
+            const sourcePath = resolveSource(doc.source);
+            let raw;
+            try {
+              raw = fs.readFileSync(sourcePath, 'utf-8');
+            } catch {
+              continue;
+            }
+
+            let body = stripFrontMatter(raw);
+            if (sourcePath.endsWith('.mdx')) {
+              body = stripLeadingMdxStatements(body);
+            }
+            body = body.trim();
+
+            const pageUrl = `${normalizedSiteUrl}${doc.permalink}`;
+            const header = /^#\s/.test(body)
+              ? `URL: ${pageUrl}\n\n`
+              : `# ${doc.title}\n\nURL: ${pageUrl}\n\n`;
+
+            const outputPath = path.join(
+              outputRoot,
+              `${relativePermalink(doc.permalink, baseUrl)}.md`,
+            );
+            fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+            fs.writeFileSync(outputPath, `${header}${body}\n`);
+          }
+        }
+      }
+    },
+
+    name: 'copy-page-button',
+  };
+};
+
+export default copyPageButtonPlugin;

--- a/packages/lexical-website/plugins/copy-page-button/index.mjs
+++ b/packages/lexical-website/plugins/copy-page-button/index.mjs
@@ -9,15 +9,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const SITE_ALIAS = '@site';
+import {MARKDOWN_NAMESPACE, relativeMarkdownPath} from './markdownPath.mjs';
 
-/**
- * Path namespace (under `static/`) where a Markdown copy of every doc page is
- * emitted, e.g. the page `/docs/intro` is written to `static/llms/docs/intro.md`
- * and served at `/llms/docs/intro.md`. Must stay in sync with the
- * `MARKDOWN_NAMESPACE` constant in `src/theme/CopyPageButton/index.tsx`.
- */
-const OUTPUT_NAMESPACE = 'llms';
+const SITE_ALIAS = '@site';
 
 function stripFrontMatter(raw) {
   return raw.replace(/^\uFEFF?---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
@@ -41,15 +35,6 @@ function stripLeadingMdxStatements(body) {
   return lines.slice(index).join('\n');
 }
 
-function relativePermalink(permalink, baseUrl) {
-  let rel = permalink;
-  if (baseUrl && rel.startsWith(baseUrl)) {
-    rel = rel.slice(baseUrl.length);
-  }
-  rel = rel.replace(/^\/+/, '').replace(/\/+$/, '');
-  return rel || 'index';
-}
-
 /**
  * Emit a clean Markdown copy of every doc page at build time so the
  * server-rendered CopyPageButton can link to / copy / hand off real Markdown
@@ -60,7 +45,7 @@ function relativePermalink(permalink, baseUrl) {
 const copyPageButtonPlugin = async function (context) {
   const {siteDir, siteConfig} = context;
   const {baseUrl, url: siteUrl} = siteConfig;
-  const outputRoot = path.join(siteDir, 'static', OUTPUT_NAMESPACE);
+  const outputRoot = path.join(siteDir, 'static', MARKDOWN_NAMESPACE);
 
   const resolveSource = source => {
     if (source.startsWith(SITE_ALIAS)) {
@@ -109,7 +94,7 @@ const copyPageButtonPlugin = async function (context) {
 
             const outputPath = path.join(
               outputRoot,
-              `${relativePermalink(doc.permalink, baseUrl)}.md`,
+              `${relativeMarkdownPath(doc.permalink, baseUrl)}.md`,
             );
             fs.mkdirSync(path.dirname(outputPath), {recursive: true});
             fs.writeFileSync(outputPath, `${header}${body}\n`);

--- a/packages/lexical-website/plugins/copy-page-button/markdownPath.mjs
+++ b/packages/lexical-website/plugins/copy-page-button/markdownPath.mjs
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Path namespace (under `static/`) where the build-time plugin emits a Markdown
+ * copy of every doc page, e.g. the page `/docs/intro` is served at
+ * `/llms/docs/intro.md`.
+ */
+export const MARKDOWN_NAMESPACE = 'llms';
+
+/**
+ * Map a doc permalink to the namespace-relative path of its generated Markdown
+ * file (without the `MARKDOWN_NAMESPACE` prefix or surrounding slashes), e.g.
+ * `/docs/api/` -> `docs/api`.
+ *
+ * Shared by the plugin that writes the file and the CopyPageButton that links
+ * to it so the two normalizations (notably trailing-slash handling for index
+ * pages) can never drift.
+ *
+ * @param {string} permalink Doc permalink, including baseUrl (e.g. `/docs/api/`).
+ * @param {string} baseUrl Site baseUrl (e.g. `/`).
+ * @returns {string}
+ */
+export function relativeMarkdownPath(permalink, baseUrl) {
+  let rel = permalink;
+  if (baseUrl && rel.startsWith(baseUrl)) {
+    rel = rel.slice(baseUrl.length);
+  }
+  return rel.replace(/^\/+/, '').replace(/\/+$/, '') || 'index';
+}

--- a/packages/lexical-website/src/components/CopyPageButton/index.tsx
+++ b/packages/lexical-website/src/components/CopyPageButton/index.tsx
@@ -10,7 +10,13 @@ import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import clsx from 'clsx';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 
 import styles from './styles.module.css';
 
@@ -20,6 +26,25 @@ import styles from './styles.module.css';
  * `OUTPUT_NAMESPACE`.
  */
 const MARKDOWN_NAMESPACE = 'llms';
+
+// location.origin can't change without a full navigation (which remounts), so
+// there is nothing to subscribe to.
+const subscribeToOrigin = () => () => {};
+const getClientOrigin = () => window.location.origin;
+
+/**
+ * The origin to build absolute Markdown URLs from. Renders with the configured
+ * Docusaurus site URL on the server (stable for hydration) and reconciles to
+ * the real browser origin on the client, so links are correct on production,
+ * preview, and local deployments alike.
+ */
+function useOrigin(serverOrigin: string): string {
+  return useSyncExternalStore(
+    subscribeToOrigin,
+    getClientOrigin,
+    () => serverOrigin,
+  );
+}
 
 function CopyIcon() {
   return (
@@ -210,22 +235,15 @@ export default function CopyPageButton(): React.ReactNode {
     }
   }, [markdownPath]);
 
-  const openInAI = useCallback(
-    (base: string, extraParams: Record<string, string> = {}) => {
-      // Resolve the Markdown URL against the live origin so it points at the
-      // current deployment (production, preview, or local) rather than a
-      // hard-coded host.
-      const absoluteMarkdownUrl = new URL(
-        markdownPath,
-        window.location.origin,
-      ).toString();
-      const prompt = `Please read and explain this documentation page: ${absoluteMarkdownUrl}\n\nPlease provide a clear summary and help me understand the key concepts covered in this documentation.`;
-      const params = new URLSearchParams({q: prompt, ...extraParams});
-      window.open(`${base}?${params.toString()}`, '_blank', 'noopener');
-    },
-    [markdownPath],
-  );
+  // Absolute URL of the Markdown file for AI tools to fetch.
+  const origin = useOrigin(new URL(siteConfig.url).origin);
+  const aiPrompt = `Please read and explain this documentation page: ${origin}${markdownPath}\n\nPlease provide a clear summary and help me understand the key concepts covered in this documentation.`;
+  const aiHref = (base: string, extraParams: Record<string, string> = {}) =>
+    `${base}?${new URLSearchParams({q: aiPrompt, ...extraParams}).toString()}`;
 
+  // "Open in <tool>" links are plain anchors (target=_blank) rather than
+  // window.open() calls: anchors are treated as user-initiated navigations and
+  // aren't silently swallowed by popup blockers.
   const items: MenuItem[] = [
     {
       description: copied
@@ -245,30 +263,30 @@ export default function CopyPageButton(): React.ReactNode {
     },
     {
       description: 'Ask ChatGPT about this page',
+      href: aiHref('https://chatgpt.com/'),
       icon: <ChatGPTIcon />,
       id: 'chatgpt',
-      onSelect: () => openInAI('https://chatgpt.com/'),
       title: 'Open in ChatGPT',
     },
     {
       description: 'Ask Claude about this page',
+      href: aiHref('https://claude.ai/new'),
       icon: <ClaudeIcon />,
       id: 'claude',
-      onSelect: () => openInAI('https://claude.ai/new'),
       title: 'Open in Claude',
     },
     {
       description: 'Ask Perplexity about this page',
+      href: aiHref('https://www.perplexity.ai/search'),
       icon: <PerplexityIcon />,
       id: 'perplexity',
-      onSelect: () => openInAI('https://www.perplexity.ai/search'),
       title: 'Open in Perplexity',
     },
     {
       description: 'Ask Gemini about this page',
+      href: aiHref('https://www.google.com/search', {udm: '50'}),
       icon: <GeminiIcon />,
       id: 'gemini',
-      onSelect: () => openInAI('https://www.google.com/search', {udm: '50'}),
       title: 'Open in Gemini',
     },
   ];

--- a/packages/lexical-website/src/components/CopyPageButton/index.tsx
+++ b/packages/lexical-website/src/components/CopyPageButton/index.tsx
@@ -18,14 +18,11 @@ import React, {
   useSyncExternalStore,
 } from 'react';
 
+import {
+  MARKDOWN_NAMESPACE,
+  relativeMarkdownPath,
+} from '../../../plugins/copy-page-button/markdownPath.mjs';
 import styles from './styles.module.css';
-
-/**
- * The path namespace under which the build-time `copy-page-button` plugin emits
- * a Markdown copy of every doc page. Must stay in sync with the plugin's
- * `OUTPUT_NAMESPACE`.
- */
-const MARKDOWN_NAMESPACE = 'llms';
 
 /**
  * Whether to show the "Open in <AI tool>" menu items. Disabled because the
@@ -192,14 +189,11 @@ export default function CopyPageButton(): React.ReactNode {
   const {metadata} = useDoc();
   const {siteConfig} = useDocusaurusContext();
 
-  // `permalink` already includes the site baseUrl. Strip it so useBaseUrl can
-  // re-add it, keeping the namespace path correct under any baseUrl.
-  const baseUrl = siteConfig.baseUrl;
-  const relativePermalink = metadata.permalink.startsWith(baseUrl)
-    ? metadata.permalink.slice(baseUrl.length)
-    : metadata.permalink.replace(/^\/+/, '');
+  // useBaseUrl re-adds the baseUrl that relativeMarkdownPath stripped, keeping
+  // the path correct under any baseUrl. The shared helper is also what the
+  // build-time plugin uses to name the file, so the two always agree.
   const markdownPath = useBaseUrl(
-    `${MARKDOWN_NAMESPACE}/${relativePermalink.replace(/^\/+/, '')}.md`,
+    `${MARKDOWN_NAMESPACE}/${relativeMarkdownPath(metadata.permalink, siteConfig.baseUrl)}.md`,
   );
 
   const [open, setOpen] = useState(false);

--- a/packages/lexical-website/src/components/CopyPageButton/index.tsx
+++ b/packages/lexical-website/src/components/CopyPageButton/index.tsx
@@ -1,0 +1,339 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import clsx from 'clsx';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+
+import styles from './styles.module.css';
+
+/**
+ * The path namespace under which the build-time `copy-page-button` plugin emits
+ * a Markdown copy of every doc page. Must stay in sync with the plugin's
+ * `OUTPUT_NAMESPACE`.
+ */
+const MARKDOWN_NAMESPACE = 'llms';
+
+function CopyIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function ViewIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="16" y1="13" x2="8" y2="13" />
+      <line x1="16" y1="17" x2="8" y2="17" />
+    </svg>
+  );
+}
+
+function ChatGPTIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="-0.17090198558635983 0.482230148717937 41.14235318283891 40.0339509076386"
+      aria-hidden="true">
+      <path d="M37.532 16.87a9.963 9.963 0 0 0-.856-8.184 10.078 10.078 0 0 0-10.855-4.835A9.964 9.964 0 0 0 18.306.5a10.079 10.079 0 0 0-9.614 6.977 9.967 9.967 0 0 0-6.664 4.834 10.08 10.08 0 0 0 1.24 11.817 9.965 9.965 0 0 0 .856 8.185 10.079 10.079 0 0 0 10.855 4.835 9.965 9.965 0 0 0 7.516 3.35 10.078 10.078 0 0 0 9.617-6.981 9.967 9.967 0 0 0 6.663-4.834 10.079 10.079 0 0 0-1.243-11.813zM22.498 37.886a7.474 7.474 0 0 1-4.799-1.735c.061-.033.168-.091.237-.134l7.964-4.6a1.294 1.294 0 0 0 .655-1.134V19.054l3.366 1.944a.12.12 0 0 1 .066.092v9.299a7.505 7.505 0 0 1-7.49 7.496zM6.392 31.006a7.471 7.471 0 0 1-.894-5.023c.06.036.162.099.237.141l7.964 4.6a1.297 1.297 0 0 0 1.308 0l9.724-5.614v3.888a.12.12 0 0 1-.048.103l-8.051 4.649a7.504 7.504 0 0 1-10.24-2.744zM4.297 13.62A7.469 7.469 0 0 1 8.2 10.333c0 .068-.004.19-.004.274v9.201a1.294 1.294 0 0 0 .654 1.132l9.723 5.614-3.366 1.944a.12.12 0 0 1-.114.01L7.04 23.856a7.504 7.504 0 0 1-2.743-10.237zm27.658 6.437l-9.724-5.615 3.367-1.943a.121.121 0 0 1 .113-.01l8.052 4.648a7.498 7.498 0 0 1-1.158 13.528v-9.476a1.293 1.293 0 0 0-.65-1.132zm3.35-5.043c-.059-.037-.162-.099-.236-.141l-7.965-4.6a1.298 1.298 0 0 0-1.308 0l-9.723 5.614v-3.888a.12.12 0 0 1 .048-.103l8.05-4.645a7.497 7.497 0 0 1 11.135 7.763zm-21.063 6.929l-3.367-1.944a.12.12 0 0 1-.065-.092v-9.299a7.497 7.497 0 0 1 12.293-5.756 6.94 6.94 0 0 0-.236.134l-7.965 4.6a1.294 1.294 0 0 0-.654 1.132l-.006 11.225zm1.829-3.943l4.33-2.501 4.332 2.5v5l-4.331 2.5-4.331-2.5V18z" />
+    </svg>
+  );
+}
+
+function ClaudeIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      fill="currentColor"
+      fillRule="evenodd"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true">
+      <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z" />
+    </svg>
+  );
+}
+
+function PerplexityIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true">
+      <path d="M22 12.2H13.4V3.7l-1.4 1.2V12.2H3.4l8.6 7.5V22h1.4v-2.3l8.6-7.5zM12 18.3 5.7 13H12v5.3zm1.4 0V13h5.9l-5.9 5.3zM12 10.7V5.6l5.7 5.1H12zm-1.4 0H4.3L10 5.6v5.1z" />
+    </svg>
+  );
+}
+
+function GeminiIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      aria-hidden="true">
+      <path
+        d="M16 8.016A8.522 8.522 0 008.016 16h-.032A8.521 8.521 0 000 8.016v-.032A8.521 8.521 0 007.984 0h.032A8.522 8.522 0 0016 7.984v.032z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function ChevronIcon({open}: {open: boolean}) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={clsx(styles.chevron, open && styles.chevronOpen)}
+      aria-hidden="true">
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+type MenuItem = {
+  id: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  href?: string;
+  onSelect?: () => void;
+};
+
+export default function CopyPageButton(): React.ReactNode {
+  const {metadata} = useDoc();
+  const {siteConfig} = useDocusaurusContext();
+
+  // `permalink` already includes the site baseUrl. Strip it so useBaseUrl can
+  // re-add it, keeping the namespace path correct under any baseUrl.
+  const baseUrl = siteConfig.baseUrl;
+  const relativePermalink = metadata.permalink.startsWith(baseUrl)
+    ? metadata.permalink.slice(baseUrl.length)
+    : metadata.permalink.replace(/^\/+/, '');
+  const markdownPath = useBaseUrl(
+    `${MARKDOWN_NAMESPACE}/${relativePermalink.replace(/^\/+/, '')}.md`,
+  );
+
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onPointerDown = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const copyMarkdown = useCallback(async () => {
+    try {
+      const response = await fetch(markdownPath);
+      const text = await response.text();
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard or fetch unavailable; fail silently.
+    }
+  }, [markdownPath]);
+
+  const openInAI = useCallback(
+    (base: string, extraParams: Record<string, string> = {}) => {
+      // Resolve the Markdown URL against the live origin so it points at the
+      // current deployment (production, preview, or local) rather than a
+      // hard-coded host.
+      const absoluteMarkdownUrl = new URL(
+        markdownPath,
+        window.location.origin,
+      ).toString();
+      const prompt = `Please read and explain this documentation page: ${absoluteMarkdownUrl}\n\nPlease provide a clear summary and help me understand the key concepts covered in this documentation.`;
+      const params = new URLSearchParams({q: prompt, ...extraParams});
+      window.open(`${base}?${params.toString()}`, '_blank', 'noopener');
+    },
+    [markdownPath],
+  );
+
+  const items: MenuItem[] = [
+    {
+      description: copied
+        ? 'Copied to clipboard'
+        : 'Copy this page as Markdown for LLMs',
+      icon: copied ? <CheckIcon /> : <CopyIcon />,
+      id: 'copy',
+      onSelect: copyMarkdown,
+      title: copied ? 'Copied!' : 'Copy as Markdown',
+    },
+    {
+      description: 'View this page as plain Markdown',
+      href: markdownPath,
+      icon: <ViewIcon />,
+      id: 'view',
+      title: 'View as Markdown',
+    },
+    {
+      description: 'Ask ChatGPT about this page',
+      icon: <ChatGPTIcon />,
+      id: 'chatgpt',
+      onSelect: () => openInAI('https://chatgpt.com/'),
+      title: 'Open in ChatGPT',
+    },
+    {
+      description: 'Ask Claude about this page',
+      icon: <ClaudeIcon />,
+      id: 'claude',
+      onSelect: () => openInAI('https://claude.ai/new'),
+      title: 'Open in Claude',
+    },
+    {
+      description: 'Ask Perplexity about this page',
+      icon: <PerplexityIcon />,
+      id: 'perplexity',
+      onSelect: () => openInAI('https://www.perplexity.ai/search'),
+      title: 'Open in Perplexity',
+    },
+    {
+      description: 'Ask Gemini about this page',
+      icon: <GeminiIcon />,
+      id: 'gemini',
+      onSelect: () => openInAI('https://www.google.com/search', {udm: '50'}),
+      title: 'Open in Gemini',
+    },
+  ];
+
+  return (
+    <div className={styles.copyPage} ref={containerRef}>
+      <button
+        type="button"
+        className={styles.trigger}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Copy this page as Markdown"
+        onClick={() => setOpen(value => !value)}>
+        <CopyIcon />
+        <span className={styles.triggerLabel}>Copy page</span>
+        <ChevronIcon open={open} />
+      </button>
+      {open && (
+        <div className={styles.menu} role="menu">
+          {items.map(item => {
+            const content = (
+              <>
+                <span className={styles.itemIcon}>{item.icon}</span>
+                <span className={styles.itemText}>
+                  <span className={styles.itemTitle}>{item.title}</span>
+                  <span className={styles.itemDescription}>
+                    {item.description}
+                  </span>
+                </span>
+              </>
+            );
+            if (item.href) {
+              return (
+                <a
+                  key={item.id}
+                  className={styles.item}
+                  href={item.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  role="menuitem"
+                  onClick={() => setOpen(false)}>
+                  {content}
+                </a>
+              );
+            }
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className={styles.item}
+                role="menuitem"
+                onClick={() => {
+                  if (item.onSelect) {
+                    item.onSelect();
+                  }
+                  if (item.id !== 'copy') {
+                    setOpen(false);
+                  }
+                }}>
+                {content}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/lexical-website/src/components/CopyPageButton/index.tsx
+++ b/packages/lexical-website/src/components/CopyPageButton/index.tsx
@@ -27,6 +27,14 @@ import styles from './styles.module.css';
  */
 const MARKDOWN_NAMESPACE = 'llms';
 
+/**
+ * Whether to show the "Open in <AI tool>" menu items. Disabled because the
+ * assistants tend to hallucinate having read the linked Markdown rather than
+ * actually fetching it. The handlers are kept (see `aiToolItems`) so they can
+ * be restored by flipping this flag.
+ */
+const ENABLE_AI_TOOL_LINKS: boolean = false;
+
 // location.origin can't change without a full navigation (which remounts), so
 // there is nothing to subscribe to.
 const subscribeToOrigin = () => () => {};
@@ -243,24 +251,9 @@ export default function CopyPageButton(): React.ReactNode {
 
   // "Open in <tool>" links are plain anchors (target=_blank) rather than
   // window.open() calls: anchors are treated as user-initiated navigations and
-  // aren't silently swallowed by popup blockers.
-  const items: MenuItem[] = [
-    {
-      description: copied
-        ? 'Copied to clipboard'
-        : 'Copy this page as Markdown for LLMs',
-      icon: copied ? <CheckIcon /> : <CopyIcon />,
-      id: 'copy',
-      onSelect: copyMarkdown,
-      title: copied ? 'Copied!' : 'Copy as Markdown',
-    },
-    {
-      description: 'View this page as plain Markdown',
-      href: markdownPath,
-      icon: <ViewIcon />,
-      id: 'view',
-      title: 'View as Markdown',
-    },
+  // aren't silently swallowed by popup blockers. Currently gated off by
+  // ENABLE_AI_TOOL_LINKS.
+  const aiToolItems: MenuItem[] = [
     {
       description: 'Ask ChatGPT about this page',
       href: aiHref('https://chatgpt.com/'),
@@ -289,6 +282,26 @@ export default function CopyPageButton(): React.ReactNode {
       id: 'gemini',
       title: 'Open in Gemini',
     },
+  ];
+
+  const items: MenuItem[] = [
+    {
+      description: copied
+        ? 'Copied to clipboard'
+        : 'Copy this page as Markdown for LLMs',
+      icon: copied ? <CheckIcon /> : <CopyIcon />,
+      id: 'copy',
+      onSelect: copyMarkdown,
+      title: copied ? 'Copied!' : 'Copy as Markdown',
+    },
+    {
+      description: 'View this page as plain Markdown',
+      href: markdownPath,
+      icon: <ViewIcon />,
+      id: 'view',
+      title: 'View as Markdown',
+    },
+    ...(ENABLE_AI_TOOL_LINKS ? aiToolItems : []),
   ];
 
   return (

--- a/packages/lexical-website/src/components/CopyPageButton/styles.module.css
+++ b/packages/lexical-website/src/components/CopyPageButton/styles.module.css
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.copyPage {
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1.2;
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  cursor: pointer;
+  transition:
+    background var(--ifm-transition-fast) ease,
+    border-color var(--ifm-transition-fast) ease;
+}
+
+.trigger:hover {
+  background: var(--ifm-color-emphasis-100);
+  border-color: var(--ifm-color-emphasis-400);
+}
+
+.triggerLabel {
+  white-space: nowrap;
+}
+
+.chevron {
+  transition: transform var(--ifm-transition-fast) ease;
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  z-index: var(--ifm-z-index-dropdown, 200);
+  min-width: 280px;
+  padding: 0.3rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-md);
+}
+
+.item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  text-align: left;
+  color: var(--ifm-font-color-base);
+  background: transparent;
+  border: none;
+  border-radius: var(--ifm-global-radius);
+  cursor: pointer;
+  font: inherit;
+}
+
+.item:hover {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+}
+
+.itemIcon {
+  display: flex;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.itemText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.itemTitle {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.itemDescription {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+}

--- a/packages/lexical-website/src/components/CopyPageButton/styles.module.css
+++ b/packages/lexical-website/src/components/CopyPageButton/styles.module.css
@@ -8,7 +8,7 @@
 .copyPage {
   position: relative;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .trigger {
@@ -49,7 +49,7 @@
 .menu {
   position: absolute;
   top: calc(100% + 0.4rem);
-  right: 0;
+  left: 0;
   z-index: var(--ifm-z-index-dropdown, 200);
   min-width: 280px;
   padding: 0.3rem;

--- a/packages/lexical-website/src/theme/DocItem/Layout/index.tsx
+++ b/packages/lexical-website/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Swizzled (ejected) from `@docusaurus/theme-classic` to render a
+ * server-side `CopyPageButton` in a persistent right-hand column.
+ *
+ * Unlike the upstream layout, the right column is rendered on every doc page
+ * (not only when a table of contents exists) so the "Copy page" button always
+ * appears in the same place. On narrow viewports the right column is hidden and
+ * the button falls back to the top of the article. Because the button is part
+ * of the static HTML, it never flashes in after hydration.
+ */
+
+import type {Props} from '@theme/DocItem/Layout';
+
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import {useWindowSize} from '@docusaurus/theme-common';
+import ContentVisibility from '@theme/ContentVisibility';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import DocItemContent from '@theme/DocItem/Content';
+import DocItemFooter from '@theme/DocItem/Footer';
+import DocItemPaginator from '@theme/DocItem/Paginator';
+import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
+import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import clsx from 'clsx';
+import React, {type ReactNode} from 'react';
+
+import CopyPageButton from '../../../components/CopyPageButton';
+import styles from './styles.module.css';
+
+function useDocTOC() {
+  const {frontMatter, toc} = useDoc();
+  const windowSize = useWindowSize();
+
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+
+  const desktop =
+    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+
+  return {
+    desktop,
+    hidden,
+    mobile,
+  };
+}
+
+export default function DocItemLayout({children}: Props): ReactNode {
+  const docTOC = useDocTOC();
+  const {metadata} = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx('col', styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            <div className={styles.copyPageMobile}>
+              <CopyPageButton />
+            </div>
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      <div className={clsx('col col--3', styles.tocCol)}>
+        <div className={styles.copyPageDesktop}>
+          <CopyPageButton />
+        </div>
+        {docTOC.desktop}
+      </div>
+    </div>
+  );
+}

--- a/packages/lexical-website/src/theme/DocItem/Layout/styles.module.css
+++ b/packages/lexical-website/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+/* Always reserve space for the right column on desktop so the layout (and the
+ * Copy page button) stays consistent across pages with and without a TOC. */
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}
+
+/* The right column always renders on desktop but is hidden on mobile, where the
+ * button falls back to the top of the article. */
+@media (max-width: 996px) {
+  .tocCol {
+    display: none;
+  }
+}
+
+.copyPageDesktop {
+  margin-bottom: 1rem;
+}
+
+.copyPageMobile {
+  margin-bottom: 0.75rem;
+}
+
+@media (min-width: 997px) {
+  .copyPageMobile {
+    display: none;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -944,6 +944,9 @@ importers:
       '@docusaurus/plugin-client-redirects':
         specifier: ^3.10.1
         version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7))(@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs':
+        specifier: ^3.10.1
+        version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7))(@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/preset-classic':
         specifier: ^3.10.1
         version: 3.10.1(@algolia/client-search@5.46.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7))(@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.15)(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
@@ -14706,7 +14709,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.2.5)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.15
       react: 19.2.5
 
   '@docusaurus/theme-classic@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.15)(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':


### PR DESCRIPTION
## Description

Adds an in-repo "Copy page" button to documentation pages (Copy / View as Markdown). The button is rendered server-side in a persistent right-hand column on every doc page so it never flashes in after hydration and stays in a consistent location even on pages without a table of contents.

A build-time plugin emits a clean Markdown copy of each doc page under /llms/<path>.md so the actions use real Markdown instead of scraping the DOM on the client. A webpack alias dedupes @docusaurus/plugin-content-docs so the swizzled DocItem/Layout shares the DocProvider context with theme-classic.

The Open in ChatGPT, Claude, Perplexity, Gemini options have been hidden and disabled for now as it seems that the vercel config and/or these providers are ignoring the actual URLs and just hallucinating.

Closes #8568

## Test plan

QA of built doc site