### PR TITLE
revert(lexical): remove root-element carveout from #8613 (keep the typing test)

### DIFF
--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -29,7 +29,6 @@ import {
   getNodeKeyFromDOMNode,
   getParentElement,
   getWindow,
-  internalGetRoot,
   isDOMTextNode,
   isDOMUnmanaged,
   isFirefoxClipboardEvents,
@@ -118,7 +117,6 @@ function $getNearestManagedNodePairFromDOMNode(
   startingDOM: Node,
   editor: LexicalEditor,
   editorState: EditorState,
-  rootElement: HTMLElement | null,
 ): [HTMLElement, LexicalNode] | undefined {
   for (
     let dom: Node | null = startingDOM;
@@ -134,16 +132,6 @@ function $getNearestManagedNodePairFromDOMNode(
           ? undefined
           : [dom, node];
       }
-    } else if (dom === rootElement) {
-      // Fallback when the root element's `__lexicalKey_*` stash (set in
-      // resetEditor by #8588) is not observable for this mutation target —
-      // e.g. a DOM mutation that targets the root element directly while
-      // typing into a fresh/near-empty editor, before a managed child has
-      // received the input. Mapping the root element to the RootNode here
-      // keeps such mutations from being silently skipped (which previously
-      // dropped typed text → word-count gate stayed at 0). This restores
-      // the carveout removed in #8588 without regressing the stash.
-      return [rootElement, internalGetRoot(editorState)];
     }
   }
 }
@@ -160,7 +148,6 @@ function flushMutations(
     updateEditorSync(editor, () => {
       const selection = $getSelection() || getLastSelection(editor);
       const badDOMTargets = new Map<HTMLElement, LexicalNode>();
-      const rootElement = editor.getRootElement();
       // We use the current editor state, as that reflects what is
       // actually "on screen".
       const currentEditorState = editor._editorState;
@@ -176,7 +163,6 @@ function flushMutations(
           targetDOM,
           editor,
           currentEditorState,
-          rootElement,
         );
         if (!pair) {
           continue;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -684,12 +684,6 @@ export function $getNodeFromDOM(dom: Node): null | LexicalNode {
   const editor = getActiveEditor();
   const nodeKey = getNodeKeyFromDOMTree(dom, editor);
   if (nodeKey === null) {
-    // Fallback for the root element when its `__lexicalKey_*` stash (set in
-    // resetEditor by #8588) is not observable here — keeps selection/mutation
-    // resolution that lands on the bare root element mapped to the RootNode.
-    if (dom === editor.getRootElement()) {
-      return $getNodeByKey('root');
-    }
     return null;
   }
   return $getNodeByKey(nodeKey);


### PR DESCRIPTION
### Summary

Reverts the source changes from #8613 (the `dom === rootElement` carveout in `$getNearestManagedNodePairFromDOMNode` and the twin fallback in `$getNodeFromDOM`). **Keeps** the black-box empty-editor typing smoke test that #8613 also added.

### Why

#8613 hypothesized that #8588's switch from the root-element carveout to the `__lexicalKey_*` root stash was dropping root-targeted DOM mutations, causing typed text not to register in a downstream app (the symptom that triggered an internal sync auto-revert).

@mayrang and @etrepum were right that this wasn't the cause: under normal mount/typing the root carries the `__lexicalKey_*` stash, so root resolution already succeeds and the carveout is a no-op. As @etrepum noted, the only way the stash goes missing is if the root **element** is replaced — and in that case the `dom === rootElement` identity check is dead too.

The actual regressor was **#8519**'s active-editor-scope tightening surfacing in a downstream `$generateHtmlFromNodes` caller. That call site opened a headless-clone update scope but passed the *original* editor to `$generateHtmlFromNodes`, so the post-#8519 `$assumeActiveEditor(editor)` check threw (`activeEditor` was the headless clone, not the passed editor). The throw aborted the update that runs on input, so typed text never committed → the word-count-gated control stayed disabled. Fixed at that call site (pass the active/headless editor); the failing e2e goes green with that fix and stays green with this carveout reverted.

### What's kept

`LexicalEmptyEditorTyping.test.ts` — a black-box "type into a fresh empty editor → text reconciles" smoke test. It's useful coverage and passes independently of the carveout (documented in the file: it does not reproduce the original regression at the jsdom level, which needs a real browser).

### Test plan

- `LexicalEmptyEditorTyping.test.ts` and core mutation/reconciler unit tests pass with the carveout removed.
- Restores #8588's intended single-key-lookup design (no per-site root special-case).

cc @mayrang @etrepum
