### PR TITLE
[lexical-rich-text] Bug Fix: Caret stuck when block has no leading or trailing text

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
@@ -9,11 +9,13 @@
 import {buildEditorFromExtensions} from '@lexical/extension';
 import {$createHeadingNode, RichTextExtension} from '@lexical/rich-text';
 import {
+  $createNodeSelection,
   $createParagraphNode,
   $createTextNode,
   $getRoot,
   $getSelection,
   $isRangeSelection,
+  $setSelection,
   LexicalEditor,
   MOVE_TO_END,
 } from 'lexical';
@@ -252,6 +254,96 @@ describe('MOVE_TO_END with no trailing text (Issue #8601)', () => {
       expect(selection.focus.type).toBe('element');
       expect(selection.focus.key).toBe(paragraph.getKey());
       expect(selection.focus.offset).toBe(3);
+    });
+  });
+});
+
+describe('MOVE_TO_END on a NodeSelection (Issue #8604)', () => {
+  test.for([
+    {
+      expected: () => {
+        const paragraph = $getRoot().getFirstChildOrThrow();
+        return {key: paragraph.getKey(), offset: 2};
+      },
+      label: 'single inline decorator collapses to the block end',
+      setup: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(decorator, text);
+        $getRoot().clear().append(paragraph);
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+    },
+    {
+      expected: () => {
+        const secondParagraph = $getRoot().getChildAtIndex(1);
+        assert(secondParagraph !== null);
+        return {key: secondParagraph.getKey(), offset: 2};
+      },
+      label: 'multi-node selection picks the iteration-order last node',
+      setup: () => {
+        const firstDecorator = $createTestDecoratorNode().setIsInline(true);
+        const firstText = $createTextNode('A');
+        const firstParagraph = $createParagraphNode().append(
+          firstDecorator,
+          firstText,
+        );
+        const secondDecorator = $createTestDecoratorNode().setIsInline(true);
+        const secondText = $createTextNode('B');
+        const secondParagraph = $createParagraphNode().append(
+          secondDecorator,
+          secondText,
+        );
+        $getRoot().clear().append(firstParagraph, secondParagraph);
+        const ns = $createNodeSelection();
+        ns.add(firstDecorator.getKey());
+        ns.add(secondDecorator.getKey());
+        $setSelection(ns);
+      },
+    },
+    {
+      // Whole-element NodeSelection on a non-inline ElementNode (the
+      // paragraph itself). The helper's `n !== targetNode` guard skips
+      // the paragraph and walks up; with no other non-inline ancestor
+      // below the root, the lookup falls back to root. Without the
+      // guard, the paragraph would resolve to itself and the caret
+      // would land at the paragraph's trailing edge — this case pins
+      // down the include-self regression.
+      expected: () => ({
+        key: 'root',
+        offset: $getRoot().getChildrenSize(),
+      }),
+      label: 'whole-element non-inline ElementNode resolves to its parent',
+      setup: () => {
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(text);
+        $getRoot().clear().append(paragraph);
+        const ns = $createNodeSelection();
+        ns.add(paragraph.getKey());
+        $setSelection(ns);
+      },
+    },
+  ])('$label', ({setup, expected}) => {
+    using editor = buildEditorFromExtensions({
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    editor.update(setup, {discrete: true});
+
+    dispatchMoveToEnd(editor, false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      const {key, offset} = expected();
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.key).toBe(key);
+      expect(selection.anchor.offset).toBe(offset);
     });
   });
 });

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToEnd.test.ts
@@ -151,15 +151,6 @@ describe('MOVE_TO_END no-op cases (Issue #8555)', () => {
         paragraph.select(1, 1);
       },
     },
-    {
-      label: 'decorator-only element (no selectable text)',
-      setup: () => {
-        const decorator = $createTestDecoratorNode().setIsInline(true);
-        const paragraph = $createParagraphNode().append(decorator);
-        $getRoot().clear().append(paragraph);
-        paragraph.select(0, 0);
-      },
-    },
   ])('no-op: $label', ({setup}) => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: setup,
@@ -176,8 +167,8 @@ describe('MOVE_TO_END no-op cases (Issue #8555)', () => {
   });
 });
 
