### PR TITLE
[*] Chore: require all changes to be backwards compatible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,16 @@ This codebase uses **both TypeScript and Flow**:
 
 When adding/modifying APIs, types must be maintained for both systems.
 
+## Backwards Compatibility
+
+**All changes MUST be backwards compatible.** Lexical is a widely-adopted OSS library, and breaking changes ripple out to every downstream consumer.
+
+- Do NOT remove or rename existing public APIs, exported functions, types, or `$` functions. Add new APIs alongside the old ones instead.
+- Do NOT change the signature, return type, or behavior of existing public APIs in ways that could break callers. Prefer additive, optional parameters.
+- Preserve the serialization format of `EditorState` and node JSON. Serialized content produced by older versions must continue to deserialize correctly.
+- If an API genuinely must change, deprecate the old one first (keep it working, document the replacement) rather than removing it outright.
+- When in doubt, assume external code depends on the current behavior and keep it intact.
+
 ## Important Development Notes
 
 ### Reconciliation and Updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Agent Instructions
 
 For detailed architectural guidance, build commands, and development workflows, see **[AGENTS.md](./AGENTS.md)**.
+
+## Backwards Compatibility
+
+**All changes MUST be backwards compatible.** Do not remove or rename existing public APIs, change their signatures/behavior, or break the `EditorState`/node JSON serialization format. Add new APIs alongside old ones and deprecate rather than delete. See the [Backwards Compatibility section in AGENTS.md](./AGENTS.md#backwards-compatibility) for details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,7 @@
-AGENTS.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Agent Instructions
+
+For detailed architectural guidance, build commands, and development workflows, see **[AGENTS.md](./AGENTS.md)**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,1 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Agent Instructions
-
-For detailed architectural guidance, build commands, and development workflows, see **[AGENTS.md](./AGENTS.md)**.
-
-## Backwards Compatibility
-
-**All changes MUST be backwards compatible.** Do not remove or rename existing public APIs, change their signatures/behavior, or break the `EditorState`/node JSON serialization format. Add new APIs alongside old ones and deprecate rather than delete. See the [Backwards Compatibility section in AGENTS.md](./AGENTS.md#backwards-compatibility) for details.
+AGENTS.md


### PR DESCRIPTION
## Description

This PR updates the AI agent guidance docs (`AGENTS.md` and `CLAUDE.md`) to make explicit that **all changes made to the Lexical codebase must be backwards compatible**.

Lexical is a widely-adopted OSS library, so breaking changes ripple out to every downstream consumer. Agents and automated tools working in this repo should know to:

- Not remove or rename existing public APIs, exported functions, types, or `$` functions — add new APIs alongside the old ones.
- Not change the signature, return type, or behavior of existing public APIs in breaking ways — prefer additive, optional parameters.
- Preserve the `EditorState` / node JSON serialization format so older content keeps deserializing.
- Deprecate rather than delete when an API genuinely must change.

### Changes
- `AGENTS.md`: new **Backwards Compatibility** section before "Important Development Notes".
- `CLAUDE.md`: a short pointer to the same rule for Claude Code, linking back to `AGENTS.md`.

Docs-only change — no code or test impact.