### PR TITLE
[lexical-playground] Chore: Audit and de-flake the e2e suite (remove all @flaky tags)

### DIFF
--- a/.github/workflows/call-e2e-test.yml
+++ b/.github/workflows/call-e2e-test.yml
@@ -40,14 +40,14 @@ jobs:
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
       - name: Run tests
         if: inputs.editor-mode != 'rich-text-with-collab'
-        run: pnpm run test-e2e-${{ inputs.prod && 'prod-' || '' }}${{ inputs.browser }} ${{ inputs.flaky && '--grep' || '--grep-invert' }} "@flaky"
+        run: pnpm run test-e2e-${{ inputs.prod && 'prod-' || '' }}${{ inputs.browser }} ${{ inputs.flaky && '--grep' || '--grep-invert' }} "@flaky"${{ inputs.flaky && ' --pass-with-no-tests' || '' }}
       - name: Run collab tests
         if: inputs.editor-mode == 'rich-text-with-collab'
         shell: bash
         run: |
           pnpm exec concurrently -k -s first \
             "pnpm run collab" \
-            "pnpm run test-e2e-collab-${{ inputs.prod && 'prod-' || '' }}${{ inputs.browser }} ${{ inputs.flaky && '--grep' || '--grep-invert' }} @flaky"
+            "pnpm run test-e2e-collab-${{ inputs.prod && 'prod-' || '' }}${{ inputs.browser }} ${{ inputs.flaky && '--grep' || '--grep-invert' }} @flaky${{ inputs.flaky && ' --pass-with-no-tests' || '' }}"
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v7

--- a/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
@@ -28,49 +28,45 @@ test.describe('Autocomplete', () => {
   test.beforeEach(({isCollab, page}) =>
     initialize({isAutocomplete: true, isCollab, page}),
   );
-  test(
-    'Can autocomplete a word',
-    {tag: '@flaky'},
-    async ({page, isPlainText}) => {
-      await focusEditor(page);
-      await page.keyboard.type('Sort by alpha');
-      await sleep(500);
-      // The ghost is a DOM-only decoration on the active TextNode's span and
-      // is intentionally not part of EditorState, so it doesn't sync through
-      // Yjs to the right collab frame.
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">
-              Sort by alpha
-              <span
-                class="PlaygroundEditorTheme__autocomplete"
-                contenteditable="false"
-                data-autocomplete-ghost="true">
-                betical (TAB)
-              </span>
+  test('Can autocomplete a word', async ({page, isPlainText}) => {
+    await focusEditor(page);
+    await page.keyboard.type('Sort by alpha');
+    await sleep(500);
+    // The ghost is a DOM-only decoration on the active TextNode's span and
+    // is intentionally not part of EditorState, so it doesn't sync through
+    // Yjs to the right collab frame.
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">
+            Sort by alpha
+            <span
+              class="PlaygroundEditorTheme__autocomplete"
+              contenteditable="false"
+              data-autocomplete-ghost="true">
+              betical (TAB)
             </span>
-          </p>
-        `,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">Sort by alpha</span>
-          </p>
-        `,
-      );
-      await page.keyboard.press('Tab');
-      await page.keyboard.type(' order:');
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">Sort by alphabetical order:</span>
-          </p>
-        `,
-      );
-    },
-  );
+          </span>
+        </p>
+      `,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Sort by alpha</span>
+        </p>
+      `,
+    );
+    await page.keyboard.press('Tab');
+    await page.keyboard.type(' order:');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Sort by alphabetical order:</span>
+        </p>
+      `,
+    );
+  });
 
   test('Can autocomplete in the same format as the original text', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
@@ -104,86 +104,87 @@ test.describe('Clear All Formatting', () => {
     );
   });
 
-  test(
-    `Should preserve the default styling of hashtags and mentions`,
-    {
-      tag: '@flaky',
-    },
-    async ({page}) => {
-      await focusEditor(page);
+  test(`Should preserve the default styling of hashtags and mentions`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
 
-      await page.keyboard.type('#facebook testing');
-      await selectAll(page);
-      await toggleItalic(page);
-      await selectFromBackgroundColorPicker(page);
-      await selectFromColorPicker(page);
-      await selectFromAdditionalStylesDropdown(page, '.clear');
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span
-              class="PlaygroundEditorTheme__hashtag"
-              data-lexical-text="true">
-              #facebook
-            </span>
-            <span data-lexical-text="true">testing</span>
-          </p>
-        `,
-      );
+    await page.keyboard.type('#facebook testing');
+    await selectAll(page);
+    await toggleItalic(page);
+    await selectFromBackgroundColorPicker(page);
+    await selectFromColorPicker(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #facebook
+          </span>
+          <span data-lexical-text="true">testing</span>
+        </p>
+      `,
+    );
 
-      await clearEditor(page);
+    await clearEditor(page);
 
-      await page.keyboard.type('@Luke');
+    await page.keyboard.type('@Luke');
 
-      await waitForSelector(page, '#typeahead-menu ul li');
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">@Luke</span>
-          </p>
-        `,
-      );
+    // Wait until "Luke Skywalker" is the *highlighted* option, not merely
+    // present: while "@Luke" is still being typed, the partial query "@Lu"
+    // also matches "Agent Kallus" (kal**lu**s), which sorts earlier in the
+    // list and is highlighted first, so pressing Enter too early selects it.
+    await waitForSelector(
+      page,
+      '#typeahead-menu ul li[aria-selected="true"]:has-text("Luke Skywalker")',
+    );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">@Luke</span>
+        </p>
+      `,
+    );
 
-      await page.keyboard.press('Enter');
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span
-              class="mention"
-              spellcheck="false"
-              style="background-color: rgba(24, 119, 232, 0.2);"
-              data-lexical-text="true">
-              Luke Skywalker
-            </span>
-          </p>
-        `,
-      );
+    await page.keyboard.press('Enter');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span
+            class="mention"
+            spellcheck="false"
+            style="background-color: rgba(24, 119, 232, 0.2);"
+            data-lexical-text="true">
+            Luke Skywalker
+          </span>
+        </p>
+      `,
+    );
 
-      await page.keyboard.type(' is testing');
-      await selectAll(page);
-      await toggleBold(page);
-      await selectFromColorPicker(page);
-      await selectFromAdditionalStylesDropdown(page, '.clear');
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span
-              class="mention"
-              spellcheck="false"
-              style="background-color: rgba(24, 119, 232, 0.2);"
-              data-lexical-text="true">
-              Luke Skywalker
-            </span>
-            <span data-lexical-text="true">is testing</span>
-          </p>
-        `,
-      );
-    },
-  );
+    await page.keyboard.type(' is testing');
+    await selectAll(page);
+    await toggleBold(page);
+    await selectFromColorPicker(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span
+            class="mention"
+            spellcheck="false"
+            style="background-color: rgba(24, 119, 232, 0.2);"
+            data-lexical-text="true">
+            Luke Skywalker
+          </span>
+          <span data-lexical-text="true">is testing</span>
+        </p>
+      `,
+    );
+  });
 
   test(`Can clear left/center/right alignment when BIU formatting already applied`, async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
@@ -816,61 +816,59 @@ test.describe('CopyAndPaste', () => {
     );
   });
 
