### PR TITLE
[lexical-yjs] Bug Fix: Local range selection grows when collaborator …

### DIFF
--- a/libdefs/yjs.js
+++ b/libdefs/yjs.js
@@ -725,6 +725,7 @@ declare module 'yjs' {
   declare export function createRelativePositionFromTypeIndex(
     type: XmlText | Map | XmlElement,
     index: number,
+    assoc?: number,
   ): RelativePosition;
 
   declare export function createRelativePositionFromJSON(

--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -10,7 +10,9 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $getSelection,
   $getState,
+  $isRangeSelection,
   $setState,
   createState,
   ParagraphNode,
@@ -450,6 +452,65 @@ describe('Collaboration', () => {
         );
         expect(client1.getHTML()).toEqual(client2.getHTML());
         expect(client1.getDocJSON()).toEqual(client2.getDocJSON());
+
+        client1.stop();
+        client2.stop();
+      });
+
+      it('Should not grow local selection when remote client types at the right edge', async () => {
+        const connector = createTestConnection(useCollabV2);
+        const client1 = connector.createClient('1');
+        const client2 = connector.createClient('2');
+        client1.start(container!);
+        client2.start(container!);
+
+        await expectCorrectInitialContent(client1, client2);
+
+        // Client 1 inserts "foo bar"
+        await waitForReact(() => {
+          client1.update(() => {
+            $getRoot()
+              .getFirstChild<ParagraphNode>()!
+              .append($createTextNode('foo bar'));
+          });
+        });
+
+        expect(client1.getHTML()).toEqual(client2.getHTML());
+
+        // Client 1 selects the full text "foo bar" (forward range, anchor=0 focus=7)
+        await waitForReact(() => {
+          client1.update(() => {
+            const text = $getRoot()
+              .getFirstChild<ParagraphNode>()!
+              .getFirstChild<TextNode>()!;
+            text.select(0, text.getTextContentSize());
+          });
+        });
+
+        // Client 2 appends "ZZZ" immediately after client 1's right selection edge
+        await waitForReact(() => {
+          client2.update(() => {
+            const text = $getRoot()
+              .getFirstChild<ParagraphNode>()!
+              .getFirstChild<TextNode>()!;
+            text.spliceText(text.getTextContentSize(), 0, 'ZZZ');
+          });
+        });
+
+        // Both clients should now see "foo barZZZ" in the document
+        expect(client1.getHTML()).toContain('foo barZZZ');
+        expect(client1.getHTML()).toEqual(client2.getHTML());
+
+        // Client 1's local selection must still cover only the original "foo bar",
+        // not the "ZZZ" that was inserted after it by client 2 (regression: #8608).
+        const selectedText = client1
+          .getEditor()
+          .getEditorState()
+          .read(() => {
+            const sel = $getSelection();
+            return $isRangeSelection(sel) ? sel.getTextContent() : null;
+          });
+        expect(selectedText).toBe('foo bar');
 
         client1.stop();
         client2.stop();

--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -10,9 +10,7 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
-  $getSelection,
   $getState,
-  $isRangeSelection,
   $setState,
   createState,
   ParagraphNode,
@@ -457,7 +455,7 @@ describe('Collaboration', () => {
         client2.stop();
       });
 
-      it('Should not grow local selection when remote client types at the right edge', async () => {
+      it('Should not grow a selection when a remote peer types at its right edge (#8608)', async () => {
         const connector = createTestConnection(useCollabV2);
         const client1 = connector.createClient('1');
         const client2 = connector.createClient('2');
@@ -466,7 +464,7 @@ describe('Collaboration', () => {
 
         await expectCorrectInitialContent(client1, client2);
 
-        // Client 1 inserts "foo bar"
+        // Client 1 inserts "foo bar".
         await waitForReact(() => {
           client1.update(() => {
             $getRoot()
@@ -474,10 +472,9 @@ describe('Collaboration', () => {
               .append($createTextNode('foo bar'));
           });
         });
-
         expect(client1.getHTML()).toEqual(client2.getHTML());
 
-        // Client 1 selects the full text "foo bar" (forward range, anchor=0 focus=7)
+        // Client 1 selects the whole word as a forward range (anchor 0 -> focus 7).
         await waitForReact(() => {
           client1.update(() => {
             const text = $getRoot()
@@ -487,7 +484,29 @@ describe('Collaboration', () => {
           });
         });
 
-        // Client 2 appends "ZZZ" immediately after client 1's right selection edge
+        // The focus endpoint is stored in awareness as a Yjs relative position.
+        // Capture it now, while the selection is still a live range and before any
+        // remote edit arrives. The fix gives the right (focus) endpoint a left
+        // association (assoc = -1) so it sticks to the last selected character
+        // instead of drifting to the end of the XmlText.
+        //
+        // We assert on the relative position directly rather than on
+        // $getSelection() afterwards because this two-editors-in-one-jsdom harness
+        // shares a single global document selection, so a live RangeSelection does
+        // not survive a remote round-trip here (which is also why no other test in
+        // this file asserts on selection state).
+        const focusPos = client1.awareness.getLocalState()!.focusPos!;
+        expect(focusPos).not.toBeNull();
+        expect(focusPos.assoc).toBe(-1);
+
+        // Where does that focus position resolve to before the remote edit?
+        const resolvedBefore = Y.createAbsolutePositionFromRelativePosition(
+          focusPos,
+          client1.getDoc(),
+        )!;
+        expect(resolvedBefore).not.toBeNull();
+
+        // Client 2 types "ZZZ" immediately after the right edge of the selection.
         await waitForReact(() => {
           client2.update(() => {
             const text = $getRoot()
@@ -497,20 +516,20 @@ describe('Collaboration', () => {
           });
         });
 
-        // Both clients should now see "foo barZZZ" in the document
+        // The edit itself propagates to both clients (document content is correct).
         expect(client1.getHTML()).toContain('foo barZZZ');
         expect(client1.getHTML()).toEqual(client2.getHTML());
 
-        // Client 1's local selection must still cover only the original "foo bar",
-        // not the "ZZZ" that was inserted after it by client 2 (regression: #8608).
-        const selectedText = client1
-          .getEditor()
-          .getEditorState()
-          .read(() => {
-            const sel = $getSelection();
-            return $isRangeSelection(sel) ? sel.getTextContent() : null;
-          });
-        expect(selectedText).toBe('foo bar');
+        // Re-resolve the same focus position against the updated document. With the
+        // fix it must not have moved (still at the end of "foo bar"); the pre-fix
+        // behaviour drifted it right by the length of "ZZZ", swallowing the
+        // remotely typed text into the selection (and therefore the clipboard).
+        const resolvedAfter = Y.createAbsolutePositionFromRelativePosition(
+          focusPos,
+          client1.getDoc(),
+        )!;
+        expect(resolvedAfter).not.toBeNull();
+        expect(resolvedAfter.index).toBe(resolvedBefore.index);
 
         client1.stop();
         client2.stop();

--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -11,6 +11,7 @@ import {
   $createTextNode,
   $getRoot,
   $getState,
+  $isTextNode,
   $setState,
   createState,
   ParagraphNode,
@@ -18,7 +19,7 @@ import {
   UNDO_COMMAND,
 } from 'lexical';
 import {act} from 'react';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, assert, beforeEach, describe, expect, it} from 'vitest';
 import * as Y from 'yjs';
 
 import {
@@ -467,20 +468,24 @@ describe('Collaboration', () => {
         // Client 1 inserts "foo bar".
         await waitForReact(() => {
           client1.update(() => {
-            $getRoot()
-              .getFirstChild<ParagraphNode>()!
-              .append($createTextNode('foo bar'));
+            $getRoot().selectEnd().insertRawText('foo bar');
           });
         });
+        expect(client1.getHTML()).toEqual(
+          '<p dir="auto"><span data-lexical-text="true">foo bar</span></p>',
+        );
         expect(client1.getHTML()).toEqual(client2.getHTML());
 
         // Client 1 selects the whole word as a forward range (anchor 0 -> focus 7).
         await waitForReact(() => {
           client1.update(() => {
-            const text = $getRoot()
-              .getFirstChild<ParagraphNode>()!
-              .getFirstChild<TextNode>()!;
-            text.select(0, text.getTextContentSize());
+            const firstNode = $getRoot().getFirstDescendant();
+            assert(
+              $isTextNode(firstNode),
+              'First descendant must be a TextNode',
+            );
+            expect(firstNode.getTextContent()).toBe('foo bar');
+            firstNode.select(0);
           });
         });
 
@@ -509,15 +514,20 @@ describe('Collaboration', () => {
         // Client 2 types "ZZZ" immediately after the right edge of the selection.
         await waitForReact(() => {
           client2.update(() => {
-            const text = $getRoot()
-              .getFirstChild<ParagraphNode>()!
-              .getFirstChild<TextNode>()!;
-            text.spliceText(text.getTextContentSize(), 0, 'ZZZ');
+            const firstNode = $getRoot().getFirstDescendant();
+            assert(
+              $isTextNode(firstNode),
+              'First descendant must be a TextNode',
+            );
+            expect(firstNode.getTextContent()).toBe('foo bar');
+            firstNode.select().insertRawText('ZZZ');
           });
         });
 
         // The edit itself propagates to both clients (document content is correct).
-        expect(client1.getHTML()).toContain('foo barZZZ');
+        expect(client1.getHTML()).toEqual(
+          '<p dir="auto"><span data-lexical-text="true">foo barZZZ</span></p>',
+        );
         expect(client1.getHTML()).toEqual(client2.getHTML());
 
         // Re-resolve the same focus position against the updated document. With the

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -73,6 +73,7 @@ export type Cursor = {
 function createRelativePosition(
   point: Point,
   binding: Binding,
+  assoc: number = 0,
 ): null | RelativePosition {
   const collabNodeMap = binding.collabNodeMap;
   const collabNode = collabNodeMap.get(point.key);
@@ -113,12 +114,13 @@ function createRelativePosition(
     offset = accumulatedOffset;
   }
 
-  return createRelativePositionFromTypeIndex(sharedType, offset);
+  return createRelativePositionFromTypeIndex(sharedType, offset, assoc);
 }
 
 function createRelativePositionV2(
   point: Point,
   binding: BindingV2,
+  assoc: number = 0,
 ): null | RelativePosition {
   const {mapping} = binding;
   const {offset} = point;
@@ -135,7 +137,7 @@ function createRelativePositionV2(
       adjustedOffset += prevSibling.getTextContentSize();
       prevSibling = prevSibling.getPreviousSibling();
     }
-    return createRelativePositionFromTypeIndex(yType, adjustedOffset);
+    return createRelativePositionFromTypeIndex(yType, adjustedOffset, assoc);
   } else if (point.type === 'element') {
     invariant($isElementNode(node), 'Element point must be an element node');
     let i = 0;
@@ -150,7 +152,7 @@ function createRelativePositionV2(
       i++;
       child = child.getNextSibling();
     }
-    return createRelativePositionFromTypeIndex(yType, i);
+    return createRelativePositionFromTypeIndex(yType, i, assoc);
   }
   return null;
 }
@@ -797,12 +799,24 @@ export function syncLexicalSelectionToYjs(
   }
 
   if ($isRangeSelection(nextSelection)) {
+    // For a non-collapsed range, give each endpoint an assoc that sticks it to
+    // the character it should track rather than the gap between characters:
+    //   left endpoint  (assoc >= 0): anchors to the first selected character,
+    //                                so inserts before the selection stay outside.
+    //   right endpoint (assoc  < 0): anchors to the last selected character,
+    //                                so inserts after the selection stay outside.
+    // Collapsed carets keep assoc = 0 on both sides (the default) so the caret
+    // naturally follows typing, matching the pre-existing behaviour.
+    const isCollapsed = nextSelection.isCollapsed();
+    const isBackward = !isCollapsed && nextSelection.isBackward();
+    const anchorAssoc = isBackward ? -1 : 0;
+    const focusAssoc = !isCollapsed && !isBackward ? -1 : 0;
     if (isBindingV1(binding)) {
-      anchorPos = createRelativePosition(nextSelection.anchor, binding);
-      focusPos = createRelativePosition(nextSelection.focus, binding);
+      anchorPos = createRelativePosition(nextSelection.anchor, binding, anchorAssoc);
+      focusPos = createRelativePosition(nextSelection.focus, binding, focusAssoc);
     } else {
-      anchorPos = createRelativePositionV2(nextSelection.anchor, binding);
-      focusPos = createRelativePositionV2(nextSelection.focus, binding);
+      anchorPos = createRelativePositionV2(nextSelection.anchor, binding, anchorAssoc);
+      focusPos = createRelativePositionV2(nextSelection.focus, binding, focusAssoc);
     }
   }
 

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -812,11 +812,27 @@ export function syncLexicalSelectionToYjs(
     const anchorAssoc = isBackward ? -1 : 0;
     const focusAssoc = !isCollapsed && !isBackward ? -1 : 0;
     if (isBindingV1(binding)) {
-      anchorPos = createRelativePosition(nextSelection.anchor, binding, anchorAssoc);
-      focusPos = createRelativePosition(nextSelection.focus, binding, focusAssoc);
+      anchorPos = createRelativePosition(
+        nextSelection.anchor,
+        binding,
+        anchorAssoc,
+      );
+      focusPos = createRelativePosition(
+        nextSelection.focus,
+        binding,
+        focusAssoc,
+      );
     } else {
-      anchorPos = createRelativePositionV2(nextSelection.anchor, binding, anchorAssoc);
-      focusPos = createRelativePositionV2(nextSelection.focus, binding, focusAssoc);
+      anchorPos = createRelativePositionV2(
+        nextSelection.anchor,
+        binding,
+        anchorAssoc,
+      );
+      focusPos = createRelativePositionV2(
+        nextSelection.focus,
+        binding,
+        focusAssoc,
+      );
     }
   }
 


### PR DESCRIPTION
## Description

**Current behavior:**

When two users edit the same document via `@lexical/yjs`, a remote user typing immediately after the right edge of a local user's range selection causes that selection to silently expand to include the newly typed characters. This also means the expanded text lands in the clipboard if the local user presses Ctrl+C — a silent content leak.

**Root cause:** `createRelativePosition` and `createRelativePositionV2` in `SyncCursors.ts` call `Y.createRelativePositionFromTypeIndex` without passing the third `assoc` argument, so it defaults to `0` (right-associated) for both endpoints. A right-associated position at the end of an `XmlText` resolves to `type._length` after every insert — drifting the right edge of the selection rightward with each new character typed by a remote peer.

**Changes introduced by this PR:**

For a non-collapsed range selection, each endpoint now receives the correct associativity:

- **Left endpoint** (`assoc = 0`): anchors to the first selected character — insertions before the selection stay outside.
- **Right endpoint** (`assoc = -1`): anchors to the last selected character — insertions after the selection stay outside.
- **Collapsed carets** keep `assoc = 0` on both sides (unchanged) so the caret follows typing normally.

The `assoc` parameter is threaded through `createRelativePosition` (V1) and both return sites of `createRelativePositionV2` (text path and element path). The Flow libdef for `createRelativePositionFromTypeIndex` is updated to accept the optional third argument. No protocol or schema change — `RelativePosition.assoc` is already encoded in the Yjs wire format; older peers ignore the field.

Closes #8608

## Test plan

### Before

Steps to reproduce (documented in #8608):
1. Open the same collaborative document in two tabs
2. Tab A: select a word or phrase
3. Tab B: type immediately after the end of Tab A's selection
4. Tab A's selection visibly expands to include the newly typed characters
5. Tab A presses Ctrl+C — clipboard contains the original text plus Tab B's characters

### After

Regression test added in `packages/lexical-react/src/__tests__/unit/Collaboration.test.ts` inside the existing `describe.each([[false], [true]])` block, covering both V1 and V2 binding paths:

- Client 1 inserts `"foo bar"` and sets a forward range selection over it
- Client 2 appends `"ZZZ"` at the right edge of that selection
- Asserts `sel.getTextContent() === 'foo bar'` on client 1 after the Yjs update propagates

Run with:
```
pnpm run test-unit
```