### PR TITLE
[Breaking Change][lexical] Feature: Generalize captured selection via setDOMUnmanaged({captureSelection}) + root __lexicalKey_* stash

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -189,6 +189,73 @@ test.describe.parallel('Tables', () => {
     expect(cellTexts[cellTexts.length - 1]).toBe('last');
   });
 
+  test(`TableSelection converts to RangeSelection when DOM selection extends onto the editor root (Issue #8584 follow-up)`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await initialize({isCollab, page});
+
+    await focusEditor(page);
+    await insertTable(page, 2, 2);
+
+    // Create a TableSelection across the first header cell (th at
+    // {x:0,y:0}) and the last body cell (td at {x:1,y:1}). The default
+    // insertTable marks row 0 and column 0 as headers, so {x:1,y:1} is
+    // the only plain td in a 2x2 table.
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
+
+    // Sanity check: the editor selection is a TableSelection.
+    const isTableSelection = await evaluate(page, () => {
+      const editor = window.lexicalEditor;
+      const sel = editor.getEditorState()._selection;
+      return Boolean(sel && 'tableKey' in sel);
+    });
+    expect(isTableSelection).toBe(true);
+
+    // Move the DOM focus onto the editor root element itself (outside the
+    // table). Before #8584 root carried no `__lexicalKey_*`, so
+    // `$getNearestNodeFromDOMNode(rootElement)` returned null and the
+    // `isFocusOutside` check in `$fixTableSelectionForSelectedTable`
+    // short-circuited — the TableSelection was never converted. After
+    // #8584 root resolves to RootNode, so `isFocusOutside` is truthy and
+    // the selection is correctly switched to a RangeSelection.
+    //
+    // The TableObserver clears the window selection when it enters
+    // TableSelection mode, so we cannot rely on the prior anchorNode —
+    // build a fresh range with a known cell as the anchor instead.
+    await evaluate(page, () => {
+      const root = document.querySelector('div[contenteditable="true"]');
+      const firstCell = document.querySelector(
+        'div[contenteditable="true"] table th, div[contenteditable="true"] table td',
+      );
+      window
+        .getSelection()
+        .setBaseAndExtent(firstCell, 0, root, root.childNodes.length);
+    });
+    await sleep(50);
+
+    const selectionAfter = await evaluate(page, () => {
+      const editor = window.lexicalEditor;
+      const sel = editor.getEditorState()._selection;
+      return {
+        isRange: Boolean(
+          sel && 'anchor' in sel && 'focus' in sel && !('tableKey' in sel),
+        ),
+        isTable: Boolean(sel && 'tableKey' in sel),
+      };
+    });
+    expect(selectionAfter.isTable).toBe(false);
+    expect(selectionAfter.isRange).toBe(true);
+  });
+
   test(`Can type inside of table cell`, async ({
     page,
     isPlainText,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -941,8 +941,16 @@ declare export class ElementDOMSlot<out T extends HTMLElement> extends DOMSlot<T
   resolveChildIndex(element: ElementNode, elementDOM: HTMLElement, initialDOM: Node, initialOffset: number): [node: ElementNode, idx: number];
 }
 
-declare export function setDOMUnmanaged(elementDOM: HTMLElement): void;
+export type SetDOMUnmanagedOptions = {captureSelection?: boolean};
+declare export function setDOMUnmanaged(
+  elementDOM: HTMLElement,
+  options?: SetDOMUnmanagedOptions,
+): void;
 declare export function isDOMUnmanaged(elementDOM: HTMLElement): boolean;
+declare export function isDOMCapturingSelection(
+  elementDOM: Node,
+  editor: LexicalEditor,
+): boolean;
 
 /**
  * LexicalDecoratorNode

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -54,6 +54,7 @@ import {
   $addUpdateTag,
   $onUpdate,
   $setSelection,
+  clearNodeKeyOnDOMNode,
   createUID,
   dispatchCommand,
   getCachedClassNameArray,
@@ -65,6 +66,7 @@ import {
   hasOwnExportDOM,
   hasOwnStaticMethod,
   markNodesWithTypesAsDirty,
+  setNodeKeyOnDOMNode,
 } from './LexicalUtils';
 import {ArtificialNode__DO_NOT_USE} from './nodes/ArtificialNode';
 import {LineBreakNode} from './nodes/LexicalLineBreakNode';
@@ -664,11 +666,19 @@ export function resetEditor(
   // Remove all the DOM nodes from the root element
   if (prevRootElement !== null) {
     prevRootElement.textContent = '';
+    clearNodeKeyOnDOMNode(prevRootElement, editor);
   }
 
   if (nextRootElement !== null) {
     nextRootElement.textContent = '';
     keyNodeMap.set('root', nextRootElement);
+    // Stash __lexicalKey_${editor._key} = 'root' on the root element so it
+    // participates in the unified key lookup (selection resolution in
+    // $internalResolveSelectionPoint, mutation handling in
+    // $getNearestManagedNodePairFromDOMNode, $getNodeFromDOM, and
+    // $getNearestNodeFromDOMNode) instead of requiring a dedicated
+    // editor.getRootElement() carveout at each call site.
+    setNodeKeyOnDOMNode(nextRootElement, editor, 'root');
   }
 }
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -100,7 +100,6 @@ import {
   $getAdjacentNode,
   $getDOMTextNode,
   $getNodeByKey,
-  $isSelectionCapturedInDecorator,
   $isTokenOrSegmented,
   $isTokenOrTab,
   $setSelection,
@@ -127,6 +126,7 @@ import {
   isDeleteLineForward,
   isDeleteWordBackward,
   isDeleteWordForward,
+  isDOMCapturingSelection,
   isDOMNode,
   isDOMTextNode,
   isEscape,
@@ -560,7 +560,7 @@ function onPointerDown(event: PointerEvent, editor: LexicalEditor) {
     updateEditorSync(editor, () => {
       // Drag & drop should not recompute selection until mouse up; otherwise the initially
       // selected content is lost.
-      if (!$isSelectionCapturedInDecorator(target)) {
+      if (!isDOMCapturingSelection(target, editor)) {
         isSelectionChangeFromMouseDown = true;
       }
     });
@@ -1082,14 +1082,13 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
 }
 
 function $handleInput(event: InputEvent): boolean {
+  const editor = getActiveEditor();
   if (
     isHTMLElement(event.target) &&
-    $isSelectionCapturedInDecorator(event.target)
+    isDOMCapturingSelection(event.target, editor)
   ) {
     return true;
   }
-
-  const editor = getActiveEditor();
   const selection = $getSelection();
   const data = event.data;
   const targetRange = getTargetRange(event);

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -29,7 +29,6 @@ import {
   getNodeKeyFromDOMNode,
   getParentElement,
   getWindow,
-  internalGetRoot,
   isDOMTextNode,
   isDOMUnmanaged,
   isFirefoxClipboardEvents,
@@ -118,7 +117,6 @@ function $getNearestManagedNodePairFromDOMNode(
   startingDOM: Node,
   editor: LexicalEditor,
   editorState: EditorState,
-  rootElement: HTMLElement | null,
 ): [HTMLElement, LexicalNode] | undefined {
   for (
     let dom: Node | null = startingDOM;
@@ -134,8 +132,6 @@ function $getNearestManagedNodePairFromDOMNode(
           ? undefined
           : [dom, node];
       }
-    } else if (dom === rootElement) {
-      return [rootElement, internalGetRoot(editorState)];
     }
   }
 }
@@ -152,7 +148,6 @@ function flushMutations(
     updateEditorSync(editor, () => {
       const selection = $getSelection() || getLastSelection(editor);
       const badDOMTargets = new Map<HTMLElement, LexicalNode>();
-      const rootElement = editor.getRootElement();
       // We use the current editor state, as that reflects what is
       // actually "on screen".
       const currentEditorState = editor._editorState;
@@ -168,7 +163,6 @@ function flushMutations(
           targetDOM,
           editor,
           currentEditorState,
-          rootElement,
         );
         if (!pair) {
           continue;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -272,6 +272,14 @@ export interface LexicalPrivateDOM {
     | undefined;
   __lexicalDir?: 'ltr' | 'rtl' | null | undefined;
   __lexicalUnmanaged?: boolean | undefined;
+  /**
+   * When true, the DOM subtree owns its own window selection — analogous to
+   * a DecoratorNode subtree. Resolution logic that would otherwise force the
+   * Lexical selection back onto a managed position treats the caret as
+   * intentional and leaves it alone. Set via the `captureSelection` option
+   * on {@link setDOMUnmanaged}.
+   */
+  __lexicalCapturedSelection?: boolean | undefined;
 }
 
 export function $removeNode(

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -51,6 +51,7 @@ import {
   $isRootOrShadowRoot,
   cloneDecorators,
   getElementByKeyOrThrow,
+  setDOMUnmanaged,
   setMutatedNode,
   setNodeKeyOnDOMNode,
 } from './LexicalUtils';
@@ -458,6 +459,13 @@ function $createNode(key: NodeKey, slot: ElementDOMSlot | null): HTMLElement {
     dom.setAttribute('data-lexical-text', 'true');
   } else if ($isDecoratorNode(node)) {
     dom.setAttribute('data-lexical-decorator', 'true');
+    // DecoratorNode DOM is selection-captured: window selection inside
+    // a decorator subtree (e.g. an embedded input) is owned by the
+    // decorator, not by Lexical's caret management. Marking it via
+    // setDOMUnmanaged unifies the decorator case with extension-owned
+    // unmanaged subtrees so callers only need isDOMCapturingSelection /
+    // isDOMUnmanaged.
+    setDOMUnmanaged(dom, {captureSelection: true});
   }
 
   if ($isElementNode(node)) {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -80,7 +80,6 @@ import {
   $getRoot,
   $hasAncestor,
   $isRootOrShadowRoot,
-  $isSelectionCapturedInDecorator,
   $isTokenOrSegmented,
   $isTokenOrTab,
   $setCompositionKey,
@@ -90,6 +89,7 @@ import {
   getNodeKeyFromDOMNode,
   getWindow,
   INTERNAL_$isBlock,
+  isDOMCapturingSelection,
   isHTMLElement,
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
@@ -2322,8 +2322,7 @@ function $internalResolveSelectionPoint(
     }
     if (
       getNodeKeyFromDOMNode(dom, editor) === undefined &&
-      dom !== editor.getRootElement() &&
-      !$isSelectionCapturedInDecorator(dom)
+      !isDOMCapturingSelection(dom, editor)
     ) {
       // The DOM caret is sitting on a node that has no Lexical key
       // (e.g. <col> inside an unmanaged <colgroup>, or any unmanaged
@@ -2334,14 +2333,14 @@ function $internalResolveSelectionPoint(
       // selection dirty so the reconciler writes a valid DOM caret back
       // at the resolved Lexical position.
       //
-      // Exceptions where the DOM caret is intentionally somewhere
-      // Lexical doesn't own and we should NOT force-sync it:
-      //  - the editor root element (tracked separately in
-      //    _keyToDOMMap as 'root'; has no __lexicalKey_* attribute);
-      //  - anything inside a DecoratorNode subtree (the decorator owns
-      //    its own DOM and may manage its own selection — for inputs
-      //    isSelectionCapturedInDecoratorInput rejects earlier, but
-      //    non-input decorator content also shouldn't be force-synced).
+      // Exclusions split across the two guard clauses:
+      //  - The first clause (`key !== undefined`) covers any DOM node
+      //    with a `__lexicalKey_*` attribute — Lexical-managed elements
+      //    and the editor root (stashed in `resetEditor`).
+      //  - `isDOMCapturingSelection` covers DecoratorNode subtrees (which
+      //    own their own DOM) and subtrees marked via
+      //    `setDOMUnmanaged(dom, {captureSelection: true})` —
+      //    extension-owned widgets that keep a native caret.
       //
       // Void elements that ARE Lexical nodes (LineBreakNode <br>,
       // empty decorator containers, etc.) have keys, so this check

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -159,10 +159,6 @@ export const scheduleMicroTask: (fn: () => void) => void =
         Promise.resolve().then(fn);
       };
 
-export function $isSelectionCapturedInDecorator(node: Node): boolean {
-  return $isDecoratorNode($getNearestNodeFromDOMNode(node));
-}
-
 export function isSelectionCapturedInDecoratorInput(anchorDOM: Node): boolean {
   const activeElement = document.activeElement;
 
@@ -571,6 +567,11 @@ export function setNodeKeyOnDOMNode(
   (dom as Node & Record<typeof prop, NodeKey | undefined>)[prop] = key;
 }
 
+export function clearNodeKeyOnDOMNode(dom: Node, editor: LexicalEditor) {
+  const prop = `__lexicalKey_${editor._key}`;
+  delete (dom as Node & Record<typeof prop, NodeKey | undefined>)[prop];
+}
+
 export function getNodeKeyFromDOMNode(
   dom: Node,
   editor: LexicalEditor,
@@ -683,10 +684,6 @@ export function $getNodeFromDOM(dom: Node): null | LexicalNode {
   const editor = getActiveEditor();
   const nodeKey = getNodeKeyFromDOMTree(dom, editor);
   if (nodeKey === null) {
-    const rootElement = editor.getRootElement();
-    if (dom === rootElement) {
-      return $getNodeByKey('root');
-    }
     return null;
   }
   return $getNodeByKey(nodeKey);
@@ -2266,17 +2263,44 @@ export function $setFormatFromDOM<T extends ElementNode>(
 }
 
 /**
+ * Options accepted by {@link setDOMUnmanaged}.
+ *
+ * @experimental
+ */
+export interface SetDOMUnmanagedOptions {
+  /**
+   * When true, the marked subtree owns its own window selection — analogous
+   * to a DecoratorNode subtree. Selection resolution that would otherwise
+   * mark the selection dirty for a caret position inside unmanaged DOM
+   * leaves it alone, so the embedded interaction (custom input, focusable
+   * widget, etc.) can keep its native caret.
+   *
+   * Pass `false` to clear a previously-set marker; omit the field to leave
+   * `__lexicalCapturedSelection` untouched.
+   */
+  captureSelection?: boolean;
+}
+
+/**
  * Mark this DOM element as unmanaged by lexical's mutation observer (like
  * decorator nodes are). Extensions that inject non-lexical decoration
  * elements into a node's DOM should mark them so the mutation observer
  * doesn't evict them as "unknown DOM children" during cleanup.
  *
+ * Pass `{captureSelection: true}` to additionally treat the subtree's
+ * window selection as decorator-like, so resolution does not force-sync
+ * the caret out of unmanaged DOM (see {@link isDOMCapturingSelection}).
+ *
  * @experimental
  */
 export function setDOMUnmanaged(
   elementDom: HTMLElement & LexicalPrivateDOM,
+  options?: SetDOMUnmanagedOptions,
 ): void {
   elementDom.__lexicalUnmanaged = true;
+  if (options && options.captureSelection !== undefined) {
+    elementDom.__lexicalCapturedSelection = options.captureSelection;
+  }
 }
 
 /**
@@ -2286,6 +2310,40 @@ export function setDOMUnmanaged(
  */
 export function isDOMUnmanaged(elementDom: Node & LexicalPrivateDOM): boolean {
   return elementDom.__lexicalUnmanaged === true;
+}
+
+/**
+ * True if the DOM node sits inside a subtree marked with
+ * `{captureSelection: true}` via {@link setDOMUnmanaged}. Walks ancestors
+ * so any descendant of a marked subtree (e.g. an `<input>` inside a marked
+ * `<div>`) reports as captured too.
+ *
+ * The walk aborts at the first DOM node that corresponds to a Lexical
+ * node in `editor` — that boundary is the implicit owner of the subtree's
+ * selection, so a captureSelection marker above it (in non-Lexical
+ * scaffolding around the editor) does not leak in.
+ *
+ * DecoratorNode DOM is marked with `setDOMUnmanaged({captureSelection:
+ * true})` by the reconciler, so decorator subtrees also report as
+ * captured here.
+ *
+ * @experimental
+ */
+export function isDOMCapturingSelection(
+  elementDom: Node & LexicalPrivateDOM,
+  editor: LexicalEditor,
+): boolean {
+  let dom: (Node & LexicalPrivateDOM) | null = elementDom;
+  while (dom != null) {
+    if (dom.__lexicalCapturedSelection === true) {
+      return true;
+    }
+    if (getNodeKeyFromDOMNode(dom, editor) !== undefined) {
+      return false;
+    }
+    dom = getParentElement(dom);
+  }
+  return false;
 }
 
 /**

--- a/packages/lexical/src/__tests__/unit/LexicalDOMCapturedSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalDOMCapturedSelection.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  buildEditorFromExtensions,
+  type LexicalEditorWithDispose,
+} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  isDOMCapturingSelection,
+  isDOMUnmanaged,
+  setDOMUnmanaged,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
+
+function createEditor(): LexicalEditorWithDispose {
+  const editor = buildEditorFromExtensions({
+    $initialEditorState: () => {
+      $getRoot()
+        .clear()
+        .append($createParagraphNode().append($createTextNode('hello')));
+    },
+    dependencies: [RichTextExtension],
+    name: 'test',
+    nodes: [TestDecoratorNode],
+  });
+  editor.setRootElement(document.createElement('div'));
+  return editor;
+}
+
+describe('setDOMUnmanaged options (Issue #8584)', () => {
+  test('default options: marks unmanaged, leaves captureSelection off', () => {
+    using editor = createEditor();
+    const dom = document.createElement('div');
+    setDOMUnmanaged(dom);
+    expect(isDOMUnmanaged(dom)).toBe(true);
+    editor.read(() => {
+      assert(!isDOMCapturingSelection(dom, editor));
+    });
+  });
+
+  test('captureSelection: true marks both unmanaged and capturing', () => {
+    using editor = createEditor();
+    const dom = document.createElement('div');
+    setDOMUnmanaged(dom, {captureSelection: true});
+    expect(isDOMUnmanaged(dom)).toBe(true);
+    editor.read(() => {
+      assert(isDOMCapturingSelection(dom, editor));
+    });
+  });
+
+  test('captureSelection: false equivalent to default', () => {
+    using editor = createEditor();
+    const dom = document.createElement('div');
+    setDOMUnmanaged(dom, {captureSelection: false});
+    expect(isDOMUnmanaged(dom)).toBe(true);
+    editor.read(() => {
+      assert(!isDOMCapturingSelection(dom, editor));
+    });
+  });
+
+  test('captureSelection: false clears an existing flag', () => {
+    using editor = createEditor();
+    const dom = document.createElement('div');
+    setDOMUnmanaged(dom, {captureSelection: true});
+    setDOMUnmanaged(dom, {captureSelection: false});
+    editor.read(() => {
+      assert(!isDOMCapturingSelection(dom, editor));
+    });
+  });
+
+  test('descendant cannot opt out when ancestor is captured (walk)', () => {
+    using editor = createEditor();
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+    setDOMUnmanaged(parent, {captureSelection: true});
+    setDOMUnmanaged(child, {captureSelection: false});
+    editor.read(() => {
+      assert(isDOMCapturingSelection(child, editor));
+    });
+  });
+
+  test('unmarked DOM is neither unmanaged nor capturing', () => {
+    using editor = createEditor();
+    const dom = document.createElement('div');
+    expect(isDOMUnmanaged(dom)).toBe(false);
+    editor.read(() => {
+      assert(!isDOMCapturingSelection(dom, editor));
+    });
+  });
+});
+
+describe('isDOMCapturingSelection (Issue #8584)', () => {
+  test('captureSelection-marked DOM returns true', () => {
+    using editor = createEditor();
+    const widget = document.createElement('div');
+    setDOMUnmanaged(widget, {captureSelection: true});
+    editor.read(() => {
+      assert(isDOMCapturingSelection(widget, editor));
+    });
+  });
+
+  test('descendant of captureSelection-marked DOM returns true', () => {
+    using editor = createEditor();
+    const widget = document.createElement('div');
+    const child = document.createElement('span');
+    widget.appendChild(child);
+    setDOMUnmanaged(widget, {captureSelection: true});
+    editor.read(() => {
+      assert(isDOMCapturingSelection(child, editor));
+    });
+  });
+
+  test('unmanaged-only DOM (no captureSelection) is not captured', () => {
+    using editor = createEditor();
+    const widget = document.createElement('div');
+    setDOMUnmanaged(widget);
+    editor.read(() => {
+      assert(!isDOMCapturingSelection(widget, editor));
+    });
+  });
+
+  test('DecoratorNode subtree still returns true (BC preserved)', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTestDecoratorNode()));
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const rootElement = editor.getRootElement();
+      const decoratorDom = rootElement!.querySelector(
+        '[data-lexical-decorator]',
+      );
+      expect(decoratorDom).not.toBeNull();
+      assert(isDOMCapturingSelection(decoratorDom!, editor));
+    });
+  });
+
+  test('plain DOM outside the editor returns false', () => {
+    using editor = createEditor();
+    const dom = document.createElement('div');
+    editor.read(() => {
+      assert(!isDOMCapturingSelection(dom, editor));
+    });
+  });
+
+  test('editor root element returns false', () => {
+    using editor = createEditor();
+    const rootElement = editor.getRootElement();
+    editor.read(() => {
+      assert(!isDOMCapturingSelection(rootElement!, editor));
+    });
+  });
+
+  test('walk aborts at a Lexical-node DOM — ancestor capture above editor does not leak in', () => {
+    using editor = createEditor();
+    // outerWrapper is non-Lexical scaffolding that wraps the editor; mark it
+    // as captureSelection. The walk from a text DOM inside the editor must
+    // NOT see this marker because there is a Lexical-node DOM (the
+    // paragraph or text element) on the path that aborts it.
+    const outerWrapper = document.createElement('div');
+    setDOMUnmanaged(outerWrapper, {captureSelection: true});
+    const rootElement = editor.getRootElement()!;
+    outerWrapper.appendChild(rootElement);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('hello')));
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const textSpan = rootElement.querySelector('[data-lexical-text]');
+      expect(textSpan).not.toBeNull();
+      assert(!isDOMCapturingSelection(textSpan!, editor));
+    });
+  });
+});

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -43,6 +43,7 @@ import {
   $getRoot,
   $isElementNode,
   $isParagraphNode,
+  $isRootNode,
   $isTextNode,
   $parseSerializedNode,
   $setCompositionKey,
@@ -390,8 +391,9 @@ describe('LexicalEditor tests', () => {
       editor.read(() => {
         const rootElement = editor.getRootElement();
         expect(rootElement).toBeDefined();
-        // The root never works for this call
-        expect($getNearestNodeFromDOMNode(rootElement!)).toBe(null);
+        // The root element now carries __lexicalKey_* = 'root' so
+        // $getNearestNodeFromDOMNode resolves it to the RootNode.
+        assert($isRootNode($getNearestNodeFromDOMNode(rootElement!)));
         const paragraphDom = rootElement!.querySelector('p');
         expect(paragraphDom).toBeDefined();
         expect(

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -308,6 +308,7 @@ export {
   INTERNAL_$isBlock,
   isBlockDomNode,
   isDocumentFragment,
+  isDOMCapturingSelection,
   isDOMDocumentNode,
   isDOMNode,
   isDOMTextNode,
@@ -325,6 +326,7 @@ export {
   removeFromParent,
   resetRandomKey,
   setDOMUnmanaged,
+  type SetDOMUnmanagedOptions,
   setNodeIndentFromDOM,
   toggleTextFormatType,
 } from './LexicalUtils';


### PR DESCRIPTION
## Description

Generalizes the "selection captured outside of Lexical" mechanism that #8582 added a partial dirty-flag guard for. Before this PR, only DecoratorNode subtrees could opt out of resolution force-syncing the DOM caret back to a managed Lexical position; DOMRenderExtension overrides and `getDOMSlot` widgets had no equivalent way to keep a native caret.

Closes #8584.

### What changed

- `setDOMUnmanaged(elementDom, options?)` accepts a `captureSelection: true` option that marks the subtree as selection-captured — analogous to a DecoratorNode subtree. Set-only; no clear path. Re-call with a different element to revoke.
- `isDOMCapturingSelection(dom)` walks ancestors so any descendant of a marked subtree (e.g. an `<input>` inside a marked `<div>`) reports as captured. Replaces internal call sites of `$isSelectionCapturedInDecorator` in `LexicalEvents` (`onPointerDown`, `$shouldPreventDefaultAndInsertText`) and `LexicalSelection` (`$internalResolveSelectionPoint` dirty-flag check).
- The reconciler now marks every `DecoratorNode` DOM with `setDOMUnmanaged(dom, {captureSelection: true})`, unifying decorator subtrees and extension-owned unmanaged subtrees behind a single check. `$isSelectionCapturedInDecorator` is removed (was internal-only, no `index.ts` re-export).
- The root element now carries `__lexicalKey_${editor._key} = 'root'` (the consistency suggestion in the second half of #8584). `$getNodeFromDOM`, `$getNearestNodeFromDOMNode`, the mutation handler in `$getNearestManagedNodePairFromDOMNode`, and the dirty-flag check now share the unified key lookup; per-site `editor.getRootElement()` carveouts are removed. New `clearNodeKeyOnDOMNode` clears the stash on `prevRootElement` during `resetEditor`.

### Backwards compatibility

`$getNearestNodeFromDOMNode(rootElement)` previously returned `null`; it now returns `RootNode`. Two existing call sites become more correct as a result:

- `lexical-clipboard` `$insertDataTransferForRichText` — drop-on-root margin used to silently fail (null), now resolves to a paragraph at the root's child-index.
- `lexical-table` `$fixTableSelectionForSelectedTable` — `isFocusOutside` used to evaluate as `null && ...` (falsy → no-op); now correctly evaluates as truthy when DOM selection extends onto the root, so a TableSelection automatically converts to a RangeSelection. Covered by a new e2e regression test.

External callers that relied on `$getNearestNodeFromDOMNode(rootElement)` returning null will need to update.

## Test plan

- [x] `pnpm tsc --noEmit -p tsconfig.json`, `pnpm flow`, prettier, eslint clean.
- [x] Full unit suite (`pnpm vitest run --project unit`) — 141 files / 2776 pass / 1 skip / 0 fail. New file `LexicalDOMCapturedSelection.test.ts` (12 tests) covers default vs `captureSelection: true`, `false` as a no-op (does not clear), the descendant walk, the "descendant cannot opt out when ancestor is captured" subtree invariant, the decorator subtree case (BC preserved via reconciler marking), and the editor root case (root carries a key but is not captured).
- [x] `LexicalEditor.test.tsx:393` — assertion updated to expect RootNode (the BC).
- [x] e2e regression locally on chromium (1.3s), firefox (1.9s), webkit (2.1s) — `pnpm test-e2e-{browser} --grep 'TableSelection converts to RangeSelection'`. Covers the `$fixTableSelectionForSelectedTable` path.
- [x] `~/Desktop/lexical-knowledge/scripts/lexical-prepush.sh` exits 0.

Refs #8582.