### PR TITLE
[ci] Bug Fix: Check npm token and fail fast in release script

### DIFF
--- a/.github/workflows/call-npm-publish.yml
+++ b/.github/workflows/call-npm-publish.yml
@@ -34,6 +34,20 @@ jobs:
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
+      # Fail fast (before the build) if the token can't authenticate, so a
+      # bad/expired/unauthorized NPM_TOKEN surfaces clearly instead of as a
+      # misleading 404 from every `pnpm publish`. Skipped on dry runs, which
+      # never publish and so don't need a token.
+      - name: Verify npm authentication
+        if: ${{ !inputs.dry-run }}
+        run: |
+          if ! whoami="$(npm whoami --registry=https://registry.npmjs.org)"; then
+            echo "::error::npm authentication failed for https://registry.npmjs.org. The NPM_TOKEN secret is missing, expired, revoked, or not authorized to publish these packages."
+            exit 1
+          fi
+          echo "Authenticated to https://registry.npmjs.org as ${whoami}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: pnpm run prepare-release
       - run: node ./scripts/npm/release.mjs --non-interactive $DRY_RUN_ARG $IGNORE_PREVIOUSLY_PUBLISHED_ARG --channel='${{ inputs.channel }}'
         env:

--- a/scripts/npm/release.mjs
+++ b/scripts/npm/release.mjs
@@ -38,33 +38,48 @@ async function publish() {
     await waitForInput();
   }
 
+  const failures = [];
   for (const pkg of pkgs) {
     console.info(`Publishing ${pkg.getNpmName()}...`);
     if (dryRun === undefined || dryRun === 0) {
       // Publish from the package root. pnpm rewrites `workspace:*` for us
       // and honors the `files` field so only the declared assets ship.
-      await exec(
+      const error = await exec(
         `cd ./packages/${pkg.getDirectoryName()} && pnpm publish --access public --tag ${channel} --no-git-checks`,
-      ).catch(err => {
-        if (
-          ignorePreviouslyPublished &&
-          err &&
-          typeof err.stderr === 'string' &&
-          /You cannot publish over the previously published version/.test(
-            err.stderr,
-          )
-        ) {
-          console.info(`Ignoring previously published error`);
-          return null;
-        }
-        console.error(`\nFailed to publish ${pkg.getNpmName()}:`);
-        console.error(err);
-        return err;
-      });
+      ).then(
+        () => null,
+        err => {
+          if (
+            ignorePreviouslyPublished &&
+            err &&
+            typeof err.stderr === 'string' &&
+            /You cannot publish over the previously published version/.test(
+              err.stderr,
+            )
+          ) {
+            console.info(`Ignoring previously published error`);
+            return null;
+          }
+          console.error(`\nFailed to publish ${pkg.getNpmName()}:`);
+          console.error(err);
+          return err;
+        },
+      );
+      if (error) {
+        failures.push(pkg.getNpmName());
+      }
       console.info(`Done!`);
     } else {
       console.info(`Dry run - skipping publish step.`);
     }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to publish ${failures.length} package(s):\n  - ${failures.join(
+        '\n  - ',
+      )}`,
+    );
   }
 }
 
@@ -88,4 +103,7 @@ async function waitForInput() {
   });
 }
 
-publish();
+publish().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Description

Release failures were getting silently ignored, and npm publish doesn't surface why a command is failing (token expired, etc.) so add a preflight to verify the token's status first.