-describe('MOVE_TO_END decorator-only safety (crash fix)', () => {
-  test('Cmd+ArrowRight on decorator-only element does not throw', () => {
+describe('MOVE_TO_END with no trailing text (Issue #8601)', () => {
+  test('Cmd+ArrowRight on decorator-only element moves caret past the last child', () => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: () => {
         const decorator = $createTestDecoratorNode().setIsInline(true);
@@ -190,18 +181,20 @@ describe('MOVE_TO_END decorator-only safety (crash fix)', () => {
       nodes: [TestDecoratorNode],
     });
 
-    // Should not throw — previously this would crash with selectEnd() on empty element
-    expect(() => dispatchMoveToEnd(editor, false)).not.toThrow();
+    dispatchMoveToEnd(editor, false);
 
     editor.read(() => {
       const selection = $getSelection();
       assert($isRangeSelection(selection));
-      // Selection remains valid
-      expect(selection.anchor.type).toBeDefined();
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.focus.type).toBe('element');
+      expect(selection.focus.key).toBe(paragraph.getKey());
+      expect(selection.focus.offset).toBe(1);
     });
   });
 
-  test('Shift+Cmd+ArrowRight on decorator-only element does not throw', () => {
+  test('Shift+Cmd+ArrowRight on decorator-only element selects past the last child', () => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: () => {
         const decorator = $createTestDecoratorNode().setIsInline(true);
@@ -214,12 +207,51 @@ describe('MOVE_TO_END decorator-only safety (crash fix)', () => {
       nodes: [TestDecoratorNode],
     });
 
-    const before = snapshotSelection(editor);
-
-    // Handler bails safely on decorator-only elements (no selectable text)
     dispatchMoveToEnd(editor, true);
 
-    // Selection unchanged — handler returned false
-    expect(snapshotSelection(editor)).toEqual(before);
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      expect(selection.isCollapsed()).toBe(false);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.key).toBe(paragraph.getKey());
+      expect(selection.anchor.offset).toBe(0);
+      expect(selection.focus.type).toBe('element');
+      expect(selection.focus.key).toBe(paragraph.getKey());
+      expect(selection.focus.offset).toBe(1);
+    });
+  });
+
+  test('Cmd+ArrowRight on [decorator][text][decorator] sandwich moves caret past the trailing decorator', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const leading = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const trailing = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(
+          leading,
+          text,
+          trailing,
+        );
+        $getRoot().clear().append(paragraph);
+        paragraph.select(0, 0);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToEnd(editor, false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.focus.type).toBe('element');
+      expect(selection.focus.key).toBe(paragraph.getKey());
+      expect(selection.focus.offset).toBe(3);
+    });
   });
 });

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
@@ -9,11 +9,13 @@
 import {buildEditorFromExtensions} from '@lexical/extension';
 import {$createHeadingNode, RichTextExtension} from '@lexical/rich-text';
 import {
+  $createNodeSelection,
   $createParagraphNode,
   $createTextNode,
   $getRoot,
   $getSelection,
   $isRangeSelection,
+  $setSelection,
   LexicalEditor,
   MOVE_TO_START,
 } from 'lexical';
