### PR TITLE
[lexical] Bug Fix: use devInvariant for update recursion guard to avoid reporting a recovered condition as an uncaught error

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -878,17 +878,16 @@ function $triggerEnqueuedUpdates(editor: LexicalEditor): void {
   if (editor._cascadeCount++ > 99) {
     editor._updates = [];
     editor._cascadeCount = 0;
-    try {
-      invariant(
-        false,
-        'One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition. Editor namespace: %s',
-        editor._config.namespace,
-      );
-    } catch (error) {
-      if (error instanceof Error) {
-        editor._onError(error);
-      }
-    }
+    // The cascade has already been broken above by clearing the update queue,
+    // so this is a recoverable internal guard rather than a fatal error. Use
+    // devInvariant so it throws loudly in development but only warns in
+    // production, instead of routing a recovered condition through _onError
+    // (typically console.error) and reporting it as an uncaught error.
+    devInvariant(
+      false,
+      'One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition. Editor namespace: %s',
+      editor._config.namespace,
+    );
     return;
   }
   const queuedUpdate = queuedUpdates.shift();

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1203,23 +1203,39 @@ describe('LexicalEditor tests', () => {
 
     expect(errorListener).toHaveBeenCalledTimes(0);
 
-    editor.update(() => {
-      $getRoot().markDirty();
-    });
+    // The recursion guard uses devInvariant: in development (and tests) it
+    // throws once the cascade limit is exceeded, while in production it only
+    // warns via console (so a recovered condition is no longer reported as an
+    // uncaught error via _onError). The cascade is broken (the update queue is
+    // cleared) before the guard signals, so the throw surfaces from the
+    // scheduled microtask rather than synchronously from editor.update().
+    const caught: Error[] = [];
+    const onUnhandled = (reason: unknown) => {
+      caught.push(reason instanceof Error ? reason : new Error(String(reason)));
+    };
+    process.on('unhandledRejection', onUnhandled);
+    process.on('uncaughtException', onUnhandled);
 
-    // drain the microtask chain produced by the cascade
-    for (let i = 0; i < 200 && errorListener.mock.calls.length === 0; i++) {
-      await Promise.resolve();
+    try {
+      editor.update(() => {
+        $getRoot().markDirty();
+      });
+
+      // drain the microtask chain produced by the cascade
+      for (let i = 0; i < 200 && caught.length === 0; i++) {
+        await Promise.resolve();
+      }
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      process.off('uncaughtException', onUnhandled);
     }
 
-    expect(errorListener).toHaveBeenCalledTimes(1);
-    expect(errorListener.mock.calls[0][0].message).toMatch(
-      /endlessly enqueueing/,
-    );
+    expect(caught).toHaveLength(1);
+    expect(caught[0].message).toMatch(/endlessly enqueueing/);
     // The error message should include the editor's namespace so the loop can
     // be attributed to a specific product/editor in error aggregation, even
     // when the production stack is minified to core frames.
-    expect(errorListener.mock.calls[0][0].message).toContain(
+    expect(caught[0].message).toContain(
       `Editor namespace: ${editor._config.namespace}`,
     );
 
@@ -1236,7 +1252,9 @@ describe('LexicalEditor tests', () => {
     for (let i = 0; i < 10; i++) {
       await Promise.resolve();
     }
-    expect(errorListener).toHaveBeenCalledTimes(1);
+    // The guard no longer routes through editor._onError — it surfaces via
+    // devInvariant (throw in dev / warn in prod) instead.
+    expect(errorListener).toHaveBeenCalledTimes(0);
   });
 
   it('Should be able to update an editor state without a root element', () => {


### PR DESCRIPTION
## Description

#8542 added a guard in `$triggerEnqueuedUpdates` that detects when update listeners endlessly enqueue more updates (infinite recursion). The guard breaks the cascade by clearing the update queue, then signaled the condition by throwing an `invariant` inside a `try/catch` and routing the error to `editor._onError`.

The problem: `editor._onError` defaults to `console.error` (and in many products is wired to error reporting). Because the recursion guard is a *recoverable, self-healing* internal condition — the cascade is already broken before it signals — routing it through `_onError` reports an already-handled, non-fatal event as an uncaught error.

This mirrors #8617, which downgraded the `$assumeActiveEditor` precondition from `invariant` to `devInvariant` for the same reason: throw loudly in development, warn quietly in production.

## What changed

- `packages/lexical/src/LexicalUpdates.ts`: the recursion guard now signals via `devInvariant` instead of `invariant` + `try/catch` + `editor._onError`.
  - **Dev:** throws (loud, visible during development) — same severity as before.
  - **Prod:** `console.warn` only — no longer surfaces as an uncaught error via `_onError`.
  - The cascade is still broken (queue cleared, `_cascadeCount` reset) *before* the signal, so recursion is stopped in both builds. The namespace is preserved in the message (`%s` interpolation) for attribution.
- `packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx`: updated the "Detects infinite recursivity on update listeners" test. Since `devInvariant` no longer routes through `_onError`, the test now captures the unhandled error surfaced from the scheduled microtask, asserts the message + namespace, confirms `_onError` is not invoked, and that the editor recovers after the cascade is cut.

## Reproduction

We attempted to construct a minimal repro of the underlying infinite-update loop (the condition #8542 guards against) but were not able to consistently reproduce it. Notes on why it is hard to trigger:

- **Recoverable, near-invisible symptom.** The guard caps the cascade, drops the batch, and the editor recovers. De-duplicated error reporting logs it about once per page load, so it presents as a single quiet log line plus a brief stutter — not a crash or a flood.
- **Unhelpful stack.** The signal throws in a deferred microtask, so the stack is all minified core frames (the detector) with no application frames pointing at the offending transform.
- **Aggregation hides specifics.** Errors are grouped by editor namespace, lumping multiple surfaces and content shapes into one bucket, and user content in the payload is privacy-stripped, so the literal triggering string isn't recoverable.

Given the difficulty of a deterministic repro, this PR focuses on the severity downgrade so that this recoverable condition no longer reports as an uncaught error in production, while remaining loud in development.

## Test plan

`pnpm test-unit packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx` — all 79 tests pass, including the updated recursion test.