-  test(
-    'Pasting a decorator node on a blank line inserts before the line',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isCollab, isPlainText}) => {
-      // TODO: This is skipped on collab because the right frame won't have the block cursor HTML
-      test.skip(isPlainText || isCollab);
+  test('Pasting a decorator node on a blank line inserts before the line', async ({
+    page,
+    isCollab,
+    isPlainText,
+  }) => {
+    // TODO: This is skipped on collab because the right frame won't have the block cursor HTML
+    test.skip(isPlainText || isCollab);
 
-      // copying and pasting the node is easier than creating the clipboard data
-      await focusEditor(page);
-      await insertYouTubeEmbed(page, YOUTUBE_SAMPLE_URL);
-      await page.keyboard.press('ArrowLeft'); // this selects the node
-      await withExclusiveClipboardAccess(async () => {
-        const clipboard = await copyToClipboard(page);
-        await page.keyboard.press('ArrowRight'); // this moves to a new line (empty paragraph node)
-        await pasteFromClipboard(page, clipboard);
+    // copying and pasting the node is easier than creating the clipboard data
+    await focusEditor(page);
+    await insertYouTubeEmbed(page, YOUTUBE_SAMPLE_URL);
+    await page.keyboard.press('ArrowLeft'); // this selects the node
+    await withExclusiveClipboardAccess(async () => {
+      const clipboard = await copyToClipboard(page);
+      await page.keyboard.press('ArrowRight'); // this moves to a new line (empty paragraph node)
+      await pasteFromClipboard(page, clipboard);
 
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-            <div contenteditable="false" data-lexical-decorator="true">
-              <div class="PlaygroundEditorTheme__embedBlock">
-                <iframe
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowfullscreen=""
-                  frameborder="0"
-                  height="315"
-                  src="https://www.youtube-nocookie.com/embed/jNQXAC9IVRw"
-                  title="YouTube video"
-                  width="560"></iframe>
-              </div>
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+          <div contenteditable="false" data-lexical-decorator="true">
+            <div class="PlaygroundEditorTheme__embedBlock">
+              <iframe
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen=""
+                frameborder="0"
+                height="315"
+                src="https://www.youtube-nocookie.com/embed/jNQXAC9IVRw"
+                title="YouTube video"
+                width="560"></iframe>
             </div>
-            <div contenteditable="false" data-lexical-decorator="true">
-              <div class="PlaygroundEditorTheme__embedBlock">
-                <iframe
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowfullscreen=""
-                  frameborder="0"
-                  height="315"
-                  src="https://www.youtube-nocookie.com/embed/jNQXAC9IVRw"
-                  title="YouTube video"
-                  width="560"></iframe>
-              </div>
+          </div>
+          <div contenteditable="false" data-lexical-decorator="true">
+            <div class="PlaygroundEditorTheme__embedBlock">
+              <iframe
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen=""
+                frameborder="0"
+                height="315"
+                src="https://www.youtube-nocookie.com/embed/jNQXAC9IVRw"
+                title="YouTube video"
+                width="560"></iframe>
             </div>
-            <div
-              class="PlaygroundEditorTheme__blockCursor"
-              contenteditable="false"
-              data-lexical-cursor="true"></div>
-          `,
-        );
-      });
-    },
-  );
+          </div>
+          <div
+            class="PlaygroundEditorTheme__blockCursor"
+            contenteditable="false"
+            data-lexical-cursor="true"></div>
+        `,
+      );
+    });
+  });
 
   test('Copy and paste paragraph into quote', async ({page, isPlainText}) => {
     test.skip(isPlainText);

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/ListsCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/ListsCopyAndPaste.spec.mjs
@@ -136,26 +136,80 @@ test.describe('Lists CopyAndPaste', () => {
     });
   });
 
-  test(
-    'Copy and paste of partial list items into the list',
-    {tag: '@flaky'},
-    async ({page, isPlainText, isCollab, browserName}) => {
-      test.skip(isPlainText);
+  test('Copy and paste of partial list items into the list', async ({
+    page,
+    isPlainText,
+    isCollab,
+    browserName,
+  }) => {
+    test.skip(isPlainText);
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      // Add three list items
-      await page.keyboard.type('- one');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('two');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('three');
+    // Add three list items
+    await page.keyboard.type('- one');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('two');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('three');
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
 
-      // Add a paragraph
-      await page.keyboard.type('Some text.');
+    // Add a paragraph
+    await page.keyboard.type('Some text.');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">one</span>
+          </li>
+          <li class="PlaygroundEditorTheme__listItem" value="2">
+            <span data-lexical-text="true">two</span>
+          </li>
+          <li class="PlaygroundEditorTheme__listItem" value="3">
+            <span data-lexical-text="true">three</span>
+          </li>
+        </ul>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Some text.</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 10,
+      anchorPath: [1, 0, 0],
+      focusOffset: 10,
+      focusPath: [1, 0, 0],
+    });
+
+    await page.keyboard.down('Shift');
+    await moveToLineBeginning(page);
+    await moveLeft(page, 3);
+    await page.keyboard.up('Shift');
+
+    await assertSelection(page, {
+      anchorOffset: 10,
+      anchorPath: [1, 0, 0],
+      focusOffset: 3,
+      focusPath: [0, 2, 0, 0],
+    });
+
+    await withExclusiveClipboardAccess(async () => {
+      // Copy the partial list item and paragraph
+      const clipboard = await copyToClipboard(page);
+
+      // Select all and remove content
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowUp');
+      if (!IS_WINDOWS && browserName === 'firefox') {
+        await page.keyboard.press('ArrowUp');
+      }
+      await moveToLineEnd(page);
+
+      await page.keyboard.down('Enter');
 
       await assertHTML(
         page,
@@ -165,9 +219,48 @@ test.describe('Lists CopyAndPaste', () => {
               <span data-lexical-text="true">one</span>
             </li>
             <li class="PlaygroundEditorTheme__listItem" value="2">
-              <span data-lexical-text="true">two</span>
+              <br />
             </li>
             <li class="PlaygroundEditorTheme__listItem" value="3">
+              <span data-lexical-text="true">two</span>
+            </li>
+            <li class="PlaygroundEditorTheme__listItem" value="4">
+              <span data-lexical-text="true">three</span>
+            </li>
+          </ul>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">Some text.</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 1],
+        focusOffset: 0,
+        focusPath: [0, 1],
+      });
+
+      await pasteFromClipboard(page, clipboard);
+
+      await assertHTML(
+        page,
+        html`
+          <ul class="PlaygroundEditorTheme__ul" dir="auto">
+            <li class="PlaygroundEditorTheme__listItem" value="1">
+              <span data-lexical-text="true">one</span>
+            </li>
+            <li class="PlaygroundEditorTheme__listItem" value="2">
+              <span data-lexical-text="true">ee</span>
+            </li>
+          </ul>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">Some text.</span>
+          </p>
+          <ul class="PlaygroundEditorTheme__ul" dir="auto">
+            <li class="PlaygroundEditorTheme__listItem" value="1">
+              <span data-lexical-text="true">two</span>
+            </li>
+            <li class="PlaygroundEditorTheme__listItem" value="2">
               <span data-lexical-text="true">three</span>
             </li>
           </ul>
@@ -182,100 +275,8 @@ test.describe('Lists CopyAndPaste', () => {
         focusOffset: 10,
         focusPath: [1, 0, 0],
       });
-
-      await page.keyboard.down('Shift');
-      await moveToLineBeginning(page);
-      await moveLeft(page, 3);
-      await page.keyboard.up('Shift');
-
-      await assertSelection(page, {
-        anchorOffset: 10,
-        anchorPath: [1, 0, 0],
-        focusOffset: 3,
-        focusPath: [0, 2, 0, 0],
-      });
-
-      await withExclusiveClipboardAccess(async () => {
-        // Copy the partial list item and paragraph
-        const clipboard = await copyToClipboard(page);
-
-        // Select all and remove content
-        await page.keyboard.press('ArrowUp');
-        await page.keyboard.press('ArrowUp');
-        if (!IS_WINDOWS && browserName === 'firefox') {
-          await page.keyboard.press('ArrowUp');
-        }
-        await moveToLineEnd(page);
-
-        await page.keyboard.down('Enter');
-
-        await assertHTML(
-          page,
-          html`
-            <ul class="PlaygroundEditorTheme__ul" dir="auto">
-              <li class="PlaygroundEditorTheme__listItem" value="1">
-                <span data-lexical-text="true">one</span>
-              </li>
-              <li class="PlaygroundEditorTheme__listItem" value="2">
-                <br />
-              </li>
-              <li class="PlaygroundEditorTheme__listItem" value="3">
-                <span data-lexical-text="true">two</span>
-              </li>
-              <li class="PlaygroundEditorTheme__listItem" value="4">
-                <span data-lexical-text="true">three</span>
-              </li>
-            </ul>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">Some text.</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [0, 1],
-          focusOffset: 0,
-          focusPath: [0, 1],
-        });
-
-        await pasteFromClipboard(page, clipboard);
-
-        await assertHTML(
-          page,
-          html`
-            <ul class="PlaygroundEditorTheme__ul" dir="auto">
-              <li class="PlaygroundEditorTheme__listItem" value="1">
-                <span data-lexical-text="true">one</span>
-              </li>
-              <li class="PlaygroundEditorTheme__listItem" value="2">
-                <span data-lexical-text="true">ee</span>
-              </li>
-            </ul>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">Some text.</span>
-            </p>
-            <ul class="PlaygroundEditorTheme__ul" dir="auto">
-              <li class="PlaygroundEditorTheme__listItem" value="1">
-                <span data-lexical-text="true">two</span>
-              </li>
-              <li class="PlaygroundEditorTheme__listItem" value="2">
-                <span data-lexical-text="true">three</span>
-              </li>
-            </ul>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">Some text.</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 10,
-          anchorPath: [1, 0, 0],
-          focusOffset: 10,
-          focusPath: [1, 0, 0],
-        });
-      });
-    },
-  );
+    });
+  });
 
   test('Copy list items and paste back into list', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -26,414 +26,412 @@ import {
 
 test.describe('History', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(
-    `Can type two paragraphs of text and correctly undo and redo`,
-    {
-      tag: '@flaky',
-    },
-    async ({isRichText, page, isCollab}) => {
-      test.skip(isCollab);
-      await page.focus('div[contenteditable="true"]');
-      await page.keyboard.type('hello');
-      await sleep(1050); // default merge interval is 1000, add 50ms as overhead due to CI latency.
-      await page.keyboard.type(' world');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('hello world again');
-      await moveLeft(page, 6);
-      await page.keyboard.type(', again and');
+  test(`Can type two paragraphs of text and correctly undo and redo`, async ({
+    isRichText,
+    page,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    await page.focus('div[contenteditable="true"]');
+    await page.keyboard.type('hello');
+    await sleep(1050); // default merge interval is 1000, add 50ms as overhead due to CI latency.
+    await page.keyboard.type(' world');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('hello world again');
+    await moveLeft(page, 6);
+    await page.keyboard.type(', again and');
 
-      if (isRichText) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-            </p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world, again and again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 22,
-          anchorPath: [1, 0, 0],
-          focusOffset: 22,
-          focusPath: [1, 0, 0],
-        });
-      } else {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-              <br />
-              <span data-lexical-text="true">hello world, again and again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 22,
-          anchorPath: [0, 2, 0],
-          focusOffset: 22,
-          focusPath: [0, 2, 0],
-        });
-      }
-
-      await undo(page);
-
-      if (isRichText) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-            </p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 11,
-          anchorPath: [1, 0, 0],
-          focusOffset: 11,
-          focusPath: [1, 0, 0],
-        });
-      } else {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-              <br />
-              <span data-lexical-text="true">hello world again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 11,
-          anchorPath: [0, 2, 0],
-          focusOffset: 11,
-          focusPath: [0, 2, 0],
-        });
-      }
-
-      await undo(page);
-
-      if (isRichText) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-            </p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <br />
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [1],
-          focusOffset: 0,
-          focusPath: [1],
-        });
-      } else {
-        assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-              <br />
-              <br />
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0],
-          focusOffset: 2,
-          focusPath: [0],
-        });
-      }
-
-      await undo(page);
-
+    if (isRichText) {
       await assertHTML(
         page,
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
             <span data-lexical-text="true">hello world</span>
           </p>
-        `,
-      );
-      await assertSelection(page, {
-        anchorOffset: 11,
-        anchorPath: [0, 0, 0],
-        focusOffset: 11,
-        focusPath: [0, 0, 0],
-      });
-
-      await undo(page);
-
-      await assertHTML(
-        page,
-        html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">hello</span>
+            <span data-lexical-text="true">hello world, again and again</span>
           </p>
         `,
       );
       await assertSelection(page, {
-        anchorOffset: 5,
-        anchorPath: [0, 0, 0],
-        focusOffset: 5,
-        focusPath: [0, 0, 0],
+        anchorOffset: 22,
+        anchorPath: [1, 0, 0],
+        focusOffset: 22,
+        focusPath: [1, 0, 0],
       });
-
-      await undo(page);
-
+    } else {
       await assertHTML(
         page,
         html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+            <br />
+            <span data-lexical-text="true">hello world, again and again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 22,
+        anchorPath: [0, 2, 0],
+        focusOffset: 22,
+        focusPath: [0, 2, 0],
+      });
+    }
+
+    await undo(page);
+
+    if (isRichText) {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+          </p>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 11,
+        anchorPath: [1, 0, 0],
+        focusOffset: 11,
+        focusPath: [1, 0, 0],
+      });
+    } else {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+            <br />
+            <span data-lexical-text="true">hello world again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 11,
+        anchorPath: [0, 2, 0],
+        focusOffset: 11,
+        focusPath: [0, 2, 0],
+      });
+    }
+
+    await undo(page);
+
+    if (isRichText) {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+          </p>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <br />
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1],
+        focusOffset: 0,
+        focusPath: [1],
+      });
+    } else {
+      assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+            <br />
+            <br />
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0],
+        focusOffset: 2,
+        focusPath: [0],
+      });
+    }
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">hello world</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 11,
+      anchorPath: [0, 0, 0],
+      focusOffset: 11,
+      focusPath: [0, 0, 0],
+    });
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">hello</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 5,
+      anchorPath: [0, 0, 0],
+      focusOffset: 5,
+      focusPath: [0, 0, 0],
+    });
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0],
+      focusOffset: 0,
+      focusPath: [0],
+    });
+
+    await redo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">hello</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 5,
+      anchorPath: [0, 0, 0],
+      focusOffset: 5,
+      focusPath: [0, 0, 0],
+    });
+
+    await redo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">hello world</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 11,
+      anchorPath: [0, 0, 0],
+      focusOffset: 11,
+      focusPath: [0, 0, 0],
+    });
+
+    await redo(page);
+
+    if (isRichText) {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+          </p>
           <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
         `,
       );
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [0],
+        anchorPath: [1],
         focusOffset: 0,
-        focusPath: [0],
+        focusPath: [1],
       });
-
-      await redo(page);
-
+    } else {
       await assertHTML(
         page,
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">hello</span>
+            <span data-lexical-text="true">hello world</span>
+            <br />
+            <br />
           </p>
         `,
       );
       await assertSelection(page, {
-        anchorOffset: 5,
-        anchorPath: [0, 0, 0],
-        focusOffset: 5,
-        focusPath: [0, 0, 0],
+        anchorOffset: 2,
+        anchorPath: [0],
+        focusOffset: 2,
+        focusPath: [0],
       });
+    }
 
-      await redo(page);
+    await redo(page);
 
+    if (isRichText) {
       await assertHTML(
         page,
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
             <span data-lexical-text="true">hello world</span>
           </p>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world again</span>
+          </p>
         `,
       );
       await assertSelection(page, {
         anchorOffset: 11,
-        anchorPath: [0, 0, 0],
+        anchorPath: [1, 0, 0],
         focusOffset: 11,
-        focusPath: [0, 0, 0],
+        focusPath: [1, 0, 0],
       });
+    } else {
+      assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+            <br />
+            <span data-lexical-text="true">hello world again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 11,
+        anchorPath: [0, 2, 0],
+        focusOffset: 11,
+        focusPath: [0, 2, 0],
+      });
+    }
 
-      await redo(page);
+    await redo(page);
 
-      if (isRichText) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-            </p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [1],
-          focusOffset: 0,
-          focusPath: [1],
-        });
-      } else {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-              <br />
-              <br />
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0],
-          focusOffset: 2,
-          focusPath: [0],
-        });
-      }
+    if (isRichText) {
+      assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+          </p>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world, again and again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 22,
+        anchorPath: [1, 0, 0],
+        focusOffset: 22,
+        focusPath: [1, 0, 0],
+      });
+    } else {
+      assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+            <br />
+            <span data-lexical-text="true">hello world, again and again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 22,
+        anchorPath: [0, 2, 0],
+        focusOffset: 22,
+        focusPath: [0, 2, 0],
+      });
+    }
 
-      await redo(page);
+    await pressBackspace(page, 4);
 
-      if (isRichText) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-            </p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 11,
-          anchorPath: [1, 0, 0],
-          focusOffset: 11,
-          focusPath: [1, 0, 0],
-        });
-      } else {
-        assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-              <br />
-              <span data-lexical-text="true">hello world again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 11,
-          anchorPath: [0, 2, 0],
-          focusOffset: 11,
-          focusPath: [0, 2, 0],
-        });
-      }
+    if (isRichText) {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+          </p>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world, again again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 18,
+        anchorPath: [1, 0, 0],
+        focusOffset: 18,
+        focusPath: [1, 0, 0],
+      });
+    } else {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+            <br />
+            <span data-lexical-text="true">hello world, again again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 18,
+        anchorPath: [0, 2, 0],
+        focusOffset: 18,
+        focusPath: [0, 2, 0],
+      });
+    }
 
-      await redo(page);
+    await undo(page);
 
