### PR TITLE
[lexical][lexical-rich-text] Bug Fix: Restore Shift+Cmd+Arrow selection extension on leading inline DecoratorNode

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
@@ -151,15 +151,6 @@ describe('MOVE_TO_END no-op cases (Issue #8555)', () => {
         paragraph.select(1, 1);
       },
     },
-    {
-      label: 'decorator-only element (no selectable text)',
-      setup: () => {
-        const decorator = $createTestDecoratorNode().setIsInline(true);
-        const paragraph = $createParagraphNode().append(decorator);
-        $getRoot().clear().append(paragraph);
-        paragraph.select(0, 0);
-      },
-    },
   ])('no-op: $label', ({setup}) => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: setup,
@@ -168,16 +159,22 @@ describe('MOVE_TO_END no-op cases (Issue #8555)', () => {
       nodes: [TestDecoratorNode],
     });
 
-    const before = snapshotSelection(editor);
-
+    // Same selection-unchanged expectation for Cmd+Arrow and
+    // Shift+Cmd+Arrow — the handler's guards don't branch on
+    // shiftKey, and the matcher accepts either, so both should
+    // fall through to native browser behavior.
+    const beforeNoShift = snapshotSelection(editor);
     dispatchMoveToEnd(editor, false);
+    expect(snapshotSelection(editor)).toEqual(beforeNoShift);
 
-    expect(snapshotSelection(editor)).toEqual(before);
+    const beforeWithShift = snapshotSelection(editor);
+    dispatchMoveToEnd(editor, true);
+    expect(snapshotSelection(editor)).toEqual(beforeWithShift);
   });
 });
 
-describe('MOVE_TO_END decorator-only safety (crash fix)', () => {
-  test('Cmd+ArrowRight on decorator-only element does not throw', () => {
+describe('MOVE_TO_END decorator-only element (no selectable text)', () => {
+  test('Cmd+ArrowRight moves caret past the decorator to element end', () => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: () => {
         const decorator = $createTestDecoratorNode().setIsInline(true);
@@ -190,18 +187,18 @@ describe('MOVE_TO_END decorator-only safety (crash fix)', () => {
       nodes: [TestDecoratorNode],
     });
 
-    // Should not throw — previously this would crash with selectEnd() on empty element
     expect(() => dispatchMoveToEnd(editor, false)).not.toThrow();
 
     editor.read(() => {
       const selection = $getSelection();
       assert($isRangeSelection(selection));
-      // Selection remains valid
-      expect(selection.anchor.type).toBeDefined();
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.offset).toBe(1);
     });
   });
 
-  test('Shift+Cmd+ArrowRight on decorator-only element does not dispatch MOVE_TO_END', () => {
+  test('Shift+Cmd+ArrowRight extends selection over the decorator', () => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: () => {
         const decorator = $createTestDecoratorNode().setIsInline(true);
@@ -214,12 +211,16 @@ describe('MOVE_TO_END decorator-only safety (crash fix)', () => {
       nodes: [TestDecoratorNode],
     });
 
-    const before = snapshotSelection(editor);
+    expect(() => dispatchMoveToEnd(editor, true)).not.toThrow();
 
-    // Shift+Cmd+Arrow should no longer match isMoveToEnd (matcher tightened)
-    dispatchMoveToEnd(editor, true);
-
-    // Selection unchanged — handler returned false
-    expect(snapshotSelection(editor)).toEqual(before);
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.isCollapsed()).toBe(false);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.offset).toBe(0);
+      expect(selection.focus.type).toBe('element');
+      expect(selection.focus.offset).toBe(1);
+    });
   });
 });

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
@@ -153,15 +153,6 @@ describe('MOVE_TO_START no-op cases (Issue #8555)', () => {
         paragraph.select(0, 0);
       },
     },
-    {
-      label: 'decorator-only element (no selectable text)',
-      setup: () => {
-        const decorator = $createTestDecoratorNode().setIsInline(true);
-        const paragraph = $createParagraphNode().append(decorator);
-        $getRoot().clear().append(paragraph);
-        paragraph.select(1, 1);
-      },
-    },
   ])('no-op: $label', ({setup}) => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: setup,
@@ -170,16 +161,22 @@ describe('MOVE_TO_START no-op cases (Issue #8555)', () => {
       nodes: [TestDecoratorNode],
     });
 
-    const before = snapshotSelection(editor);
-
+    // Same selection-unchanged expectation for Cmd+Arrow and
+    // Shift+Cmd+Arrow — the handler's guards don't branch on
+    // shiftKey, and the matcher accepts either, so both should
+    // fall through to native browser behavior.
+    const beforeNoShift = snapshotSelection(editor);
     dispatchMoveToStart(editor, false);
+    expect(snapshotSelection(editor)).toEqual(beforeNoShift);
 
-    expect(snapshotSelection(editor)).toEqual(before);
+    const beforeWithShift = snapshotSelection(editor);
+    dispatchMoveToStart(editor, true);
+    expect(snapshotSelection(editor)).toEqual(beforeWithShift);
   });
 });
 
