### PR TITLE
[lexical] Bug Fix: TabNode.setTextContent for Safari IME composition

### DIFF
--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -8,7 +8,6 @@
 
 import type {DOMConversionMap, NodeKey} from '../LexicalNode';
 
-import devInvariant from '@lexical/internal/devInvariant';
 import invariant from '@lexical/internal/invariant';
 
 import {IS_UNMERGEABLE} from '../LexicalConstants';
@@ -58,11 +57,18 @@ export class TabNode extends TextNode {
     return $createTabNode().updateFromJSON(serializedTabNode);
   }
 
-  setTextContent(text: string): this {
-    devInvariant(
-      text === '\t' || text === '',
-      'TabNode does not support setTextContent',
-    );
+  /**
+   * Always normalizes the stored content to `'\t'` regardless of input — see
+   * comment below for the rationale.
+   */
+  setTextContent(_text: string): this {
+    // The stored content is canonical regardless of input. Safari's
+    // MutationObserver can deliver mid-IME-composition writes onto the
+    // TabNode's `\t` text node (verified with Korean), and `flushMutations`
+    // then calls this with the in-flight composition payload; throwing here
+    // cascaded through `onError` and froze the editor (#8596). The dropped
+    // check was guarding caller assumptions, not stored state — the
+    // reconciler renders the canonical content on the next update.
     return super.setTextContent('\t');
   }
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
@@ -323,5 +323,29 @@ describe('LexicalTabNode tests', () => {
         });
       });
     });
+
+    test('setTextContent normalizes back to \\t without throwing (#8596)', () => {
+      // Safari's MutationObserver can deliver mid-IME-composition text writes
+      // straight onto the TabNode's `\t` text node (verified with Korean), and
+      // `flushMutations` then calls `TabNode.setTextContent` with the
+      // in-flight composition payload (e.g. `'\tㅁ'`). The call must not throw
+      // — a throw cascades through `onError` and freezes the editor.
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const paragraph = $getRoot().getFirstChild();
+          invariant($isElementNode(paragraph));
+          const tabNode = $createTabNode();
+          paragraph.append(tabNode);
+          expect(() => tabNode.setTextContent('\tㅁ')).not.toThrow();
+          expect(tabNode.getTextContent()).toBe('\t');
+          expect(() => tabNode.setTextContent('arbitrary')).not.toThrow();
+          expect(tabNode.getTextContent()).toBe('\t');
+          expect(() => tabNode.setTextContent('')).not.toThrow();
+          expect(tabNode.getTextContent()).toBe('\t');
+        },
+        {discrete: true},
+      );
+    });
   });
 });


### PR DESCRIPTION
## Description

Closes #8596.

In Safari, the MutationObserver delivers mid-IME-composition text writes straight onto the `TabNode`'s `\t` text node — IMEs that compose onto the existing text node (verified with Korean) cause Safari to rewrite it to e.g. `\tㅁ`. `flushMutations` then calls `TabNode.setTextContent('\tㅁ')`, the current `devInvariant` throws, and the throw cascades through `onError`: composition stays stuck, Backspace / Enter / English input all stop responding until a hard refresh.

The throw has existed since `TabNode` was introduced. The only earlier hit on it was selection-based typing across the node, which #7602 already covered by treating `TabNode` as token-mode. The MutationObserver / IME path is a separate route into the same method and was uncovered.

Drop the `devInvariant` check entirely. The body already normalizes to `\t` via `super.setTextContent('\t')`, so removing the check changes nothing about the stored content — the reconciler still renders the canonical `\t` on the next update. The dropped check was guarding caller assumptions, not stored state.

A few notes for reviewers:

- Only `setTextContent` sits on the Safari MutationObserver path. `spliceText` is gated by the `$isTabNode(firstNode)` early-return in `LexicalSelection.ts`; `setDetail` / `setMode` aren't on any IME-triggered path. Those invariants stay.
- `packages/lexical-yjs/src/CollabTextNode.ts` calls `setTextContent(collabText)` on synced text nodes, including a `TabNode` whose remote text might be non-`\t`. The dev throw previously surfaced that drift in dev; in prod it was already a warn-only path. After this change dev matches prod's behavior — silently normalize to `\t`. Not a new prod regression.

## Test plan

- [x] `pnpm tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm flow` — clean
- [x] prettier + eslint clean on changed files
- [x] `pnpm vitest run --project unit -t "LexicalTabNode tests"` — 18 passed (new test added: `setTextContent normalizes back to \t without throwing (#8596)` covering the `setTextContent('\tㅁ')` shape `flushMutations` produces, plus an arbitrary string and `''`)
- [x] Manual: Safari (macOS 26.3.1) on local `vite build` + `vite preview` of `lexical-playground` — `foo` + `Tab` + Korean composition now completes; Backspace removes the `TabNode`, Enter inserts a paragraph, English typing resumes, copy/paste preserves `\t`, Markdown shortcuts still fire.
- [x] Manual: Chromium parity — same flows behave identically (no regression from removing the check on the non-Safari path).
- [x] Manual: confirmed no text loss via a MutationObserver on the contenteditable. After `foo` + `Tab` + Korean composition, Safari writes the in-flight jamo onto the TabNode's `\t` text node and the normalize fires; the Korean character then lands on a sibling TextNode (input / `CONTROLLED_TEXT_INSERTION` path) and composition continues there. Final editor state: `paragraph[text "foo", tab "\t", text "안녕하세요"]` — Korean preserved.