### PR TITLE
build(deps): bump webpack-dev-server to >=5.2.4 (CVE-2026-6402)

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
       "prettier": "3.8.1",
       "yaml@^1": "^1.10.3",
       "uuid": ">=14.0.0",
+      "webpack-dev-server": ">=5.2.4",
       "onnxruntime-node": "link:./stubs/empty",
       "sharp": "link:./stubs/empty",
       "yjs": "$yjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   prettier: 3.8.1
   yaml@^1: ^1.10.3
   uuid: '>=14.0.0'
+  webpack-dev-server: '>=5.2.4'
   onnxruntime-node: link:./stubs/empty
   sharp: link:./stubs/empty
   yjs: ^13.6.31
@@ -12294,8 +12295,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.3:
-    resolution: {integrity: sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==}
+  webpack-dev-server@5.2.4:
+    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -14421,7 +14422,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(postcss@8.5.15))
+      webpack-dev-server: 5.2.4(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(postcss@8.5.15))
       webpack-merge: 6.0.1
     optionalDependencies:
       '@docusaurus/faster': 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(postcss@8.5.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7)(postcss@8.5.15)
@@ -14492,7 +14493,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.107.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(webpack@5.107.2(esbuild@0.27.7))
+      webpack-dev-server: 5.2.4(webpack@5.107.2(esbuild@0.27.7))
       webpack-merge: 6.0.1
     optionalDependencies:
       '@docusaurus/faster': 3.10.1(@docusaurus/types@3.10.1(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.21)(esbuild@0.27.7)
@@ -14559,7 +14560,7 @@ snapshots:
       browserslist: 4.28.2
       lightningcss: 1.32.0
       semver: 7.7.4
-      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(esbuild@0.27.7))
+      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0))
       tslib: 2.8.1
       webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)
     transitivePeerDependencies:
@@ -18106,7 +18107,7 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.2.15
+      '@types/react': 19.2.16
 
   '@types/react@19.2.14':
     dependencies:
@@ -26008,18 +26009,18 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
+  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)):
+    dependencies:
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)
+    optional: true
+
   swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(postcss@8.5.15)):
     dependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       '@swc/counter': 0.1.3
       webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
-
-  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(esbuild@0.27.7)):
-    dependencies:
-      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
-      '@swc/counter': 0.1.3
-      webpack: 5.107.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
-    optional: true
 
   swr@2.3.8(react@19.2.5):
     dependencies:
@@ -26059,13 +26060,13 @@ snapshots:
       lightningcss: 1.32.0
       postcss: 8.5.15
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(esbuild@0.27.7)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)
     optionalDependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       '@swc/html': 1.15.24
@@ -26798,7 +26799,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.107.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
 
-  webpack-dev-server@5.2.3(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(postcss@8.5.15)):
+  webpack-dev-server@5.2.4(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(postcss@8.5.15)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -26836,7 +26837,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.2.3(webpack@5.107.2(esbuild@0.27.7)):
+  webpack-dev-server@5.2.4(webpack@5.107.2(esbuild@0.27.7)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -26912,7 +26913,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(esbuild@0.27.7))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Remediates GitHub security alert **GHSA-79cf-xcqc-c78w** / **CVE-2026-6402** (medium severity) for `webpack-dev-server`.

- Affected: `webpack-dev-server <= 5.2.3`
- Fixed in: `5.2.4`

`webpack-dev-server` is a **transitive** dependency (pulled in via `@docusaurus/core` in `packages/lexical-website`), so this adds a `pnpm.overrides` entry pinning it to `>=5.2.4` — consistent with the existing security overrides already in `package.json` (`uuid`, `postcss`, etc.) — and regenerates `pnpm-lock.yaml`.

## Changes

- `package.json`: add `"webpack-dev-server": ">=5.2.4"` to `pnpm.overrides`
- `pnpm-lock.yaml`: regenerated — `webpack-dev-server` now resolves to `5.2.4`

## References

- CVE-2026-6402
- GHSA-79cf-xcqc-c78w
- https://github.com/webpack/webpack-dev-server/security/advisories/GHSA-79cf-xcqc-c78w