-describe('MOVE_TO_START decorator-only safety (crash fix)', () => {
-  test('Cmd+ArrowLeft on decorator-only element does not throw', () => {
+describe('MOVE_TO_START decorator-only element (no selectable text)', () => {
+  test('Cmd+ArrowLeft moves caret before the decorator', () => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: () => {
         const decorator = $createTestDecoratorNode().setIsInline(true);
@@ -197,7 +194,35 @@ describe('MOVE_TO_START decorator-only safety (crash fix)', () => {
     editor.read(() => {
       const selection = $getSelection();
       assert($isRangeSelection(selection));
-      expect(selection.anchor.type).toBeDefined();
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.offset).toBe(0);
+    });
+  });
+
+  test('Shift+Cmd+ArrowLeft extends selection over the decorator', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(decorator);
+        $getRoot().clear().append(paragraph);
+        paragraph.select(1, 1);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    expect(() => dispatchMoveToStart(editor, true)).not.toThrow();
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.isCollapsed()).toBe(false);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.offset).toBe(1);
+      expect(selection.focus.type).toBe('element');
+      expect(selection.focus.offset).toBe(0);
     });
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1296,16 +1296,20 @@ export function registerRichText(
         if (!$isDecoratorNode(firstChild) || !firstChild.isInline()) {
           return false;
         }
-        const lastDescendant = element.getLastDescendant();
-        if (lastDescendant == null || $isDecoratorNode(lastDescendant)) {
-          // No selectable text — fall through to native browser behavior.
-          return false;
-        }
         // Native browser cursor traversal stops at the inline decorator's
         // contenteditable=false boundary when the caret starts at element
         // offset 0, so MOVE_TO_END leaves the caret stuck. Move it ourselves.
         const elementKey = element.getKey();
-        const ending = element.selectEnd();
+        const lastDescendant = element.getLastDescendant();
+        const ending = $isTextNode(lastDescendant)
+          ? lastDescendant.select()
+          : // Decorator-only element: target the position after the decorator
+            // explicitly rather than recursing through element.selectEnd() →
+            // decorator.selectEnd() → parent.select(childrenSize, ...).
+            element.select(
+              element.getChildrenSize(),
+              element.getChildrenSize(),
+            );
         if (event.shiftKey) {
           ending.anchor.set(elementKey, 0, 'element');
         }
@@ -1333,11 +1337,6 @@ export function registerRichText(
         }
         const firstChild = focusBlock.getFirstChild();
         if (!$isDecoratorNode(firstChild) || !firstChild.isInline()) {
-          return false;
-        }
-        const lastDescendant = focusBlock.getLastDescendant();
-        if (lastDescendant == null || $isDecoratorNode(lastDescendant)) {
-          // No selectable text — fall through to native browser behavior.
           return false;
         }
         // Cross-block selections fall through to native handling. The

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1164,7 +1164,10 @@ export function isMoveBackward(event: KeyboardEventModifiers): boolean {
 }
 
 export function isMoveToStart(event: KeyboardEventModifiers): boolean {
-  return isExactShortcutMatch(event, 'ArrowLeft', CONTROL_OR_META);
+  return isExactShortcutMatch(event, 'ArrowLeft', {
+    ...CONTROL_OR_META,
+    shiftKey: 'any',
+  });
 }
 
 export function isMoveForward(event: KeyboardEventModifiers): boolean {
@@ -1174,7 +1177,10 @@ export function isMoveForward(event: KeyboardEventModifiers): boolean {
 }
 
 export function isMoveToEnd(event: KeyboardEventModifiers): boolean {
-  return isExactShortcutMatch(event, 'ArrowRight', CONTROL_OR_META);
+  return isExactShortcutMatch(event, 'ArrowRight', {
+    ...CONTROL_OR_META,
+    shiftKey: 'any',
+  });
 }
 
 export function isMoveUp(event: KeyboardEventModifiers): boolean {

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -323,7 +323,7 @@ describe('LexicalUtils tests', () => {
       );
     });
 
-    test('isMoveToEnd() / isMoveToStart() reject Shift modifier', () => {
+    test('isMoveToEnd() / isMoveToStart() accept Shift modifier', () => {
       const modifier = IS_APPLE ? {metaKey: true} : {ctrlKey: true};
 
       const rightWithoutShift = new KeyboardEvent('keydown', {
@@ -345,10 +345,13 @@ describe('LexicalUtils tests', () => {
         shiftKey: true,
       });
 
+      // Both with and without Shift match. The handlers that consume
+      // these matchers branch on `event.shiftKey` to choose between
+      // moving the caret and extending the selection.
       expect(isMoveToEnd(rightWithoutShift)).toBe(true);
-      expect(isMoveToEnd(rightWithShift)).toBe(false);
+      expect(isMoveToEnd(rightWithShift)).toBe(true);
       expect(isMoveToStart(leftWithoutShift)).toBe(true);
-      expect(isMoveToStart(leftWithShift)).toBe(false);
+      expect(isMoveToStart(leftWithShift)).toBe(true);
 
       // Wrong direction rejected
       expect(isMoveToEnd(leftWithoutShift)).toBe(false);


### PR DESCRIPTION
## Description

PR #8577 removed `shiftKey: 'any'` from `isMoveToStart` / `isMoveToEnd` to avoid a reported crash on decorator-only paragraphs. That also disabled the Shift+Cmd+Arrow selection-extension functionality #8558 added. Per the #8577 discussion, the matcher's Shift behavior was intentional — the right fix is to address the `selectEnd()` recursion on decorator-only elements, not to disable the matcher.

### What changed

- `isMoveToStart` / `isMoveToEnd` accept Shift again (`shiftKey: 'any'` restored).
- `MOVE_TO_END` handler calls `node.select()` directly, branching on `lastDescendant`: text → `text.select()`, otherwise → `element.select(childrenSize, childrenSize)`. The decorator-only path is now explicit instead of routed through `element.selectEnd()` → `decorator.selectEnd()` → `parent.select(...)`.
- `MOVE_TO_START` handler drops the `lastDescendant === decorator` guard. That handler never called `selectStart()`, so the guard was symmetry-only.

### Behavior on decorator-only paragraphs

Cmd+ArrowLeft / Right now move the caret to the position before / after the decorator. Shift variants extend the selection over it. Previously these fell through to native, which left the caret stuck.

### Out of scope

`text [decorator] long-wrapping-text` still uses native Cmd+ArrowRight (= visual line end) while `[decorator] long-wrapping-text` jumps to paragraph end via this handler. That inconsistency was introduced by #8558 and isn't touched here.

## Test plan

- [x] Unit tests in `RichTextInlineDecoratorMoveToEnd.test.ts` + `RichTextInlineDecoratorMoveToStart.test.ts` — `decorator-only` cases moved out of `no-op` into cursor-move / decorator-selected expectations; mixed-content cases preserved.
- [x] Full unit suite (`pnpm vitest run --project unit`) — 140 files / 2764 pass / 1 skip / 0 fail.
- [x] `pnpm tsc --noEmit -p tsconfig.json`, `pnpm flow`, prettier, eslint clean.
- [x] Manual playground (Chrome + Safari):
  - Decorator-only paragraph (`[equation]`):
    - `[eq]|` + Cmd+ArrowLeft → caret moves to element offset 0.
    - `[eq]|` + Shift+Cmd+ArrowLeft → selection (anchor=element 1, focus=element 0).
    - `|[eq]` + Cmd+ArrowRight → caret moves to element offset 1.
    - `|[eq]` + Shift+Cmd+ArrowRight → selection (anchor=element 0, focus=element 1).
  - Mixed content (`[equation]hello`):
    - `|[eq]hello` + Cmd+ArrowRight → caret at text "hello" end.
    - `|[eq]hello` + Shift+Cmd+ArrowRight → selection (anchor=element 0, focus=text end).
    - `[eq]hello|` + Cmd+ArrowLeft → caret at element offset 0.
    - `[eq]hello|` + Shift+Cmd+ArrowLeft → selection (anchor=text end, focus=element 0).
  - Wrapping text (#8558 behavior preserved):
    - `[equation]long-wrapping-text` — Cmd+ArrowRight / Shift+Cmd+ArrowRight reach paragraph end (handler fires).
    - `text [equation] long-wrapping-text` — handler doesn't fire (first child is text); native Cmd+ArrowRight reaches visual line end only.

Refs #8558, #8577.