-      if (isRichText) {
-        assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-            </p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world, again and again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 22,
-          anchorPath: [1, 0, 0],
-          focusOffset: 22,
-          focusPath: [1, 0, 0],
-        });
-      } else {
-        assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-              <br />
-              <span data-lexical-text="true">hello world, again and again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 22,
-          anchorPath: [0, 2, 0],
-          focusOffset: 22,
-          focusPath: [0, 2, 0],
-        });
-      }
-
-      await pressBackspace(page, 4);
-
-      if (isRichText) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-            </p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world, again again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 18,
-          anchorPath: [1, 0, 0],
-          focusOffset: 18,
-          focusPath: [1, 0, 0],
-        });
-      } else {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-              <br />
-              <span data-lexical-text="true">hello world, again again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 18,
-          anchorPath: [0, 2, 0],
-          focusOffset: 18,
-          focusPath: [0, 2, 0],
-        });
-      }
-
-      await undo(page);
-
-      if (isRichText) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-            </p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world, again and again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 22,
-          anchorPath: [1, 0, 0],
-          focusOffset: 22,
-          focusPath: [1, 0, 0],
-        });
-      } else {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">hello world</span>
-              <br />
-              <span data-lexical-text="true">hello world, again and again</span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 22,
-          anchorPath: [0, 2, 0],
-          focusOffset: 22,
-          focusPath: [0, 2, 0],
-        });
-      }
-    },
-  );
+    if (isRichText) {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+          </p>
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world, again and again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 22,
+        anchorPath: [1, 0, 0],
+        focusOffset: 22,
+        focusPath: [1, 0, 0],
+      });
+    } else {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <span data-lexical-text="true">hello world</span>
+            <br />
+            <span data-lexical-text="true">hello world, again and again</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 22,
+        anchorPath: [0, 2, 0],
+        focusOffset: 22,
+        focusPath: [0, 2, 0],
+      });
+    }
+  });
 
   test('Can coalesce when switching inline styles (#1151)', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -34,126 +34,127 @@ async function toggleBulletList(page) {
 
 test.describe('HorizontalRule', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(
-    'Can create a horizontal rule and move selection around it',
-    {tag: '@flaky'},
-    async ({page, isCollab, isPlainText, browserName}) => {
-      test.skip(isPlainText);
-      await focusEditor(page);
+  test('Can create a horizontal rule and move selection around it', async ({
+    page,
+    isCollab,
+    isPlainText,
+    browserName,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
 
-      await selectFromInsertDropdown(page, '.horizontal-rule');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
 
-      await waitForSelector(page, 'hr');
+    await waitForSelector(page, 'hr');
 
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <hr
+          class="PlaygroundEditorTheme__hr"
+          contenteditable="false"
+          data-lexical-decorator="true" />
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2],
+      focusOffset: 0,
+      focusPath: [2],
+    });
+
+    await page.keyboard.press('ArrowUp');
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0],
+      focusOffset: 0,
+      focusPath: [0],
+    });
+
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2],
+      focusOffset: 0,
+      focusPath: [2],
+    });
+
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0],
+      focusOffset: 0,
+      focusPath: [0],
+    });
+
+    await page.keyboard.type('Some text');
+
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2],
+      focusOffset: 0,
+      focusPath: [2],
+    });
+
+    await page.keyboard.type('Some more text');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Some text</span>
+        </p>
+        <hr
+          class="PlaygroundEditorTheme__hr"
+          contenteditable="false"
+          data-lexical-decorator="true" />
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Some more text</span>
+        </p>
+      `,
+    );
+
+    await moveToLineBeginning(page);
+
+    await page.keyboard.press('ArrowLeft');
+
+    await page.keyboard.press('ArrowLeft');
+
+    await assertSelection(page, {
+      anchorOffset: 1,
+      anchorPath: [0],
+      focusOffset: 1,
+      focusPath: [0],
+    });
+
+    await pressBackspace(page, 10);
+
+    // Collab doesn't process the cursor correctly
+    if (!isCollab) {
       await assertHTML(
         page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <hr
-            class="PlaygroundEditorTheme__hr"
-            contenteditable="false"
-            data-lexical-decorator="true" />
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
+        '<div class="PlaygroundEditorTheme__blockCursor" contenteditable="false" data-lexical-cursor="true"></div><hr class="PlaygroundEditorTheme__hr" data-lexical-decorator="true" contenteditable="false"><p class="PlaygroundEditorTheme__paragraph" dir="auto"><span data-lexical-text="true">Some more text</span></p>',
       );
+    }
 
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [2],
-        focusOffset: 0,
-        focusPath: [2],
-      });
-
-      await page.keyboard.press('ArrowUp');
-
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [0],
-        focusOffset: 0,
-        focusPath: [0],
-      });
-
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('ArrowRight');
-
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [2],
-        focusOffset: 0,
-        focusPath: [2],
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [0],
-        focusOffset: 0,
-        focusPath: [0],
-      });
-
-      await page.keyboard.type('Some text');
-
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('ArrowRight');
-
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [2],
-        focusOffset: 0,
-        focusPath: [2],
-      });
-
-      await page.keyboard.type('Some more text');
-
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">Some text</span>
-          </p>
-          <hr
-            class="PlaygroundEditorTheme__hr"
-            contenteditable="false"
-            data-lexical-decorator="true" />
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">Some more text</span>
-          </p>
-        `,
-      );
-
-      await moveToLineBeginning(page);
-
-      await page.keyboard.press('ArrowLeft');
-
-      await page.keyboard.press('ArrowLeft');
-
-      await assertSelection(page, {
-        anchorOffset: 1,
-        anchorPath: [0],
-        focusOffset: 1,
-        focusPath: [0],
-      });
-
-      await pressBackspace(page, 10);
-
-      // Collab doesn't process the cursor correctly
-      if (!isCollab) {
-        await assertHTML(
-          page,
-          '<div class="PlaygroundEditorTheme__blockCursor" contenteditable="false" data-lexical-cursor="true"></div><hr class="PlaygroundEditorTheme__hr" data-lexical-decorator="true" contenteditable="false"><p class="PlaygroundEditorTheme__paragraph" dir="auto"><span data-lexical-text="true">Some more text</span></p>',
-        );
-      }
-
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [],
-        focusOffset: 0,
-        focusPath: [],
-      });
-    },
-  );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [],
+      focusOffset: 0,
+      focusPath: [],
+    });
+  });
 
   test('Will add a horizontal rule at the end of a current TextNode and move selection to the new ParagraphNode.', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -407,140 +407,132 @@ test.describe.parallel('Links', () => {
     );
   });
 
