### PR TITLE
[lexical] Refactor: $assumeEditor now uses devInvariant instead of invariant to warn instead of throwing in prod

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -9,6 +9,7 @@
 import type {SerializedEditorState} from './LexicalEditorState';
 import type {LexicalNode, SerializedLexicalNode} from './LexicalNode';
 
+import devInvariant from '@lexical/internal/devInvariant';
 import invariant from '@lexical/internal/invariant';
 
 import {
@@ -121,7 +122,7 @@ export function $assumeActiveEditor(editor: LexicalEditor): void {
   if (getActiveEditorState() !== null && activeEditor === null) {
     activeEditor = editor;
   }
-  invariant(
+  devInvariant(
     activeEditor === editor,
     'The given editor argument does not match $getEditor() in this context. Use editor.getEditorState().read(..., {editor}) if this cross-editor call is intentional.',
   );


### PR DESCRIPTION
## Description

Follow-up to #8616 https://github.com/facebook/lexical/pull/8613#issuecomment-4608797399

`$assumeEditor` was added to `$generateHtmlFromNodes` to allow legacy code to interop with the new requirement of having an active editor without immediately changing call sites. The active editor is used for EditorConfig.dom lookup in this case so that DOMRenderExtension can be used to override html export functionality.

As a sanity check, this code also verified that the legacy threaded `editor` argument matched the active editor `$getEditor()` with an `invariant` - a mismatch could provide inconsistent results that would be hard to debug without this check. This divergent behavior is unlikely to happen today, because the legacy code is unlikely to be using these new features with non-default configuration, so to make transition a little easier we can downgrade to a `devInvariant` which will warn in prod (but still throw in dev).

## Test plan

Trivial change, existing tests cover the expected behavior and we have coverage for what devInvariant is supposed to do.