### PR TITLE
[lexical-code-shiki] Bug Fix: Set the unsupported syntax flag only once

### DIFF
--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -174,10 +174,11 @@ function $codeNodeTransform(
         node.setIsSyntaxHighlightSupported(true);
       }
     } else {
-      if (node.getIsSyntaxHighlightSupported()) {
+      const loadingTask = loadCodeLanguage(language, editor, nodeKey);
+      // if the language is not supported, the download will not occur
+      if (!loadingTask && node.getIsSyntaxHighlightSupported()) {
         node.setIsSyntaxHighlightSupported(false);
       }
-      loadCodeLanguage(language, editor, nodeKey);
       inFlight = true;
     }
   } else if (node.getIsSyntaxHighlightSupported()) {

--- a/packages/lexical-code-shiki/src/FacadeShiki.ts
+++ b/packages/lexical-code-shiki/src/FacadeShiki.ts
@@ -64,7 +64,7 @@ export function isCodeLanguageLoaded(language: string) {
  * @param editor - Lexical editor instance to update after the language loads.
  * @param codeNodeKey - Key of the {@link CodeNode} to mark as syntax-highlight-supported.
  * @returns A Promise that resolves when the language is ready,
- * or `undefined` if the {@link language} was already loaded or is not supported.
+ * or `undefined` if the `language` was already loaded or is not supported.
  */
 export function loadCodeLanguage(
   language: string,

--- a/packages/lexical-code-shiki/src/FacadeShiki.ts
+++ b/packages/lexical-code-shiki/src/FacadeShiki.ts
@@ -53,6 +53,19 @@ export function isCodeLanguageLoaded(language: string) {
   return shiki.getLoadedLanguages().includes(langId);
 }
 
+/**
+ * Loads a syntax highlighting grammar for the given language via Shiki.
+ * If the language is already loaded or is not supported, the call is a no-op.
+ *
+ * When both `editor` and `codeNodeKey` are passed, the corresponding
+ * {@link CodeNode} is updated to enable syntax highlighting once the
+ * language becomes available
+ * @param language language identifier (e.g. `"typescript"`, `"diff-js"`)
+ * @param editor - Lexical editor instance to update after the language loads.
+ * @param codeNodeKey - Key of the {@link CodeNode} to mark as syntax-highlight-supported.
+ * @returns A Promise that resolves when the language is ready,
+ * or `undefined` if the {@link language} was already loaded or is not supported.
+ */
 export function loadCodeLanguage(
   language: string,
   editor?: LexicalEditor,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

While the syntax highlighter is loading, the CodeNode transform may continuously update the state of `node.setIsSyntaxHighlightSupported(false)`. To fix this continuous updating, the return value from the `loadCodeLanguage` function is checked so `node.setIsSyntaxHighlightSupported(false)` is called only if the language is not supported

Closes #8605
Closes #8607

## Test plan

### Before

Switching from prism to shiki caused an infinite transform loop while loading the language highlighting module


### After

When switching from prism to shiki, the unsupported syntax flag is set only if the highlighting module did not occur