-  test(
-    `Can create a link with some text after, insert paragraph, then backspace, it should merge correctly`,
-    {
-      tag: '@flaky',
-    },
-    async ({page}) => {
-      await focusEditor(page);
-      await page.keyboard.type(' abc def ');
-      await moveLeft(page, 5);
-      await selectCharacters(page, 'left', 3);
+  test(`Can create a link with some text after, insert paragraph, then backspace, it should merge correctly`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc def ');
+    await moveLeft(page, 5);
+    await selectCharacters(page, 'left', 3);
 
-      // link
-      await click(page, '.link');
-      await click(page, '.link-confirm');
+    // link
+    await click(page, '.link');
+    await click(page, '.link-confirm');
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true"></span>
-            <a
-              class="PlaygroundEditorTheme__link"
-              href="https://"
-              rel="noreferrer">
-              <span data-lexical-text="true">abc</span>
-            </a>
-            <span data-lexical-text="true">def</span>
-          </p>
-        `,
-      );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">abc</span>
+          </a>
+          <span data-lexical-text="true">def</span>
+        </p>
+      `,
+    );
 
-      await moveLeft(page, 1);
-      await moveRight(page, 2);
-      await page.keyboard.press('Enter');
+    await moveLeft(page, 1);
+    await moveRight(page, 2);
+    await page.keyboard.press('Enter');
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true"></span>
-            <a
-              class="PlaygroundEditorTheme__link"
-              href="https://"
-              rel="noreferrer">
-              <span data-lexical-text="true">ab</span>
-            </a>
-          </p>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <a
-              class="PlaygroundEditorTheme__link"
-              href="https://"
-              rel="noreferrer">
-              <span data-lexical-text="true">c</span>
-            </a>
-            <span data-lexical-text="true">def</span>
-          </p>
-        `,
-      );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">ab</span>
+          </a>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">c</span>
+          </a>
+          <span data-lexical-text="true">def</span>
+        </p>
+      `,
+    );
 
-      await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true"></span>
-            <a
-              class="PlaygroundEditorTheme__link"
-              href="https://"
-              rel="noreferrer">
-              <span data-lexical-text="true">abc</span>
-            </a>
-            <span data-lexical-text="true">def</span>
-          </p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">abc</span>
+          </a>
+          <span data-lexical-text="true">def</span>
+        </p>
+      `,
+    );
+  });
 
-  test(
-    `Can backspace across a link and it deletes text, not the whole link`,
-    {
-      tag: '@flaky',
-    },
-    async ({page}) => {
-      await focusEditor(page);
-      await page.keyboard.type(' abc def ');
-      await moveLeft(page, 5);
-      await selectCharacters(page, 'left', 3);
+  test(`Can backspace across a link and it deletes text, not the whole link`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc def ');
+    await moveLeft(page, 5);
+    await selectCharacters(page, 'left', 3);
 
-      // link
-      await click(page, '.link');
-      await click(page, '.link-confirm');
+    // link
+    await click(page, '.link');
+    await click(page, '.link-confirm');
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true"></span>
-            <a
-              class="PlaygroundEditorTheme__link"
-              href="https://"
-              rel="noreferrer">
-              <span data-lexical-text="true">abc</span>
-            </a>
-            <span data-lexical-text="true">def</span>
-          </p>
-        `,
-      );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">abc</span>
+          </a>
+          <span data-lexical-text="true">def</span>
+        </p>
+      `,
+    );
 
-      await moveRight(page, 4);
+    await moveRight(page, 4);
 
-      await page.keyboard.press('Backspace');
-      await page.keyboard.press('Backspace');
-      await page.keyboard.press('Backspace');
-      await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true"></span>
-            <a
-              class="PlaygroundEditorTheme__link"
-              href="https://"
-              rel="noreferrer">
-              <span data-lexical-text="true">ab</span>
-            </a>
-            <span data-lexical-text="true">f</span>
-          </p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">ab</span>
+          </a>
+          <span data-lexical-text="true">f</span>
+        </p>
+      `,
+    );
+  });
 
   test(`Can create a link then replace it with plain text`, async ({page}) => {
     await focusEditor(page);
@@ -1841,120 +1833,111 @@ test.describe.parallel('Links', () => {
     );
   });
 
-  test(
-    'Can handle pressing Enter inside a Link',
-    {tag: '@flaky'},
-    async ({page}) => {
-      await focusEditor(page);
-      await page.keyboard.type('Hello awesome');
-      await selectAll(page);
-      await click(page, '.link');
-      await click(page, '.link-confirm');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.type('world');
+  test('Can handle pressing Enter inside a Link', async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello awesome');
+    await selectAll(page);
+    await click(page, '.link');
+    await click(page, '.link-confirm');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type('world');
 
-      await moveToLineBeginning(page);
-      await moveRight(page, 6);
+    await moveToLineBeginning(page);
+    await moveRight(page, 6);
 
-      await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
 
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto">
-            <a href="https://" rel="noreferrer">
-              <span data-lexical-text="true">Hello</span>
-            </a>
-          </p>
-          <p dir="auto">
-            <a href="https://" rel="noreferrer">
-              <span data-lexical-text="true">awesome</span>
-            </a>
-            <span data-lexical-text="true">world</span>
-          </p>
-        `,
-        undefined,
-        {ignoreClasses: true},
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto">
+          <a href="https://" rel="noreferrer">
+            <span data-lexical-text="true">Hello</span>
+          </a>
+        </p>
+        <p dir="auto">
+          <a href="https://" rel="noreferrer">
+            <span data-lexical-text="true">awesome</span>
+          </a>
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 
-  test(
-    'Can handle pressing Enter inside a Link containing multiple TextNodes',
-    {tag: '@flaky'},
-    async ({page, isCollab}) => {
-      await focusEditor(page);
-      await page.keyboard.type('Hello ');
-      await toggleBold(page);
-      await page.keyboard.type('awe');
-      await toggleBold(page);
-      await page.keyboard.type('some');
-      await selectAll(page);
-      await click(page, '.link');
-      await click(page, '.link-confirm');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.type(' world');
+  test('Can handle pressing Enter inside a Link containing multiple TextNodes', async ({
+    page,
+    isCollab,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello ');
+    await toggleBold(page);
+    await page.keyboard.type('awe');
+    await toggleBold(page);
+    await page.keyboard.type('some');
+    await selectAll(page);
+    await click(page, '.link');
+    await click(page, '.link-confirm');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type(' world');
 
-      await moveToLineBeginning(page);
-      await moveRight(page, 6);
+    await moveToLineBeginning(page);
+    await moveRight(page, 6);
 
-      await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
 
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto">
-            <a href="https://" rel="noreferrer">
-              <span data-lexical-text="true">Hello</span>
-            </a>
-          </p>
-          <p dir="auto">
-            <a href="https://" rel="noreferrer">
-              <strong data-lexical-text="true">awe</strong>
-              <span data-lexical-text="true">some</span>
-            </a>
-            <span data-lexical-text="true">world</span>
-          </p>
-        `,
-        undefined,
-        {ignoreClasses: true},
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto">
+          <a href="https://" rel="noreferrer">
+            <span data-lexical-text="true">Hello</span>
+          </a>
+        </p>
+        <p dir="auto">
+          <a href="https://" rel="noreferrer">
+            <strong data-lexical-text="true">awe</strong>
+            <span data-lexical-text="true">some</span>
+          </a>
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 
-  test(
-    'Can handle pressing Enter at the beginning of a Link',
-    {
-      tag: '@flaky',
-    },
-    async ({page}) => {
-      await focusEditor(page);
-      await page.keyboard.type('Hello awesome');
-      await selectAll(page);
-      await click(page, '.link');
-      await click(page, '.link-confirm');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.type(' world');
+  test('Can handle pressing Enter at the beginning of a Link', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello awesome');
+    await selectAll(page);
+    await click(page, '.link');
+    await click(page, '.link-confirm');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type(' world');
 
-      await moveToLineBeginning(page);
-      await page.keyboard.press('Enter');
+    await moveToLineBeginning(page);
+    await page.keyboard.press('Enter');
 
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto"><br /></p>
-          <p dir="auto">
-            <a href="https://" rel="noreferrer">
-              <span data-lexical-text="true">Hello awesome</span>
-            </a>
-            <span data-lexical-text="true">world</span>
-          </p>
-        `,
-        undefined,
-        {ignoreClasses: true},
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto"><br /></p>
+        <p dir="auto">
+          <a href="https://" rel="noreferrer">
+            <span data-lexical-text="true">Hello awesome</span>
+          </a>
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 
   test('Can handle pressing Enter at the end of a Link', async ({
     isCollab,

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -169,57 +169,54 @@ test.describe('Checklist focus option', () => {
 test.describe.parallel('Nested List', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
 
-  test(
-    `Can create a list and partially copy some content out of it`,
-    {
-      tag: '@flaky',
-    },
-    async ({page, isCollab}) => {
-      await focusEditor(page);
-      await page.keyboard.type(
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam venenatis risus ac cursus efficitur. Cras efficitur magna odio, lacinia posuere mauris placerat in. Etiam eu congue nisl. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nulla vulputate justo id eros convallis, vel pellentesque orci hendrerit. Pellentesque accumsan molestie eros, vitae tempor nisl semper sit amet. Sed vulputate leo dolor, et bibendum quam feugiat eget. Praesent vestibulum libero sed enim ornare, in consequat dui posuere. Maecenas ornare vestibulum felis, non elementum urna imperdiet sit amet.',
-      );
-      await toggleBulletList(page);
-      await moveToEditorBeginning(page);
-      await moveRight(page, 6);
-      await selectCharacters(page, 'right', 11);
+  test(`Can create a list and partially copy some content out of it`, async ({
+    page,
+    isCollab,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam venenatis risus ac cursus efficitur. Cras efficitur magna odio, lacinia posuere mauris placerat in. Etiam eu congue nisl. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nulla vulputate justo id eros convallis, vel pellentesque orci hendrerit. Pellentesque accumsan molestie eros, vitae tempor nisl semper sit amet. Sed vulputate leo dolor, et bibendum quam feugiat eget. Praesent vestibulum libero sed enim ornare, in consequat dui posuere. Maecenas ornare vestibulum felis, non elementum urna imperdiet sit amet.',
+    );
+    await toggleBulletList(page);
+    await moveToEditorBeginning(page);
+    await moveRight(page, 6);
+    await selectCharacters(page, 'right', 11);
 
-      await withExclusiveClipboardAccess(async () => {
-        const clipboard = await copyToClipboard(page);
+    await withExclusiveClipboardAccess(async () => {
+      const clipboard = await copyToClipboard(page);
 
-        await moveToEditorEnd(page);
-        await page.keyboard.press('Enter');
-        await page.keyboard.press('Enter');
+      await moveToEditorEnd(page);
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
 
-        await pasteFromClipboard(page, clipboard);
-      });
+      await pasteFromClipboard(page, clipboard);
+    });
 
-      await assertHTML(
-        page,
-        html`
-          <ul class="PlaygroundEditorTheme__ul" dir="auto">
-            <li class="PlaygroundEditorTheme__listItem" value="1">
-              <span data-lexical-text="true">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
-                venenatis risus ac cursus efficitur. Cras efficitur magna odio,
-                lacinia posuere mauris placerat in. Etiam eu congue nisl.
-                Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
-                posuere cubilia curae; Nulla vulputate justo id eros convallis,
-                vel pellentesque orci hendrerit. Pellentesque accumsan molestie
-                eros, vitae tempor nisl semper sit amet. Sed vulputate leo
-                dolor, et bibendum quam feugiat eget. Praesent vestibulum libero
-                sed enim ornare, in consequat dui posuere. Maecenas ornare
-                vestibulum felis, non elementum urna imperdiet sit amet.
-              </span>
-            </li>
-          </ul>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">ipsum dolor</span>
-          </p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+              venenatis risus ac cursus efficitur. Cras efficitur magna odio,
+              lacinia posuere mauris placerat in. Etiam eu congue nisl.
+              Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+              posuere cubilia curae; Nulla vulputate justo id eros convallis,
+              vel pellentesque orci hendrerit. Pellentesque accumsan molestie
+              eros, vitae tempor nisl semper sit amet. Sed vulputate leo dolor,
+              et bibendum quam feugiat eget. Praesent vestibulum libero sed enim
+              ornare, in consequat dui posuere. Maecenas ornare vestibulum
+              felis, non elementum urna imperdiet sit amet.
+            </span>
+          </li>
+        </ul>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">ipsum dolor</span>
+        </p>
+      `,
+    );
+  });
 
   test('Should outdent if indented when the backspace key is pressed', async ({
     page,
@@ -2614,71 +2611,68 @@ test.describe.parallel('Nested List', () => {
     );
   });
 
-  test(
-    'can navigate and check/uncheck with keyboard',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isCollab}) => {
-      await focusEditor(page);
-      await toggleCheckList(page);
-      //
-      // [ ] a
-      // [ ] b
-      //     [ ] c
-      //         [ ] d
-      //         [ ] e
-      // [ ] f
-      await page.keyboard.type('a');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('b');
-      await page.keyboard.press('Enter');
-      await click(page, '.toolbar-item.alignment');
-      await click(page, 'button:has-text("Indent")');
-      await page.keyboard.type('c');
-      await page.keyboard.press('Enter');
-      await click(page, '.toolbar-item.alignment');
-      await click(page, 'button:has-text("Indent")');
-      await page.keyboard.type('d');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('e');
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Backspace');
-      await page.keyboard.press('Backspace');
-      await page.keyboard.type('f');
+  test('can navigate and check/uncheck with keyboard', async ({
+    page,
+    isCollab,
+  }) => {
+    await focusEditor(page);
+    await toggleCheckList(page);
+    //
+    // [ ] a
+    // [ ] b
+    //     [ ] c
+    //         [ ] d
+    //         [ ] e
+    // [ ] f
+    await page.keyboard.type('a');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('b');
+    await page.keyboard.press('Enter');
+    await click(page, '.toolbar-item.alignment');
+    await click(page, 'button:has-text("Indent")');
+    await page.keyboard.type('c');
+    await page.keyboard.press('Enter');
+    await click(page, '.toolbar-item.alignment');
+    await click(page, 'button:has-text("Indent")');
+    await page.keyboard.type('d');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('e');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('f');
 
-      const assertCheckCount = async (checkCount, uncheckCount) => {
-        const pageOrFrame = await (isCollab ? page.frame('left') : page);
-        await expect(
-          pageOrFrame.locator('li[role="checkbox"][aria-checked="true"]'),
-        ).toHaveCount(checkCount);
-        await expect(
-          pageOrFrame.locator('li[role="checkbox"][aria-checked="false"]'),
-        ).toHaveCount(uncheckCount);
-      };
+    const assertCheckCount = async (checkCount, uncheckCount) => {
+      const pageOrFrame = await (isCollab ? page.frame('left') : page);
+      await expect(
+        pageOrFrame.locator('li[role="checkbox"][aria-checked="true"]'),
+      ).toHaveCount(checkCount);
+      await expect(
+        pageOrFrame.locator('li[role="checkbox"][aria-checked="false"]'),
+      ).toHaveCount(uncheckCount);
+    };
 
-      await assertCheckCount(0, 6);
+    await assertCheckCount(0, 6);
 
-      // Go back to select checkbox
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
+    // Go back to select checkbox
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('Space');
+
+    await repeat(5, async () => {
+      await page.keyboard.press('ArrowUp', {delay: 50});
       await page.keyboard.press('Space');
+    });
 
-      await repeat(5, async () => {
-        await page.keyboard.press('ArrowUp', {delay: 50});
-        await page.keyboard.press('Space');
-      });
+    await assertCheckCount(6, 0);
 
-      await assertCheckCount(6, 0);
+    await repeat(3, async () => {
+      await page.keyboard.press('ArrowDown', {delay: 50});
+      await page.keyboard.press('Space');
+    });
 
-      await repeat(3, async () => {
-        await page.keyboard.press('ArrowDown', {delay: 50});
-        await page.keyboard.press('Space');
-      });
-
-      await assertCheckCount(3, 3);
-    },
-  );
+    await assertCheckCount(3, 3);
+  });
 
   test('replaces existing element node', async ({page}) => {
     // Create two quote blocks, select it and format to a list
@@ -2736,56 +2730,52 @@ test.describe.parallel('Nested List', () => {
     });
   });
 
-  test(
-    'remove list breaks when selection in empty nested list item 2',
-    {
-      tag: '@flaky',
-    },
-    async ({page}) => {
-      await focusEditor(page);
-      await page.keyboard.type('Hello World');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('a');
-      await toggleBulletList(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('b');
-      await page.keyboard.press('ArrowUp');
-      await page.keyboard.press('Enter');
-      await click(page, '.toolbar-item.alignment');
-      await click(page, 'button:has-text("Indent")');
-      await toggleBulletList(page);
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">Hello World</span>
-          </p>
-          <ul class="PlaygroundEditorTheme__ul" dir="auto">
-            <li class="PlaygroundEditorTheme__listItem" value="1">
-              <span data-lexical-text="true">a</span>
-            </li>
-          </ul>
-          <p
-            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
-            dir="auto"
-            style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
-            <br />
-          </p>
-          <ul class="PlaygroundEditorTheme__ul" dir="auto">
-            <li class="PlaygroundEditorTheme__listItem" value="1">
-              <span data-lexical-text="true">b</span>
-            </li>
-          </ul>
-        `,
-      );
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [2],
-        focusOffset: 0,
-        focusPath: [2],
-      });
-    },
-  );
+  test('remove list breaks when selection in empty nested list item 2', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello World');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('a');
+    await toggleBulletList(page);
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('b');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('Enter');
+    await click(page, '.toolbar-item.alignment');
+    await click(page, 'button:has-text("Indent")');
+    await toggleBulletList(page);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Hello World</span>
+        </p>
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">a</span>
+          </li>
+        </ul>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
+          dir="auto"
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
+          <br />
+        </p>
+        <ul class="PlaygroundEditorTheme__ul" dir="auto">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <span data-lexical-text="true">b</span>
+          </li>
+        </ul>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2],
+      focusOffset: 0,
+      focusPath: [2],
+    });
+  });
   test('new list item should preserve format from previous list item even after new list item is indented', async ({
     page,
   }) => {

--- a/packages/lexical-playground/__tests__/e2e/Navigation.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Navigation.spec.mjs
@@ -508,62 +508,28 @@ test.describe('Keyboard Navigation', () => {
       // navigate through the text
       // 1 left
       await moveToPrevWord(page);
-      if (browserName === 'webkit') {
-        await assertSelection(page, {
-          anchorOffset: 7,
-          anchorPath: [0, 2, 0],
-          focusOffset: 7,
-          focusPath: [0, 2, 0],
-        });
-      } else if (browserName === 'firefox') {
-        await assertSelection(page, {
-          anchorOffset: 7,
-          anchorPath: [0, 2, 0],
-          focusOffset: 7,
-          focusPath: [0, 2, 0],
-        });
-      } else {
-        await assertSelection(page, {
-          anchorOffset: 7,
-          anchorPath: [0, 2, 0],
-          focusOffset: 7,
-          focusPath: [0, 2, 0],
-        });
-      }
+      await assertSelection(page, {
+        anchorOffset: 7,
+        anchorPath: [0, 2, 0],
+        focusOffset: 7,
+        focusPath: [0, 2, 0],
+      });
       // 2 left
       await moveToPrevWord(page);
-      if (browserName === 'firefox') {
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0, 2, 0],
-          focusOffset: 2,
-          focusPath: [0, 2, 0],
-        });
-      } else {
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0, 2, 0],
-          focusOffset: 2,
-          focusPath: [0, 2, 0],
-        });
-      }
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 2, 0],
+        focusOffset: 2,
+        focusPath: [0, 2, 0],
+      });
       // 3 left
       await moveToPrevWord(page);