@@ -259,6 +261,92 @@ describe('MOVE_TO_START with no leading text (Issue #8601)', () => {
       expect(selection.focus.type).toBe('element');
       expect(selection.focus.key).toBe(paragraph.getKey());
       expect(selection.focus.offset).toBe(0);
+    });
+  });
+});
+
+describe('MOVE_TO_START on a NodeSelection (Issue #8604)', () => {
+  test.for([
+    {
+      expected: () => {
+        const paragraph = $getRoot().getFirstChildOrThrow();
+        return {key: paragraph.getKey(), offset: 0};
+      },
+      label: 'single inline decorator collapses to the block start',
+      setup: () => {
+        const decorator = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(text, decorator);
+        $getRoot().clear().append(paragraph);
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+    },
+    {
+      expected: () => {
+        const firstParagraph = $getRoot().getFirstChildOrThrow();
+        return {key: firstParagraph.getKey(), offset: 0};
+      },
+      label: 'multi-node selection picks the iteration-order first node',
+      setup: () => {
+        const firstDecorator = $createTestDecoratorNode().setIsInline(true);
+        const firstText = $createTextNode('A');
+        const firstParagraph = $createParagraphNode().append(
+          firstText,
+          firstDecorator,
+        );
+        const secondDecorator = $createTestDecoratorNode().setIsInline(true);
+        const secondText = $createTextNode('B');
+        const secondParagraph = $createParagraphNode().append(
+          secondText,
+          secondDecorator,
+        );
+        $getRoot().clear().append(firstParagraph, secondParagraph);
+        const ns = $createNodeSelection();
+        ns.add(firstDecorator.getKey());
+        ns.add(secondDecorator.getKey());
+        $setSelection(ns);
+      },
+    },
+    {
+      // Whole-element NodeSelection on a non-inline ElementNode (the
+      // paragraph itself). The helper's `n !== targetNode` guard skips
+      // the paragraph and walks up; with no other non-inline ancestor
+      // below the root, the lookup falls back to root. Without the
+      // guard, the paragraph would resolve to itself and the caret
+      // would land at the paragraph's leading edge — this case pins
+      // down the include-self regression.
+      expected: () => ({key: 'root', offset: 0}),
+      label: 'whole-element non-inline ElementNode resolves to its parent',
+      setup: () => {
+        const text = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(text);
+        $getRoot().clear().append(paragraph);
+        const ns = $createNodeSelection();
+        ns.add(paragraph.getKey());
+        $setSelection(ns);
+      },
+    },
+  ])('$label', ({setup, expected}) => {
+    using editor = buildEditorFromExtensions({
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    editor.update(setup, {discrete: true});
+
+    dispatchMoveToStart(editor, false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      const {key, offset} = expected();
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.key).toBe(key);
+      expect(selection.anchor.offset).toBe(offset);
     });
   });
 });

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextInlineDecoratorMoveToStart.test.ts
@@ -153,15 +153,6 @@ describe('MOVE_TO_START no-op cases (Issue #8555)', () => {
         paragraph.select(0, 0);
       },
     },
-    {
-      label: 'decorator-only element (no selectable text)',
-      setup: () => {
-        const decorator = $createTestDecoratorNode().setIsInline(true);
-        const paragraph = $createParagraphNode().append(decorator);
-        $getRoot().clear().append(paragraph);
-        paragraph.select(1, 1);
-      },
-    },
   ])('no-op: $label', ({setup}) => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: setup,
@@ -178,8 +169,8 @@ describe('MOVE_TO_START no-op cases (Issue #8555)', () => {
   });
 });
 
