### PR TITLE
build(deps): bump vitest to ^4.1.8 in examples (CVE-2026-47429)

### DIFF
--- a/examples/agent-example/package.json
+++ b/examples/agent-example/package.json
@@ -36,7 +36,7 @@
     "tailwindcss": "^4.2.1",
     "typescript": "^5.9.2",
     "vite": "^7.3.2",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.8"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.52.0",

--- a/examples/extension-sveltekit-ssr-hydration/package.json
+++ b/examples/extension-sveltekit-ssr-hydration/package.json
@@ -34,7 +34,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tailwindcss/vite": "^4.2.1",
     "@types/node": "^22.19.13",
-    "@vitest/browser": "^3.2.4",
+    "@vitest/browser": "^4.1.8",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.15.0",
@@ -51,7 +51,7 @@
     "typescript-eslint": "^8.56.1",
     "vite": "^7.3.2",
     "vite-plugin-devtools-json": "^1.0.0",
-    "vitest": "^3.2.4",
+    "vitest": "^4.1.8",
     "vitest-browser-svelte": "^0.1.0"
   },
   "optionalDependencies": {

--- a/examples/markdown-editor/package.json
+++ b/examples/markdown-editor/package.json
@@ -34,7 +34,7 @@
     "tailwindcss": "^4.2.1",
     "typescript": "^5.9.2",
     "vite": "^7.3.2",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.8"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.52.0",


### PR DESCRIPTION
## Summary

Remediates GitHub security alert **GHSA-5xrq-8626-4rwp** / **CVE-2026-47429** (critical severity) for `vitest`.

- Affected: `vitest < 4.1.0`
- Fixed in: `4.1.0`

The flagged manifest is `examples/extension-sveltekit-ssr-hydration/package.json`, but two other standalone examples (`agent-example`, `markdown-editor`) pin the same vulnerable `vitest ^3.2.4`, so all three are bumped here. The root workspace already uses `vitest ^4.1.8`; the `examples/**` dirs are excluded from the pnpm workspace and installed independently.

## Changes

- `extension-sveltekit-ssr-hydration`: `vitest` + `@vitest/browser` -> `^4.1.8`
- `agent-example`: `vitest` -> `^4.1.8`
- `markdown-editor`: `vitest` -> `^4.1.8`

## Note / follow-up

`extension-sveltekit-ssr-hydration` also depends on `vitest-browser-svelte@^0.1.0`, whose latest (`2.1.1`) declares peer `vitest@^4.0.0`. That bump is intentionally **left out** of this security-scoped change to keep the diff minimal, and may warrant a follow-up for peer-dependency compatibility.

## References

- CVE-2026-47429
- GHSA-5xrq-8626-4rwp
- https://github.com/vitest-dev/vitest/security/advisories/GHSA-5xrq-8626-4rwp