-      if (browserName === 'firefox') {
-        await assertSelection(page, {
-          anchorOffset: 6,
-          anchorPath: [0, 0, 0],
-          focusOffset: 6,
-          focusPath: [0, 0, 0],
-        });
-      } else {
-        await assertSelection(page, {
-          anchorOffset: 6,
-          anchorPath: [0, 0, 0],
-          focusOffset: 6,
-          focusPath: [0, 0, 0],
-        });
-      }
+      await assertSelection(page, {
+        anchorOffset: 6,
+        anchorPath: [0, 0, 0],
+        focusOffset: 6,
+        focusPath: [0, 0, 0],
+      });
       // 4 left
       await moveToPrevWord(page);
       await assertSelection(page, {

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1305,10 +1305,8 @@ test.describe.parallel('Selection', () => {
     page,
     isPlainText,
     isCollab,
-    browserName,
   }) => {
     test.skip(isPlainText || isCollab);
-    test.skip(browserName === 'firefox');
     await page.keyboard.type('קצת');
     await insertDateTime(page);
     await moveLeft(page);

--- a/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
@@ -20,78 +20,74 @@ import {
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 test.describe('Tab', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(
-    `can tab + IME`,
-    {tag: '@flaky'},
-    async ({page, isPlainText, browserName}) => {
-      // CDP session is only available in Chromium
-      test.skip(
-        isPlainText || browserName === 'firefox' || browserName === 'webkit',
-      );
+  test(`can tab + IME`, async ({page, isPlainText, browserName}) => {
+    // CDP session is only available in Chromium
+    test.skip(
+      isPlainText || browserName === 'firefox' || browserName === 'webkit',
+    );
 
-      const client = await page.context().newCDPSession(page);
-      async function imeType() {
-        // await page.keyboard.imeSetComposition('ｓ', 1, 1);
-        await client.send('Input.imeSetComposition', {
-          selectionStart: 1,
-          selectionEnd: 1,
-          text: 'ｓ',
-        });
-        // await page.keyboard.imeSetComposition('す', 1, 1);
-        await client.send('Input.imeSetComposition', {
-          selectionStart: 1,
-          selectionEnd: 1,
-          text: 'す',
-        });
-        // await page.keyboard.imeSetComposition('すｓ', 2, 2);
-        await client.send('Input.imeSetComposition', {
-          selectionStart: 2,
-          selectionEnd: 2,
-          text: 'すｓ',
-        });
-        // await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
-        await client.send('Input.imeSetComposition', {
-          selectionStart: 3,
-          selectionEnd: 3,
-          text: 'すｓｈ',
-        });
-        // await page.keyboard.imeSetComposition('すし', 2, 2);
-        await client.send('Input.imeSetComposition', {
-          selectionStart: 2,
-          selectionEnd: 2,
-          text: 'すし',
-        });
-        // await page.keyboard.insertText('すし');
-        await client.send('Input.insertText', {
-          text: 'すし',
-        });
-        await page.keyboard.type(' ');
-      }
-      await focusEditor(page);
-      await enableCompositionKeyEvents(page);
-      // Indent
-      await page.keyboard.press('Tab');
-      await imeType();
-      await page.keyboard.press('Tab');
-      await imeType();
+    const client = await page.context().newCDPSession(page);
+    async function imeType() {
+      // await page.keyboard.imeSetComposition('ｓ', 1, 1);
+      await client.send('Input.imeSetComposition', {
+        selectionStart: 1,
+        selectionEnd: 1,
+        text: 'ｓ',
+      });
+      // await page.keyboard.imeSetComposition('す', 1, 1);
+      await client.send('Input.imeSetComposition', {
+        selectionStart: 1,
+        selectionEnd: 1,
+        text: 'す',
+      });
+      // await page.keyboard.imeSetComposition('すｓ', 2, 2);
+      await client.send('Input.imeSetComposition', {
+        selectionStart: 2,
+        selectionEnd: 2,
+        text: 'すｓ',
+      });
+      // await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
+      await client.send('Input.imeSetComposition', {
+        selectionStart: 3,
+        selectionEnd: 3,
+        text: 'すｓｈ',
+      });
+      // await page.keyboard.imeSetComposition('すし', 2, 2);
+      await client.send('Input.imeSetComposition', {
+        selectionStart: 2,
+        selectionEnd: 2,
+        text: 'すし',
+      });
+      // await page.keyboard.insertText('すし');
+      await client.send('Input.insertText', {
+        text: 'すし',
+      });
+      await page.keyboard.type(' ');
+    }
+    await focusEditor(page);
+    await enableCompositionKeyEvents(page);
+    // Indent
+    await page.keyboard.press('Tab');
+    await imeType();
+    await page.keyboard.press('Tab');
+    await imeType();
 
-      await assertHTML(
-        page,
-        html`
-          <p
-            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
-            dir="auto"
-            style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
-            <span data-lexical-text="true">すし</span>
-            <span
-              class="PlaygroundEditorTheme__tabNode"
-              data-lexical-text="true"></span>
-            <span data-lexical-text="true">すし</span>
-          </p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent"
+          dir="auto"
+          style="padding-inline-start: calc(1 * var(--lexical-indent-base-value, 40px))">
+          <span data-lexical-text="true">すし</span>
+          <span
+            class="PlaygroundEditorTheme__tabNode"
+            data-lexical-text="true"></span>
+          <span data-lexical-text="true">すし</span>
+        </p>
+      `,
+    );
+  });
 
   test('can tab inside code block #4399', async ({page, isPlainText}) => {
     test.skip(isPlainText);

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -847,67 +847,65 @@ test.describe.parallel('Tables', () => {
     });
   });
 
-  test(
-    `Can select cells using Table selection`,
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test(`Can select cells using Table selection`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
-      await insertTable(page, 2, 3);
+    await focusEditor(page);
+    await insertTable(page, 2, 3);
 
-      await fillTablePartiallyWithText(page);
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 1, y: 1},
-        true,
-        false,
-      );
+    await fillTablePartiallyWithText(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto"><br /></p>
-          <table dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
-                <p dir="auto"><span data-lexical-text="true">a</span></p>
-              </th>
-              <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
-                <p dir="auto"><span data-lexical-text="true">bb</span></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">cc</span></p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
-                <p dir="auto"><span data-lexical-text="true">d</span></p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
-                <p dir="auto"><span data-lexical-text="true">e</span></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><span data-lexical-text="true">f</span></p>
-              </td>
-            </tr>
-          </table>
-          <p dir="auto"><br /></p>
-        `,
-        undefined,
-        {ignoreClasses: true},
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto"><br /></p>
+        <table dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
+              <p dir="auto"><span data-lexical-text="true">a</span></p>
+            </th>
+            <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
+              <p dir="auto"><span data-lexical-text="true">bb</span></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">cc</span></p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
+              <p dir="auto"><span data-lexical-text="true">d</span></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
+              <p dir="auto"><span data-lexical-text="true">e</span></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><span data-lexical-text="true">f</span></p>
+            </td>
+          </tr>
+        </table>
+        <p dir="auto"><br /></p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 
   test(`Can select cells using Table selection via keyboard`, async ({
     page,
@@ -993,72 +991,70 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    `Can style text using Table selection`,
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test(`Can style text using Table selection`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
-      await insertTable(page, 2, 3);
+    await focusEditor(page);
+    await insertTable(page, 2, 3);
 
-      await fillTablePartiallyWithText(page);
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 1, y: 1},
-        true,
-        false,
-      );
+    await fillTablePartiallyWithText(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
-      await clickSelectors(page, ['.bold', '.italic', '.underline']);
+    await clickSelectors(page, ['.bold', '.italic', '.underline']);
 
-      await selectFromAdditionalStylesDropdown(page, '.strikethrough');
+    await selectFromAdditionalStylesDropdown(page, '.strikethrough');
 
-      // Check that the character styles are applied.
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto"><br /></p>
-          <table dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
-                <p dir="auto"><strong data-lexical-text="true">a</strong></p>
-              </th>
-              <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
-                <p dir="auto"><strong data-lexical-text="true">bb</strong></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">cc</span></p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
-                <p dir="auto"><strong data-lexical-text="true">d</strong></p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
-                <p dir="auto"><strong data-lexical-text="true">e</strong></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><span data-lexical-text="true">f</span></p>
-              </td>
-            </tr>
-          </table>
-          <p dir="auto"><br /></p>
-        `,
-        undefined,
-        {ignoreClasses: true},
-      );
-    },
-  );
+    // Check that the character styles are applied.
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto"><br /></p>
+        <table dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
+              <p dir="auto"><strong data-lexical-text="true">a</strong></p>
+            </th>
+            <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
+              <p dir="auto"><strong data-lexical-text="true">bb</strong></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">cc</span></p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
+              <p dir="auto"><strong data-lexical-text="true">d</strong></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCellSelected" dir="auto">
+              <p dir="auto"><strong data-lexical-text="true">e</strong></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><span data-lexical-text="true">f</span></p>
+            </td>
+          </tr>
+        </table>
+        <p dir="auto"><br /></p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 
   test(`Can style on empty table cells and paragraphs with no text`, async ({
     page,
@@ -1195,165 +1191,161 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    `Can copy + paste (internal) using Table selection`,
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test(`Can copy + paste (internal) using Table selection`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
-      await insertTable(page, 2, 3);
+    await focusEditor(page);
+    await insertTable(page, 2, 3);
 
-      await fillTablePartiallyWithText(page);
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 1, y: 1},
-        true,
-        false,
-      );
+    await fillTablePartiallyWithText(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
-      await withExclusiveClipboardAccess(async () => {
-        const clipboard = await copyToClipboard(page);
+    await withExclusiveClipboardAccess(async () => {
+      const clipboard = await copyToClipboard(page);
 
-        // For some reason you need to click the paragraph twice for this to pass
-        // on Collab Firefox.
-        await click(page, 'div.ContentEditable__root > p:first-of-type');
-        await click(page, 'div.ContentEditable__root > p:first-of-type');
+      // For some reason you need to click the paragraph twice for this to pass
+      // on Collab Firefox.
+      await click(page, 'div.ContentEditable__root > p:first-of-type');
+      await click(page, 'div.ContentEditable__root > p:first-of-type');
 
-        await pasteFromClipboard(page, clipboard);
-      });
+      await pasteFromClipboard(page, clipboard);
+    });
 
-      // Check that the character styles are applied.
-      await assertHTML(
-        page,
-        html`
-          <table dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">a</span></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">bb</span></p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">d</span></p>
-              </th>
-              <td dir="auto">
-                <p dir="auto"><span data-lexical-text="true">e</span></p>
-              </td>
-            </tr>
-          </table>
-          <table dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">a</span></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">bb</span></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">cc</span></p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">d</span></p>
-              </th>
-              <td dir="auto">
-                <p dir="auto"><span data-lexical-text="true">e</span></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><span data-lexical-text="true">f</span></p>
-              </td>
-            </tr>
-          </table>
-          <p dir="auto"><br /></p>
-        `,
-        undefined,
-        {ignoreClasses: true},
-      );
-    },
-  );
+    // Check that the character styles are applied.
+    await assertHTML(
+      page,
+      html`
+        <table dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">a</span></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">bb</span></p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">d</span></p>
+            </th>
+            <td dir="auto">
+              <p dir="auto"><span data-lexical-text="true">e</span></p>
+            </td>
+          </tr>
+        </table>
+        <table dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">a</span></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">bb</span></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">cc</span></p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">d</span></p>
+            </th>
+            <td dir="auto">
+              <p dir="auto"><span data-lexical-text="true">e</span></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><span data-lexical-text="true">f</span></p>
+            </td>
+          </tr>
+        </table>
+        <p dir="auto"><br /></p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 
-  test(
-    `Can clear text using Table selection`,
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test(`Can clear text using Table selection`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
-      await insertTable(page, 2, 3);
+    await focusEditor(page);
+    await insertTable(page, 2, 3);
 
-      await fillTablePartiallyWithText(page);
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 1, y: 1},
-        true,
-        false,
-      );
+    await fillTablePartiallyWithText(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
-      await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
 
-      // Check that the text was cleared.
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto"><br /></p>
-          <table dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">cc</span></p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><span data-lexical-text="true">f</span></p>
-              </td>
-            </tr>
-          </table>
-          <p dir="auto"><br /></p>
-        `,
-        undefined,
-        {ignoreClasses: true},
-      );
-    },
-  );
+    // Check that the text was cleared.
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto"><br /></p>
+        <table dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">cc</span></p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><span data-lexical-text="true">f</span></p>
+            </td>
+          </tr>
+        </table>
+        <p dir="auto"><br /></p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 
   test(`Range Selection is corrected when it contains a partial Table.`, async ({
     page,
@@ -1553,76 +1545,75 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    'Table selection: can select multiple cells and insert a decorator',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab, browserName}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test('Table selection: can select multiple cells and insert a decorator', async ({
+    page,
+    isPlainText,
+    isCollab,
+    browserName,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      await insertTable(page, 2, 2);
+    await insertTable(page, 2, 2);
 
-      await click(page, '.PlaygroundEditorTheme__tableCell:first-child');
-      await page.keyboard.type('Hello');
+    await click(page, '.PlaygroundEditorTheme__tableCell:first-child');
+    await page.keyboard.type('Hello');
 
-      await page.keyboard.down('Shift');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('ArrowDown');
-      await page.keyboard.up('Shift');
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.up('Shift');
 
-      await insertDateTime(page);
-      await page.keyboard.type(' <- it works!');
+    await insertDateTime(page);
+    await page.keyboard.type(' <- it works!');
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">Hello</span>
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  ${getExpectedDateTimeHtml()}
-                  <span data-lexical-text="true">&lt;- it works!</span>
-                </p>
-              </td>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">Hello</span>
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                ${getExpectedDateTimeHtml()}
+                <span data-lexical-text="true">&lt;- it works!</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+  });
 
   test('Table selection: can backspace lines, backspacing empty cell does not destroy it #3278', async ({
     page,
@@ -1910,99 +1901,97 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    'Resize merged cells width (2)',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test('Resize merged cells width (2)', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      await insertTable(page, 3, 3);
-      await click(page, '.PlaygroundEditorTheme__tableCell');
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 1, y: 1},
-        true,
-        false,
-      );
-      await mergeTableCells(page);
-      await click(page, 'th');
-      const resizerBoundingBox = await selectorBoundingBox(
-        page,
-        '.TableCellResizer__resizer:first-child',
-      );
-      const x = resizerBoundingBox.x + resizerBoundingBox.width / 2;
-      const y = resizerBoundingBox.y + resizerBoundingBox.height / 2;
-      await page.mouse.move(x, y);
-      await page.mouse.down();
-      await page.mouse.move(x + 50, y);
-      await page.mouse.up();
+    await insertTable(page, 3, 3);
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
+    await mergeTableCells(page);
+    await click(page, 'th');
+    const resizerBoundingBox = await selectorBoundingBox(
+      page,
+      '.TableCellResizer__resizer:first-child',
+    );
+    const x = resizerBoundingBox.x + resizerBoundingBox.width / 2;
+    const y = resizerBoundingBox.y + resizerBoundingBox.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 50, y);
+    await page.mouse.up();
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 142px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                colspan="2"
-                dir="auto"
-                rowspan="2">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 142px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2"
+              dir="auto"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+  });
 
   test('Resize merged cells height', async ({
     browserName,
@@ -2331,414 +2320,412 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    'Merge/unmerge with already merged cells',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test('Merge/unmerge with already merged cells', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      // 1. Create a 5x5 table
-      await insertTable(page, 5, 5);
+    // 1. Create a 5x5 table
+    await insertTable(page, 5, 5);
 
-      // 2. Type the letters in specific cells
-      await click(page, '.PlaygroundEditorTheme__tableCell');
+    // 2. Type the letters in specific cells
+    await click(page, '.PlaygroundEditorTheme__tableCell');
 
-      // Move to cell for 'a' and type
-      await moveRight(page, 1);
-      await moveDown(page, 2);
-      await page.keyboard.type('a');
+    // Move to cell for 'a' and type
+    await moveRight(page, 1);
+    await moveDown(page, 2);
+    await page.keyboard.type('a');
 
-      // Move to cell for 'b' and type
-      await moveRight(page, 1);
-      await page.keyboard.type('b');
+    // Move to cell for 'b' and type
+    await moveRight(page, 1);
+    await page.keyboard.type('b');
 
-      // Move to cell for 'c' and type
-      await moveLeft(page, 2);
-      await moveDown(page, 1);
-      await page.keyboard.type('c');
+    // Move to cell for 'c' and type
+    await moveLeft(page, 2);
+    await moveDown(page, 1);
+    await page.keyboard.type('c');
 
-      // Move to cell for 'd' and type
-      await moveRight(page, 1);
-      await page.keyboard.type('d');
+    // Move to cell for 'd' and type
+    await moveRight(page, 1);
+    await page.keyboard.type('d');
 
-      // Move to cell for 'e' and type
-      await moveRight(page, 1);
-      await page.keyboard.type('e');
+    // Move to cell for 'e' and type
+    await moveRight(page, 1);
+    await page.keyboard.type('e');
 
-      // Move to cell for 'f' and type
-      await moveDown(page, 1);
-      await page.keyboard.type('f');
+    // Move to cell for 'f' and type
+    await moveDown(page, 1);
+    await page.keyboard.type('f');
 
-      // 3. First merge: Select and merge cells a,b,c,d
-      await selectCellsFromTableCords(
-        page,
-        {x: 1, y: 2},
-        {x: 2, y: 3},
-        false,
-        false,
-      );
-      await mergeTableCells(page);
-      // 4. Second merge: Select and merge cells e,f
-      await selectCellsFromTableCords(
-        page,
-        {x: 1, y: 3},
-        {x: 3, y: 4},
-        false,
-        false,
-      );
-      await mergeTableCells(page);
+    // 3. First merge: Select and merge cells a,b,c,d
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 2},
+      {x: 2, y: 3},
+      false,
+      false,
+    );
+    await mergeTableCells(page);
+    // 4. Second merge: Select and merge cells e,f
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 3},
+      {x: 3, y: 4},
+      false,
+      false,
+    );
+    await mergeTableCells(page);
 
-      // 5. Final merge: Non-rectangular selection attempt
-      await selectCellsFromTableCords(
-        page,
-        {x: 2, y: 4},
-        {x: 1, y: 3},
-        false,
-        false,
-      );
-      await mergeTableCells(page);
-      // 6. Assert the final state
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 92px;" />
-              <col style="width: 92px;" />
-              <col style="width: 92px;" />
-              <col style="width: 92px;" />
-              <col style="width: 92px;" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td
-                class="PlaygroundEditorTheme__tableCell"
-                colspan="3"
-                dir="auto"
-                rowspan="3">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">a</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">b</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">c</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">d</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">e</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">f</span>
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
+    // 5. Final merge: Non-rectangular selection attempt
+    await selectCellsFromTableCords(
+      page,
+      {x: 2, y: 4},
+      {x: 1, y: 3},
+      false,
+      false,
+    );
+    await mergeTableCells(page);
+    // 6. Assert the final state
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              colspan="3"
+              dir="auto"
+              rowspan="3">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">a</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">b</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">c</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">d</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">e</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">f</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
 
-      await unmergeTableCell(page);
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 92px;" />
-              <col style="width: 92px;" />
-              <col style="width: 92px;" />
-              <col style="width: 92px;" />
-              <col style="width: 92px;" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">a</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">b</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">c</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">d</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">e</span>
-                </p>
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <span data-lexical-text="true">f</span>
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
-    },
-  );
+    await unmergeTableCell(page);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">a</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">b</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">c</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">d</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">e</span>
+              </p>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <span data-lexical-text="true">f</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+  });
 
   test('Merged cell tab navigation forward', async ({
     page,
@@ -3310,185 +3297,183 @@ test.describe.parallel('Tables', () => {
     },
   );
 
-  test(
-    'Merge multiple merged cells and then unmerge',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test('Merge multiple merged cells and then unmerge', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      await insertTable(page, 3, 3);
+    await insertTable(page, 3, 3);
 
-      await click(page, '.PlaygroundEditorTheme__tableCell');
-      await moveDown(page, 1);
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 0, y: 1},
-        true,
-        true,
-      );
-      await mergeTableCells(page);
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await moveDown(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 0, y: 1},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
 
-      await moveRight(page, 1);
-      await selectCellsFromTableCords(
-        page,
-        {x: 1, y: 0},
-        {x: 2, y: 0},
-        true,
-        true,
-      );
-      await mergeTableCells(page);
+    await moveRight(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 2, y: 0},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
 
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 1, y: 0},
-        true,
-        true,
-      );
-      await mergeTableCells(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 0},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                colspan="3"
-                dir="auto"
-                rowspan="2">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto"><br /></tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="3"
+              dir="auto"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto"><br /></tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
 
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 0, y: 0},
-        true,
-        true,
-      );
-      await unmergeTableCell(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 0, y: 0},
+      true,
+      true,
+    );
+    await unmergeTableCell(page);
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+  });
 
   test('Insert row above (with conflicting merged cell)', async ({
     page,
@@ -3755,79 +3740,74 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    'Delete rows (with conflicting merged cell)',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test('Delete rows (with conflicting merged cell)', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      await insertTable(page, 4, 2);
+    await insertTable(page, 4, 2);
 
-      await selectCellsFromTableCords(
-        page,
-        {x: 1, y: 1},
-        {x: 1, y: 3},
-        false,
-        false,
-      );
-      await mergeTableCells(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 1},
+      {x: 1, y: 3},
+      false,
+      false,
+    );
+    await mergeTableCells(page);
 
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 0, y: 1},
-        true,
-        true,
-      );
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 0, y: 1},
+      true,
+      true,
+    );
 
