### PR TITLE
[lexical-extension][lexical-react][lexical-playground] Chore: Add Vitest browser-mode tests via the Playwright runner

### DIFF
--- a/.github/workflows/call-browser-tests.yml
+++ b/.github/workflows/call-browser-tests.yml
@@ -12,8 +12,6 @@ permissions: {}
 jobs:
   browser-test:
     runs-on: ${{ inputs.os }}
-    # WebKit is only reliable on macOS runners in CI, matching the e2e matrix.
-    if: (inputs.browser != 'webkit' || inputs.os == 'macos-latest')
     env:
       CI: true
       # Drives the `instances` selection in vitest.config.mts.

--- a/.github/workflows/call-browser-tests.yml
+++ b/.github/workflows/call-browser-tests.yml
@@ -1,0 +1,40 @@
+name: Lexical browser test runner
+
+on:
+  workflow_call:
+    inputs:
+      os: {required: false, type: string, default: 'ubuntu-latest'}
+      node-version: {required: false, type: string, default: '24.x'}
+      browser: {required: false, type: string, default: 'chromium'}
+
+permissions: {}
+
+jobs:
+  browser-test:
+    runs-on: ${{ inputs.os }}
+    # WebKit is only reliable on macOS runners in CI, matching the e2e matrix.
+    if: (inputs.browser != 'webkit' || inputs.os == 'macos-latest')
+    env:
+      CI: true
+      # Drives the `instances` selection in vitest.config.mts.
+      VITEST_BROWSER: ${{ inputs.browser }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ inputs.node-version }}
+      - uses: ./.github/actions/setup-playwright
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Run browser tests
+        run: pnpm run test-browser
+      - name: Upload Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: Browser Test Results ${{ inputs.os }}-${{ inputs.browser }}-${{ inputs.node-version }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .vitest-attachments/
+            packages/**/__tests__/browser/**/__screenshots__/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/call-core-tests.yml
+++ b/.github/workflows/call-core-tests.yml
@@ -37,3 +37,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: pnpm run test-unit
+
+  # Default browser-mode run: linux + chromium only. The extended suite
+  # (tests-extended.yml) fans these out across more browsers and operating
+  # systems.
+  browser:
+    uses: ./.github/workflows/call-browser-tests.yml
+    with:
+      os: 'ubuntu-latest'
+      node-version: '24.x'
+      browser: 'chromium'

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -182,8 +182,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-2022']
-        browser: ['chromium', 'firefox', 'webkit']
+        # Each combination is fully specified. ubuntu + chromium is already
+        # covered by the default browser run in call-core-tests.yml, and WebKit
+        # is only exercised on macOS, so neither is repeated here.
+        include:
+          - {os: 'ubuntu-latest', browser: 'firefox'}
+          - {os: 'macos-latest', browser: 'chromium'}
+          - {os: 'macos-latest', browser: 'firefox'}
+          - {os: 'macos-latest', browser: 'webkit'}
+          - {os: 'windows-2022', browser: 'chromium'}
+          - {os: 'windows-2022', browser: 'firefox'}
     uses: ./.github/workflows/call-browser-tests.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -175,3 +175,17 @@ jobs:
     needs: check_should_run
     if: needs.check_should_run.outputs.should_run == 'true'
     uses: ./.github/workflows/call-integration-tests.yml
+
+  browser-tests:
+    needs: check_should_run
+    if: needs.check_should_run.outputs.should_run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-2022']
+        browser: ['chromium', 'firefox', 'webkit']
+    uses: ./.github/workflows/call-browser-tests.yml
+    with:
+      os: ${{ matrix.os }}
+      node-version: '24.x'
+      browser: ${{ matrix.browser }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ npm
 e2e-screenshots
 test-results
 playwright-report
+# Failure screenshots and attachments written by the vitest browser-mode tests
+__screenshots__
+.vitest-attachments
 /SOURCE_CODE_REVIEW.md
 /playwright.local.config.mjs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,10 @@ This file provides detailed guidance for AI agents and automated tools working w
 - `pnpm run build-types` - Build TypeScript type definitions and validate them
 
 ### Testing
-- `pnpm run test-unit` - Run all unit tests (Vitest)
+- `pnpm run test-unit` - Run all unit tests (Vitest, jsdom)
 - `pnpm run test-unit-watch` - Run unit tests in watch mode
+- `pnpm run test-browser` - Run browser-mode unit tests (Vitest + Playwright, real browser)
+- `pnpm run test-browser-watch` - Run browser-mode tests in watch mode
 - `pnpm run test-e2e-chromium` - Run E2E tests in Chromium (requires dev server running)
 - `pnpm run test-e2e-firefox` - Run E2E tests in Firefox
 - `pnpm run test-e2e-webkit` - Run E2E tests in WebKit
@@ -174,7 +176,15 @@ When adding/modifying APIs, types must be maintained for both systems.
 Always access node properties/methods within read/update context. Nodes automatically resolve to their latest version via their key. Don't store node references across update boundaries.
 
 ### Testing Strategy
-- **Unit tests** - Vitest, located in `packages/**/__tests__/unit/**/*.test.{ts,tsx}`
+- **Unit tests** - Vitest (jsdom), located in `packages/**/__tests__/unit/**/*.test.{ts,tsx}`
+- **Browser tests** - Vitest browser mode driven by the Playwright runner, located in
+  `packages/**/__tests__/browser/**/*.test.{ts,tsx}`. Use these for behavior that depends on
+  a real layout/selection engine instead of stubbing the missing jsdom functionality from
+  `vitest.setup.mts` (e.g. `Range.getBoundingClientRect`, the Selection API). Run with
+  `pnpm run test-browser`; the browser set is controlled by the `VITEST_BROWSER` env var
+  (comma-separated, default `chromium`). Prefer building editors with the extension APIs
+  (`buildEditorFromExtensions`, or `LexicalExtensionComposer`/`LexicalExtensionEditorComposer`
+  in React).
 - **E2E tests** - Playwright, located in `packages/lexical-playground/__tests__/e2e/**/*.spec.{ts,mjs}`
 - E2E tests require the playground dev server running
 - Use `pnpm run debug-test-e2e-chromium` to debug E2E tests with browser UI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,12 @@ Always access node properties/methods within read/update context. Nodes automati
   (comma-separated, default `chromium`). Prefer building editors with the extension APIs
   (`buildEditorFromExtensions`, or `LexicalExtensionComposer`/`LexicalExtensionEditorComposer`
   in React).
+  - **Do not use `using`/`Disposable` in browser tests (or any browser-facing code).**
+    Explicit Resource Management (`using`, `Symbol.dispose`, `Disposable`) is not supported
+    in WebKit/Safari yet, so the syntax throws a `SyntaxError` there. `using` is fine in unit
+    tests (jsdom/Node), but browser tests should clean up with
+    `onTestFinished(() => editor.dispose())` instead — `editor.dispose()` is a plain method
+    available on the result of `buildEditorFromExtensions`.
 - **E2E tests** - Playwright, located in `packages/lexical-playground/__tests__/e2e/**/*.spec.{ts,mjs}`
 - E2E tests require the playground dev server running
 - Use `pnpm run debug-test-e2e-chromium` to debug E2E tests with browser UI

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "vitest": "vitest",
     "test-unit": "vitest --project unit --project scripts-unit --no-watch",
     "test-unit-watch": "vitest --project unit --project scripts-unit",
+    "test-browser": "vitest --project browser --no-watch",
+    "test-browser-watch": "vitest --project browser",
     "bench": "vitest bench --project bench --project bench-dom --run",
     "test-eslint-integration": "node packages/lexical-eslint-plugin/__tests__/integration/integration-test.mjs",
     "test-integration": "vitest --project integration --no-watch",
@@ -148,6 +150,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/semver": "^7.7.1",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/browser-playwright": "^4.1.8",
     "baseline-browser-mapping": "^2.10.25",
     "chokidar": "^5.0.0",
     "concurrently": "^9.2.1",
@@ -179,6 +182,7 @@
     "lint-staged": "^16.0.0",
     "minimist": "^1.2.5",
     "npm-run-all": "^4.1.5",
+    "playwright": "^1.60.0",
     "prettier": "^3.8.1",
     "prettier-plugin-hermes-parser": "^0.36.0",
     "prettier-plugin-organize-attributes": "^1.0.0",
@@ -194,7 +198,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
     "vite": "^8.0.10",
-    "vitest": "^4.1.5",
+    "vitest": "^4.1.8",
     "y-websocket": "^2.1.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/semver": "^7.7.1",
-    "@vitejs/plugin-react": "^6.0.1",
+    "@vitejs/plugin-react": "^6.0.2",
     "@vitest/browser-playwright": "^4.1.8",
     "baseline-browser-mapping": "^2.10.25",
     "chokidar": "^5.0.0",
@@ -197,7 +197,7 @@
     "typedoc": "^0.28.19",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
-    "vite": "^8.0.10",
+    "vite": "^8.0.16",
     "vitest": "^4.1.8",
     "y-websocket": "^2.1.0"
   },

--- a/packages/lexical-extension/src/__tests__/browser/BuildEditorFromExtensions.test.ts
+++ b/packages/lexical-extension/src/__tests__/browser/BuildEditorFromExtensions.test.ts
@@ -28,15 +28,22 @@ function $prepopulate(): void {
 // the block. The contentEditable is reachable via editor.getRootElement(), and
 // document.body is reset between tests, so nothing else needs cleaning up.
 function setUpEditor() {
-  const editor = buildEditorFromExtensions(
-    RichTextExtension,
-    defineExtension({$initialEditorState: $prepopulate, name: '[root]'}),
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: $prepopulate,
+      afterRegistration(editor, _config, _state) {
+        const rootElement = document.createElement('div');
+        rootElement.contentEditable = 'true';
+        document.body.appendChild(rootElement);
+        editor.setRootElement(rootElement);
+        return () => {
+          document.body.removeChild(rootElement);
+        };
+      },
+      dependencies: [RichTextExtension],
+      name: '[root]',
+    }),
   );
-  const rootElement = document.createElement('div');
-  rootElement.contentEditable = 'true';
-  document.body.appendChild(rootElement);
-  editor.setRootElement(rootElement);
-  return editor;
 }
 
 describe('buildEditorFromExtensions (browser)', () => {

--- a/packages/lexical-extension/src/__tests__/browser/BuildEditorFromExtensions.test.ts
+++ b/packages/lexical-extension/src/__tests__/browser/BuildEditorFromExtensions.test.ts
@@ -9,7 +9,7 @@
 import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
-import {afterEach, describe, expect, test} from 'vitest';
+import {describe, expect, test} from 'vitest';
 
 // These tests intentionally avoid the jsdom polyfills in vitest.setup.mts and
 // instead assert against a real layout/selection engine. The same assertions
@@ -17,39 +17,32 @@ import {afterEach, describe, expect, test} from 'vitest';
 // under jsdom (see vitest.setup.mts), which is exactly the kind of mocking the
 // browser project lets us drop.
 
-const cleanups: Array<() => void> = [];
-
-afterEach(() => {
-  for (const cleanup of cleanups.splice(0)) {
-    cleanup();
-  }
-});
-
 function $prepopulate(): void {
   $getRoot().append(
     $createParagraphNode().append($createTextNode('Hello from a real browser')),
   );
 }
 
-function mountEditor(): {contentEditable: HTMLElement} {
+// `buildEditorFromExtensions` returns a Disposable editor, so callers use
+// `using editor = setUpEditor()` and the editor tears itself down at the end of
+// the block. The contentEditable is reachable via editor.getRootElement(), and
+// document.body is reset between tests, so nothing else needs cleaning up.
+function setUpEditor() {
   const editor = buildEditorFromExtensions(
     RichTextExtension,
     defineExtension({$initialEditorState: $prepopulate, name: '[root]'}),
   );
-  const contentEditable = document.createElement('div');
-  contentEditable.contentEditable = 'true';
-  document.body.appendChild(contentEditable);
-  editor.setRootElement(contentEditable);
-  cleanups.push(() => {
-    editor.dispose();
-    contentEditable.remove();
-  });
-  return {contentEditable};
+  const rootElement = document.createElement('div');
+  rootElement.contentEditable = 'true';
+  document.body.appendChild(rootElement);
+  editor.setRootElement(rootElement);
+  return editor;
 }
 
 describe('buildEditorFromExtensions (browser)', () => {
   test('reconciles the initial editor state into the real DOM', () => {
-    const {contentEditable} = mountEditor();
+    using editor = setUpEditor();
+    const contentEditable = editor.getRootElement()!;
     expect(contentEditable.querySelector('p')).not.toBeNull();
     expect(contentEditable.textContent).toBe('Hello from a real browser');
     // The browser honors contentEditable; jsdom does not keep this in sync
@@ -58,10 +51,10 @@ describe('buildEditorFromExtensions (browser)', () => {
   });
 
   test('Range.getBoundingClientRect reports real layout', () => {
-    const {contentEditable} = mountEditor();
-    const textSpan = contentEditable.querySelector(
-      '[data-lexical-text="true"]',
-    )!;
+    using editor = setUpEditor();
+    const textSpan = editor
+      .getRootElement()!
+      .querySelector('[data-lexical-text="true"]')!;
     const range = document.createRange();
     range.selectNodeContents(textSpan);
     const rect = range.getBoundingClientRect();
@@ -72,12 +65,12 @@ describe('buildEditorFromExtensions (browser)', () => {
   });
 
   test('the native Selection API round-trips a real range', () => {
-    const {contentEditable} = mountEditor();
+    using editor = setUpEditor();
     // Lexical renders text inside a <span data-lexical-text="true">, so the
     // actual Text node is its first child.
-    const textNode = contentEditable.querySelector(
-      '[data-lexical-text="true"]',
-    )!.firstChild as Text;
+    const textNode = editor
+      .getRootElement()!
+      .querySelector('[data-lexical-text="true"]')!.firstChild as Text;
     const domSelection = window.getSelection()!;
     domSelection.removeAllRanges();
     const range = document.createRange();

--- a/packages/lexical-extension/src/__tests__/browser/BuildEditorFromExtensions.test.ts
+++ b/packages/lexical-extension/src/__tests__/browser/BuildEditorFromExtensions.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {afterEach, describe, expect, test} from 'vitest';
+
+// These tests intentionally avoid the jsdom polyfills in vitest.setup.mts and
+// instead assert against a real layout/selection engine. The same assertions
+// would require stubbing Range.getBoundingClientRect and the Selection API
+// under jsdom (see vitest.setup.mts), which is exactly the kind of mocking the
+// browser project lets us drop.
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) {
+    cleanup();
+  }
+});
+
+function $prepopulate(): void {
+  $getRoot().append(
+    $createParagraphNode().append($createTextNode('Hello from a real browser')),
+  );
+}
+
+function mountEditor(): {contentEditable: HTMLElement} {
+  const editor = buildEditorFromExtensions(
+    RichTextExtension,
+    defineExtension({$initialEditorState: $prepopulate, name: '[root]'}),
+  );
+  const contentEditable = document.createElement('div');
+  contentEditable.contentEditable = 'true';
+  document.body.appendChild(contentEditable);
+  editor.setRootElement(contentEditable);
+  cleanups.push(() => {
+    editor.dispose();
+    contentEditable.remove();
+  });
+  return {contentEditable};
+}
+
+describe('buildEditorFromExtensions (browser)', () => {
+  test('reconciles the initial editor state into the real DOM', () => {
+    const {contentEditable} = mountEditor();
+    expect(contentEditable.querySelector('p')).not.toBeNull();
+    expect(contentEditable.textContent).toBe('Hello from a real browser');
+    // The browser honors contentEditable; jsdom does not keep this in sync
+    // with the attribute without the override in vitest.setup.mts.
+    expect(contentEditable.isContentEditable).toBe(true);
+  });
+
+  test('Range.getBoundingClientRect reports real layout', () => {
+    const {contentEditable} = mountEditor();
+    const textSpan = contentEditable.querySelector(
+      '[data-lexical-text="true"]',
+    )!;
+    const range = document.createRange();
+    range.selectNodeContents(textSpan);
+    const rect = range.getBoundingClientRect();
+    // A real engine lays out the glyphs so the selected text has a non-zero
+    // footprint. jsdom has no layout and the setup file stubs this to zeros.
+    expect(rect.width).toBeGreaterThan(0);
+    expect(rect.height).toBeGreaterThan(0);
+  });
+
+  test('the native Selection API round-trips a real range', () => {
+    const {contentEditable} = mountEditor();
+    // Lexical renders text inside a <span data-lexical-text="true">, so the
+    // actual Text node is its first child.
+    const textNode = contentEditable.querySelector(
+      '[data-lexical-text="true"]',
+    )!.firstChild as Text;
+    const domSelection = window.getSelection()!;
+    domSelection.removeAllRanges();
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 5);
+    domSelection.addRange(range);
+    expect(domSelection.toString()).toBe('Hello');
+  });
+});

--- a/packages/lexical-extension/src/__tests__/browser/BuildEditorFromExtensions.test.ts
+++ b/packages/lexical-extension/src/__tests__/browser/BuildEditorFromExtensions.test.ts
@@ -9,13 +9,17 @@
 import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
-import {describe, expect, test} from 'vitest';
+import {describe, expect, onTestFinished, test} from 'vitest';
 
 // These tests intentionally avoid the jsdom polyfills in vitest.setup.mts and
 // instead assert against a real layout/selection engine. The same assertions
 // would require stubbing Range.getBoundingClientRect and the Selection API
 // under jsdom (see vitest.setup.mts), which is exactly the kind of mocking the
 // browser project lets us drop.
+//
+// Note: `using`/`Disposable` (Explicit Resource Management) is not supported in
+// WebKit/Safari yet, so browser tests dispose with onTestFinished instead of
+// the `using` keyword. See AGENTS.md.
 
 function $prepopulate(): void {
   $getRoot().append(
@@ -23,19 +27,20 @@ function $prepopulate(): void {
   );
 }
 
-// `buildEditorFromExtensions` returns a Disposable editor, so callers use
-// `using editor = setUpEditor()` and the editor tears itself down at the end of
-// the block. The contentEditable is reachable via editor.getRootElement(), and
-// document.body is reset between tests, so nothing else needs cleaning up.
+// Builds an editor whose contentEditable is created in the afterRegistration
+// phase (the earliest point setRootElement should run) and removed when the
+// editor is disposed. The contentEditable is reachable via
+// editor.getRootElement(), and the editor is disposed via onTestFinished — see
+// the note above about `using` not being available in browser tests.
 function setUpEditor() {
-  return buildEditorFromExtensions(
+  const editor = buildEditorFromExtensions(
     defineExtension({
       $initialEditorState: $prepopulate,
-      afterRegistration(editor, _config, _state) {
+      afterRegistration(builtEditor, _config, _state) {
         const rootElement = document.createElement('div');
         rootElement.contentEditable = 'true';
         document.body.appendChild(rootElement);
-        editor.setRootElement(rootElement);
+        builtEditor.setRootElement(rootElement);
         return () => {
           document.body.removeChild(rootElement);
         };
@@ -44,11 +49,13 @@ function setUpEditor() {
       name: '[root]',
     }),
   );
+  onTestFinished(() => editor.dispose());
+  return editor;
 }
 
 describe('buildEditorFromExtensions (browser)', () => {
   test('reconciles the initial editor state into the real DOM', () => {
-    using editor = setUpEditor();
+    const editor = setUpEditor();
     const contentEditable = editor.getRootElement()!;
     expect(contentEditable.querySelector('p')).not.toBeNull();
     expect(contentEditable.textContent).toBe('Hello from a real browser');
@@ -58,7 +65,7 @@ describe('buildEditorFromExtensions (browser)', () => {
   });
 
   test('Range.getBoundingClientRect reports real layout', () => {
-    using editor = setUpEditor();
+    const editor = setUpEditor();
     const textSpan = editor
       .getRootElement()!
       .querySelector('[data-lexical-text="true"]')!;
@@ -72,7 +79,7 @@ describe('buildEditorFromExtensions (browser)', () => {
   });
 
   test('the native Selection API round-trips a real range', () => {
-    using editor = setUpEditor();
+    const editor = setUpEditor();
     // Lexical renders text inside a <span data-lexical-text="true">, so the
     // actual Text node is its first child.
     const textNode = editor

--- a/packages/lexical-playground/vite.config.ts
+++ b/packages/lexical-playground/vite.config.ts
@@ -15,11 +15,15 @@ import viteMonorepoResolutionPlugin from '../../scripts/vite/lexicalMonorepoPlug
 import viteCopyEsm from './viteCopyEsm';
 import viteCopyExcalidrawAssets from './viteCopyExcalidrawAssets';
 
+// react() returns Plugin[]; widening it to PluginOption[] here lets the plugins
+// array below infer as PluginOption[] (every other entry is a Plugin, which is
+// a PluginOption) without annotating the whole array. That matters because
+// comparing the inferred plugin union against vite's recursively-defined
+// PluginOption type overflows with "Excessive stack depth" on newer vite type
+// definitions; widening the one array-valued entry keeps the check shallow.
+const reactPlugins: PluginOption[] = react();
+
 // https://vitejs.dev/config/
-// The return type is annotated as UserConfig so TypeScript checks the config
-// object against it directly instead of bidirectionally comparing the inferred
-// `plugins` union against vite's overload signatures, which overflows with
-// "Excessive stack depth" on newer vite type definitions.
 export default defineConfig(
   ({mode}): UserConfig => ({
     build: {
@@ -66,9 +70,9 @@ export default defineConfig(
         ],
         presets: [['@babel/preset-react', {runtime: 'automatic'}]],
       }),
-      react(),
+      ...reactPlugins,
       ...viteCopyExcalidrawAssets(),
       viteCopyEsm(),
-    ] as PluginOption[],
+    ],
   }),
 );

--- a/packages/lexical-playground/vite.config.ts
+++ b/packages/lexical-playground/vite.config.ts
@@ -8,7 +8,7 @@
 
 import babel from '@rollup/plugin-babel';
 import react from '@vitejs/plugin-react';
-import {defineConfig} from 'vite';
+import {defineConfig, type PluginOption, type UserConfig} from 'vite';
 
 import transformErrorMessages from '../../scripts/error-codes/transform-error-messages.mjs';
 import viteMonorepoResolutionPlugin from '../../scripts/vite/lexicalMonorepoPlugin';
@@ -16,53 +16,59 @@ import viteCopyEsm from './viteCopyEsm';
 import viteCopyExcalidrawAssets from './viteCopyExcalidrawAssets';
 
 // https://vitejs.dev/config/
-export default defineConfig(({mode}) => ({
-  build: {
-    outDir: 'build',
-    rollupOptions: {
-      input: {
-        main: new URL('./index.html', import.meta.url).pathname,
-        split: new URL('./split/index.html', import.meta.url).pathname,
+// The return type is annotated as UserConfig so TypeScript checks the config
+// object against it directly instead of bidirectionally comparing the inferred
+// `plugins` union against vite's overload signatures, which overflows with
+// "Excessive stack depth" on newer vite type definitions.
+export default defineConfig(
+  ({mode}): UserConfig => ({
+    build: {
+      outDir: 'build',
+      rollupOptions: {
+        input: {
+          main: new URL('./index.html', import.meta.url).pathname,
+          split: new URL('./split/index.html', import.meta.url).pathname,
+        },
       },
-    },
-    target: 'es2022',
-    ...(mode === 'production'
-      ? {
-          minify: 'terser',
-          terserOptions: {
-            compress: {
-              toplevel: true,
+      target: 'es2022',
+      ...(mode === 'production'
+        ? {
+            minify: 'terser',
+            terserOptions: {
+              compress: {
+                toplevel: true,
+              },
+              keep_classnames: true,
             },
-            keep_classnames: true,
-          },
-        }
-      : {minify: false}),
-  },
-  plugins: [
-    viteMonorepoResolutionPlugin(),
-    babel({
-      babelHelpers: 'bundled',
-      babelrc: false,
-      configFile: false,
-      exclude: '**/node_modules/**',
-      extensions: ['jsx', 'js', 'ts', 'tsx', 'mjs'],
-      plugins: [
-        '@babel/plugin-transform-flow-strip-types',
-        ...(mode !== 'production'
-          ? [
-              [
-                transformErrorMessages,
-                {
-                  noMinify: true,
-                },
-              ],
-            ]
-          : []),
-      ],
-      presets: [['@babel/preset-react', {runtime: 'automatic'}]],
-    }),
-    react(),
-    ...viteCopyExcalidrawAssets(),
-    viteCopyEsm(),
-  ],
-}));
+          }
+        : {minify: false}),
+    },
+    plugins: [
+      viteMonorepoResolutionPlugin(),
+      babel({
+        babelHelpers: 'bundled',
+        babelrc: false,
+        configFile: false,
+        exclude: '**/node_modules/**',
+        extensions: ['jsx', 'js', 'ts', 'tsx', 'mjs'],
+        plugins: [
+          '@babel/plugin-transform-flow-strip-types',
+          ...(mode !== 'production'
+            ? [
+                [
+                  transformErrorMessages,
+                  {
+                    noMinify: true,
+                  },
+                ],
+              ]
+            : []),
+        ],
+        presets: [['@babel/preset-react', {runtime: 'automatic'}]],
+      }),
+      react(),
+      ...viteCopyExcalidrawAssets(),
+      viteCopyEsm(),
+    ] as PluginOption[],
+  }),
+);

--- a/packages/lexical-react/src/__tests__/browser/LexicalExtensionComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/browser/LexicalExtensionComposer.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {defineExtension} from '@lexical/extension';
+import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
+import {RichTextExtension} from '@lexical/rich-text';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import * as React from 'react';
+import {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, describe, expect, test} from 'vitest';
+
+function $prepopulate(): void {
+  $getRoot().append(
+    $createParagraphNode().append($createTextNode('Composed in the browser')),
+  );
+}
+
+// Module-scoped so the extension argument is stable across renders, as the
+// LexicalExtensionComposer contract requires.
+const extension = defineExtension({
+  $initialEditorState: $prepopulate,
+  dependencies: [RichTextExtension],
+  name: '[root]',
+});
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+  if (root) {
+    const currentRoot = root;
+    act(() => currentRoot.unmount());
+    root = null;
+  }
+  if (container) {
+    container.remove();
+    container = null;
+  }
+});
+
+function render(ui: React.ReactElement): HTMLElement {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  const currentContainer = container;
+  act(() => {
+    root = createRoot(currentContainer);
+    root.render(ui);
+  });
+  return currentContainer;
+}
+
+describe('LexicalExtensionComposer (browser)', () => {
+  test('renders a real contentEditable with the initial editor state', () => {
+    const el = render(<LexicalExtensionComposer extension={extension} />);
+    const contentEditable = el.querySelector(
+      '[contenteditable="true"]',
+    ) as HTMLElement | null;
+    expect(contentEditable).not.toBeNull();
+    expect(contentEditable!.textContent).toBe('Composed in the browser');
+    // Real layout: jsdom would report a zero-height box here.
+    expect(contentEditable!.getBoundingClientRect().height).toBeGreaterThan(0);
+  });
+});

--- a/packages/lexical-react/src/__tests__/browser/LexicalExtensionComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/browser/LexicalExtensionComposer.test.tsx
@@ -10,10 +10,9 @@ import {defineExtension} from '@lexical/extension';
 import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
 import {RichTextExtension} from '@lexical/rich-text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
-import * as React from 'react';
-import {act} from 'react';
-import {createRoot, type Root} from 'react-dom/client';
-import {afterEach, describe, expect, test} from 'vitest';
+import {act, type ReactElement} from 'react';
+import {createRoot} from 'react-dom/client';
+import {describe, expect, test} from 'vitest';
 
 function $prepopulate(): void {
   $getRoot().append(
@@ -29,36 +28,33 @@ const extension = defineExtension({
   name: '[root]',
 });
 
-let container: HTMLDivElement | null = null;
-let root: Root | null = null;
-
-afterEach(() => {
-  if (root) {
-    const currentRoot = root;
-    act(() => currentRoot.unmount());
-    root = null;
-  }
-  if (container) {
-    container.remove();
-    container = null;
-  }
-});
-
-function render(ui: React.ReactElement): HTMLElement {
-  container = document.createElement('div');
+// Mounts `ui` into a fresh container and returns a Disposable, so callers use
+// `using view = renderReact(...)` and React unmounts at the end of the block
+// instead of in an afterEach. document.body is reset between tests, so the
+// container itself needs no explicit removal.
+function renderReact(ui: ReactElement): Disposable & {container: HTMLElement} {
+  const container = document.createElement('div');
   document.body.appendChild(container);
-  const currentContainer = container;
+  const root = createRoot(container);
   act(() => {
-    root = createRoot(currentContainer);
     root.render(ui);
   });
-  return currentContainer;
+  return {
+    container,
+    [Symbol.dispose]() {
+      act(() => {
+        root.unmount();
+      });
+    },
+  };
 }
 
 describe('LexicalExtensionComposer (browser)', () => {
   test('renders a real contentEditable with the initial editor state', () => {
-    const el = render(<LexicalExtensionComposer extension={extension} />);
-    const contentEditable = el.querySelector(
+    using view = renderReact(
+      <LexicalExtensionComposer extension={extension} />,
+    );
+    const contentEditable = view.container.querySelector(
       '[contenteditable="true"]',
     ) as HTMLElement | null;
     expect(contentEditable).not.toBeNull();

--- a/packages/lexical-react/src/__tests__/browser/LexicalExtensionComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/browser/LexicalExtensionComposer.test.tsx
@@ -12,7 +12,7 @@ import {RichTextExtension} from '@lexical/rich-text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import {act, type ReactElement} from 'react';
 import {createRoot} from 'react-dom/client';
-import {describe, expect, test} from 'vitest';
+import {describe, expect, onTestFinished, test} from 'vitest';
 
 function $prepopulate(): void {
   $getRoot().append(
@@ -28,33 +28,32 @@ const extension = defineExtension({
   name: '[root]',
 });
 
-// Mounts `ui` into a fresh container and returns a Disposable, so callers use
-// `using view = renderReact(...)` and React unmounts at the end of the block
-// instead of in an afterEach. document.body is reset between tests, so the
-// container itself needs no explicit removal.
-function renderReact(ui: ReactElement): Disposable & {container: HTMLElement} {
+// Renders `ui` into a fresh container and unmounts when the test finishes.
+// Cleanup uses onTestFinished rather than a `using`/Disposable helper because
+// Explicit Resource Management is not supported in WebKit/Safari yet (see
+// AGENTS.md). document.body is reset between tests, so the container itself
+// needs no explicit removal.
+function renderReact(ui: ReactElement): {container: HTMLElement} {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
     root.render(ui);
   });
-  return {
-    container,
-    [Symbol.dispose]() {
-      act(() => {
-        root.unmount();
-      });
-    },
-  };
+  onTestFinished(() => {
+    act(() => {
+      root.unmount();
+    });
+  });
+  return {container};
 }
 
 describe('LexicalExtensionComposer (browser)', () => {
   test('renders a real contentEditable with the initial editor state', () => {
-    using view = renderReact(
+    const {container} = renderReact(
       <LexicalExtensionComposer extension={extension} />,
     );
-    const contentEditable = view.container.querySelector(
+    const contentEditable = container.querySelector(
       '[contenteditable="true"]',
     ) as HTMLElement | null;
     expect(contentEditable).not.toBeNull();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,11 +129,11 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
       '@vitest/browser-playwright':
         specifier: ^4.1.8
-        version: 4.1.8(playwright@1.60.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
+        version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
       baseline-browser-mapping:
         specifier: ^2.10.25
         version: 2.10.25
@@ -273,11 +273,11 @@ importers:
         specifier: ^8.59.1
         version: 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
       vite:
-        specifier: ^8.0.10
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
       y-websocket:
         specifier: ^2.1.0
         version: 2.1.0(yjs@13.6.30)
@@ -3545,6 +3545,9 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
 
@@ -4171,8 +4174,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -4183,8 +4198,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -4195,8 +4222,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -4209,8 +4249,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -4223,8 +4277,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -4237,8 +4305,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -4248,14 +4329,31 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -4268,6 +4366,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-alias@6.0.0':
     resolution: {integrity: sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==}
@@ -5581,6 +5682,19 @@ packages:
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitejs/plugin-react@6.0.2':
+    resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
@@ -10598,6 +10712,10 @@ packages:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -11139,6 +11257,11 @@ packages:
 
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -11795,6 +11918,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -12261,6 +12388,49 @@ packages:
     peerDependencies:
       '@types/node': 25.6.0
       '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': 25.6.0
+      '@vitejs/devtools': ^0.1.18
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -16645,6 +16815,8 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@oxc-project/types@0.133.0': {}
+
   '@package-json/types@0.0.12': {}
 
   '@pandacss/is-valid-prop@1.10.0': {}
@@ -17259,37 +17431,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
@@ -17299,10 +17507,23 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
@@ -17310,6 +17531,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-alias@6.0.0(rollup@4.60.2)':
     optionalDependencies:
@@ -18570,29 +18793,34 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
 
-  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))':
     dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
+
+  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)':
+  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
       '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -18609,13 +18837,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -24901,6 +25129,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
@@ -25507,6 +25741,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   rollup-plugin-copy@3.5.0:
     dependencies:
@@ -26308,6 +26563,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
 
   tinyrainbow@3.1.0: {}
@@ -26827,10 +27087,25 @@ snapshots:
       terser: 5.46.2
       yaml: 2.8.4
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)):
+  vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.2
+      yaml: 2.8.4
+
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -26847,12 +27122,12 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
-      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
       happy-dom: 20.9.0
       jsdom: 29.1.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      '@vitest/browser-playwright':
+        specifier: ^4.1.8
+        version: 4.1.8(playwright@1.60.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
       baseline-browser-mapping:
         specifier: ^2.10.25
         version: 2.10.25
@@ -224,6 +227,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -270,8 +276,8 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
       vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
       y-websocket:
         specifier: ^2.1.0
         version: 2.1.0(yjs@13.6.30)
@@ -2182,10 +2188,6 @@ packages:
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
@@ -2213,6 +2215,9 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@braintree/sanitize-url@6.0.2':
     resolution: {integrity: sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==}
@@ -5587,11 +5592,22 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@vitest/expect@4.1.5':
-    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+  '@vitest/browser-playwright@4.1.8':
+    resolution: {integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.8
 
-  '@vitest/mocker@4.1.5':
-    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+  '@vitest/browser@4.1.8':
+    resolution: {integrity: sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==}
+    peerDependencies:
+      vitest: 4.1.8
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5601,20 +5617,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.5':
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.1.5':
-    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.1.5':
-    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@4.1.5':
-    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@4.1.5':
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -10174,6 +10190,10 @@ packages:
   png-chunks-extract@1.0.0:
     resolution: {integrity: sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q==}
 
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
 
@@ -11378,6 +11398,10 @@ packages:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -12273,20 +12297,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.5:
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': 25.6.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -13015,7 +13039,7 @@ snapshots:
   '@atlaskit/drag-and-drop-hitbox@0.8.1':
     dependencies:
       '@atlaskit/drag-and-drop': 0.15.1
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   '@atlaskit/drag-and-drop-indicator@0.11.1(@types/react@19.2.15)(react@19.2.5)':
     dependencies:
@@ -13031,7 +13055,7 @@ snapshots:
 
   '@atlaskit/drag-and-drop@0.15.1':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       bind-event-listener: 2.1.1
       raf-schd: 4.0.3
 
@@ -13059,7 +13083,7 @@ snapshots:
     dependencies:
       '@atlaskit/ds-lib': 2.7.0(@types/react@19.2.15)(react@19.2.5)
       '@atlaskit/platform-feature-flags': 0.3.0
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       bind-event-listener: 3.0.0
@@ -13989,8 +14013,6 @@ snapshots:
 
   '@babel/runtime@7.28.2': {}
 
-  '@babel/runtime@7.29.2': {}
-
   '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
@@ -14038,6 +14060,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@blazediff/core@1.9.1': {}
 
   '@braintree/sanitize-url@6.0.2': {}
 
@@ -14470,7 +14494,7 @@ snapshots:
       '@babel/preset-env': 7.29.3(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.1
       '@docusaurus/utils': 3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -14495,7 +14519,7 @@ snapshots:
       '@babel/preset-env': 7.29.3(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.1
       '@docusaurus/utils': 3.10.1(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -14575,7 +14599,7 @@ snapshots:
       postcss: 8.5.13
       postcss-loader: 7.3.4(postcss@8.5.13)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.27.7))
       postcss-preset-env: 10.6.1(postcss@8.5.13)
-      terser-webpack-plugin: 5.5.0(esbuild@0.27.7)(webpack@5.106.2(esbuild@0.27.7))
+      terser-webpack-plugin: 5.5.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(webpack@5.106.2(esbuild@0.27.7))
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(esbuild@0.27.7)))(webpack@5.106.2(esbuild@0.27.7))
       webpack: 5.106.2(esbuild@0.27.7)
@@ -14826,7 +14850,7 @@ snapshots:
       browserslist: 4.28.2
       lightningcss: 1.32.0
       semver: 7.7.4
-      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7))
+      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.2(esbuild@0.27.7))
       tslib: 2.8.1
       webpack: 5.106.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)
     transitivePeerDependencies:
@@ -15913,7 +15937,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.28.6
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -17119,7 +17143,7 @@ snapshots:
 
   '@radix-ui/react-tabs@1.0.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-context': 1.0.0(react@19.2.5)
       '@radix-ui/react-direction': 1.0.0(react@19.2.5)
@@ -18546,44 +18570,74 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
 
-  '@vitest/expect@4.1.5':
+  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))':
+  '@vitest/mocker@4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))':
     dependencies:
-      '@vitest/spy': 4.1.5
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)
 
-  '@vitest/pretty-format@4.1.5':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.5':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.5':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.5': {}
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@4.1.5':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
+      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -24383,6 +24437,8 @@ snapshots:
     dependencies:
       crc-32: 0.3.0
 
+  pngjs@7.0.0: {}
+
   points-on-curve@0.2.0: {}
 
   points-on-curve@1.0.1: {}
@@ -25049,13 +25105,13 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
       webpack: 5.106.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)
 
   react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.2(esbuild@0.27.7)):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
       webpack: 5.106.2(esbuild@0.27.7)
 
@@ -25082,13 +25138,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 19.2.5
       react-router: 5.3.4(react@19.2.5)
 
   react-router-dom@5.3.4(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -25099,7 +25155,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -25813,6 +25869,12 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@7.1.2:
@@ -26148,6 +26210,13 @@ snapshots:
       '@swc/counter': 0.1.3
       webpack: 5.106.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)
 
+  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.2(esbuild@0.27.7)):
+    dependencies:
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      webpack: 5.106.2(esbuild@0.27.7)
+    optional: true
+
   swr@2.3.8(react@19.2.5):
     dependencies:
       dequal: 2.0.3
@@ -26183,7 +26252,7 @@ snapshots:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       esbuild: 0.27.7
 
-  terser-webpack-plugin@5.5.0(esbuild@0.27.7)(webpack@5.106.2(esbuild@0.27.7)):
+  terser-webpack-plugin@5.5.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(webpack@5.106.2(esbuild@0.27.7)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -26191,6 +26260,7 @@ snapshots:
       terser: 5.46.2
       webpack: 5.106.2(esbuild@0.27.7)
     optionalDependencies:
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       esbuild: 0.27.7
 
   terser@5.44.0:
@@ -26757,15 +26827,15 @@ snapshots:
       terser: 5.46.2
       yaml: 2.8.4
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4)):
     dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -26782,6 +26852,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.4))(vitest@4.1.8)
       happy-dom: 20.9.0
       jsdom: 29.1.1
     transitivePeerDependencies:
@@ -27079,7 +27150,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.5.0(esbuild@0.27.7)(webpack@5.106.2(esbuild@0.27.7))
+      terser-webpack-plugin: 5.5.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(webpack@5.106.2(esbuild@0.27.7))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     transitivePeerDependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,6 +7,7 @@
  */
 
 import react from '@vitejs/plugin-react';
+import {playwright} from '@vitest/browser-playwright';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -43,6 +44,18 @@ function tsconfigTestAliases(): {find: RegExp; replacement: string}[] {
   });
 }
 
+// Browser-mode tests (packages/**/__tests__/browser) run in a real browser via
+// Playwright instead of jsdom, so unit tests that lean heavily on jsdom mocks
+// can be ported to a more realistic environment. The browsers to launch are
+// taken from the comma-separated VITEST_BROWSER env var (default: chromium) so
+// the default CI job can stay on linux + chromium while the extended matrix
+// fans out across firefox/webkit and additional operating systems.
+const browserInstances = (process.env.VITEST_BROWSER || 'chromium')
+  .split(',')
+  .map(name => name.trim())
+  .filter(Boolean)
+  .map(browser => ({browser}));
+
 export default defineConfig({
   resolve: {
     alias: tsconfigTestAliases(),
@@ -68,6 +81,49 @@ export default defineConfig({
           environment: 'jsdom',
           include: ['packages/**/__tests__/unit/**/*.test{.ts,.tsx,.js,.jsx}'],
           name: 'unit',
+          setupFiles: ['./vitest.setup.mts'],
+          typecheck: {
+            tsconfig: './tsconfig.test.json',
+          },
+        },
+      },
+      {
+        define: {
+          // https://react.dev/blog/2022/03/08/react-18-upgrade-guide#configuring-your-testing-environment
+          IS_REACT_ACT_ENVIRONMENT: true,
+        },
+        extends: true,
+        // Pre-bundle React (and react-dom/client) together so browser tests
+        // that render React share a single React instance with the
+        // source-aliased @lexical/react packages. Without this the optimized
+        // react-dom/client bundle gets its own copy and hooks fail with a null
+        // dispatcher ("Cannot read properties of null (reading 'useMemo')").
+        optimizeDeps: {
+          include: [
+            'react',
+            'react/jsx-dev-runtime',
+            'react-dom',
+            'react-dom/client',
+          ],
+        },
+        plugins: [react()],
+        test: {
+          browser: {
+            enabled: true,
+            // Headless everywhere by default so the suite runs the same way in
+            // CI and in headless dev containers. Pass `--browser.headless=false`
+            // (or use the Vitest UI) to debug in a real window locally.
+            headless: true,
+            instances: browserInstances,
+            provider: playwright(),
+          },
+          env: {
+            LEXICAL_VERSION: JSON.stringify(
+              `${process.env.npm_package_version}+git`,
+            ),
+          },
+          include: ['packages/**/__tests__/browser/**/*.test{.ts,.tsx}'],
+          name: 'browser',
           setupFiles: ['./vitest.setup.mts'],
           typecheck: {
             tsconfig: './tsconfig.test.json',


### PR DESCRIPTION
## Description

Our unit tests run under jsdom and lean heavily on hand-written polyfills in `vitest.setup.mts` (PointerEvent, DataTransfer, ClipboardEvent, execCommand, `Range.getBoundingClientRect`, `contentEditable`/Selection behavior, …) to stand in for functionality jsdom doesn't implement. That mocking is fragile and can drift from real browser behavior.

This PR adds a Vitest **browser** project that runs in a real browser through the Playwright runner, so tests that depend on a real layout/selection engine can be ported out of jsdom. Existing unit tests are untouched.

What's included:

- **Vitest browser project** (`vitest.config.mts`): Playwright provider, headless,
  collecting `packages/**/__tests__/browser/**/*.test.{ts,tsx}`. The browser set is
  driven by the comma-separated `VITEST_BROWSER` env var (default `chromium`), and
  React is deduped via `optimizeDeps` so browser tests share a single React instance
  with the source-aliased `@lexical/react`.
- **Scripts**: `pnpm run test-browser` and `pnpm run test-browser-watch`.
- **CI**:
  - Default (every PR/push): linux + chromium, wired into `call-core-tests.yml` via a
    new reusable `call-browser-tests.yml`.
  - Extended (`tests-extended.yml`): a fully-specified `include` matrix — ubuntu+firefox,
    macOS+{chromium,firefox,webkit}, windows+{chromium,firefox}. ubuntu+chromium is
    already the default job and WebKit only runs on macOS, so no combination is
    generated just to be skipped.
- **Example tests** using the extension APIs (not `createEditor`):
  - `lexical-extension/…/BuildEditorFromExtensions.test.ts` — builds an editor whose
    contentEditable is created in the extension's `afterRegistration` phase, and
    asserts real `Range.getBoundingClientRect` and the Selection API.
  - `lexical-react/…/LexicalExtensionComposer.test.tsx` — renders a real
    `contentEditable` and checks real layout.

  Both clean up with `onTestFinished(() => editor.dispose())` rather than `using`:
  Explicit Resource Management (`using` / `Symbol.dispose` / `Disposable`) isn't
  supported in WebKit/Safari yet, so the syntax can't be relied on in browser tests
  (it stays fine in jsdom/Node unit tests). This is documented in `AGENTS.md`.
- **Dependency bumps**: `vitest` 4.1.5 → 4.1.8 (+ `@vitest/browser-playwright`,
  `playwright`); `vite` 8.0.10 → 8.0.16; `@vitejs/plugin-react` 6.0.1 → 6.0.2.
- **Playground vite config**: the newer vite types overflow TypeScript's recursive
  `PluginOption` comparison ("Excessive stack depth"). Binding the one array-valued
  plugin entry (`react()`) to `PluginOption[]` via a checked annotation lets the
  plugins array infer as `PluginOption[]` without an `as` cast.
- Ignore browser-mode artifact dirs (`__screenshots__`, `.vitest-attachments`) and
  document the workflow in `AGENTS.md`.

## Test plan

### Before

Behavior that needs a real layout/selection engine (`Range.getBoundingClientRect`, the
Selection API, `contentEditable`) could only be tested under jsdom by stubbing it in
`vitest.setup.mts`; there was no browser-mode harness.

### After

`pnpm run test-browser` runs the new suite in a real browser (default chromium), and
passes on Chromium, Firefox, and WebKit (`VITEST_BROWSER=webkit`):

```
 RUN  v4.1.8

 Test Files  2 passed (2)
      Tests  4 passed (4)
```

`pnpm run tsc`, `eslint`, and `prettier` all pass.