### PR TITLE
[*] Bug Fix: Surface a clear error when TypeScript (<5.2) can't read the package exports

### DIFF
--- a/packages/lexical-clipboard/package.json
+++ b/packages/lexical-clipboard/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalClipboard.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/extension": "workspace:*",
     "@lexical/html": "workspace:*",
@@ -33,6 +33,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalClipboard.dev.mjs",
         "production": "./dist/LexicalClipboard.prod.mjs",
@@ -40,6 +41,7 @@
         "default": "./dist/LexicalClipboard.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalClipboard.dev.js",
         "production": "./dist/LexicalClipboard.prod.js",
@@ -59,5 +61,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-code-core/package.json
+++ b/packages/lexical-code-core/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalCodeCore.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/extension": "workspace:*",
     "@lexical/html": "workspace:*",
@@ -28,6 +28,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalCodeCore.dev.mjs",
         "production": "./dist/LexicalCodeCore.prod.mjs",
@@ -35,6 +36,7 @@
         "default": "./dist/LexicalCodeCore.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalCodeCore.dev.js",
         "production": "./dist/LexicalCodeCore.prod.js",
@@ -54,5 +56,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-code-prism/package.json
+++ b/packages/lexical-code-prism/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalCodePrism.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/code-core": "workspace:*",
     "@lexical/extension": "workspace:*",
@@ -31,6 +31,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalCodePrism.dev.mjs",
         "production": "./dist/LexicalCodePrism.prod.mjs",
@@ -38,6 +39,7 @@
         "default": "./dist/LexicalCodePrism.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalCodePrism.dev.js",
         "production": "./dist/LexicalCodePrism.prod.js",
@@ -57,5 +59,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-code-shiki/package.json
+++ b/packages/lexical-code-shiki/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalCodeShiki.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/code-core": "workspace:*",
     "@lexical/extension": "workspace:*",
@@ -35,6 +35,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalCodeShiki.dev.mjs",
         "production": "./dist/LexicalCodeShiki.prod.mjs",
@@ -42,6 +43,7 @@
         "default": "./dist/LexicalCodeShiki.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalCodeShiki.dev.js",
         "production": "./dist/LexicalCodeShiki.prod.js",
@@ -61,5 +63,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalCode.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/code-core": "workspace:*",
     "@lexical/code-prism": "workspace:*",
@@ -28,6 +28,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalCode.dev.mjs",
         "production": "./dist/LexicalCode.prod.mjs",
@@ -35,6 +36,7 @@
         "default": "./dist/LexicalCode.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalCode.dev.js",
         "production": "./dist/LexicalCode.prod.js",
@@ -54,5 +56,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-devtools-core/package.json
+++ b/packages/lexical-devtools-core/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalDevtoolsCore.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/html": "workspace:*",
     "@lexical/link": "workspace:*",
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "react": ">=17.x",
-    "react-dom": ">=17.x"
+    "react-dom": ">=17.x",
+    "typescript": ">=5.2"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalDevtoolsCore.dev.mjs",
         "production": "./dist/LexicalDevtoolsCore.prod.mjs",
@@ -41,6 +43,7 @@
         "default": "./dist/LexicalDevtoolsCore.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalDevtoolsCore.dev.js",
         "production": "./dist/LexicalDevtoolsCore.prod.js",
@@ -60,5 +63,17 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-dragon/package.json
+++ b/packages/lexical-dragon/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalDragon.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -23,6 +23,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalDragon.dev.mjs",
         "production": "./dist/LexicalDragon.prod.mjs",
@@ -30,6 +31,7 @@
         "default": "./dist/LexicalDragon.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalDragon.dev.js",
         "production": "./dist/LexicalDragon.prod.js",
@@ -53,5 +55,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-eslint-plugin/package.json
+++ b/packages/lexical-eslint-plugin/package.json
@@ -16,19 +16,21 @@
     "directory": "packages/lexical-eslint-plugin"
   },
   "main": "./dist/LexicalEslintPlugin.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "bugs": {
     "url": "https://github.com/facebook/lexical/issues"
   },
   "homepage": "https://lexical.dev/docs/packages/lexical-eslint-plugin",
   "sideEffects": false,
   "peerDependencies": {
-    "eslint": ">=7.31.0"
+    "eslint": ">=7.31.0",
+    "typescript": ">=5.2"
   },
   "exports": {
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalEslintPlugin.dev.mjs",
         "production": "./dist/LexicalEslintPlugin.prod.mjs",
@@ -36,6 +38,7 @@
         "default": "./dist/LexicalEslintPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalEslintPlugin.dev.js",
         "production": "./dist/LexicalEslintPlugin.prod.js",
@@ -60,5 +63,17 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-extension/package.json
+++ b/packages/lexical-extension/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/lexical-extension"
   },
   "main": "./dist/LexicalExtension.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "bugs": {
     "url": "https://github.com/facebook/lexical/issues"
   },
@@ -32,6 +32,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalExtension.dev.mjs",
         "production": "./dist/LexicalExtension.prod.mjs",
@@ -39,6 +40,7 @@
         "default": "./dist/LexicalExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalExtension.dev.js",
         "production": "./dist/LexicalExtension.prod.js",
@@ -58,5 +60,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-file/package.json
+++ b/packages/lexical-file/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalFile.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -24,6 +24,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalFile.dev.mjs",
         "production": "./dist/LexicalFile.prod.mjs",
@@ -31,6 +32,7 @@
         "default": "./dist/LexicalFile.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalFile.dev.js",
         "production": "./dist/LexicalFile.prod.js",
@@ -53,5 +55,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-hashtag/package.json
+++ b/packages/lexical-hashtag/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalHashtag.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/text": "workspace:*",
     "@lexical/utils": "workspace:*",
@@ -27,6 +27,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalHashtag.dev.mjs",
         "production": "./dist/LexicalHashtag.prod.mjs",
@@ -34,6 +35,7 @@
         "default": "./dist/LexicalHashtag.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalHashtag.dev.js",
         "production": "./dist/LexicalHashtag.prod.js",
@@ -53,5 +55,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -19,12 +19,14 @@
     "./dom": {
       "source": "./src/dom.ts",
       "browser": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/dom.d.ts",
         "development": "./dist/LexicalHeadlessDom.browser.dev.mjs",
         "production": "./dist/LexicalHeadlessDom.browser.prod.mjs",
         "default": "./dist/LexicalHeadlessDom.browser.mjs"
       },
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/dom.d.ts",
         "development": "./dist/LexicalHeadlessDom.dev.mjs",
         "production": "./dist/LexicalHeadlessDom.prod.mjs",
@@ -32,6 +34,7 @@
         "default": "./dist/LexicalHeadlessDom.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/dom.d.ts",
         "development": "./dist/LexicalHeadlessDom.dev.js",
         "production": "./dist/LexicalHeadlessDom.prod.js",
@@ -41,6 +44,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalHeadless.dev.mjs",
         "production": "./dist/LexicalHeadless.prod.mjs",
@@ -48,6 +52,7 @@
         "default": "./dist/LexicalHeadless.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalHeadless.dev.js",
         "production": "./dist/LexicalHeadless.prod.js",
@@ -72,5 +77,21 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "types": "./dist/typescript-too-old.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-history/package.json
+++ b/packages/lexical-history/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalHistory.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/extension": "workspace:*",
     "@lexical/utils": "workspace:*",
@@ -27,6 +27,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalHistory.dev.mjs",
         "production": "./dist/LexicalHistory.prod.mjs",
@@ -34,6 +35,7 @@
         "default": "./dist/LexicalHistory.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalHistory.dev.js",
         "production": "./dist/LexicalHistory.prod.js",
@@ -53,5 +55,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-html/package.json
+++ b/packages/lexical-html/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalHtml.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -29,6 +29,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalHtml.dev.mjs",
         "production": "./dist/LexicalHtml.prod.mjs",
@@ -36,6 +37,7 @@
         "default": "./dist/LexicalHtml.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalHtml.dev.js",
         "production": "./dist/LexicalHtml.prod.js",