-      await deleteTableRows(page);
+    await deleteTableRows(page);
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td
-                class="PlaygroundEditorTheme__tableCell"
-                dir="auto"
-                rowspan="2">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto" rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+  });
 
   test('Delete selected rows (with merged cell overflowing selection from top and bottom)', async ({
     page,
@@ -4487,61 +4467,55 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    'Delete columns backward',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test('Delete columns backward', async ({page, isPlainText, isCollab}) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      await insertTable(page, 2, 4);
+    await insertTable(page, 2, 4);
 
-      await selectCellsFromTableCords(
-        page,
-        {x: 3, y: 1},
-        {x: 1, y: 1},
-        false,
-        false,
-      );
+    await selectCellsFromTableCords(
+      page,
+      {x: 3, y: 1},
+      {x: 1, y: 1},
+      false,
+      false,
+    );
 
-      await deleteTableColumns(page);
+    await deleteTableColumns(page);
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+  });
 
   test('Delete columns forward at end of table', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -3123,179 +3123,177 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    'Select multiple merged cells (selection expands to a rectangle)',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test('Select multiple merged cells (selection expands to a rectangle)', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      await insertTable(page, 3, 3);
+    await insertTable(page, 3, 3);
 
-      await click(page, '.PlaygroundEditorTheme__tableCell');
-      await moveDown(page, 1);
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 0, y: 1},
-        true,
-        true,
-      );
-      await mergeTableCells(page);
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await moveDown(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 0, y: 1},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
 
-      await moveRight(page, 1);
-      await selectCellsFromTableCords(
-        page,
-        {x: 1, y: 0},
-        {x: 2, y: 0},
-        true,
-        true,
-      );
-      await mergeTableCells(page);
+    await moveRight(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 2, y: 0},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
 
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 1, y: 0},
-        true,
-        true,
-      );
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 0},
+      true,
+      true,
+    );
 
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table
-            class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection"
-            dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader PlaygroundEditorTheme__tableCellSelected"
-                dir="auto"
-                rowspan="2">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader PlaygroundEditorTheme__tableCellSelected"
-                colspan="2"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <td
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellSelected"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellSelected"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-          <table class="PlaygroundEditorTheme__table" dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto"
-                rowspan="2">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                colspan="2"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </th>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-              <td class="PlaygroundEditorTheme__tableCell" dir="auto">
-                <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                  <br />
-                </p>
-              </td>
-            </tr>
-          </table>
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-        `,
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table
+          class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection"
+          dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader PlaygroundEditorTheme__tableCellSelected"
+              dir="auto"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader PlaygroundEditorTheme__tableCellSelected"
+              colspan="2"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <td
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellSelected"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellSelected"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+        <table class="PlaygroundEditorTheme__table" dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" dir="auto">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
+      `,
+    );
+  });
 
   test('Merge multiple merged cells and then unmerge', async ({
     page,
@@ -4868,89 +4866,87 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test(
-    'Can align text using Table selection',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
-      await initialize({isCollab, page});
+  test('Can align text using Table selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
 
-      await focusEditor(page);
-      await insertTable(page, 2, 3);
+    await focusEditor(page);
+    await insertTable(page, 2, 3);
 
-      await fillTablePartiallyWithText(page);
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 0},
-        {x: 1, y: 1},
-        true,
-        false,
-      );
+    await fillTablePartiallyWithText(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
-      await selectFromAlignDropdown(page, '.center-align');
+    await selectFromAlignDropdown(page, '.center-align');
 
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto"><br /></p>
-          <table dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCellSelected"
-                dir="auto"
-                style="text-align: center">
-                <p dir="auto" style="text-align: center">
-                  <span data-lexical-text="true">a</span>
-                </p>
-              </th>
-              <th
-                class="PlaygroundEditorTheme__tableCellSelected"
-                dir="auto"
-                style="text-align: center">
-                <p dir="auto" style="text-align: center">
-                  <span data-lexical-text="true">bb</span>
-                </p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><span data-lexical-text="true">cc</span></p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th
-                class="PlaygroundEditorTheme__tableCellSelected"
-                dir="auto"
-                style="text-align: center">
-                <p dir="auto" style="text-align: center">
-                  <span data-lexical-text="true">d</span>
-                </p>
-              </th>
-              <td
-                class="PlaygroundEditorTheme__tableCellSelected"
-                dir="auto"
-                style="text-align: center">
-                <p dir="auto" style="text-align: center">
-                  <span data-lexical-text="true">e</span>
-                </p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><span data-lexical-text="true">f</span></p>
-              </td>
-            </tr>
-          </table>
-          <p dir="auto"><br /></p>
-        `,
-        undefined,
-        {ignoreClasses: true},
-      );
-    },
-  );
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto"><br /></p>
+        <table dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCellSelected"
+              dir="auto"
+              style="text-align: center">
+              <p dir="auto" style="text-align: center">
+                <span data-lexical-text="true">a</span>
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCellSelected"
+              dir="auto"
+              style="text-align: center">
+              <p dir="auto" style="text-align: center">
+                <span data-lexical-text="true">bb</span>
+              </p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><span data-lexical-text="true">cc</span></p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th
+              class="PlaygroundEditorTheme__tableCellSelected"
+              dir="auto"
+              style="text-align: center">
+              <p dir="auto" style="text-align: center">
+                <span data-lexical-text="true">d</span>
+              </p>
+            </th>
+            <td
+              class="PlaygroundEditorTheme__tableCellSelected"
+              dir="auto"
+              style="text-align: center">
+              <p dir="auto" style="text-align: center">
+                <span data-lexical-text="true">e</span>
+              </p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><span data-lexical-text="true">f</span></p>
+            </td>
+          </tr>
+        </table>
+        <p dir="auto"><br /></p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 
   test('Paste and insert new lines after unmerging cells', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -1179,63 +1179,63 @@ test.describe.parallel('TextFormatting', () => {
     expect(isButtonActiveStatusDisplayedCorrectly).toBe(true);
   });
 
-  test(
-    'Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode; ',
-    {tag: '@flaky'},
-    async ({page, isCollab, isPlainText}) => {
-      test.skip(isPlainText);
-      await focusEditor(page);
+  test('Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode; ', async ({
+    page,
+    isCollab,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
 
-      await page.keyboard.type('A');
-      await insertDateTime(page);
-      await page.keyboard.type('BC');
+    await page.keyboard.type('A');
+    await insertDateTime(page);
+    await page.keyboard.type('BC');
 
-      await moveLeft(page, 1);
-      await selectCharacters(page, 'left', 2);
+    await moveLeft(page, 1);
+    await selectCharacters(page, 'left', 2);
 
-      if (!isCollab) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span data-lexical-text="true">A</span>
-              ${getExpectedDateTimeHtml({selected: true})}
-              <span data-lexical-text="true">BC</span>
-            </p>
-          `,
-        );
-      }
-      await toggleBold(page);
+    if (!isCollab) {
       await assertHTML(
         page,
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
             <span data-lexical-text="true">A</span>
-            ${getExpectedDateTimeHtml({formats: ['bold']})}
-            <strong
-              class="PlaygroundEditorTheme__textBold"
-              data-lexical-text="true">
-              B
-            </strong>
-            <span data-lexical-text="true">C</span>
-          </p>
-        `,
-      );
-      await toggleBold(page);
-      await assertHTML(
-        page,
-        // After formatting the text, the selection will be reset from the decorator node,
-        // so it will retain its previous format when toggleBold is triggered again
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">A</span>
-            ${getExpectedDateTimeHtml({formats: ['bold']})}
+            ${getExpectedDateTimeHtml({selected: true})}
             <span data-lexical-text="true">BC</span>
           </p>
         `,
       );
-    },
-  );
+    }
+    await toggleBold(page);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">A</span>
+          ${getExpectedDateTimeHtml({formats: ['bold']})}
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            B
+          </strong>
+          <span data-lexical-text="true">C</span>
+        </p>
+      `,
+    );
+    await toggleBold(page);
+    await assertHTML(
+      page,
+      // After formatting the text, the selection will be reset from the decorator node,
+      // so it will retain its previous format when toggleBold is triggered again
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">A</span>
+          ${getExpectedDateTimeHtml({formats: ['bold']})}
+          <span data-lexical-text="true">BC</span>
+        </p>
+      `,
+    );
+  });
 
   test('Multiline selection format ignores new lines', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -28,6 +28,7 @@ import {
   selectFromAlignDropdown,
   selectFromInsertDropdown,
   test,
+  waitForSelector,
 } from '../utils/index.mjs';
 
 test.describe('Toolbar', () => {
@@ -40,233 +41,232 @@ test.describe('Toolbar', () => {
     }),
   );
 
-  test(
-    'Insert image caption + table',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText}) => {
-      // TODO(collab-v2): nested editors are not supported yet
-      test.skip(isPlainText || IS_COLLAB_V2);
-      await focusEditor(page);
+  test('Insert image caption + table', async ({page, isPlainText}) => {
+    // TODO(collab-v2): nested editors are not supported yet
+    test.skip(isPlainText || IS_COLLAB_V2);
+    await focusEditor(page);
 
-      // Add caption
-      await insertSampleImage(page);
-      // Catch flakiness earlier
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto">
-            <span contenteditable="false" data-lexical-decorator="true">
-              <div draggable="false">
-                <img
-                  alt="Yellow flower in tilt shift lens"
-                  draggable="false"
-                  src="${SAMPLE_IMAGE_URL}" />
+    // Add caption
+    await insertSampleImage(page);
+    // The image is rendered behind React.Suspense (fallback={null}) and only
+    // appears once the sample asset finishes loading; under parallel load
+    // that can exceed assertHTML's 5s retry window, leaving an empty
+    // decorator. Wait for the <img> explicitly before asserting.
+    await waitForSelector(page, '.editor-image img', {timeout: 30000});
+    // Catch flakiness earlier
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto">
+          <span contenteditable="false" data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}" />
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+      undefined,
+      {
+        ignoreClasses: true,
+        ignoreInlineStyles: true,
+      },
+    );
+    await click(page, '.editor-image img');
+    await click(page, '.image-caption-button');
+    await focus(page, '.ImageNode__contentEditable');
+    await page.keyboard.type('Yellow flower in tilt shift lens');
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto">
+          <span contenteditable="false" data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}" />
+            </div>
+            <div>
+              <div
+                contenteditable="true"
+                role="textbox"
+                spellcheck="true"
+                aria-placeholder="Enter a caption..."
+                data-lexical-editor="true">
+                <p dir="auto">
+                  <span data-lexical-text="true">
+                    Yellow flower in tilt shift lens
+                  </span>
+                </p>
               </div>
-            </span>
-            <br />
-          </p>
-        `,
-        undefined,
-        {
-          ignoreClasses: true,
-          ignoreInlineStyles: true,
-        },
-      );
-      await click(page, '.editor-image img');
-      await click(page, '.image-caption-button');
-      await focus(page, '.ImageNode__contentEditable');
-      await page.keyboard.type('Yellow flower in tilt shift lens');
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto">
-            <span contenteditable="false" data-lexical-decorator="true">
-              <div draggable="false">
-                <img
-                  alt="Yellow flower in tilt shift lens"
-                  draggable="false"
-                  src="${SAMPLE_IMAGE_URL}" />
-              </div>
-              <div>
-                <div
-                  contenteditable="true"
-                  role="textbox"
-                  spellcheck="true"
-                  aria-placeholder="Enter a caption..."
-                  data-lexical-editor="true">
-                  <p dir="auto">
-                    <span data-lexical-text="true">
-                      Yellow flower in tilt shift lens
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </span>
-            <br />
-          </p>
-        `,
-        undefined,
-        {
-          ignoreClasses: true,
-          ignoreInlineStyles: true,
-        },
-        actualHtml =>
-          // flaky fix: remove the extra <p dir="auto"><br /></p> that appears occasionally in CI runs
-          actualHtml.replace(
-            html`
-              <p dir="auto">
-                <span data-lexical-text="true">
-                  Yellow flower in tilt shift lens
-                </span>
-              </p>
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+      undefined,
+      {
+        ignoreClasses: true,
+        ignoreInlineStyles: true,
+      },
+      actualHtml =>
+        // flaky fix: remove the extra <p dir="auto"><br /></p> that appears occasionally in CI runs
+        actualHtml.replace(
+          html`
+            <p dir="auto">
+              <span data-lexical-text="true">
+                Yellow flower in tilt shift lens
+              </span>
+            </p>
+            <p dir="auto"><br /></p>
+          `,
+          html`
+            <p dir="auto">
+              <span data-lexical-text="true">
+                Yellow flower in tilt shift lens
+              </span>
+            </p>
+          `,
+        ),
+    );
+
+    // Delete image
+    // TODO Revisit the a11y side of NestedEditors
+    await evaluate(page, () => {
+      const p = document.querySelector('[contenteditable="true"] p');
+      document.getSelection().setBaseAndExtent(p, 0, p, 0);
+    });
+    await selectAll(page);
+    await page.keyboard.press('Delete');
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto"><br /></p>
+      `,
+      undefined,
+      {
+        ignoreClasses: true,
+        ignoreInlineStyles: true,
+      },
+    );
+
+    // Add table
+    await selectFromInsertDropdown(page, '.table');
+    await click(page, '[data-test-id="table-model-confirm-insert"] button');
+
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto">
+          <br />
+        </p>
+        <table dir="auto">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr dir="auto">
+            <th dir="auto">
               <p dir="auto"><br /></p>
-            `,
-            html`
-              <p dir="auto">
-                <span data-lexical-text="true">
-                  Yellow flower in tilt shift lens
-                </span>
-              </p>
-            `,
-          ),
-      );
-
-      // Delete image
-      // TODO Revisit the a11y side of NestedEditors
-      await evaluate(page, () => {
-        const p = document.querySelector('[contenteditable="true"] p');
-        document.getSelection().setBaseAndExtent(p, 0, p, 0);
-      });
-      await selectAll(page);
-      await page.keyboard.press('Delete');
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto"><br /></p>
-        `,
-        undefined,
-        {
-          ignoreClasses: true,
-          ignoreInlineStyles: true,
-        },
-      );
-
-      // Add table
-      await selectFromInsertDropdown(page, '.table');
-      await click(page, '[data-test-id="table-model-confirm-insert"] button');
-
-      await assertHTML(
-        page,
-        html`
-          <p dir="auto">
-            <br />
-          </p>
-          <table dir="auto">
-            <colgroup>
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-              <col style="width: 92px" />
-            </colgroup>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-            </tr>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-            </tr>
-            <tr dir="auto">
-              <th dir="auto">
-                <p dir="auto"><br /></p>
-              </th>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-              <td dir="auto">
-                <p dir="auto"><br /></p>
-              </td>
-            </tr>
-          </table>
-          <p dir="auto"><br /></p>
-        `,
-        undefined,
-        {
-          ignoreClasses: true,
-          ignoreInlineStyles: true,
-        },
-      );
-    },
-  );
+            </th>
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+          </tr>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+          </tr>
+          <tr dir="auto">
+            <th dir="auto">
+              <p dir="auto"><br /></p>
+            </th>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+            <td dir="auto">
+              <p dir="auto"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p dir="auto"><br /></p>
+      `,
+      undefined,
+      {
+        ignoreClasses: true,
+        ignoreInlineStyles: true,
+      },
+    );
+  });
 
   test('Center align image', async ({page, isPlainText, isCollab}) => {
     // Image selection can't be synced in collab

--- a/packages/lexical-playground/__tests__/regression/429-swapping-emoji.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/429-swapping-emoji.spec.mjs
@@ -18,85 +18,40 @@ import {
 
 test.describe('Regression test #429', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(
-    `Can add new lines before the line with emoji`,
-    {tag: '@flaky'},
-    async ({isRichText, page}) => {
-      await focusEditor(page);
-      await page.keyboard.type(':) or :(');
+  test(`Can add new lines before the line with emoji`, async ({
+    isRichText,
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(':) or :(');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span class="emoji happysmile" data-lexical-text="true">
+            <span class="emoji-inner">🙂</span>
+          </span>
+          <span data-lexical-text="true">or</span>
+          <span class="emoji unhappysmile" data-lexical-text="true">
+            <span class="emoji-inner">🙁</span>
+          </span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [0, 2, 0, 0],
+      focusOffset: 2,
+      focusPath: [0, 2, 0, 0],
+    });
+
+    await moveLeft(page, 6);
+    await page.keyboard.press('Enter');
+    if (isRichText) {
       await assertHTML(
         page,
         html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span class="emoji happysmile" data-lexical-text="true">
-              <span class="emoji-inner">🙂</span>
-            </span>
-            <span data-lexical-text="true">or</span>
-            <span class="emoji unhappysmile" data-lexical-text="true">
-              <span class="emoji-inner">🙁</span>
-            </span>
-          </p>
-        `,
-      );
-      await assertSelection(page, {
-        anchorOffset: 2,
-        anchorPath: [0, 2, 0, 0],
-        focusOffset: 2,
-        focusPath: [0, 2, 0, 0],
-      });
-
-      await moveLeft(page, 6);
-      await page.keyboard.press('Enter');
-      if (isRichText) {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <span class="emoji happysmile" data-lexical-text="true">
-                <span class="emoji-inner">🙂</span>
-              </span>
-              <span data-lexical-text="true">or</span>
-              <span class="emoji unhappysmile" data-lexical-text="true">
-                <span class="emoji-inner">🙁</span>
-              </span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [1, 0, 0, 0],
-          focusOffset: 0,
-          focusPath: [1, 0, 0, 0],
-        });
-      } else {
-        await assertHTML(
-          page,
-          html`
-            <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-              <br />
-              <span class="emoji happysmile" data-lexical-text="true">
-                <span class="emoji-inner">🙂</span>
-              </span>
-              <span data-lexical-text="true">or</span>
-              <span class="emoji unhappysmile" data-lexical-text="true">
-                <span class="emoji-inner">🙁</span>
-              </span>
-            </p>
-          `,
-        );
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [0, 1, 0, 0],
-          focusOffset: 0,
-          focusPath: [0, 1, 0, 0],
-        });
-      }
-
-      await page.keyboard.press('Backspace');
-      await assertHTML(
-        page,
-        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto"><br /></p>
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
             <span class="emoji happysmile" data-lexical-text="true">
               <span class="emoji-inner">🙂</span>
@@ -110,10 +65,54 @@ test.describe('Regression test #429', () => {
       );
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [0, 0, 0, 0],
+        anchorPath: [1, 0, 0, 0],
         focusOffset: 0,
-        focusPath: [0, 0, 0, 0],
+        focusPath: [1, 0, 0, 0],
       });
