### PR TITLE
Include editor namespace in infinite-update-loop detector error

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -880,7 +880,8 @@ function $triggerEnqueuedUpdates(editor: LexicalEditor): void {
     try {
       invariant(
         false,
-        'One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition.',
+        'One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition. Editor namespace: %s',
+        editor._config.namespace,
       );
     } catch (error) {
       if (error instanceof Error) {

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1216,6 +1216,12 @@ describe('LexicalEditor tests', () => {
     expect(errorListener.mock.calls[0][0].message).toMatch(
       /endlessly enqueueing/,
     );
+    // The error message should include the editor's namespace so the loop can
+    // be attributed to a specific product/editor in error aggregation, even
+    // when the production stack is minified to core frames.
+    expect(errorListener.mock.calls[0][0].message).toContain(
+      `Editor namespace: ${editor._config.namespace}`,
+    );
 
     unregisterListener();
 


### PR DESCRIPTION
## Description

The infinite-update-loop circuit-breaker added in #8542 fires when update listeners endlessly re-enqueue updates (`editor._cascadeCount > 99`). It is working as intended, but its output is currently hard to act on.

When the loop fires, the thrown error is surfaced via `editor._onError` at the core boundary, so the aggregated stack is entirely minified core frames with an empty deferred stack. There is no way to attribute the loop to a specific editor instance or plugin without a dev repro — and the loop often only reproduces under specific product conditions.

This appends the editor's namespace to the thrown error message using the existing `invariant(%s)` parameterization:

```ts
invariant(
  false,
  'One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition. Editor namespace: %s',
  editor._config.namespace,
);
```

`editor._config.namespace` is set distinctly per product/editor, so this immediately partitions the aggregated error by editor in error reporting — with zero new logging surface.

## Why this shape

- **No behavior change** — same circuit-breaker, same drop-queue, same `_onError` path. Only the message string gains a `%s` arg.
- Uses the existing `invariant(%s)` pattern, so it slots into the error-code / `codes.json` minification cleanly.
- Kept minimal (namespace only). A follow-up could add the first non-core stack frame if attribution is still ambiguous.

## Test plan

Extended the existing `Detects infinite recursivity on update listeners` test in `packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx` to assert the thrown error message contains the editor's namespace, in addition to the existing `/endlessly enqueueing/` assertion.

---
_This PR was raised by [Navi](https://navibot.dev?utm_source=github&utm_medium=pull_request&ref=potatowagon) on behalf of Sherry Wong, at the request of the Lexical sync oncall._