@@ -55,5 +57,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-internal/package.json
+++ b/packages/lexical-internal/package.json
@@ -19,6 +19,7 @@
     "./devInvariant": {
       "source": "./src/devInvariant.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/devInvariant.d.ts",
         "development": "./dist/LexicalInternalDevInvariant.dev.mjs",
         "production": "./dist/LexicalInternalDevInvariant.prod.mjs",
@@ -26,6 +27,7 @@
         "default": "./dist/LexicalInternalDevInvariant.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/devInvariant.d.ts",
         "development": "./dist/LexicalInternalDevInvariant.dev.js",
         "production": "./dist/LexicalInternalDevInvariant.prod.js",
@@ -35,6 +37,7 @@
     "./devInvariant.js": {
       "source": "./src/devInvariant.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/devInvariant.d.ts",
         "development": "./dist/LexicalInternalDevInvariant.dev.mjs",
         "production": "./dist/LexicalInternalDevInvariant.prod.mjs",
@@ -42,6 +45,7 @@
         "default": "./dist/LexicalInternalDevInvariant.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/devInvariant.d.ts",
         "development": "./dist/LexicalInternalDevInvariant.dev.js",
         "production": "./dist/LexicalInternalDevInvariant.prod.js",
@@ -51,6 +55,7 @@
     "./formatDevErrorMessage": {
       "source": "./src/formatDevErrorMessage.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatDevErrorMessage.d.ts",
         "development": "./dist/LexicalInternalFormatDevErrorMessage.dev.mjs",
         "production": "./dist/LexicalInternalFormatDevErrorMessage.prod.mjs",
@@ -58,6 +63,7 @@
         "default": "./dist/LexicalInternalFormatDevErrorMessage.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatDevErrorMessage.d.ts",
         "development": "./dist/LexicalInternalFormatDevErrorMessage.dev.js",
         "production": "./dist/LexicalInternalFormatDevErrorMessage.prod.js",
@@ -67,6 +73,7 @@
     "./formatDevErrorMessage.js": {
       "source": "./src/formatDevErrorMessage.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatDevErrorMessage.d.ts",
         "development": "./dist/LexicalInternalFormatDevErrorMessage.dev.mjs",
         "production": "./dist/LexicalInternalFormatDevErrorMessage.prod.mjs",
@@ -74,6 +81,7 @@
         "default": "./dist/LexicalInternalFormatDevErrorMessage.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatDevErrorMessage.d.ts",
         "development": "./dist/LexicalInternalFormatDevErrorMessage.dev.js",
         "production": "./dist/LexicalInternalFormatDevErrorMessage.prod.js",
@@ -83,6 +91,7 @@
     "./formatDevWarningMessage": {
       "source": "./src/formatDevWarningMessage.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatDevWarningMessage.d.ts",
         "development": "./dist/LexicalInternalFormatDevWarningMessage.dev.mjs",
         "production": "./dist/LexicalInternalFormatDevWarningMessage.prod.mjs",
@@ -90,6 +99,7 @@
         "default": "./dist/LexicalInternalFormatDevWarningMessage.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatDevWarningMessage.d.ts",
         "development": "./dist/LexicalInternalFormatDevWarningMessage.dev.js",
         "production": "./dist/LexicalInternalFormatDevWarningMessage.prod.js",
@@ -99,6 +109,7 @@
     "./formatDevWarningMessage.js": {
       "source": "./src/formatDevWarningMessage.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatDevWarningMessage.d.ts",
         "development": "./dist/LexicalInternalFormatDevWarningMessage.dev.mjs",
         "production": "./dist/LexicalInternalFormatDevWarningMessage.prod.mjs",
@@ -106,6 +117,7 @@
         "default": "./dist/LexicalInternalFormatDevWarningMessage.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatDevWarningMessage.d.ts",
         "development": "./dist/LexicalInternalFormatDevWarningMessage.dev.js",
         "production": "./dist/LexicalInternalFormatDevWarningMessage.prod.js",
@@ -115,6 +127,7 @@
     "./formatProdErrorMessage": {
       "source": "./src/formatProdErrorMessage.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatProdErrorMessage.d.ts",
         "development": "./dist/LexicalInternalFormatProdErrorMessage.dev.mjs",
         "production": "./dist/LexicalInternalFormatProdErrorMessage.prod.mjs",
@@ -122,6 +135,7 @@
         "default": "./dist/LexicalInternalFormatProdErrorMessage.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatProdErrorMessage.d.ts",
         "development": "./dist/LexicalInternalFormatProdErrorMessage.dev.js",
         "production": "./dist/LexicalInternalFormatProdErrorMessage.prod.js",
@@ -131,6 +145,7 @@
     "./formatProdErrorMessage.js": {
       "source": "./src/formatProdErrorMessage.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatProdErrorMessage.d.ts",
         "development": "./dist/LexicalInternalFormatProdErrorMessage.dev.mjs",
         "production": "./dist/LexicalInternalFormatProdErrorMessage.prod.mjs",
@@ -138,6 +153,7 @@
         "default": "./dist/LexicalInternalFormatProdErrorMessage.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatProdErrorMessage.d.ts",
         "development": "./dist/LexicalInternalFormatProdErrorMessage.dev.js",
         "production": "./dist/LexicalInternalFormatProdErrorMessage.prod.js",
@@ -147,6 +163,7 @@
     "./formatProdWarningMessage": {
       "source": "./src/formatProdWarningMessage.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatProdWarningMessage.d.ts",
         "development": "./dist/LexicalInternalFormatProdWarningMessage.dev.mjs",
         "production": "./dist/LexicalInternalFormatProdWarningMessage.prod.mjs",
@@ -154,6 +171,7 @@
         "default": "./dist/LexicalInternalFormatProdWarningMessage.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatProdWarningMessage.d.ts",
         "development": "./dist/LexicalInternalFormatProdWarningMessage.dev.js",
         "production": "./dist/LexicalInternalFormatProdWarningMessage.prod.js",
@@ -163,6 +181,7 @@
     "./formatProdWarningMessage.js": {
       "source": "./src/formatProdWarningMessage.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatProdWarningMessage.d.ts",
         "development": "./dist/LexicalInternalFormatProdWarningMessage.dev.mjs",
         "production": "./dist/LexicalInternalFormatProdWarningMessage.prod.mjs",
@@ -170,6 +189,7 @@
         "default": "./dist/LexicalInternalFormatProdWarningMessage.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/formatProdWarningMessage.d.ts",
         "development": "./dist/LexicalInternalFormatProdWarningMessage.dev.js",
         "production": "./dist/LexicalInternalFormatProdWarningMessage.prod.js",
@@ -179,6 +199,7 @@
     "./invariant": {
       "source": "./src/invariant.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/invariant.d.ts",
         "development": "./dist/LexicalInternalInvariant.dev.mjs",
         "production": "./dist/LexicalInternalInvariant.prod.mjs",
@@ -186,6 +207,7 @@
         "default": "./dist/LexicalInternalInvariant.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/invariant.d.ts",
         "development": "./dist/LexicalInternalInvariant.dev.js",
         "production": "./dist/LexicalInternalInvariant.prod.js",
@@ -195,6 +217,7 @@
     "./invariant.js": {
       "source": "./src/invariant.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/invariant.d.ts",
         "development": "./dist/LexicalInternalInvariant.dev.mjs",
         "production": "./dist/LexicalInternalInvariant.prod.mjs",
@@ -202,6 +225,7 @@
         "default": "./dist/LexicalInternalInvariant.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/invariant.d.ts",
         "development": "./dist/LexicalInternalInvariant.dev.js",
         "production": "./dist/LexicalInternalInvariant.prod.js",
@@ -211,6 +235,7 @@
     "./version": {
       "source": "./src/version.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/version.d.ts",
         "development": "./dist/LexicalInternalVersion.dev.mjs",
         "production": "./dist/LexicalInternalVersion.prod.mjs",
@@ -218,6 +243,7 @@
         "default": "./dist/LexicalInternalVersion.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/version.d.ts",
         "development": "./dist/LexicalInternalVersion.dev.js",
         "production": "./dist/LexicalInternalVersion.prod.js",
@@ -227,6 +253,7 @@
     "./version.js": {
       "source": "./src/version.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/version.d.ts",
         "development": "./dist/LexicalInternalVersion.dev.mjs",
         "production": "./dist/LexicalInternalVersion.prod.mjs",
@@ -234,6 +261,7 @@
         "default": "./dist/LexicalInternalVersion.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/version.d.ts",
         "development": "./dist/LexicalInternalVersion.dev.js",
         "production": "./dist/LexicalInternalVersion.prod.js",
@@ -243,6 +271,7 @@
     "./warnOnlyOnce": {
       "source": "./src/warnOnlyOnce.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/warnOnlyOnce.d.ts",
         "development": "./dist/LexicalInternalWarnOnlyOnce.dev.mjs",
         "production": "./dist/LexicalInternalWarnOnlyOnce.prod.mjs",
@@ -250,6 +279,7 @@
         "default": "./dist/LexicalInternalWarnOnlyOnce.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/warnOnlyOnce.d.ts",
         "development": "./dist/LexicalInternalWarnOnlyOnce.dev.js",
         "production": "./dist/LexicalInternalWarnOnlyOnce.prod.js",
@@ -259,6 +289,7 @@
     "./warnOnlyOnce.js": {
       "source": "./src/warnOnlyOnce.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/warnOnlyOnce.d.ts",
         "development": "./dist/LexicalInternalWarnOnlyOnce.dev.mjs",
         "production": "./dist/LexicalInternalWarnOnlyOnce.prod.mjs",
@@ -266,6 +297,7 @@
         "default": "./dist/LexicalInternalWarnOnlyOnce.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/warnOnlyOnce.d.ts",
         "development": "./dist/LexicalInternalWarnOnlyOnce.dev.js",
         "production": "./dist/LexicalInternalWarnOnlyOnce.prod.js",
@@ -285,5 +317,21 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "types": "./dist/typescript-too-old.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-link/package.json
+++ b/packages/lexical-link/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalLink.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/extension": "workspace:*",
     "@lexical/html": "workspace:*",
@@ -29,6 +29,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalLink.dev.mjs",
         "production": "./dist/LexicalLink.prod.mjs",
@@ -36,6 +37,7 @@
         "default": "./dist/LexicalLink.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalLink.dev.js",
         "production": "./dist/LexicalLink.prod.js",
@@ -55,5 +57,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-list/package.json
+++ b/packages/lexical-list/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalList.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/extension": "workspace:*",
     "@lexical/html": "workspace:*",
@@ -29,6 +29,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalList.dev.mjs",
         "production": "./dist/LexicalList.prod.mjs",
@@ -36,6 +37,7 @@
         "default": "./dist/LexicalList.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalList.dev.js",
         "production": "./dist/LexicalList.prod.js",
@@ -55,5 +57,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-mark/package.json
+++ b/packages/lexical-mark/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalMark.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/utils": "workspace:*",
     "lexical": "workspace:*"
@@ -26,6 +26,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalMark.dev.mjs",
         "production": "./dist/LexicalMark.prod.mjs",
@@ -33,6 +34,7 @@
         "default": "./dist/LexicalMark.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalMark.dev.js",
         "production": "./dist/LexicalMark.prod.js",
@@ -52,5 +54,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-markdown/package.json
+++ b/packages/lexical-markdown/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalMarkdown.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/code-core": "workspace:*",
     "@lexical/internal": "workspace:*",
@@ -33,6 +33,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalMarkdown.dev.mjs",
         "production": "./dist/LexicalMarkdown.prod.mjs",
@@ -40,6 +41,7 @@
         "default": "./dist/LexicalMarkdown.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalMarkdown.dev.js",
         "production": "./dist/LexicalMarkdown.prod.js",
@@ -59,5 +61,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-offset/package.json
+++ b/packages/lexical-offset/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalOffset.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -22,6 +22,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalOffset.dev.mjs",
         "production": "./dist/LexicalOffset.prod.mjs",
@@ -29,6 +30,7 @@
         "default": "./dist/LexicalOffset.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalOffset.dev.js",
         "production": "./dist/LexicalOffset.prod.js",
@@ -52,5 +54,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-overflow/package.json
+++ b/packages/lexical-overflow/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalOverflow.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -22,6 +22,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalOverflow.dev.mjs",
         "production": "./dist/LexicalOverflow.prod.mjs",
@@ -29,6 +30,7 @@
         "default": "./dist/LexicalOverflow.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalOverflow.dev.js",
         "production": "./dist/LexicalOverflow.prod.js",
@@ -51,5 +53,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-plain-text/package.json
+++ b/packages/lexical-plain-text/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalPlainText.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -21,6 +21,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalPlainText.dev.mjs",
         "production": "./dist/LexicalPlainText.prod.mjs",
@@ -28,6 +29,7 @@
         "default": "./dist/LexicalPlainText.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalPlainText.dev.js",
         "production": "./dist/LexicalPlainText.prod.js",
@@ -55,5 +57,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -34,10 +34,14 @@
   "peerDependencies": {
     "react": ">=17.x",
     "react-dom": ">=17.x",
+    "typescript": ">=5.2",
     "yjs": ">=13.5.22"
   },
   "peerDependenciesMeta": {
     "yjs": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },
@@ -50,6 +54,7 @@
     "./ExtensionComponent": {
       "source": "./src/ExtensionComponent.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ExtensionComponent.d.ts",
         "development": "./dist/LexicalExtensionComponent.dev.mjs",
         "production": "./dist/LexicalExtensionComponent.prod.mjs",
@@ -57,6 +62,7 @@
         "default": "./dist/LexicalExtensionComponent.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ExtensionComponent.d.ts",
         "development": "./dist/LexicalExtensionComponent.dev.js",
         "production": "./dist/LexicalExtensionComponent.prod.js",
@@ -66,6 +72,7 @@
     "./ExtensionComponent.js": {
       "source": "./src/ExtensionComponent.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ExtensionComponent.d.ts",
         "development": "./dist/LexicalExtensionComponent.dev.mjs",
         "production": "./dist/LexicalExtensionComponent.prod.mjs",
@@ -73,6 +80,7 @@
         "default": "./dist/LexicalExtensionComponent.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ExtensionComponent.d.ts",
         "development": "./dist/LexicalExtensionComponent.dev.js",
         "production": "./dist/LexicalExtensionComponent.prod.js",
@@ -82,6 +90,7 @@
     "./LexicalAutoEmbedPlugin": {
       "source": "./src/LexicalAutoEmbedPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoEmbedPlugin.d.ts",
         "development": "./dist/LexicalAutoEmbedPlugin.dev.mjs",
         "production": "./dist/LexicalAutoEmbedPlugin.prod.mjs",
@@ -89,6 +98,7 @@
         "default": "./dist/LexicalAutoEmbedPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoEmbedPlugin.d.ts",
         "development": "./dist/LexicalAutoEmbedPlugin.dev.js",
         "production": "./dist/LexicalAutoEmbedPlugin.prod.js",
@@ -98,6 +108,7 @@
     "./LexicalAutoEmbedPlugin.js": {
       "source": "./src/LexicalAutoEmbedPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoEmbedPlugin.d.ts",
         "development": "./dist/LexicalAutoEmbedPlugin.dev.mjs",
         "production": "./dist/LexicalAutoEmbedPlugin.prod.mjs",
@@ -105,6 +116,7 @@
         "default": "./dist/LexicalAutoEmbedPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoEmbedPlugin.d.ts",
         "development": "./dist/LexicalAutoEmbedPlugin.dev.js",
         "production": "./dist/LexicalAutoEmbedPlugin.prod.js",
@@ -114,6 +126,7 @@
     "./LexicalAutoFocusPlugin": {
       "source": "./src/LexicalAutoFocusPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoFocusPlugin.d.ts",
         "development": "./dist/LexicalAutoFocusPlugin.dev.mjs",
         "production": "./dist/LexicalAutoFocusPlugin.prod.mjs",
@@ -121,6 +134,7 @@
         "default": "./dist/LexicalAutoFocusPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoFocusPlugin.d.ts",
         "development": "./dist/LexicalAutoFocusPlugin.dev.js",
         "production": "./dist/LexicalAutoFocusPlugin.prod.js",
@@ -130,6 +144,7 @@
     "./LexicalAutoFocusPlugin.js": {
       "source": "./src/LexicalAutoFocusPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoFocusPlugin.d.ts",
         "development": "./dist/LexicalAutoFocusPlugin.dev.mjs",
         "production": "./dist/LexicalAutoFocusPlugin.prod.mjs",
@@ -137,6 +152,7 @@
         "default": "./dist/LexicalAutoFocusPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoFocusPlugin.d.ts",
         "development": "./dist/LexicalAutoFocusPlugin.dev.js",
         "production": "./dist/LexicalAutoFocusPlugin.prod.js",
@@ -146,6 +162,7 @@
     "./LexicalAutoLinkPlugin": {
       "source": "./src/LexicalAutoLinkPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoLinkPlugin.d.ts",
         "development": "./dist/LexicalAutoLinkPlugin.dev.mjs",
         "production": "./dist/LexicalAutoLinkPlugin.prod.mjs",
@@ -153,6 +170,7 @@
         "default": "./dist/LexicalAutoLinkPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoLinkPlugin.d.ts",
         "development": "./dist/LexicalAutoLinkPlugin.dev.js",
         "production": "./dist/LexicalAutoLinkPlugin.prod.js",
@@ -162,6 +180,7 @@
     "./LexicalAutoLinkPlugin.js": {
       "source": "./src/LexicalAutoLinkPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoLinkPlugin.d.ts",
         "development": "./dist/LexicalAutoLinkPlugin.dev.mjs",
         "production": "./dist/LexicalAutoLinkPlugin.prod.mjs",
@@ -169,6 +188,7 @@
         "default": "./dist/LexicalAutoLinkPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalAutoLinkPlugin.d.ts",
         "development": "./dist/LexicalAutoLinkPlugin.dev.js",
         "production": "./dist/LexicalAutoLinkPlugin.prod.js",
@@ -178,6 +198,7 @@
     "./LexicalBlockWithAlignableContents": {
       "source": "./src/LexicalBlockWithAlignableContents.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalBlockWithAlignableContents.d.ts",
         "development": "./dist/LexicalBlockWithAlignableContents.dev.mjs",
         "production": "./dist/LexicalBlockWithAlignableContents.prod.mjs",
@@ -185,6 +206,7 @@
         "default": "./dist/LexicalBlockWithAlignableContents.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalBlockWithAlignableContents.d.ts",
         "development": "./dist/LexicalBlockWithAlignableContents.dev.js",
         "production": "./dist/LexicalBlockWithAlignableContents.prod.js",
@@ -194,6 +216,7 @@
     "./LexicalBlockWithAlignableContents.js": {
       "source": "./src/LexicalBlockWithAlignableContents.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalBlockWithAlignableContents.d.ts",
         "development": "./dist/LexicalBlockWithAlignableContents.dev.mjs",
         "production": "./dist/LexicalBlockWithAlignableContents.prod.mjs",
@@ -201,6 +224,7 @@
         "default": "./dist/LexicalBlockWithAlignableContents.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalBlockWithAlignableContents.d.ts",
         "development": "./dist/LexicalBlockWithAlignableContents.dev.js",
         "production": "./dist/LexicalBlockWithAlignableContents.prod.js",
@@ -210,6 +234,7 @@
     "./LexicalCharacterLimitPlugin": {
       "source": "./src/LexicalCharacterLimitPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCharacterLimitPlugin.d.ts",
         "development": "./dist/LexicalCharacterLimitPlugin.dev.mjs",
         "production": "./dist/LexicalCharacterLimitPlugin.prod.mjs",
@@ -217,6 +242,7 @@
         "default": "./dist/LexicalCharacterLimitPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCharacterLimitPlugin.d.ts",
         "development": "./dist/LexicalCharacterLimitPlugin.dev.js",
         "production": "./dist/LexicalCharacterLimitPlugin.prod.js",
@@ -226,6 +252,7 @@
     "./LexicalCharacterLimitPlugin.js": {
       "source": "./src/LexicalCharacterLimitPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCharacterLimitPlugin.d.ts",
         "development": "./dist/LexicalCharacterLimitPlugin.dev.mjs",
         "production": "./dist/LexicalCharacterLimitPlugin.prod.mjs",
@@ -233,6 +260,7 @@
         "default": "./dist/LexicalCharacterLimitPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCharacterLimitPlugin.d.ts",
         "development": "./dist/LexicalCharacterLimitPlugin.dev.js",
         "production": "./dist/LexicalCharacterLimitPlugin.prod.js",
@@ -242,6 +270,7 @@
     "./LexicalCheckListPlugin": {
       "source": "./src/LexicalCheckListPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCheckListPlugin.d.ts",
         "development": "./dist/LexicalCheckListPlugin.dev.mjs",
         "production": "./dist/LexicalCheckListPlugin.prod.mjs",
@@ -249,6 +278,7 @@
         "default": "./dist/LexicalCheckListPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCheckListPlugin.d.ts",
         "development": "./dist/LexicalCheckListPlugin.dev.js",
         "production": "./dist/LexicalCheckListPlugin.prod.js",
@@ -258,6 +288,7 @@
     "./LexicalCheckListPlugin.js": {
       "source": "./src/LexicalCheckListPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCheckListPlugin.d.ts",
         "development": "./dist/LexicalCheckListPlugin.dev.mjs",
         "production": "./dist/LexicalCheckListPlugin.prod.mjs",
@@ -265,6 +296,7 @@
         "default": "./dist/LexicalCheckListPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCheckListPlugin.d.ts",
         "development": "./dist/LexicalCheckListPlugin.dev.js",
         "production": "./dist/LexicalCheckListPlugin.prod.js",
@@ -274,6 +306,7 @@
     "./LexicalClearEditorPlugin": {
       "source": "./src/LexicalClearEditorPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalClearEditorPlugin.d.ts",
         "development": "./dist/LexicalClearEditorPlugin.dev.mjs",
         "production": "./dist/LexicalClearEditorPlugin.prod.mjs",
@@ -281,6 +314,7 @@
         "default": "./dist/LexicalClearEditorPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalClearEditorPlugin.d.ts",
         "development": "./dist/LexicalClearEditorPlugin.dev.js",
         "production": "./dist/LexicalClearEditorPlugin.prod.js",
@@ -290,6 +324,7 @@
     "./LexicalClearEditorPlugin.js": {
       "source": "./src/LexicalClearEditorPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalClearEditorPlugin.d.ts",
         "development": "./dist/LexicalClearEditorPlugin.dev.mjs",
         "production": "./dist/LexicalClearEditorPlugin.prod.mjs",
@@ -297,6 +332,7 @@
         "default": "./dist/LexicalClearEditorPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalClearEditorPlugin.d.ts",
         "development": "./dist/LexicalClearEditorPlugin.dev.js",
         "production": "./dist/LexicalClearEditorPlugin.prod.js",
@@ -306,6 +342,7 @@
     "./LexicalClickableLinkPlugin": {
       "source": "./src/LexicalClickableLinkPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalClickableLinkPlugin.d.ts",
         "development": "./dist/LexicalClickableLinkPlugin.dev.mjs",
         "production": "./dist/LexicalClickableLinkPlugin.prod.mjs",
@@ -313,6 +350,7 @@
         "default": "./dist/LexicalClickableLinkPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalClickableLinkPlugin.d.ts",
         "development": "./dist/LexicalClickableLinkPlugin.dev.js",
         "production": "./dist/LexicalClickableLinkPlugin.prod.js",
@@ -322,6 +360,7 @@
     "./LexicalClickableLinkPlugin.js": {
       "source": "./src/LexicalClickableLinkPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalClickableLinkPlugin.d.ts",
         "development": "./dist/LexicalClickableLinkPlugin.dev.mjs",
         "production": "./dist/LexicalClickableLinkPlugin.prod.mjs",
@@ -329,6 +368,7 @@
         "default": "./dist/LexicalClickableLinkPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalClickableLinkPlugin.d.ts",
         "development": "./dist/LexicalClickableLinkPlugin.dev.js",
         "production": "./dist/LexicalClickableLinkPlugin.prod.js",
@@ -338,6 +378,7 @@
     "./LexicalCollaborationContext": {
       "source": "./src/LexicalCollaborationContext.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCollaborationContext.d.ts",
         "development": "./dist/LexicalCollaborationContext.dev.mjs",
         "production": "./dist/LexicalCollaborationContext.prod.mjs",
@@ -345,6 +386,7 @@
         "default": "./dist/LexicalCollaborationContext.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCollaborationContext.d.ts",
         "development": "./dist/LexicalCollaborationContext.dev.js",
         "production": "./dist/LexicalCollaborationContext.prod.js",
@@ -354,6 +396,7 @@
     "./LexicalCollaborationContext.js": {
       "source": "./src/LexicalCollaborationContext.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCollaborationContext.d.ts",
         "development": "./dist/LexicalCollaborationContext.dev.mjs",
         "production": "./dist/LexicalCollaborationContext.prod.mjs",
@@ -361,6 +404,7 @@
         "default": "./dist/LexicalCollaborationContext.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCollaborationContext.d.ts",
         "development": "./dist/LexicalCollaborationContext.dev.js",
         "production": "./dist/LexicalCollaborationContext.prod.js",
@@ -370,6 +414,7 @@
     "./LexicalCollaborationPlugin": {
       "source": "./src/LexicalCollaborationPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCollaborationPlugin.d.ts",
         "development": "./dist/LexicalCollaborationPlugin.dev.mjs",
         "production": "./dist/LexicalCollaborationPlugin.prod.mjs",
@@ -377,6 +422,7 @@
         "default": "./dist/LexicalCollaborationPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCollaborationPlugin.d.ts",
         "development": "./dist/LexicalCollaborationPlugin.dev.js",
         "production": "./dist/LexicalCollaborationPlugin.prod.js",
@@ -386,6 +432,7 @@
     "./LexicalCollaborationPlugin.js": {
       "source": "./src/LexicalCollaborationPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCollaborationPlugin.d.ts",
         "development": "./dist/LexicalCollaborationPlugin.dev.mjs",
         "production": "./dist/LexicalCollaborationPlugin.prod.mjs",
@@ -393,6 +440,7 @@
         "default": "./dist/LexicalCollaborationPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalCollaborationPlugin.d.ts",
         "development": "./dist/LexicalCollaborationPlugin.dev.js",
         "production": "./dist/LexicalCollaborationPlugin.prod.js",
@@ -402,6 +450,7 @@
     "./LexicalComposer": {
       "source": "./src/LexicalComposer.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalComposer.d.ts",
         "development": "./dist/LexicalComposer.dev.mjs",
         "production": "./dist/LexicalComposer.prod.mjs",
@@ -409,6 +458,7 @@
         "default": "./dist/LexicalComposer.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalComposer.d.ts",
         "development": "./dist/LexicalComposer.dev.js",
         "production": "./dist/LexicalComposer.prod.js",
@@ -418,6 +468,7 @@
     "./LexicalComposer.js": {
       "source": "./src/LexicalComposer.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalComposer.d.ts",
         "development": "./dist/LexicalComposer.dev.mjs",
         "production": "./dist/LexicalComposer.prod.mjs",
@@ -425,6 +476,7 @@
         "default": "./dist/LexicalComposer.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalComposer.d.ts",
         "development": "./dist/LexicalComposer.dev.js",
         "production": "./dist/LexicalComposer.prod.js",
@@ -434,6 +486,7 @@
     "./LexicalComposerContext": {
       "source": "./src/LexicalComposerContext.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalComposerContext.d.ts",
         "development": "./dist/LexicalComposerContext.dev.mjs",
         "production": "./dist/LexicalComposerContext.prod.mjs",
@@ -441,6 +494,7 @@
         "default": "./dist/LexicalComposerContext.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalComposerContext.d.ts",
         "development": "./dist/LexicalComposerContext.dev.js",
         "production": "./dist/LexicalComposerContext.prod.js",
@@ -450,6 +504,7 @@
     "./LexicalComposerContext.js": {
       "source": "./src/LexicalComposerContext.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalComposerContext.d.ts",
         "development": "./dist/LexicalComposerContext.dev.mjs",
         "production": "./dist/LexicalComposerContext.prod.mjs",
@@ -457,6 +512,7 @@
         "default": "./dist/LexicalComposerContext.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalComposerContext.d.ts",
         "development": "./dist/LexicalComposerContext.dev.js",
         "production": "./dist/LexicalComposerContext.prod.js",
@@ -466,6 +522,7 @@
     "./LexicalContentEditable": {
       "source": "./src/LexicalContentEditable.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalContentEditable.d.ts",
         "development": "./dist/LexicalContentEditable.dev.mjs",
         "production": "./dist/LexicalContentEditable.prod.mjs",
@@ -473,6 +530,7 @@
         "default": "./dist/LexicalContentEditable.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalContentEditable.d.ts",
         "development": "./dist/LexicalContentEditable.dev.js",
         "production": "./dist/LexicalContentEditable.prod.js",
@@ -482,6 +540,7 @@
     "./LexicalContentEditable.js": {
       "source": "./src/LexicalContentEditable.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalContentEditable.d.ts",
         "development": "./dist/LexicalContentEditable.dev.mjs",
         "production": "./dist/LexicalContentEditable.prod.mjs",
@@ -489,6 +548,7 @@
         "default": "./dist/LexicalContentEditable.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalContentEditable.d.ts",
         "development": "./dist/LexicalContentEditable.dev.js",
         "production": "./dist/LexicalContentEditable.prod.js",
@@ -498,6 +558,7 @@
     "./LexicalDecoratorBlockNode": {
       "source": "./src/LexicalDecoratorBlockNode.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalDecoratorBlockNode.d.ts",
         "development": "./dist/LexicalDecoratorBlockNode.dev.mjs",
         "production": "./dist/LexicalDecoratorBlockNode.prod.mjs",
@@ -505,6 +566,7 @@
         "default": "./dist/LexicalDecoratorBlockNode.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalDecoratorBlockNode.d.ts",
         "development": "./dist/LexicalDecoratorBlockNode.dev.js",
         "production": "./dist/LexicalDecoratorBlockNode.prod.js",
@@ -514,6 +576,7 @@
     "./LexicalDecoratorBlockNode.js": {
       "source": "./src/LexicalDecoratorBlockNode.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalDecoratorBlockNode.d.ts",
         "development": "./dist/LexicalDecoratorBlockNode.dev.mjs",
         "production": "./dist/LexicalDecoratorBlockNode.prod.mjs",
@@ -521,6 +584,7 @@
         "default": "./dist/LexicalDecoratorBlockNode.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalDecoratorBlockNode.d.ts",
         "development": "./dist/LexicalDecoratorBlockNode.dev.js",
         "production": "./dist/LexicalDecoratorBlockNode.prod.js",
@@ -530,6 +594,7 @@
     "./LexicalDraggableBlockPlugin": {
       "source": "./src/LexicalDraggableBlockPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalDraggableBlockPlugin.d.ts",
         "development": "./dist/LexicalDraggableBlockPlugin.dev.mjs",
         "production": "./dist/LexicalDraggableBlockPlugin.prod.mjs",
@@ -537,6 +602,7 @@
         "default": "./dist/LexicalDraggableBlockPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalDraggableBlockPlugin.d.ts",
         "development": "./dist/LexicalDraggableBlockPlugin.dev.js",
         "production": "./dist/LexicalDraggableBlockPlugin.prod.js",
@@ -546,6 +612,7 @@
     "./LexicalDraggableBlockPlugin.js": {
       "source": "./src/LexicalDraggableBlockPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalDraggableBlockPlugin.d.ts",
         "development": "./dist/LexicalDraggableBlockPlugin.dev.mjs",
         "production": "./dist/LexicalDraggableBlockPlugin.prod.mjs",
@@ -553,6 +620,7 @@
         "default": "./dist/LexicalDraggableBlockPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalDraggableBlockPlugin.d.ts",
         "development": "./dist/LexicalDraggableBlockPlugin.dev.js",
         "production": "./dist/LexicalDraggableBlockPlugin.prod.js",
@@ -562,6 +630,7 @@
     "./LexicalEditorRefPlugin": {
       "source": "./src/LexicalEditorRefPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalEditorRefPlugin.d.ts",
         "development": "./dist/LexicalEditorRefPlugin.dev.mjs",
         "production": "./dist/LexicalEditorRefPlugin.prod.mjs",
@@ -569,6 +638,7 @@
         "default": "./dist/LexicalEditorRefPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalEditorRefPlugin.d.ts",
         "development": "./dist/LexicalEditorRefPlugin.dev.js",
         "production": "./dist/LexicalEditorRefPlugin.prod.js",
@@ -578,6 +648,7 @@
     "./LexicalEditorRefPlugin.js": {
       "source": "./src/LexicalEditorRefPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalEditorRefPlugin.d.ts",
         "development": "./dist/LexicalEditorRefPlugin.dev.mjs",
         "production": "./dist/LexicalEditorRefPlugin.prod.mjs",
@@ -585,6 +656,7 @@
         "default": "./dist/LexicalEditorRefPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalEditorRefPlugin.d.ts",
         "development": "./dist/LexicalEditorRefPlugin.dev.js",
         "production": "./dist/LexicalEditorRefPlugin.prod.js",
@@ -594,6 +666,7 @@
     "./LexicalErrorBoundary": {
       "source": "./src/LexicalErrorBoundary.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalErrorBoundary.d.ts",
         "development": "./dist/LexicalErrorBoundary.dev.mjs",
         "production": "./dist/LexicalErrorBoundary.prod.mjs",
@@ -601,6 +674,7 @@
         "default": "./dist/LexicalErrorBoundary.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalErrorBoundary.d.ts",
         "development": "./dist/LexicalErrorBoundary.dev.js",
         "production": "./dist/LexicalErrorBoundary.prod.js",
@@ -610,6 +684,7 @@
     "./LexicalErrorBoundary.js": {
       "source": "./src/LexicalErrorBoundary.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalErrorBoundary.d.ts",
         "development": "./dist/LexicalErrorBoundary.dev.mjs",
         "production": "./dist/LexicalErrorBoundary.prod.mjs",
@@ -617,6 +692,7 @@
         "default": "./dist/LexicalErrorBoundary.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalErrorBoundary.d.ts",
         "development": "./dist/LexicalErrorBoundary.dev.js",
         "production": "./dist/LexicalErrorBoundary.prod.js",
@@ -626,6 +702,7 @@
     "./LexicalExtensionComposer": {
       "source": "./src/LexicalExtensionComposer.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalExtensionComposer.d.ts",
         "development": "./dist/LexicalExtensionComposer.dev.mjs",
         "production": "./dist/LexicalExtensionComposer.prod.mjs",
@@ -633,6 +710,7 @@
         "default": "./dist/LexicalExtensionComposer.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalExtensionComposer.d.ts",
         "development": "./dist/LexicalExtensionComposer.dev.js",
         "production": "./dist/LexicalExtensionComposer.prod.js",
@@ -642,6 +720,7 @@
     "./LexicalExtensionComposer.js": {
       "source": "./src/LexicalExtensionComposer.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalExtensionComposer.d.ts",
         "development": "./dist/LexicalExtensionComposer.dev.mjs",
         "production": "./dist/LexicalExtensionComposer.prod.mjs",
@@ -649,6 +728,7 @@
         "default": "./dist/LexicalExtensionComposer.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalExtensionComposer.d.ts",
         "development": "./dist/LexicalExtensionComposer.dev.js",
         "production": "./dist/LexicalExtensionComposer.prod.js",
@@ -658,6 +738,7 @@
     "./LexicalExtensionEditorComposer": {
       "source": "./src/LexicalExtensionEditorComposer.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalExtensionEditorComposer.d.ts",
         "development": "./dist/LexicalExtensionEditorComposer.dev.mjs",
         "production": "./dist/LexicalExtensionEditorComposer.prod.mjs",
@@ -665,6 +746,7 @@
         "default": "./dist/LexicalExtensionEditorComposer.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalExtensionEditorComposer.d.ts",
         "development": "./dist/LexicalExtensionEditorComposer.dev.js",
         "production": "./dist/LexicalExtensionEditorComposer.prod.js",
@@ -674,6 +756,7 @@
     "./LexicalExtensionEditorComposer.js": {
       "source": "./src/LexicalExtensionEditorComposer.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalExtensionEditorComposer.d.ts",
         "development": "./dist/LexicalExtensionEditorComposer.dev.mjs",
         "production": "./dist/LexicalExtensionEditorComposer.prod.mjs",
@@ -681,6 +764,7 @@
         "default": "./dist/LexicalExtensionEditorComposer.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalExtensionEditorComposer.d.ts",
         "development": "./dist/LexicalExtensionEditorComposer.dev.js",
         "production": "./dist/LexicalExtensionEditorComposer.prod.js",
@@ -690,6 +774,7 @@
     "./LexicalHashtagPlugin": {
       "source": "./src/LexicalHashtagPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHashtagPlugin.d.ts",
         "development": "./dist/LexicalHashtagPlugin.dev.mjs",
         "production": "./dist/LexicalHashtagPlugin.prod.mjs",
@@ -697,6 +782,7 @@
         "default": "./dist/LexicalHashtagPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHashtagPlugin.d.ts",
         "development": "./dist/LexicalHashtagPlugin.dev.js",
         "production": "./dist/LexicalHashtagPlugin.prod.js",
@@ -706,6 +792,7 @@
     "./LexicalHashtagPlugin.js": {
       "source": "./src/LexicalHashtagPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHashtagPlugin.d.ts",
         "development": "./dist/LexicalHashtagPlugin.dev.mjs",
         "production": "./dist/LexicalHashtagPlugin.prod.mjs",
@@ -713,6 +800,7 @@
         "default": "./dist/LexicalHashtagPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHashtagPlugin.d.ts",
         "development": "./dist/LexicalHashtagPlugin.dev.js",
         "production": "./dist/LexicalHashtagPlugin.prod.js",
@@ -722,6 +810,7 @@
     "./LexicalHistoryPlugin": {
       "source": "./src/LexicalHistoryPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHistoryPlugin.d.ts",
         "development": "./dist/LexicalHistoryPlugin.dev.mjs",
         "production": "./dist/LexicalHistoryPlugin.prod.mjs",
@@ -729,6 +818,7 @@
         "default": "./dist/LexicalHistoryPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHistoryPlugin.d.ts",
         "development": "./dist/LexicalHistoryPlugin.dev.js",
         "production": "./dist/LexicalHistoryPlugin.prod.js",
@@ -738,6 +828,7 @@
     "./LexicalHistoryPlugin.js": {
       "source": "./src/LexicalHistoryPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHistoryPlugin.d.ts",
         "development": "./dist/LexicalHistoryPlugin.dev.mjs",
         "production": "./dist/LexicalHistoryPlugin.prod.mjs",
@@ -745,6 +836,7 @@
         "default": "./dist/LexicalHistoryPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHistoryPlugin.d.ts",
         "development": "./dist/LexicalHistoryPlugin.dev.js",
         "production": "./dist/LexicalHistoryPlugin.prod.js",
@@ -754,6 +846,7 @@
     "./LexicalHorizontalRuleNode": {
       "source": "./src/LexicalHorizontalRuleNode.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHorizontalRuleNode.d.ts",
         "development": "./dist/LexicalHorizontalRuleNode.dev.mjs",
         "production": "./dist/LexicalHorizontalRuleNode.prod.mjs",
@@ -761,6 +854,7 @@
         "default": "./dist/LexicalHorizontalRuleNode.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHorizontalRuleNode.d.ts",
         "development": "./dist/LexicalHorizontalRuleNode.dev.js",
         "production": "./dist/LexicalHorizontalRuleNode.prod.js",
@@ -770,6 +864,7 @@
     "./LexicalHorizontalRuleNode.js": {
       "source": "./src/LexicalHorizontalRuleNode.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHorizontalRuleNode.d.ts",
         "development": "./dist/LexicalHorizontalRuleNode.dev.mjs",
         "production": "./dist/LexicalHorizontalRuleNode.prod.mjs",
@@ -777,6 +872,7 @@
         "default": "./dist/LexicalHorizontalRuleNode.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHorizontalRuleNode.d.ts",
         "development": "./dist/LexicalHorizontalRuleNode.dev.js",
         "production": "./dist/LexicalHorizontalRuleNode.prod.js",
@@ -786,6 +882,7 @@
     "./LexicalHorizontalRulePlugin": {
       "source": "./src/LexicalHorizontalRulePlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHorizontalRulePlugin.d.ts",
         "development": "./dist/LexicalHorizontalRulePlugin.dev.mjs",
         "production": "./dist/LexicalHorizontalRulePlugin.prod.mjs",
@@ -793,6 +890,7 @@
         "default": "./dist/LexicalHorizontalRulePlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHorizontalRulePlugin.d.ts",
         "development": "./dist/LexicalHorizontalRulePlugin.dev.js",
         "production": "./dist/LexicalHorizontalRulePlugin.prod.js",
@@ -802,6 +900,7 @@
     "./LexicalHorizontalRulePlugin.js": {
       "source": "./src/LexicalHorizontalRulePlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHorizontalRulePlugin.d.ts",
         "development": "./dist/LexicalHorizontalRulePlugin.dev.mjs",
         "production": "./dist/LexicalHorizontalRulePlugin.prod.mjs",
@@ -809,6 +908,7 @@
         "default": "./dist/LexicalHorizontalRulePlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalHorizontalRulePlugin.d.ts",
         "development": "./dist/LexicalHorizontalRulePlugin.dev.js",
         "production": "./dist/LexicalHorizontalRulePlugin.prod.js",
@@ -818,6 +918,7 @@
     "./LexicalLinkPlugin": {
       "source": "./src/LexicalLinkPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalLinkPlugin.d.ts",
         "development": "./dist/LexicalLinkPlugin.dev.mjs",
         "production": "./dist/LexicalLinkPlugin.prod.mjs",
@@ -825,6 +926,7 @@
         "default": "./dist/LexicalLinkPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalLinkPlugin.d.ts",
         "development": "./dist/LexicalLinkPlugin.dev.js",
         "production": "./dist/LexicalLinkPlugin.prod.js",
@@ -834,6 +936,7 @@
     "./LexicalLinkPlugin.js": {
       "source": "./src/LexicalLinkPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalLinkPlugin.d.ts",
         "development": "./dist/LexicalLinkPlugin.dev.mjs",
         "production": "./dist/LexicalLinkPlugin.prod.mjs",
@@ -841,6 +944,7 @@
         "default": "./dist/LexicalLinkPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalLinkPlugin.d.ts",
         "development": "./dist/LexicalLinkPlugin.dev.js",
         "production": "./dist/LexicalLinkPlugin.prod.js",
@@ -850,6 +954,7 @@
     "./LexicalListPlugin": {
       "source": "./src/LexicalListPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalListPlugin.d.ts",
         "development": "./dist/LexicalListPlugin.dev.mjs",
         "production": "./dist/LexicalListPlugin.prod.mjs",
@@ -857,6 +962,7 @@
         "default": "./dist/LexicalListPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalListPlugin.d.ts",
         "development": "./dist/LexicalListPlugin.dev.js",
         "production": "./dist/LexicalListPlugin.prod.js",
@@ -866,6 +972,7 @@
     "./LexicalListPlugin.js": {
       "source": "./src/LexicalListPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalListPlugin.d.ts",
         "development": "./dist/LexicalListPlugin.dev.mjs",
         "production": "./dist/LexicalListPlugin.prod.mjs",
@@ -873,6 +980,7 @@
         "default": "./dist/LexicalListPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalListPlugin.d.ts",
         "development": "./dist/LexicalListPlugin.dev.js",
         "production": "./dist/LexicalListPlugin.prod.js",
@@ -882,6 +990,7 @@
     "./LexicalMarkdownShortcutPlugin": {
       "source": "./src/LexicalMarkdownShortcutPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalMarkdownShortcutPlugin.d.ts",
         "development": "./dist/LexicalMarkdownShortcutPlugin.dev.mjs",
         "production": "./dist/LexicalMarkdownShortcutPlugin.prod.mjs",
@@ -889,6 +998,7 @@
         "default": "./dist/LexicalMarkdownShortcutPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalMarkdownShortcutPlugin.d.ts",
         "development": "./dist/LexicalMarkdownShortcutPlugin.dev.js",
         "production": "./dist/LexicalMarkdownShortcutPlugin.prod.js",
@@ -898,6 +1008,7 @@
     "./LexicalMarkdownShortcutPlugin.js": {
       "source": "./src/LexicalMarkdownShortcutPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalMarkdownShortcutPlugin.d.ts",
         "development": "./dist/LexicalMarkdownShortcutPlugin.dev.mjs",
         "production": "./dist/LexicalMarkdownShortcutPlugin.prod.mjs",
@@ -905,6 +1016,7 @@
         "default": "./dist/LexicalMarkdownShortcutPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalMarkdownShortcutPlugin.d.ts",
         "development": "./dist/LexicalMarkdownShortcutPlugin.dev.js",
         "production": "./dist/LexicalMarkdownShortcutPlugin.prod.js",
@@ -914,6 +1026,7 @@
     "./LexicalNestedComposer": {
       "source": "./src/LexicalNestedComposer.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNestedComposer.d.ts",
         "development": "./dist/LexicalNestedComposer.dev.mjs",
         "production": "./dist/LexicalNestedComposer.prod.mjs",
@@ -921,6 +1034,7 @@
         "default": "./dist/LexicalNestedComposer.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNestedComposer.d.ts",
         "development": "./dist/LexicalNestedComposer.dev.js",
         "production": "./dist/LexicalNestedComposer.prod.js",
@@ -930,6 +1044,7 @@
     "./LexicalNestedComposer.js": {
       "source": "./src/LexicalNestedComposer.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNestedComposer.d.ts",
         "development": "./dist/LexicalNestedComposer.dev.mjs",
         "production": "./dist/LexicalNestedComposer.prod.mjs",
@@ -937,6 +1052,7 @@
         "default": "./dist/LexicalNestedComposer.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNestedComposer.d.ts",
         "development": "./dist/LexicalNestedComposer.dev.js",
         "production": "./dist/LexicalNestedComposer.prod.js",
@@ -946,6 +1062,7 @@
     "./LexicalNodeContextMenuPlugin": {
       "source": "./src/LexicalNodeContextMenuPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeContextMenuPlugin.d.ts",
         "development": "./dist/LexicalNodeContextMenuPlugin.dev.mjs",
         "production": "./dist/LexicalNodeContextMenuPlugin.prod.mjs",
@@ -953,6 +1070,7 @@
         "default": "./dist/LexicalNodeContextMenuPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeContextMenuPlugin.d.ts",
         "development": "./dist/LexicalNodeContextMenuPlugin.dev.js",
         "production": "./dist/LexicalNodeContextMenuPlugin.prod.js",
@@ -962,6 +1080,7 @@
     "./LexicalNodeContextMenuPlugin.js": {
       "source": "./src/LexicalNodeContextMenuPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeContextMenuPlugin.d.ts",
         "development": "./dist/LexicalNodeContextMenuPlugin.dev.mjs",
         "production": "./dist/LexicalNodeContextMenuPlugin.prod.mjs",
@@ -969,6 +1088,7 @@
         "default": "./dist/LexicalNodeContextMenuPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeContextMenuPlugin.d.ts",
         "development": "./dist/LexicalNodeContextMenuPlugin.dev.js",
         "production": "./dist/LexicalNodeContextMenuPlugin.prod.js",
@@ -978,6 +1098,7 @@
     "./LexicalNodeEventPlugin": {
       "source": "./src/LexicalNodeEventPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeEventPlugin.d.ts",
         "development": "./dist/LexicalNodeEventPlugin.dev.mjs",
         "production": "./dist/LexicalNodeEventPlugin.prod.mjs",
@@ -985,6 +1106,7 @@
         "default": "./dist/LexicalNodeEventPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeEventPlugin.d.ts",
         "development": "./dist/LexicalNodeEventPlugin.dev.js",
         "production": "./dist/LexicalNodeEventPlugin.prod.js",
@@ -994,6 +1116,7 @@
     "./LexicalNodeEventPlugin.js": {
       "source": "./src/LexicalNodeEventPlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeEventPlugin.d.ts",
         "development": "./dist/LexicalNodeEventPlugin.dev.mjs",
         "production": "./dist/LexicalNodeEventPlugin.prod.mjs",
@@ -1001,6 +1124,7 @@
         "default": "./dist/LexicalNodeEventPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeEventPlugin.d.ts",
         "development": "./dist/LexicalNodeEventPlugin.dev.js",
         "production": "./dist/LexicalNodeEventPlugin.prod.js",
@@ -1010,6 +1134,7 @@
     "./LexicalNodeMenuPlugin": {
       "source": "./src/LexicalNodeMenuPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeMenuPlugin.d.ts",
         "development": "./dist/LexicalNodeMenuPlugin.dev.mjs",
         "production": "./dist/LexicalNodeMenuPlugin.prod.mjs",
@@ -1017,6 +1142,7 @@
         "default": "./dist/LexicalNodeMenuPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeMenuPlugin.d.ts",
         "development": "./dist/LexicalNodeMenuPlugin.dev.js",
         "production": "./dist/LexicalNodeMenuPlugin.prod.js",
@@ -1026,6 +1152,7 @@
     "./LexicalNodeMenuPlugin.js": {
       "source": "./src/LexicalNodeMenuPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeMenuPlugin.d.ts",
         "development": "./dist/LexicalNodeMenuPlugin.dev.mjs",
         "production": "./dist/LexicalNodeMenuPlugin.prod.mjs",
@@ -1033,6 +1160,7 @@
         "default": "./dist/LexicalNodeMenuPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalNodeMenuPlugin.d.ts",
         "development": "./dist/LexicalNodeMenuPlugin.dev.js",
         "production": "./dist/LexicalNodeMenuPlugin.prod.js",
@@ -1042,6 +1170,7 @@
     "./LexicalOnChangePlugin": {
       "source": "./src/LexicalOnChangePlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalOnChangePlugin.d.ts",
         "development": "./dist/LexicalOnChangePlugin.dev.mjs",
         "production": "./dist/LexicalOnChangePlugin.prod.mjs",
@@ -1049,6 +1178,7 @@
         "default": "./dist/LexicalOnChangePlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalOnChangePlugin.d.ts",
         "development": "./dist/LexicalOnChangePlugin.dev.js",
         "production": "./dist/LexicalOnChangePlugin.prod.js",
@@ -1058,6 +1188,7 @@
     "./LexicalOnChangePlugin.js": {
       "source": "./src/LexicalOnChangePlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalOnChangePlugin.d.ts",
         "development": "./dist/LexicalOnChangePlugin.dev.mjs",
         "production": "./dist/LexicalOnChangePlugin.prod.mjs",
@@ -1065,6 +1196,7 @@
         "default": "./dist/LexicalOnChangePlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalOnChangePlugin.d.ts",
         "development": "./dist/LexicalOnChangePlugin.dev.js",
         "production": "./dist/LexicalOnChangePlugin.prod.js",
@@ -1074,6 +1206,7 @@
     "./LexicalPlainTextPlugin": {
       "source": "./src/LexicalPlainTextPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalPlainTextPlugin.d.ts",
         "development": "./dist/LexicalPlainTextPlugin.dev.mjs",
         "production": "./dist/LexicalPlainTextPlugin.prod.mjs",
@@ -1081,6 +1214,7 @@
         "default": "./dist/LexicalPlainTextPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalPlainTextPlugin.d.ts",
         "development": "./dist/LexicalPlainTextPlugin.dev.js",
         "production": "./dist/LexicalPlainTextPlugin.prod.js",
@@ -1090,6 +1224,7 @@
     "./LexicalPlainTextPlugin.js": {
       "source": "./src/LexicalPlainTextPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalPlainTextPlugin.d.ts",
         "development": "./dist/LexicalPlainTextPlugin.dev.mjs",
         "production": "./dist/LexicalPlainTextPlugin.prod.mjs",
@@ -1097,6 +1232,7 @@
         "default": "./dist/LexicalPlainTextPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalPlainTextPlugin.d.ts",
         "development": "./dist/LexicalPlainTextPlugin.dev.js",
         "production": "./dist/LexicalPlainTextPlugin.prod.js",
@@ -1106,6 +1242,7 @@
     "./LexicalRichTextPlugin": {
       "source": "./src/LexicalRichTextPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalRichTextPlugin.d.ts",
         "development": "./dist/LexicalRichTextPlugin.dev.mjs",
         "production": "./dist/LexicalRichTextPlugin.prod.mjs",
@@ -1113,6 +1250,7 @@
         "default": "./dist/LexicalRichTextPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalRichTextPlugin.d.ts",
         "development": "./dist/LexicalRichTextPlugin.dev.js",
         "production": "./dist/LexicalRichTextPlugin.prod.js",
@@ -1122,6 +1260,7 @@
     "./LexicalRichTextPlugin.js": {
       "source": "./src/LexicalRichTextPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalRichTextPlugin.d.ts",
         "development": "./dist/LexicalRichTextPlugin.dev.mjs",
         "production": "./dist/LexicalRichTextPlugin.prod.mjs",
@@ -1129,6 +1268,7 @@
         "default": "./dist/LexicalRichTextPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalRichTextPlugin.d.ts",
         "development": "./dist/LexicalRichTextPlugin.dev.js",
         "production": "./dist/LexicalRichTextPlugin.prod.js",
@@ -1138,6 +1278,7 @@
     "./LexicalSelectionAlwaysOnDisplay": {
       "source": "./src/LexicalSelectionAlwaysOnDisplay.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalSelectionAlwaysOnDisplay.d.ts",
         "development": "./dist/LexicalSelectionAlwaysOnDisplay.dev.mjs",
         "production": "./dist/LexicalSelectionAlwaysOnDisplay.prod.mjs",
@@ -1145,6 +1286,7 @@
         "default": "./dist/LexicalSelectionAlwaysOnDisplay.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalSelectionAlwaysOnDisplay.d.ts",
         "development": "./dist/LexicalSelectionAlwaysOnDisplay.dev.js",
         "production": "./dist/LexicalSelectionAlwaysOnDisplay.prod.js",
@@ -1154,6 +1296,7 @@
     "./LexicalSelectionAlwaysOnDisplay.js": {
       "source": "./src/LexicalSelectionAlwaysOnDisplay.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalSelectionAlwaysOnDisplay.d.ts",
         "development": "./dist/LexicalSelectionAlwaysOnDisplay.dev.mjs",
         "production": "./dist/LexicalSelectionAlwaysOnDisplay.prod.mjs",
@@ -1161,6 +1304,7 @@
         "default": "./dist/LexicalSelectionAlwaysOnDisplay.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalSelectionAlwaysOnDisplay.d.ts",
         "development": "./dist/LexicalSelectionAlwaysOnDisplay.dev.js",
         "production": "./dist/LexicalSelectionAlwaysOnDisplay.prod.js",
@@ -1170,6 +1314,7 @@
     "./LexicalTabIndentationPlugin": {
       "source": "./src/LexicalTabIndentationPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTabIndentationPlugin.d.ts",
         "development": "./dist/LexicalTabIndentationPlugin.dev.mjs",
         "production": "./dist/LexicalTabIndentationPlugin.prod.mjs",
@@ -1177,6 +1322,7 @@
         "default": "./dist/LexicalTabIndentationPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTabIndentationPlugin.d.ts",
         "development": "./dist/LexicalTabIndentationPlugin.dev.js",
         "production": "./dist/LexicalTabIndentationPlugin.prod.js",
@@ -1186,6 +1332,7 @@
     "./LexicalTabIndentationPlugin.js": {
       "source": "./src/LexicalTabIndentationPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTabIndentationPlugin.d.ts",
         "development": "./dist/LexicalTabIndentationPlugin.dev.mjs",
         "production": "./dist/LexicalTabIndentationPlugin.prod.mjs",
@@ -1193,6 +1340,7 @@
         "default": "./dist/LexicalTabIndentationPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTabIndentationPlugin.d.ts",
         "development": "./dist/LexicalTabIndentationPlugin.dev.js",
         "production": "./dist/LexicalTabIndentationPlugin.prod.js",
@@ -1202,6 +1350,7 @@
     "./LexicalTableOfContentsPlugin": {
       "source": "./src/LexicalTableOfContentsPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTableOfContentsPlugin.d.ts",
         "development": "./dist/LexicalTableOfContentsPlugin.dev.mjs",
         "production": "./dist/LexicalTableOfContentsPlugin.prod.mjs",
@@ -1209,6 +1358,7 @@
         "default": "./dist/LexicalTableOfContentsPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTableOfContentsPlugin.d.ts",
         "development": "./dist/LexicalTableOfContentsPlugin.dev.js",
         "production": "./dist/LexicalTableOfContentsPlugin.prod.js",
@@ -1218,6 +1368,7 @@
     "./LexicalTableOfContentsPlugin.js": {
       "source": "./src/LexicalTableOfContentsPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTableOfContentsPlugin.d.ts",
         "development": "./dist/LexicalTableOfContentsPlugin.dev.mjs",
         "production": "./dist/LexicalTableOfContentsPlugin.prod.mjs",
@@ -1225,6 +1376,7 @@
         "default": "./dist/LexicalTableOfContentsPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTableOfContentsPlugin.d.ts",
         "development": "./dist/LexicalTableOfContentsPlugin.dev.js",
         "production": "./dist/LexicalTableOfContentsPlugin.prod.js",
@@ -1234,6 +1386,7 @@
     "./LexicalTablePlugin": {
       "source": "./src/LexicalTablePlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTablePlugin.d.ts",
         "development": "./dist/LexicalTablePlugin.dev.mjs",
         "production": "./dist/LexicalTablePlugin.prod.mjs",
@@ -1241,6 +1394,7 @@
         "default": "./dist/LexicalTablePlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTablePlugin.d.ts",
         "development": "./dist/LexicalTablePlugin.dev.js",
         "production": "./dist/LexicalTablePlugin.prod.js",
@@ -1250,6 +1404,7 @@
     "./LexicalTablePlugin.js": {
       "source": "./src/LexicalTablePlugin.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTablePlugin.d.ts",
         "development": "./dist/LexicalTablePlugin.dev.mjs",
         "production": "./dist/LexicalTablePlugin.prod.mjs",
@@ -1257,6 +1412,7 @@
         "default": "./dist/LexicalTablePlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTablePlugin.d.ts",
         "development": "./dist/LexicalTablePlugin.dev.js",
         "production": "./dist/LexicalTablePlugin.prod.js",
@@ -1266,6 +1422,7 @@
     "./LexicalTreeView": {
       "source": "./src/LexicalTreeView.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTreeView.d.ts",
         "development": "./dist/LexicalTreeView.dev.mjs",
         "production": "./dist/LexicalTreeView.prod.mjs",
@@ -1273,6 +1430,7 @@
         "default": "./dist/LexicalTreeView.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTreeView.d.ts",
         "development": "./dist/LexicalTreeView.dev.js",
         "production": "./dist/LexicalTreeView.prod.js",
@@ -1282,6 +1440,7 @@
     "./LexicalTreeView.js": {
       "source": "./src/LexicalTreeView.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTreeView.d.ts",
         "development": "./dist/LexicalTreeView.dev.mjs",
         "production": "./dist/LexicalTreeView.prod.mjs",
@@ -1289,6 +1448,7 @@
         "default": "./dist/LexicalTreeView.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTreeView.d.ts",
         "development": "./dist/LexicalTreeView.dev.js",
         "production": "./dist/LexicalTreeView.prod.js",
@@ -1298,6 +1458,7 @@
     "./LexicalTypeaheadMenuPlugin": {
       "source": "./src/LexicalTypeaheadMenuPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTypeaheadMenuPlugin.d.ts",
         "development": "./dist/LexicalTypeaheadMenuPlugin.dev.mjs",
         "production": "./dist/LexicalTypeaheadMenuPlugin.prod.mjs",
@@ -1305,6 +1466,7 @@
         "default": "./dist/LexicalTypeaheadMenuPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTypeaheadMenuPlugin.d.ts",
         "development": "./dist/LexicalTypeaheadMenuPlugin.dev.js",
         "production": "./dist/LexicalTypeaheadMenuPlugin.prod.js",
@@ -1314,6 +1476,7 @@
     "./LexicalTypeaheadMenuPlugin.js": {
       "source": "./src/LexicalTypeaheadMenuPlugin.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTypeaheadMenuPlugin.d.ts",
         "development": "./dist/LexicalTypeaheadMenuPlugin.dev.mjs",
         "production": "./dist/LexicalTypeaheadMenuPlugin.prod.mjs",
@@ -1321,6 +1484,7 @@
         "default": "./dist/LexicalTypeaheadMenuPlugin.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/LexicalTypeaheadMenuPlugin.d.ts",
         "development": "./dist/LexicalTypeaheadMenuPlugin.dev.js",
         "production": "./dist/LexicalTypeaheadMenuPlugin.prod.js",
@@ -1330,6 +1494,7 @@
     "./ReactExtension": {
       "source": "./src/ReactExtension.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactExtension.d.ts",
         "development": "./dist/LexicalReactExtension.dev.mjs",
         "production": "./dist/LexicalReactExtension.prod.mjs",
@@ -1337,6 +1502,7 @@
         "default": "./dist/LexicalReactExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactExtension.d.ts",
         "development": "./dist/LexicalReactExtension.dev.js",
         "production": "./dist/LexicalReactExtension.prod.js",
@@ -1346,6 +1512,7 @@
     "./ReactExtension.js": {
       "source": "./src/ReactExtension.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactExtension.d.ts",
         "development": "./dist/LexicalReactExtension.dev.mjs",
         "production": "./dist/LexicalReactExtension.prod.mjs",
@@ -1353,6 +1520,7 @@
         "default": "./dist/LexicalReactExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactExtension.d.ts",
         "development": "./dist/LexicalReactExtension.dev.js",
         "production": "./dist/LexicalReactExtension.prod.js",
@@ -1362,6 +1530,7 @@
     "./ReactPluginHostExtension": {
       "source": "./src/ReactPluginHostExtension.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactPluginHostExtension.d.ts",
         "development": "./dist/LexicalReactPluginHostExtension.dev.mjs",
         "production": "./dist/LexicalReactPluginHostExtension.prod.mjs",
@@ -1369,6 +1538,7 @@
         "default": "./dist/LexicalReactPluginHostExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactPluginHostExtension.d.ts",
         "development": "./dist/LexicalReactPluginHostExtension.dev.js",
         "production": "./dist/LexicalReactPluginHostExtension.prod.js",
@@ -1378,6 +1548,7 @@
     "./ReactPluginHostExtension.js": {
       "source": "./src/ReactPluginHostExtension.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactPluginHostExtension.d.ts",
         "development": "./dist/LexicalReactPluginHostExtension.dev.mjs",
         "production": "./dist/LexicalReactPluginHostExtension.prod.mjs",
@@ -1385,6 +1556,7 @@
         "default": "./dist/LexicalReactPluginHostExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactPluginHostExtension.d.ts",
         "development": "./dist/LexicalReactPluginHostExtension.dev.js",
         "production": "./dist/LexicalReactPluginHostExtension.prod.js",
@@ -1394,6 +1566,7 @@
     "./ReactProviderExtension": {
       "source": "./src/ReactProviderExtension.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactProviderExtension.d.ts",
         "development": "./dist/LexicalReactProviderExtension.dev.mjs",
         "production": "./dist/LexicalReactProviderExtension.prod.mjs",
@@ -1401,6 +1574,7 @@
         "default": "./dist/LexicalReactProviderExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactProviderExtension.d.ts",
         "development": "./dist/LexicalReactProviderExtension.dev.js",
         "production": "./dist/LexicalReactProviderExtension.prod.js",
@@ -1410,6 +1584,7 @@
     "./ReactProviderExtension.js": {
       "source": "./src/ReactProviderExtension.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactProviderExtension.d.ts",
         "development": "./dist/LexicalReactProviderExtension.dev.mjs",
         "production": "./dist/LexicalReactProviderExtension.prod.mjs",
@@ -1417,6 +1592,7 @@
         "default": "./dist/LexicalReactProviderExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/ReactProviderExtension.d.ts",
         "development": "./dist/LexicalReactProviderExtension.dev.js",
         "production": "./dist/LexicalReactProviderExtension.prod.js",
@@ -1426,6 +1602,7 @@
     "./TreeViewExtension": {
       "source": "./src/TreeViewExtension.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/TreeViewExtension.d.ts",
         "development": "./dist/LexicalTreeViewExtension.dev.mjs",
         "production": "./dist/LexicalTreeViewExtension.prod.mjs",
@@ -1433,6 +1610,7 @@
         "default": "./dist/LexicalTreeViewExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/TreeViewExtension.d.ts",
         "development": "./dist/LexicalTreeViewExtension.dev.js",
         "production": "./dist/LexicalTreeViewExtension.prod.js",
@@ -1442,6 +1620,7 @@
     "./TreeViewExtension.js": {
       "source": "./src/TreeViewExtension.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/TreeViewExtension.d.ts",
         "development": "./dist/LexicalTreeViewExtension.dev.mjs",
         "production": "./dist/LexicalTreeViewExtension.prod.mjs",
@@ -1449,6 +1628,7 @@
         "default": "./dist/LexicalTreeViewExtension.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/TreeViewExtension.d.ts",
         "development": "./dist/LexicalTreeViewExtension.dev.js",
         "production": "./dist/LexicalTreeViewExtension.prod.js",
@@ -1458,6 +1638,7 @@
     "./useExtensionComponent": {
       "source": "./src/useExtensionComponent.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useExtensionComponent.d.ts",
         "development": "./dist/useLexicalExtensionComponent.dev.mjs",
         "production": "./dist/useLexicalExtensionComponent.prod.mjs",
@@ -1465,6 +1646,7 @@
         "default": "./dist/useLexicalExtensionComponent.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useExtensionComponent.d.ts",
         "development": "./dist/useLexicalExtensionComponent.dev.js",
         "production": "./dist/useLexicalExtensionComponent.prod.js",
@@ -1474,6 +1656,7 @@
     "./useExtensionComponent.js": {
       "source": "./src/useExtensionComponent.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useExtensionComponent.d.ts",
         "development": "./dist/useLexicalExtensionComponent.dev.mjs",
         "production": "./dist/useLexicalExtensionComponent.prod.mjs",
@@ -1481,6 +1664,7 @@
         "default": "./dist/useLexicalExtensionComponent.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useExtensionComponent.d.ts",
         "development": "./dist/useLexicalExtensionComponent.dev.js",
         "production": "./dist/useLexicalExtensionComponent.prod.js",
@@ -1490,6 +1674,7 @@
     "./useExtensionSignalValue": {
       "source": "./src/useExtensionSignalValue.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useExtensionSignalValue.d.ts",
         "development": "./dist/useLexicalExtensionSignalValue.dev.mjs",
         "production": "./dist/useLexicalExtensionSignalValue.prod.mjs",
@@ -1497,6 +1682,7 @@
         "default": "./dist/useLexicalExtensionSignalValue.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useExtensionSignalValue.d.ts",
         "development": "./dist/useLexicalExtensionSignalValue.dev.js",
         "production": "./dist/useLexicalExtensionSignalValue.prod.js",
@@ -1506,6 +1692,7 @@
     "./useExtensionSignalValue.js": {
       "source": "./src/useExtensionSignalValue.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useExtensionSignalValue.d.ts",
         "development": "./dist/useLexicalExtensionSignalValue.dev.mjs",
         "production": "./dist/useLexicalExtensionSignalValue.prod.mjs",
@@ -1513,6 +1700,7 @@
         "default": "./dist/useLexicalExtensionSignalValue.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useExtensionSignalValue.d.ts",
         "development": "./dist/useLexicalExtensionSignalValue.dev.js",
         "production": "./dist/useLexicalExtensionSignalValue.prod.js",
@@ -1522,6 +1710,7 @@
     "./useLexicalEditable": {
       "source": "./src/useLexicalEditable.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalEditable.d.ts",
         "development": "./dist/useLexicalEditable.dev.mjs",
         "production": "./dist/useLexicalEditable.prod.mjs",
@@ -1529,6 +1718,7 @@
         "default": "./dist/useLexicalEditable.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalEditable.d.ts",
         "development": "./dist/useLexicalEditable.dev.js",
         "production": "./dist/useLexicalEditable.prod.js",
@@ -1538,6 +1728,7 @@
     "./useLexicalEditable.js": {
       "source": "./src/useLexicalEditable.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalEditable.d.ts",
         "development": "./dist/useLexicalEditable.dev.mjs",
         "production": "./dist/useLexicalEditable.prod.mjs",
@@ -1545,6 +1736,7 @@
         "default": "./dist/useLexicalEditable.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalEditable.d.ts",
         "development": "./dist/useLexicalEditable.dev.js",
         "production": "./dist/useLexicalEditable.prod.js",
@@ -1554,6 +1746,7 @@
     "./useLexicalIsTextContentEmpty": {
       "source": "./src/useLexicalIsTextContentEmpty.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalIsTextContentEmpty.d.ts",
         "development": "./dist/useLexicalIsTextContentEmpty.dev.mjs",
         "production": "./dist/useLexicalIsTextContentEmpty.prod.mjs",
@@ -1561,6 +1754,7 @@
         "default": "./dist/useLexicalIsTextContentEmpty.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalIsTextContentEmpty.d.ts",
         "development": "./dist/useLexicalIsTextContentEmpty.dev.js",
         "production": "./dist/useLexicalIsTextContentEmpty.prod.js",
@@ -1570,6 +1764,7 @@
     "./useLexicalIsTextContentEmpty.js": {
       "source": "./src/useLexicalIsTextContentEmpty.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalIsTextContentEmpty.d.ts",
         "development": "./dist/useLexicalIsTextContentEmpty.dev.mjs",
         "production": "./dist/useLexicalIsTextContentEmpty.prod.mjs",
@@ -1577,6 +1772,7 @@
         "default": "./dist/useLexicalIsTextContentEmpty.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalIsTextContentEmpty.d.ts",
         "development": "./dist/useLexicalIsTextContentEmpty.dev.js",
         "production": "./dist/useLexicalIsTextContentEmpty.prod.js",
@@ -1586,6 +1782,7 @@
     "./useLexicalNodeSelection": {
       "source": "./src/useLexicalNodeSelection.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalNodeSelection.d.ts",
         "development": "./dist/useLexicalNodeSelection.dev.mjs",
         "production": "./dist/useLexicalNodeSelection.prod.mjs",
@@ -1593,6 +1790,7 @@
         "default": "./dist/useLexicalNodeSelection.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalNodeSelection.d.ts",
         "development": "./dist/useLexicalNodeSelection.dev.js",
         "production": "./dist/useLexicalNodeSelection.prod.js",
@@ -1602,6 +1800,7 @@
     "./useLexicalNodeSelection.js": {
       "source": "./src/useLexicalNodeSelection.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalNodeSelection.d.ts",
         "development": "./dist/useLexicalNodeSelection.dev.mjs",
         "production": "./dist/useLexicalNodeSelection.prod.mjs",
@@ -1609,6 +1808,7 @@
         "default": "./dist/useLexicalNodeSelection.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalNodeSelection.d.ts",
         "development": "./dist/useLexicalNodeSelection.dev.js",
         "production": "./dist/useLexicalNodeSelection.prod.js",
@@ -1618,6 +1818,7 @@
     "./useLexicalSubscription": {
       "source": "./src/useLexicalSubscription.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalSubscription.d.ts",
         "development": "./dist/useLexicalSubscription.dev.mjs",
         "production": "./dist/useLexicalSubscription.prod.mjs",
@@ -1625,6 +1826,7 @@
         "default": "./dist/useLexicalSubscription.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalSubscription.d.ts",
         "development": "./dist/useLexicalSubscription.dev.js",
         "production": "./dist/useLexicalSubscription.prod.js",
@@ -1634,6 +1836,7 @@
     "./useLexicalSubscription.js": {
       "source": "./src/useLexicalSubscription.tsx",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalSubscription.d.ts",
         "development": "./dist/useLexicalSubscription.dev.mjs",
         "production": "./dist/useLexicalSubscription.prod.mjs",
@@ -1641,6 +1844,7 @@
         "default": "./dist/useLexicalSubscription.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalSubscription.d.ts",
         "development": "./dist/useLexicalSubscription.dev.js",
         "production": "./dist/useLexicalSubscription.prod.js",
@@ -1650,6 +1854,7 @@
     "./useLexicalTextEntity": {
       "source": "./src/useLexicalTextEntity.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalTextEntity.d.ts",
         "development": "./dist/useLexicalTextEntity.dev.mjs",
         "production": "./dist/useLexicalTextEntity.prod.mjs",
@@ -1657,6 +1862,7 @@
         "default": "./dist/useLexicalTextEntity.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalTextEntity.d.ts",
         "development": "./dist/useLexicalTextEntity.dev.js",
         "production": "./dist/useLexicalTextEntity.prod.js",
@@ -1666,6 +1872,7 @@
     "./useLexicalTextEntity.js": {
       "source": "./src/useLexicalTextEntity.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalTextEntity.d.ts",
         "development": "./dist/useLexicalTextEntity.dev.mjs",
         "production": "./dist/useLexicalTextEntity.prod.mjs",
@@ -1673,6 +1880,7 @@
         "default": "./dist/useLexicalTextEntity.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/useLexicalTextEntity.d.ts",
         "development": "./dist/useLexicalTextEntity.dev.js",
         "production": "./dist/useLexicalTextEntity.prod.js",
@@ -1697,5 +1905,13 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "types": "./dist/typescript-too-old.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  }
 }

--- a/packages/lexical-rich-text/package.json
+++ b/packages/lexical-rich-text/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalRichText.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -21,6 +21,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalRichText.dev.mjs",
         "production": "./dist/LexicalRichText.prod.mjs",
@@ -28,6 +29,7 @@
         "default": "./dist/LexicalRichText.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalRichText.dev.js",
         "production": "./dist/LexicalRichText.prod.js",
@@ -56,5 +58,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-selection/package.json
+++ b/packages/lexical-selection/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalSelection.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -23,6 +23,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalSelection.dev.mjs",
         "production": "./dist/LexicalSelection.prod.mjs",
@@ -30,6 +31,7 @@
         "default": "./dist/LexicalSelection.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalSelection.dev.js",
         "production": "./dist/LexicalSelection.prod.js",
@@ -53,5 +55,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-table/package.json
+++ b/packages/lexical-table/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalTable.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/clipboard": "workspace:*",
     "@lexical/extension": "workspace:*",
@@ -30,6 +30,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalTable.dev.mjs",
         "production": "./dist/LexicalTable.prod.mjs",
@@ -37,6 +38,7 @@
         "default": "./dist/LexicalTable.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalTable.dev.js",
         "production": "./dist/LexicalTable.prod.js",
@@ -56,5 +58,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-tailwind/package.json
+++ b/packages/lexical-tailwind/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/lexical-tailwind"
   },
   "main": "./dist/LexicalTailwind.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "bugs": {
     "url": "https://github.com/facebook/lexical/issues"
   },
@@ -36,6 +36,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalTailwind.dev.mjs",
         "production": "./dist/LexicalTailwind.prod.mjs",
@@ -43,6 +44,7 @@
         "default": "./dist/LexicalTailwind.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalTailwind.dev.js",
         "production": "./dist/LexicalTailwind.prod.js",
@@ -62,5 +64,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-text/package.json
+++ b/packages/lexical-text/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalText.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -23,6 +23,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalText.dev.mjs",
         "production": "./dist/LexicalText.prod.mjs",
@@ -30,6 +31,7 @@
         "default": "./dist/LexicalText.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalText.dev.js",
         "production": "./dist/LexicalText.prod.js",
@@ -53,5 +55,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-utils/package.json
+++ b/packages/lexical-utils/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalUtils.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/internal": "workspace:*",
     "@lexical/selection": "workspace:*",
@@ -27,6 +27,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalUtils.dev.mjs",
         "production": "./dist/LexicalUtils.prod.mjs",
@@ -34,6 +35,7 @@
         "default": "./dist/LexicalUtils.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalUtils.dev.js",
         "production": "./dist/LexicalUtils.prod.js",
@@ -53,5 +55,20 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical-yjs/package.json
+++ b/packages/lexical-yjs/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/LexicalYjs.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/internal": "workspace:*",
     "@lexical/selection": "workspace:*",
@@ -23,6 +23,7 @@
     "yjs": "^13.6.31"
   },
   "peerDependencies": {
+    "typescript": ">=5.2",
     "yjs": ">=13.5.22"
   },
   "repository": {
@@ -36,6 +37,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalYjs.dev.mjs",
         "production": "./dist/LexicalYjs.prod.mjs",
@@ -43,6 +45,7 @@
         "default": "./dist/LexicalYjs.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/LexicalYjs.dev.js",
         "production": "./dist/LexicalYjs.prod.js",
@@ -62,5 +65,17 @@
     "!src/**/*.bench.tsx",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/lexical/package.json
+++ b/packages/lexical/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "version": "0.45.0",
   "main": "./dist/Lexical.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/typescript-too-old.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/lexical.git",
@@ -23,6 +23,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/Lexical.dev.mjs",
         "production": "./dist/Lexical.prod.mjs",
@@ -30,6 +31,7 @@
         "default": "./dist/Lexical.mjs"
       },
       "require": {
+        "types@<5.2": "./dist/typescript-too-old.d.ts",
         "types": "./dist/index.d.ts",
         "development": "./dist/Lexical.dev.js",
         "production": "./dist/Lexical.prod.js",
@@ -52,5 +54,20 @@
   ],
   "dependencies": {
     "@lexical/internal": "workspace:*"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/typescript-too-old.d.ts"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       '@lexical/internal':
         specifier: workspace:*
         version: link:../lexical-internal
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-clipboard:
     dependencies:
@@ -484,6 +487,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-code:
     dependencies:
@@ -499,6 +505,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-code-core:
     dependencies:
@@ -514,6 +523,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-code-prism:
     dependencies:
@@ -529,6 +541,9 @@ importers:
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
     devDependencies:
       '@types/prismjs':
         specifier: ^1.26.6
@@ -560,6 +575,9 @@ importers:
       shiki:
         specifier: ^4.2.0
         version: 4.2.0
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
     devDependencies:
       '@shikijs/types':
         specifier: ^4.2.0
@@ -658,6 +676,9 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-dragon:
     dependencies:
@@ -667,12 +688,18 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-eslint-plugin:
     dependencies:
       eslint:
         specifier: '>=7.31.0'
         version: 10.3.0(jiti@2.7.0)
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
     devDependencies:
       '@types/eslint':
         specifier: ^9.6.1
@@ -701,12 +728,18 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-file:
     dependencies:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-hashtag:
     dependencies:
@@ -719,6 +752,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-headless:
     dependencies:
@@ -731,6 +767,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-history:
     dependencies:
@@ -743,6 +782,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-html:
     dependencies:
@@ -761,8 +803,15 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
-  packages/lexical-internal: {}
+  packages/lexical-internal:
+    dependencies:
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-link:
     dependencies:
@@ -781,6 +830,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-list:
     dependencies:
@@ -799,6 +851,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-mark:
     dependencies:
@@ -808,6 +863,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-markdown:
     dependencies:
@@ -838,6 +896,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-offset:
     dependencies:
@@ -847,12 +908,18 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-overflow:
     dependencies:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-plain-text:
     dependencies:
@@ -874,6 +941,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-playground:
     dependencies:
@@ -1100,6 +1170,9 @@ importers:
       react-error-boundary:
         specifier: ^6.1.1
         version: 6.1.1(react@19.2.5)
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
       yjs:
         specifier: ^13.6.31
         version: 13.6.31
@@ -1134,6 +1207,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-selection:
     dependencies:
@@ -1143,6 +1219,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-table:
     dependencies:
@@ -1164,6 +1243,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-tailwind:
     dependencies:
@@ -1173,6 +1255,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
     devDependencies:
       '@tailwindcss/cli':
         specifier: ^4.3.0
@@ -1192,6 +1277,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-utils:
     dependencies:
@@ -1204,6 +1292,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
 
   packages/lexical-website:
     dependencies:
@@ -1352,6 +1443,9 @@ importers:
       lexical:
         specifier: workspace:*
         version: link:../lexical
+      typescript:
+        specifier: '>=5.2'
+        version: 6.0.3
     devDependencies:
       yjs:
         specifier: ^13.6.31
@@ -18106,7 +18200,7 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.2.15
+      '@types/react': 19.2.16
 
   '@types/react@19.2.14':
     dependencies:

--- a/scripts/__tests__/unit/build.test.ts
+++ b/scripts/__tests__/unit/build.test.ts
@@ -12,6 +12,12 @@ import * as path from 'node:path';
 import {describe, expect, it, test} from 'vitest';
 
 import {packagesManager} from '../../shared/packagesManager';
+import {
+  MIN_TYPESCRIPT_VERSION,
+  tooOldStubPath,
+  tooOldTypesVersions,
+  TYPESCRIPT_TOO_OLD_CONDITION,
+} from '../../shared/typescriptTooOld';
 import npmToWwwName from '../../www/npmToWwwName';
 
 const monorepoPackageJson = (
@@ -81,6 +87,50 @@ describe('public package.json audits (`pnpm run update-packages` to fix most iss
           );
         },
       );
+      describe('TypeScript "too old" guard (clear error for stale TypeScript)', () => {
+        const tombstone = tooOldStubPath('dist');
+        it('points the legacy "types" field at the stub', () => {
+          // Only consumers that cannot read "exports" resolve "types", so the
+          // stub is what an old/classic-resolution TypeScript sees.
+          expect(packageJson.types).toBe(tombstone);
+        });
+        it('redirects the root and every subpath via "typesVersions"', () => {
+          expect(packageJson.typesVersions).toEqual(
+            tooOldTypesVersions('dist'),
+          );
+        });
+        const exportsEntries = Object.entries(
+          packageJson.exports as Record<
+            string,
+            Record<string, Record<string, string>>
+          >,
+        );
+        test.each(exportsEntries)(
+          'exports["%s"] redirects sub-minimum TypeScript before the "types" condition',
+          (_subpath, entry) => {
+            for (const group of [entry.import, entry.require]) {
+              if (!group) {
+                continue;
+              }
+              const keys = Object.keys(group);
+              expect(group[TYPESCRIPT_TOO_OLD_CONDITION]).toBe(tombstone);
+              // The versioned condition must sit immediately before plain
+              // `types` so it wins for the (old) versions it matches.
+              expect(keys.indexOf(TYPESCRIPT_TOO_OLD_CONDITION)).toBe(
+                keys.indexOf('types') - 1,
+              );
+            }
+          },
+        );
+        it('declares an optional typescript peer dependency at the minimum version', () => {
+          expect(packageJson.peerDependencies?.typescript).toBe(
+            `>=${MIN_TYPESCRIPT_VERSION}`,
+          );
+          expect(packageJson.peerDependenciesMeta?.typescript).toEqual({
+            optional: true,
+          });
+        });
+      });
       if (!sourceFiles.includes('index')) {
         it('must not export a top-level module without an index.tsx?', () => {
           expect(exportedModules).not.toContain(npmName);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -23,6 +23,10 @@ import {rollup} from 'rollup';
 import transformErrorMessages from './error-codes/transform-error-messages.mjs';
 import {exec} from './shared/childProcess.mjs';
 import {packagesManager} from './shared/packagesManager.mjs';
+import {
+  getTypeScriptTooOldStub,
+  TYPESCRIPT_TOO_OLD_BASENAME,
+} from './shared/typescriptTooOld.mjs';
 import npmToWwwName from './www/npmToWwwName.mjs';
 
 const __dirname = import.meta.dirname;
@@ -547,6 +551,22 @@ function copyFlowStubsIntoDist(pkg, outputPath) {
   }
 }
 
+/**
+ * Emit the "TypeScript too old" stub declaration into the build output. The
+ * package.json `types`, `typesVersions`, and `types@<min>` export condition
+ * (set by scripts/updateVersion.mjs) all point at this file so a consumer
+ * whose TypeScript cannot read the package.json "exports" map gets a clear
+ * upgrade message instead of a misleading "Cannot find module".
+ *
+ * @param {string} outputPath
+ */
+function writeTypeScriptTooOldStub(outputPath) {
+  fs.writeFileSync(
+    path.resolve(outputPath, TYPESCRIPT_TOO_OLD_BASENAME),
+    getTypeScriptTooOldStub(),
+  );
+}
+
 async function buildAll() {
   // Always emit .d.ts for npm builds so a `pnpm link` consumer gets types
   // out of the box. Skip for www (it consumes Flow stubs instead).
@@ -626,6 +646,7 @@ async function buildAll() {
 
     if (!isWWW) {
       moveTSDeclarationFilesIntoDist(packageName, outputPath);
+      writeTypeScriptTooOldStub(outputPath);
       copyFlowStubsIntoDist(pkg, outputPath);
     }
   }

--- a/scripts/shared/typescriptTooOld.mjs
+++ b/scripts/shared/typescriptTooOld.mjs
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Lexical publishes its TypeScript declarations exclusively through the
+ * package.json "exports" map. A consumer can only read types from "exports"
+ * with TypeScript >= 5.0 and `moduleResolution` set to "bundler", "node16",
+ * or "nodenext". A consumer using classic `moduleResolution` (or an old
+ * TypeScript) ignores "exports" entirely, so every subpath import (e.g.
+ * `@lexical/react/ReactExtension`) resolves to nothing and reports a
+ * misleading `TS2307: Cannot find module ... or its corresponding type
+ * declarations`, which looks like a missing install.
+ *
+ * To turn that into a clear, actionable error we point the *legacy*
+ * type-resolution fields (`types`, `typesVersions`, and a `types@<MIN>`
+ * "exports" condition) at the stub declaration file described here. Modern
+ * resolvers never see the stub because "exports" takes priority over `types`
+ * and `typesVersions` (TypeScript >= 4.9); only the consumers we want to fail
+ * resolve it.
+ */
+
+/**
+ * The minimum TypeScript version that can consume Lexical's published types.
+ *
+ * Empirically (checking the built `.d.ts` against TypeScript 4.4 - 5.4):
+ * - `< 4.7` cannot read types from "exports" at all (no node16/nodenext).
+ * - `>= 4.7` works with `moduleResolution` node16/nodenext when the consumer
+ *   uses `skipLibCheck`.
+ * - `moduleResolution: bundler` requires `>= 5.0`.
+ * - `skipLibCheck: false` requires `>= 5.2`, because the public
+ *   `LexicalEditorWithDispose` interface extends the global `Disposable`
+ *   type, which only exists in the TypeScript 5.2 lib.
+ *
+ * 5.2 is therefore the lowest version that works across every supported
+ * consumer configuration.
+ */
+export const MIN_TYPESCRIPT_VERSION = '5.2';
+
+/**
+ * Basename of the stub `.d.ts` emitted into every public package's dist.
+ */
+export const TYPESCRIPT_TOO_OLD_BASENAME = 'typescript-too-old.d.ts';
+
+/**
+ * The "exports" condition key that redirects consumers which *do* read
+ * "exports" but are below {@link MIN_TYPESCRIPT_VERSION} (TypeScript 4.9 up to
+ * but not including the minimum) to the stub. Must be ordered before the plain
+ * `types` condition so it wins when it matches.
+ */
+export const TYPESCRIPT_TOO_OLD_CONDITION = `types@<${MIN_TYPESCRIPT_VERSION}`;
+
+/**
+ * The dist-relative path to the stub for a given dist directory name.
+ *
+ * @param {string} distDir
+ * @returns {string}
+ */
+export function tooOldStubPath(distDir) {
+  return `./${distDir}/${TYPESCRIPT_TOO_OLD_BASENAME}`;
+}
+
+/**
+ * The `typesVersions` value that redirects the package root and every subpath
+ * to the stub for any TypeScript that consults `typesVersions` — i.e. any
+ * TypeScript that is not resolving types through "exports" (classic
+ * `moduleResolution`, at any version). The `"*"` version range is used (rather
+ * than `"<5.0"`) so that even a modern TypeScript misconfigured with classic
+ * `moduleResolution` gets the message instead of "Cannot find module".
+ *
+ * @param {string} distDir
+ * @returns {Record<string, Record<string, string[]>>}
+ */
+export function tooOldTypesVersions(distDir) {
+  return {'*': {'*': [tooOldStubPath(distDir)]}};
+}
+
+/**
+ * Contents of the stub `.d.ts`. The leading comment is the breadcrumb a
+ * consumer sees when they jump to the resolved declaration; the unresolved
+ * side-effect import surfaces the same guidance as a diagnostic for consumers
+ * that are not using `skipLibCheck`.
+ *
+ * @returns {string}
+ */
+export function getTypeScriptTooOldStub() {
+  return `/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// You are seeing this declaration file because your TypeScript cannot read
+// Lexical's types through the package.json "exports" field.
+//
+// Lexical requires TypeScript >= ${MIN_TYPESCRIPT_VERSION} with "moduleResolution" set to
+// "bundler", "node16", or "nodenext". To fix this:
+//   1. Upgrade TypeScript to >= ${MIN_TYPESCRIPT_VERSION}.
+//   2. In tsconfig.json set "moduleResolution" to "bundler" (recommended for
+//      apps/bundlers) or "node16" / "nodenext", and a matching "module".
+import 'Lexical requires TypeScript >=${MIN_TYPESCRIPT_VERSION} with moduleResolution bundler, node16, or nodenext';
+export {};
+`;
+}

--- a/scripts/updateVersion.mjs
+++ b/scripts/updateVersion.mjs
@@ -14,6 +14,12 @@ import prettier from 'prettier';
 import {PackageMetadata} from './shared/PackageMetadata.mjs';
 import {packagesManager} from './shared/packagesManager.mjs';
 import readMonorepoPackageJson from './shared/readMonorepoPackageJson.mjs';
+import {
+  MIN_TYPESCRIPT_VERSION,
+  tooOldStubPath,
+  tooOldTypesVersions,
+  TYPESCRIPT_TOO_OLD_CONDITION,
+} from './shared/typescriptTooOld.mjs';
 import npmToWwwName from './www/npmToWwwName.mjs';
 
 const monorepoPackageJson = readMonorepoPackageJson();
@@ -178,16 +184,22 @@ function exportEntry(
   // last per #5731. Keys are in descending priority order.
   const prefix = `./${DIST_DIR}/${basename}`;
   const types = `./${DIST_DIR}/${typesBasename}`;
+  // Redirect consumers that read "exports" but are below the minimum supported
+  // TypeScript version (TypeScript 4.9 understands `types@`, up to but not
+  // including the minimum) to the "too old" stub. Must precede `types`.
+  const tooOld = tooOldStubPath(DIST_DIR);
   return {
     /* eslint-disable sort-keys-fix/sort-keys-fix */
     ...(sourceRelPath ? {source: `./${sourceRelPath}`} : null),
     import: {
+      [TYPESCRIPT_TOO_OLD_CONDITION]: tooOld,
       types,
       ...withEnvironments(`${prefix}.mjs`),
       node: `${prefix}.node.mjs`,
       default: `${prefix}.mjs`,
     },
     require: {
+      [TYPESCRIPT_TOO_OLD_CONDITION]: tooOld,
       types,
       ...withEnvironments(`${prefix}.js`),
       default: `${prefix}.js`,
@@ -207,7 +219,9 @@ function withBrowser(exports) {
     Object.entries(exports.import).flatMap(([k, v]) => {
       if (k === 'node') {
         return [];
-      } else if (k === 'types') {
+      } else if (k === 'types' || k.startsWith('types@')) {
+        // `types` and the versioned `types@<min>` condition point at .d.ts
+        // files, never a browser bundle; pass them through unchanged.
         return [[k, v]];
       }
       return [[k, v.replace(/((?:\.dev|\.prod)?\.m?js)$/, '.browser$1')]];
@@ -308,18 +322,19 @@ function updatePublicPackage(pkg) {
   // If there's a main we expect a single entry point
   if (packageJson.main) {
     const mainBase = stripDistPrefix(packageJson.main);
-    const typesBase = packageJson.types
-      ? stripDistPrefix(packageJson.types)
-      : undefined;
     packageJson.main = `./${DIST_DIR}/${mainBase}`;
     packageJson.module = `./${DIST_DIR}/${replaceExtension(mainBase, '.mjs')}`;
-    if (typesBase) {
-      packageJson.types = `./${DIST_DIR}/${typesBase}`;
-    }
     const sourceRelPath = findMainSourceRelPath(
       pkg,
       replaceExtension(mainBase, ''),
     );
+    // Derive the declaration basename from the entry source (the build emits
+    // e.g. src/index.ts -> dist/index.d.ts) rather than from the existing
+    // `types` field: `types` is rewritten to the "too old" stub below, so
+    // reading it here would corrupt the real types on a second run.
+    const typesBase = sourceRelPath
+      ? `${path.basename(sourceRelPath).replace(/\.(tsx?|js)$/, '')}.d.ts`
+      : 'index.d.ts';
     packageJson.exports = {
       '.': exportEntry(
         replaceExtension(mainBase, ''),
@@ -358,6 +373,28 @@ function updatePublicPackage(pkg) {
     }
     packageJson.exports = exports;
   }
+  // Tombstone the legacy type-resolution fields. A consumer whose TypeScript
+  // cannot read "exports" (classic moduleResolution, at any version) resolves
+  // `types` for the package root and `typesVersions` for every subpath; point
+  // both at the "too old" stub so they get a clear upgrade message instead of
+  // a misleading "Cannot find module". Modern resolvers ignore both fields
+  // because "exports" takes priority over them (TypeScript >= 4.9).
+  packageJson.types = tooOldStubPath(DIST_DIR);
+  packageJson.typesVersions = tooOldTypesVersions(DIST_DIR);
+  // Advise (but do not require) a supported TypeScript at install time. npm and
+  // pnpm surface a peer-dependency warning when an out-of-range `typescript` is
+  // present; `optional` keeps it from being installed or hard-required for
+  // consumers that don't use TypeScript. This complements the type-check-time
+  // guard above with an earlier, install-time signal.
+  packageJson.peerDependencies = {
+    ...packageJson.peerDependencies,
+    typescript: `>=${MIN_TYPESCRIPT_VERSION}`,
+  };
+  packageJson.peerDependenciesMeta = {
+    ...packageJson.peerDependenciesMeta,
+    typescript: {optional: true},
+  };
+  pkg.sortDependencies('peerDependencies');
   // Whitelist what ships to npm. The package root is the publish root, so
   // we no longer need a separate `npm/` copy step.
   packageJson.files = [...PUBLIC_FILES_FIELD];


### PR DESCRIPTION
## Description

Lexical publishes its TypeScript declarations exclusively through the package.json `"exports"` map. A consumer using classic `moduleResolution` (or TypeScript older than 4.7) ignores `"exports"` entirely, so every subpath import — e.g. `@lexical/react/ReactExtension` — resolves to nothing and reports:

```
TS2307: Cannot find module '@lexical/react/ReactExtension' or its corresponding type declarations.
```

That phrasing looks like a missing install, so it sends people down the wrong path (reinstalling, checking dependencies) instead of fixing the real cause: their TypeScript is too old or misconfigured.

This points the **legacy** type-resolution fields at a generated "too old" stub so those consumers get an actionable upgrade message instead. It's safe because, since TypeScript 4.9, `"exports"` takes priority over `types`/`typesVersions` — so modern resolvers never see the stub, and only the consumers we want to fail resolve it.

Generated by `scripts/updateVersion.mjs` for every public package:

- **`types` + `typesVersions`** (`"*": { "*": [stub] }`) redirect the package root **and every subpath** for any TypeScript that consults them (i.e. any TypeScript not resolving types through `"exports"`, at any version).
- **`types@<5.2`**, ordered immediately before `types` in each exports entry, redirects consumers that *do* read `"exports"` but are below the minimum supported version (TypeScript 4.9+ understands the `types@` selector).
- An **optional `typescript` peer dependency** (`">=5.2"`, `peerDependenciesMeta.typescript.optional`) so npm/pnpm emit an install-time warning for an out-of-range TypeScript, complementing the type-check-time guard.

The stub (`dist/typescript-too-old.d.ts`) is emitted by `scripts/build.mjs`; it carries an explanatory comment plus a deliberate diagnostic.

**Why 5.2?** It's the empirically measured lower bound across consumer configurations:

| Consumer config | Minimum TypeScript |
| --- | --- |
| classic `moduleResolution: node` | never (cannot read `"exports"`) |
| `node16`/`nodenext` + `skipLibCheck: true` | 4.7 |
| `moduleResolution: bundler` | 5.0 |
| any resolution + `skipLibCheck: false` | **5.2** |

The `skipLibCheck: false` floor is 5.2 because the public `LexicalEditorWithDispose` interface extends the global `Disposable` type, which only exists in the TypeScript 5.2 lib. 5.2 is therefore the lowest version that works in every supported configuration.

This also fixes a latent idempotency bug surfaced by the change: the single-entry exports branch derived the declaration basename from `packageJson.types`, which the stub now overwrites — so a second `update-version` run pointed the real `types` condition at the stub. It now derives the basename from the entry source instead, and the generator is idempotent from a clean checkout.

## Test plan

Validated on TypeScript 4.4 – 6.0 against the real built packages, plus new per-package audits in `scripts/__tests__/unit/build.test.ts`.

### Before

A classic-resolution consumer (TypeScript 4.4, or any version with `moduleResolution: node`) importing a subpath:

```
TS2307: Cannot find module '@lexical/react/ReactExtension' or its corresponding type declarations.
```

### After

- **Classic resolution / TypeScript < 5.2:** the import resolves to `dist/typescript-too-old.d.ts` (no more "Cannot find module"); the file documents the fix, and `skipLibCheck: false` consumers also see `Lexical requires TypeScript >=5.2 with moduleResolution bundler, node16, or nodenext`.
- **Modern resolution at/above the floor:** real types resolve unchanged.

```
TS 4.9  (node16)   => guard fires (redirected to stub)
TS 5.1  (bundler)  => guard fires (redirected to stub)
TS 5.2  (bundler)  => OK: real types resolve
TS 5.4  (bundler)  => OK: real types resolve
TS 6.0  (node16/nodenext/bundler) => OK: real types resolve, tombstone ignored
```

- `pnpm exec vitest --project scripts-unit` — 860 passing (includes new guard + peer-dep audits across all public packages)
- `pnpm run tsc-scripts` — clean
- `node ./scripts/updateVersion.mjs` is idempotent from a clean checkout (identical output on repeated runs)