-    },
-  );
+    } else {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+            <br />
+            <span class="emoji happysmile" data-lexical-text="true">
+              <span class="emoji-inner">🙂</span>
+            </span>
+            <span data-lexical-text="true">or</span>
+            <span class="emoji unhappysmile" data-lexical-text="true">
+              <span class="emoji-inner">🙁</span>
+            </span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 1, 0, 0],
+        focusOffset: 0,
+        focusPath: [0, 1, 0, 0],
+      });
+    }
+
+    await page.keyboard.press('Backspace');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span class="emoji happysmile" data-lexical-text="true">
+            <span class="emoji-inner">🙂</span>
+          </span>
+          <span data-lexical-text="true">or</span>
+          <span class="emoji unhappysmile" data-lexical-text="true">
+            <span class="emoji-inner">🙁</span>
+          </span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 0, 0, 0],
+      focusOffset: 0,
+      focusPath: [0, 0, 0, 0],
+    });
+  });
 });

--- a/packages/lexical-playground/__tests__/regression/4697-repeated-table-selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4697-repeated-table-selection.spec.mjs
@@ -18,41 +18,39 @@ import {
 
 test.describe('Regression test #4697', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(
-    'repeated table selection results in table selection',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
+  test('repeated table selection results in table selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      await insertTable(page, 4, 4);
+    await insertTable(page, 4, 4);
 
-      await click(page, '.PlaygroundEditorTheme__tableCell');
-      await selectCellsFromTableCords(
-        page,
-        {x: 1, y: 1},
-        {x: 2, y: 2},
-        false,
-        false,
-      );
-      await page.pause();
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 1},
+      {x: 2, y: 2},
+      false,
+      false,
+    );
+    await page.pause();
 
-      await selectCellsFromTableCords(
-        page,
-        {x: 2, y: 1},
-        {x: 2, y: 2},
-        false,
-        false,
-      );
-      await page.pause();
+    await selectCellsFromTableCords(
+      page,
+      {x: 2, y: 1},
+      {x: 2, y: 2},
+      false,
+      false,
+    );
+    await page.pause();
 
-      await assertTableSelectionCoordinates(page, {
-        anchor: {x: 2, y: 1},
-        focus: {x: 2, y: 2},
-      });
-    },
-  );
+    await assertTableSelectionCoordinates(page, {
+      anchor: {x: 2, y: 1},
+      focus: {x: 2, y: 2},
+    });
+  });
 });