-describe('MOVE_TO_START decorator-only safety (crash fix)', () => {
-  test('Cmd+ArrowLeft on decorator-only element does not throw', () => {
+describe('MOVE_TO_START with no leading text (Issue #8601)', () => {
+  test('Cmd+ArrowLeft on decorator-only element moves caret to element offset 0', () => {
     using editor = buildEditorFromExtensions({
       $initialEditorState: () => {
         const decorator = $createTestDecoratorNode().setIsInline(true);
@@ -192,12 +183,82 @@ describe('MOVE_TO_START decorator-only safety (crash fix)', () => {
       nodes: [TestDecoratorNode],
     });
 
-    expect(() => dispatchMoveToStart(editor, false)).not.toThrow();
+    dispatchMoveToStart(editor, false);
 
     editor.read(() => {
       const selection = $getSelection();
       assert($isRangeSelection(selection));
-      expect(selection.anchor.type).toBeDefined();
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.key).toBe(paragraph.getKey());
+      expect(selection.anchor.offset).toBe(0);
+    });
+  });
+
+  test('Cmd+ArrowLeft from text caret inside [decorator][text][decorator] moves to element offset 0', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const leading = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const trailing = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(
+          leading,
+          text,
+          trailing,
+        );
+        $getRoot().clear().append(paragraph);
+        text.select(2, 2);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToStart(editor, false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      expect(selection.isCollapsed()).toBe(true);
+      expect(selection.anchor.type).toBe('element');
+      expect(selection.anchor.key).toBe(paragraph.getKey());
+      expect(selection.anchor.offset).toBe(0);
+    });
+  });
+
+  test('Shift+Cmd+ArrowLeft from text caret inside [decorator][text][decorator] selects back to element offset 0', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const leading = $createTestDecoratorNode().setIsInline(true);
+        const text = $createTextNode('hello');
+        const trailing = $createTestDecoratorNode().setIsInline(true);
+        const paragraph = $createParagraphNode().append(
+          leading,
+          text,
+          trailing,
+        );
+        $getRoot().clear().append(paragraph);
+        text.select(3, 3);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode],
+    });
+
+    dispatchMoveToStart(editor, true);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      expect(selection.isCollapsed()).toBe(false);
+      expect(selection.anchor.type).toBe('text');
+      expect(selection.anchor.offset).toBe(3);
+      expect(selection.focus.type).toBe('element');
+      expect(selection.focus.key).toBe(paragraph.getKey());
+      expect(selection.focus.offset).toBe(0);
     });
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1296,16 +1296,21 @@ export function registerRichText(
         if (!$isDecoratorNode(firstChild) || !firstChild.isInline()) {
           return false;
         }
-        const lastDescendant = element.getLastDescendant();
-        if (lastDescendant == null || $isDecoratorNode(lastDescendant)) {
-          // No selectable text — fall through to native browser behavior.
-          return false;
-        }
         // Native browser cursor traversal stops at the inline decorator's
         // contenteditable=false boundary when the caret starts at element
         // offset 0, so MOVE_TO_END leaves the caret stuck. Move it ourselves.
+        // When the block has no trailing text (only decorators, or a
+        // [decorator…decorator] sandwich), land the caret at the element
+        // offset past the last child so it clears the trailing boundary too.
         const elementKey = element.getKey();
-        const ending = element.selectEnd();
+        const lastDescendant = element.getLastDescendant();
+        const ending =
+          lastDescendant == null || $isDecoratorNode(lastDescendant)
+            ? element.select(
+                element.getChildrenSize(),
+                element.getChildrenSize(),
+              )
+            : element.selectEnd();
         if (event.shiftKey) {
           ending.anchor.set(elementKey, 0, 'element');
         }
@@ -1333,11 +1338,6 @@ export function registerRichText(
         }
         const firstChild = focusBlock.getFirstChild();
         if (!$isDecoratorNode(firstChild) || !firstChild.isInline()) {
-          return false;
-        }
-        const lastDescendant = focusBlock.getLastDescendant();
-        if (lastDescendant == null || $isDecoratorNode(lastDescendant)) {
-          // No selectable text — fall through to native browser behavior.
           return false;
         }
         // Cross-block selections fall through to native handling. The

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -18,6 +18,7 @@ import type {
   LexicalNode,
   LexicalUpdateJSON,
   NodeKey,
+  NodeSelection,
   ParagraphNode,
   PasteCommandType,
   RangeSelection,
@@ -647,6 +648,61 @@ const DEFAULT_ESCAPE_FORMAT_TRIGGERS: EscapeFormatTriggerConfig = {
   lowercase: {enter: true, space: true, tab: true},
   uppercase: {enter: true, space: true, tab: true},
 };
+
+/**
+ * Collapse a NodeSelection to a caret at the surrounding block's edge for
+ * MOVE_TO_START / MOVE_TO_END. Picks the first node in the selection's
+ * iteration order for MOVE_TO_START (`isBackward = true`) or the last for
+ * MOVE_TO_END, walks up to the picked node's nearest non-inline ancestor,
+ * and lands the caret at that block's offset `0` or `childrenSize`.
+ *
+ * A decorator nested inside an element-decorator host (e.g. inside a card
+ * title paragraph) promotes to the surrounding paragraph rather than the
+ * host's edge — the `n !== targetNode` guard excludes the node itself, so
+ * a whole-element NodeSelection (the host) snaps to its parent block, not
+ * its own interior. Falls back to the root when no non-inline ancestor
+ * below the root matches, which lands the caret at the document edge.
+ *
+ * `NodeSelection.getNodes()` iterates `_nodes: Set<NodeKey>` in
+ * Set-insertion order, not strict document order. In practice a
+ * NodeSelection is single-node (image / mention click), so the framing
+ * is "first / last in the selection" rather than "first / last in the
+ * document".
+ *
+ * Distinct from `KEY_ARROW_LEFT_COMMAND` / `KEY_ARROW_RIGHT_COMMAND`,
+ * which step to the immediate sibling via `selectPrevious` /
+ * `selectNext`. Cmd+Arrow is a line-end command rather than a one-step
+ * caret move, so the block edge is the intended target. `event.shiftKey`
+ * is not honored — NodeSelection has no natural "extend toward block
+ * edge" semantic.
+ *
+ * Always calls `preventDefault` and `stopPropagation` so Chrome's
+ * native Cmd+Arrow page-navigate cannot fall through.
+ *
+ * @internal
+ */
+function $promoteNodeSelectionToBlockEdge(
+  selection: NodeSelection,
+  isBackward: boolean,
+  event: KeyboardEvent,
+): boolean {
+  event.preventDefault();
+  event.stopPropagation();
+  const nodes = selection.getNodes();
+  if (nodes.length === 0) {
+    return true;
+  }
+  const targetNode = isBackward ? nodes[0] : nodes[nodes.length - 1];
+  const block: ElementNode =
+    $findMatchingParent(
+      targetNode,
+      (n): n is ElementNode =>
+        n !== targetNode && $isElementNode(n) && !n.isInline(),
+    ) ?? $getRoot();
+  const offset = isBackward ? 0 : block.getChildrenSize();
+  block.select(offset, offset);
+  return true;
+}
 
 export function registerRichText(
   editor: LexicalEditor,
@@ -1281,6 +1337,9 @@ export function registerRichText(
       MOVE_TO_END,
       event => {
         const selection = $getSelection();
+        if ($isNodeSelection(selection)) {
+          return $promoteNodeSelectionToBlockEdge(selection, false, event);
+        }
         if (!$isRangeSelection(selection)) {
           return false;
         }
@@ -1324,6 +1383,9 @@ export function registerRichText(
       MOVE_TO_START,
       event => {
         const selection = $getSelection();
+        if ($isNodeSelection(selection)) {
+          return $promoteNodeSelectionToBlockEdge(selection, true, event);
+        }
         if (!$isRangeSelection(selection)) {
           return false;
         }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -53,6 +53,7 @@ import {
 } from '@lexical/utils';
 import {
   $applyNodeReplacement,
+  $comparePointCaretNext,
   $createParagraphNode,
   $createRangeSelection,
   $createTabNode,
@@ -60,6 +61,7 @@ import {
   $getNearestNodeFromDOMNode,
   $getRoot,
   $getSelection,
+  $getSiblingCaret,
   $insertNodes,
   $isDecoratorNode,
   $isElementNode,
@@ -651,23 +653,24 @@ const DEFAULT_ESCAPE_FORMAT_TRIGGERS: EscapeFormatTriggerConfig = {
 
 /**
  * Collapse a NodeSelection to a caret at the surrounding block's edge for
- * MOVE_TO_START / MOVE_TO_END. Picks the first node in the selection's
- * iteration order for MOVE_TO_START (`isBackward = true`) or the last for
- * MOVE_TO_END, walks up to the picked node's nearest non-inline ancestor,
- * and lands the caret at that block's offset `0` or `childrenSize`.
+ * MOVE_TO_START / MOVE_TO_END. Picks the document-order first node for
+ * MOVE_TO_START (`isBackward = true`) or last for MOVE_TO_END, walks up
+ * to the picked node's nearest non-inline ancestor, and lands the caret
+ * at that block's offset `0` or `childrenSize`.
  *
- * A decorator nested inside an element-decorator host (e.g. inside a card
- * title paragraph) promotes to the surrounding paragraph rather than the
- * host's edge — the `n !== targetNode` guard excludes the node itself, so
- * a whole-element NodeSelection (the host) snaps to its parent block, not
- * its own interior. Falls back to the root when no non-inline ancestor
- * below the root matches, which lands the caret at the document edge.
+ * Document order is resolved via `$comparePointCaretNext` over each
+ * selected node's `'next'` sibling caret — `NodeSelection.getNodes()`
+ * iterates `_nodes: Set<NodeKey>` in click-insertion order, so a Set-
+ * index pick would land on the most-recently-clicked node, not the
+ * document-order first / last.
  *
- * `NodeSelection.getNodes()` iterates `_nodes: Set<NodeKey>` in
- * Set-insertion order, not strict document order. In practice a
- * NodeSelection is single-node (image / mention click), so the framing
- * is "first / last in the selection" rather than "first / last in the
- * document".
+ * A decorator nested inside an element-decorator host (e.g. inside a
+ * card title paragraph) promotes to the surrounding paragraph rather
+ * than the host's edge — the `n !== targetNode` guard excludes the
+ * node itself, so a whole-element NodeSelection (the host) snaps to
+ * its parent block, not its own interior. Falls back to the root when
+ * no non-inline ancestor below the root matches, which lands the
+ * caret at the document edge.
  *
  * Distinct from `KEY_ARROW_LEFT_COMMAND` / `KEY_ARROW_RIGHT_COMMAND`,
  * which step to the immediate sibling via `selectPrevious` /
@@ -692,7 +695,11 @@ function $promoteNodeSelectionToBlockEdge(
   if (nodes.length === 0) {
     return true;
   }
-  const targetNode = isBackward ? nodes[0] : nodes[nodes.length - 1];
+  const sorted = nodes
+    .map(node => $getSiblingCaret(node, 'next'))
+    .sort($comparePointCaretNext);
+  const targetNode = (isBackward ? sorted[0] : sorted[sorted.length - 1])
+    .origin;
   const block: ElementNode =
     $findMatchingParent(
       targetNode,
@@ -1357,19 +1364,14 @@ export function registerRichText(
         }
         // Native browser cursor traversal stops at the inline decorator's
         // contenteditable=false boundary when the caret starts at element
-        // offset 0, so MOVE_TO_END leaves the caret stuck. Move it ourselves.
-        // When the block has no trailing text (only decorators, or a
-        // [decorator…decorator] sandwich), land the caret at the element
-        // offset past the last child so it clears the trailing boundary too.
+        // offset 0, so MOVE_TO_END leaves the caret stuck. Move it
+        // ourselves. `element.selectEnd()` already handles every
+        // last-descendant case correctly — text descendant produces a
+        // text-type selection at the end of the run, decorator descendant
+        // and the empty-element fallback both produce an element-type
+        // selection at offset childrenSize.
         const elementKey = element.getKey();
-        const lastDescendant = element.getLastDescendant();
-        const ending =
-          lastDescendant == null || $isDecoratorNode(lastDescendant)
-            ? element.select(
-                element.getChildrenSize(),
-                element.getChildrenSize(),
-              )
-            : element.selectEnd();
+        const ending = element.selectEnd();
         if (event.shiftKey) {
           ending.anchor.set(elementKey, 0, 'element');
         }


### PR DESCRIPTION
## Description

`MOVE_TO_END` / `MOVE_TO_START` handlers added in #8558 fall through to the native browser when the target element has no trailing / leading text — last/first descendant is a decorator, or the element holds only decorators. The assumption was that the native caret would take over, but Mac Chrome and Safari stop the caret at the inline decorator's `contenteditable=false` boundary in those cases too, leaving the cursor stuck. Windows Chromium handles it natively.

This PR drops the fall-through branches and lets the handlers finish the move themselves:

- `MOVE_TO_END`: when `lastDescendant` is null or a decorator, land the caret at `element.getChildrenSize()` — the element offset past the last child.
- `MOVE_TO_START`: drop the `lastDescendant === decorator || null` branch entirely. The rest of the handler already sets focus to element offset 0, which is the right target regardless of what the last descendant is.

Closes #8601

## NodeSelection branch (#8604 discussion)

@levensta noticed `MOVE_TO_END` / `MOVE_TO_START` fire on `NodeSelection` too, but the handler's `RangeSelection` guard fell through and Chrome's native Cmd+Arrow took over — navigating browser history out of the editor.

Per @etrepum's design in the PR thread, the NodeSelection branch collapses to a RangeSelection at the iteration-order first node's leading edge (MOVE_TO_START) or last node's trailing edge (MOVE_TO_END), resolved to the nearest non-inline ancestor's offset 0 / childrenSize (root as the fallback). A decorator nested inside an element-decorator host promotes to the surrounding paragraph rather than past the host.

## Test plan

- [x] `pnpm vitest run --project unit packages/lexical-rich-text packages/lexical-code-core` — 101/101 pass (6 new scenarios for #8601 + 6 new for the NodeSelection branch + no regression on the #8558 tests).
- [x] Manual on Mac Chrome + Safari, comparing `playground.lexical.dev` (before) vs local build (after), using the doc state from the issue:
  - Single inline decorator + Cmd+→ → caret moves past the decorator.
  - `[decorator][text][decorator]`, caret at start + Cmd+→ → caret lands past the trailing decorator.
  - `[decorator][text][decorator]`, caret in text + Cmd+← → caret lands at element offset 0.
  - Shift variants of the above select the right range.
  - NodeSelection on a clicked inline decorator + Cmd+→ / Cmd+← → caret lands at the surrounding paragraph's edge; no browser-history navigation.
  - Regression: leading-decorator + text + Cmd+→ still lands at end of text (unchanged from #8558).
  - Regression: text-only paragraph behaves as native (handler early-returns).
- [x] tsc / flow / prettier / eslint clean.