### PR TITLE
[lexical][lexical-website] Documentation Update: SKIP_DOM_SELECTION_TAG is ignored during initial editor state

### DIFF
--- a/packages/lexical-website/docs/concepts/selection.md
+++ b/packages/lexical-website/docs/concepts/selection.md
@@ -147,6 +147,24 @@ editor.update(() => {
 });
 ```
 
+`SKIP_DOM_SELECTION_TAG` does not apply to the initial editor state setup
+(`editorState` supplied to `createEditor` or the `$initialEditorState`
+property of the root extension). On first mount the editor still scrolls
+to and focuses the initial selection. To prevent that, call
+`$setSelection(null)` inside your initial state setup function:
+
+```js
+const editor = createEditor({
+  // ...
+  editorState: (editor) => {
+    editor.update(() => {
+      // ... build your initial nodes ...
+      $setSelection(null);
+    });
+  },
+});
+```
+
 If you have to support older versions of Lexical, you can mark the editor
 as not editable during the update or dispatch.
 

--- a/packages/lexical/src/LexicalUpdateTags.ts
+++ b/packages/lexical/src/LexicalUpdateTags.ts
@@ -48,7 +48,12 @@ export const SKIP_SCROLL_INTO_VIEW_TAG = 'skip-scroll-into-view';
 
 /**
  * Indicates that the update should skip updating the DOM selection
- * This is useful when you want to make updates without changing the selection or focus
+ * This is useful when you want to make updates without changing the selection or focus.
+ *
+ * Note: this tag has no effect on the initial editor state setup (e.g. an `editorState`
+ * supplied via `createEditor` or `$initialEditorState`). If you need the editor to not
+ * scroll to or focus the initial selection on first mount, call `$setSelection(null)`
+ * inside your initial state setup function instead.
  */
 export const SKIP_DOM_SELECTION_TAG = 'skip-dom-selection';
 


### PR DESCRIPTION
## Description

`SKIP_DOM_SELECTION_TAG` is intentionally a no-op during the initial editor state (whether passed via `createEditor`'s `editorState` option or `$initialEditorState` on the root extension): tags only propagate through user-driven `editor.update()` calls, and the initial mount runs outside of any such update. That limitation was undocumented, which surfaced as confusion in #8610.

This PR documents it in two places, with no runtime behaviour changes:

- JSDoc next to the `SKIP_DOM_SELECTION_TAG` constant in `packages/lexical/src/LexicalUpdateTags.ts`
- The Focus section of the Selection page on the website (`packages/lexical-website/docs/concepts/selection.md`), including the `$setSelection(null)` workaround for suppressing the initial scroll/focus

Closes #8610
Closes #8951

## Test plan

### Before

- `SKIP_DOM_SELECTION_TAG` JSDoc gave no hint that the initial editor state ignores the tag.
- The website's Focus section described the tag without the initial-mount caveat.

### After

- JSDoc states the tag is ignored during initial editor state setup and points to the workaround.
- Website Focus section explains the limitation and shows the `$setSelection(null)` pattern.

Docs-only change — `pnpm build` is clean across the affected packages, and I read through the rendered JSDoc and the rebuilt website page.