--- a/packages/lexical-playground/__tests__/regression/4872-full-row-span-cell-merge.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4872-full-row-span-cell-merge.spec.mjs
@@ -18,41 +18,39 @@ import {
 
 test.describe('Regression test #4872', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(
-    'merging two full rows does not break table selection',
-    {
-      tag: '@flaky',
-    },
-    async ({page, isPlainText, isCollab}) => {
-      test.skip(isPlainText);
+  test('merging two full rows does not break table selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
 
-      await focusEditor(page);
+    await focusEditor(page);
 
-      await insertTable(page, 5, 5);
+    await insertTable(page, 5, 5);
 
-      await click(page, '.PlaygroundEditorTheme__tableCell');
-      await selectCellsFromTableCords(
-        page,
-        {x: 0, y: 1},
-        {x: 4, y: 2},
-        true,
-        false,
-      );
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 1},
+      {x: 4, y: 2},
+      true,
+      false,
+    );
 
-      await mergeTableCells(page);
+    await mergeTableCells(page);
 
-      await selectCellsFromTableCords(
-        page,
-        {x: 1, y: 4},
-        {x: 2, y: 4},
-        false,
-        false,
-      );
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 4},
+      {x: 2, y: 4},
+      false,
+      false,
+    );
 
-      await assertTableSelectionCoordinates(page, {
-        anchor: {x: 1, y: 4},
-        focus: {x: 2, y: 4},
-      });
-    },
-  );
+    await assertTableSelectionCoordinates(page, {
+      anchor: {x: 1, y: 4},
+      focus: {x: 2, y: 4},
+    });
+  });
 });

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -148,21 +148,36 @@ export async function initialize({
  */
 async function exposeLexicalEditor(page) {
   if (IS_COLLAB) {
-    await Promise.all(
-      ['left', 'right'].map(async name => {
-        const frameLocator = page.frameLocator(`[name="${name}"]`);
-        // Collab startup connects to a single shared y-websocket server; under
-        // parallel test load the websocket connect (and its reconnect backoff)
-        // can exceed the default 5s expect timeout, which was the dominant
-        // source of @flaky collab failures. Give the connection generous time.
-        await expect(
-          frameLocator.locator('.action-button.connect'),
-        ).toHaveAttribute('title', /Disconnect/, {timeout: 30000});
-        await expect(
-          frameLocator.locator('[data-lexical-editor="true"] p'),
-        ).toBeVisible({timeout: 30000});
-      }),
-    );
+    // The split view loads the playground in two iframes that connect to a
+    // single shared y-websocket server. Under parallel test load one frame
+    // occasionally fails to boot/activate collab within the timeout (its
+    // ".action-button.connect" toolbar button never appears, or the websocket
+    // connect/backoff runs long) -- the dominant residual source of @flaky
+    // collab failures. Reload and retry a few times so a transient
+    // boot/connect hiccup during setup doesn't fail the whole test.
+    const waitForCollabFramesReady = () =>
+      Promise.all(
+        ['left', 'right'].map(async name => {
+          const frameLocator = page.frameLocator(`[name="${name}"]`);
+          await expect(
+            frameLocator.locator('.action-button.connect'),
+          ).toHaveAttribute('title', /Disconnect/, {timeout: 15000});
+          await expect(
+            frameLocator.locator('[data-lexical-editor="true"] p'),
+          ).toBeVisible({timeout: 15000});
+        }),
+      );
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await waitForCollabFramesReady();
+        break;
+      } catch (err) {
+        if (attempt >= 2) {
+          throw err;
+        }
+        await page.reload();
+      }
+    }
     // Ensure that they started up with the correct empty state
     await assertHTML(
       page,

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -151,12 +151,16 @@ async function exposeLexicalEditor(page) {
     await Promise.all(
       ['left', 'right'].map(async name => {
         const frameLocator = page.frameLocator(`[name="${name}"]`);
+        // Collab startup connects to a single shared y-websocket server; under
+        // parallel test load the websocket connect (and its reconnect backoff)
+        // can exceed the default 5s expect timeout, which was the dominant
+        // source of @flaky collab failures. Give the connection generous time.
         await expect(
           frameLocator.locator('.action-button.connect'),
-        ).toHaveAttribute('title', /Disconnect/);
+        ).toHaveAttribute('title', /Disconnect/, {timeout: 30000});
         await expect(
           frameLocator.locator('[data-lexical-editor="true"] p'),
-        ).toBeVisible();
+        ).toBeVisible({timeout: 30000});
       }),
     );
     // Ensure that they started up with the correct empty state


### PR DESCRIPTION
## Description

Cleans up the Playwright e2e suite: removes stale browser workarounds, audits every `@flaky` test, fixes the ones that are genuinely flaky, and removes all `@flaky` tags. No library/product code is changed — this is test-suite maintenance only.

**1. Drop stale Firefox workarounds** (follow-up to the selection fix in #8582)
- Remove the Firefox `test.skip` on *Move left from last node in RTL #7775* — it passes on the current Firefox.
- Collapse three dead Firefox/WebKit assertion branches in `Navigation.spec` whose values were already identical to the default. Other Firefox branches were verified still-needed (inline-node caret positions, `selectAll` root selection, decorator focus) or left alone because they encode `IS_WINDOWS`-specific behavior that can't be verified from Linux.

**2. Audit every `@flaky` test (32 total)**
Ran the suite against the CI-equivalent setup (static playground build on `:4000` + collab websocket on `:1234`, chromium + firefox × {rich-text, plain-text, rich-text-with-collab}, `--retries=0`, `--repeat-each` 10–50). Note: running against the live dev server inflates flakiness massively, so a built static server is required to get representative results.
- **26 tests never failed** across ~40–80 runs each → tags removed.
- **6 tests genuinely flaked** → root-caused and fixed (below).

**3. Fix the genuinely-flaky tests**
- **Collab setup (whole-suite, dominant cause):** `exposeLexicalEditor` waited for the right frame's connect button with the default 5s timeout, and under parallel load a split-view iframe occasionally fails to connect *or* to boot/activate collab at all (~1/60, chromium+collab). The readiness check now retries with a `page.reload()` between attempts (3×, 15s each), so a transient setup hiccup recovers instead of failing the test. This hardens *every* collab test.
- **`ClearFormatting` mention typeahead:** pressed Enter on a partial-query menu (`@Lu` matches "Agent Ka**llu**s", highlighted first), selecting the wrong mention. Now waits for "Luke Skywalker" to be the `aria-selected` option.
- **`Toolbar` image insert:** the image renders behind `React.Suspense` (`fallback={null}`) and only appears after the asset loads, which can exceed the 5s assert under load. Now waits for `.editor-image img` before asserting.

**Result:** no `@flaky` tags remain in the e2e suite, and the collab test harness is materially more robust.

> The diff is large but almost entirely Prettier re-indentation: removing the `{tag: '@flaky'}` options argument turns 3-arg `test()` calls back into 2-arg calls and de-indents the bodies. `git diff -w` shows the real changes are only the tag/workaround removals plus the helper edits in `utils/index.mjs`.

## Test plan

Automated — Playwright, against the CI-equivalent static build (`:4000`) + collab server (`:1234`), `--retries=0`:

### Before
- `ClearFormatting` "default styling of hashtags and mentions": ~25% failure on firefox + collab (wrong mention selected).
- `Toolbar` "Insert image caption + table": intermittent empty image decorator.
- Collab tests: ~1/60 setup failures (`exposeLexicalEditor` timeout waiting for the connect button) under `--repeat-each` stress; 3 failures in a 180-run chromium+collab sample.

### After
- `ClearFormatting`: 30/30 firefox + collab.
- Collab boot-stall fix: **200/200** chromium + collab and **120/120** firefox + collab (`--repeat-each=50/30`, `--retries=0`).
- Full `@flaky` set across all 6 CI configs: stable; `playwright test --list` parses all 2124 tests.
