### PR TITLE
fix: prevent MOVE_TO_END/MOVE_TO_START crash on decorator-only elements

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
@@ -151,6 +151,15 @@ describe('MOVE_TO_END no-op cases (Issue #8555)', () => {
         paragraph.select(1, 1);
       },
     },
+    {
+      label: 'decorator-only element (no selectable text)',
+      setup: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(decorator);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+    },
   ])('no-op: $label', ({setup}) => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: setup,
@@ -163,6 +172,54 @@ describe('MOVE_TO_END no-op cases (Issue #8555)', () => {
 
     dispatchMoveToEnd(editor, false);
 
+    expect(snapshotSelection(editor)).toEqual(before);
+  });
+});
+
+describe('MOVE_TO_END decorator-only safety (crash fix)', () => {
+  test('Cmd+ArrowRight on decorator-only element does not throw', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(decorator);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    // Should not throw — previously this would crash with selectEnd() on empty element
+    expect(() => dispatchMoveToEnd(editor, false)).not.toThrow();
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      // Selection remains valid
+      expect(selection.anchor.type).toBeDefined();
+    });
+  });
+
+  test('Shift+Cmd+ArrowRight on decorator-only element does not dispatch MOVE_TO_END', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(decorator);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    const before = snapshotSelection(editor);
+
+    // Shift+Cmd+Arrow should no longer match isMoveToEnd (matcher tightened)
+    dispatchMoveToEnd(editor, true);
+
+    // Selection unchanged — handler returned false
     expect(snapshotSelection(editor)).toEqual(before);
   });
 });

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
@@ -153,6 +153,15 @@ describe('MOVE_TO_START no-op cases (Issue #8555)', () => {
         paragraph.select(0, 0);
       },
     },
+    {
+      label: 'decorator-only element (no selectable text)',
+      setup: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(decorator);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(1, 1);
+      },
+    },
   ])('no-op: $label', ({setup}) => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: setup,
@@ -166,5 +175,29 @@ describe('MOVE_TO_START no-op cases (Issue #8555)', () => {
     dispatchMoveToStart(editor, false);
 
     expect(snapshotSelection(editor)).toEqual(before);
+  });
+});
+
+describe('MOVE_TO_START decorator-only safety (crash fix)', () => {
+  test('Cmd+ArrowLeft on decorator-only element does not throw', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(decorator);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(1, 1);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    expect(() => dispatchMoveToStart(editor, false)).not.toThrow();
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.anchor.type).toBeDefined();
+    });
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1296,6 +1296,11 @@ export function registerRichText(
         if (!$isDecoratorNode(firstChild) || !firstChild.isInline()) {
           return false;
         }
+        const lastDescendant = element.getLastDescendant();
+        if (lastDescendant == null || $isDecoratorNode(lastDescendant)) {
+          // No selectable text — fall through to native browser behavior.
+          return false;
+        }
         // Native browser cursor traversal stops at the inline decorator's
         // contenteditable=false boundary when the caret starts at element
         // offset 0, so MOVE_TO_END leaves the caret stuck. Move it ourselves.
@@ -1328,6 +1333,11 @@ export function registerRichText(
         }
         const firstChild = focusBlock.getFirstChild();
         if (!$isDecoratorNode(firstChild) || !firstChild.isInline()) {
+          return false;
+        }
+        const lastDescendant = focusBlock.getLastDescendant();
+        if (lastDescendant == null || $isDecoratorNode(lastDescendant)) {
+          // No selectable text — fall through to native browser behavior.
           return false;
         }
         // Cross-block selections fall through to native handling. The

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1157,10 +1157,7 @@ export function isMoveBackward(event: KeyboardEventModifiers): boolean {
 }
 
 export function isMoveToStart(event: KeyboardEventModifiers): boolean {
-  return isExactShortcutMatch(event, 'ArrowLeft', {
-    ...CONTROL_OR_META,
-    shiftKey: 'any',
-  });
+  return isExactShortcutMatch(event, 'ArrowLeft', CONTROL_OR_META);
 }
 
 export function isMoveForward(event: KeyboardEventModifiers): boolean {
@@ -1170,10 +1167,7 @@ export function isMoveForward(event: KeyboardEventModifiers): boolean {
 }
 
 export function isMoveToEnd(event: KeyboardEventModifiers): boolean {
-  return isExactShortcutMatch(event, 'ArrowRight', {
-    ...CONTROL_OR_META,
-    shiftKey: 'any',
-  });
+  return isExactShortcutMatch(event, 'ArrowRight', CONTROL_OR_META);
 }
 
 export function isMoveUp(event: KeyboardEventModifiers): boolean {

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -323,7 +323,7 @@ describe('LexicalUtils tests', () => {
       );
     });
 
-    test('isMoveToEnd() / isMoveToStart() accept Shift modifier', () => {
+    test('isMoveToEnd() / isMoveToStart() reject Shift modifier', () => {
       const modifier = IS_APPLE ? {metaKey: true} : {ctrlKey: true};
 
       const rightWithoutShift = new KeyboardEvent('keydown', {
@@ -346,9 +346,9 @@ describe('LexicalUtils tests', () => {
       });
 
       expect(isMoveToEnd(rightWithoutShift)).toBe(true);
-      expect(isMoveToEnd(rightWithShift)).toBe(true);
+      expect(isMoveToEnd(rightWithShift)).toBe(false);
       expect(isMoveToStart(leftWithoutShift)).toBe(true);
-      expect(isMoveToStart(leftWithShift)).toBe(true);
+      expect(isMoveToStart(leftWithShift)).toBe(false);
 
       // Wrong direction rejected
       expect(isMoveToEnd(leftWithoutShift)).toBe(false);


### PR DESCRIPTION
## Summary

PR #8558 ("Fix: cursor stuck before leading inline DecoratorNode") broadened the `isMoveToStart`/`isMoveToEnd` shortcut matchers to `shiftKey: 'any'`, so `Shift+Cmd+Arrow` (a selection-extension shortcut on macOS) now dispatches `MOVE_TO_START`/`MOVE_TO_END` in addition to the previous `Cmd+Arrow`. The new command handlers call `element.selectEnd()`/`selectStart()` unconditionally on the parent element. When the editor contains only an inline DecoratorNode (e.g. a chip-only composer), the element has no selectable text content and `selectEnd()` throws.

## Changes

1. **Tightens `isMoveToStart`/`isMoveToEnd` matchers** back to `Cmd+Arrow` only (removes `shiftKey: 'any'`), so `Shift+Cmd+Arrow` falls through to native selection-extension behavior.

2. **Adds defensive checks** in `MOVE_TO_END`/`MOVE_TO_START` handlers: before calling `selectEnd()`/`selectStart()`, checks whether the element has a non-decorator last/first descendant. If not (decorator-only element), returns `false` to fall through to native browser behavior.

## Test Plan

Added test cases to both `RichTextInlineDecoratorMoveToEnd.test.ts` and `RichTextInlineDecoratorMoveToStart.test.ts`:

1. **Decorator-only Cmd+Arrow** — editor with a single inline DecoratorNode (no surrounding text). Dispatch Cmd+ArrowRight. Assert: no throw, selection remains valid.
2. **Decorator-only Shift+Cmd+Arrow** — same setup, dispatch Shift+Cmd+ArrowRight. Assert: handler returns false (native selection-extension fires instead), no throw.
3. **Mixed-content still works** — existing tests confirm the original PR #8558 behavior (decorator + text) is preserved.

## Impact

~469 affected users in 24h before revert. This fix allows the revert to be re-landed safely.