### PR TITLE
[lexical-playground] Chore: De-flake collab "Undo with collaboration on" e2e test

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
@@ -22,6 +22,7 @@ import {
   assertSelection,
   click,
   focusEditor,
+  freezeCollabUndoGrouping,
   html,
   initialize,
   test,
@@ -44,6 +45,11 @@ test.describe('Collaboration', () => {
     test.skip(!isCollab);
 
     await focusEditor(page);
+    // The two `undo`s below each expect to revert an entire edit group as a unit
+    // (the "hello world again" burst, then the whole checklist). Disable the Yjs
+    // UndoManager's wall-clock capture window so a CI stall can't split a group
+    // across stack items and leave a partial revert — see the helper's doc.
+    await freezeCollabUndoGrouping(page);
     await page.keyboard.type('hello');
     await page.keyboard.press('Enter');
     await page.keyboard.press('Enter');

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -765,6 +765,55 @@ export async function advanceHistoryClock(page, overheadMs = 50) {
   );
 }
 
+/**
+ * Make collaborative undo grouping deterministic by removing the Yjs
+ * `UndoManager`'s wall-clock capture window for the editor under test.
+ *
+ * In collab, `@lexical/history` is disabled in favor of the Yjs `UndoManager`,
+ * which coalesces consecutive local edits into a single undo stack item only
+ * while each lands within `captureTimeout` (500ms by default) of the previous
+ * one, measured with `Date.now()`. Unlike the local-history clock that
+ * {@link advanceHistoryClock} drives, that timer isn't injectable — so under CI
+ * load a stall longer than the window silently splits one logical edit group
+ * across several stack items. A later `undo()` then reverts only the last
+ * fragment, which is the intermittent "expected an empty paragraph, received
+ * leftover typed text / a leftover list item" failure this guards against.
+ *
+ * Setting `captureTimeout` to Infinity drops the time dimension entirely:
+ * grouping is then governed solely by explicit boundaries — `advanceHistoryClock`
+ * (which calls `stopCapturing()`) and the `stopCapturing()` the `UndoManager`
+ * performs automatically after every undo/redo. Both reset `lastChange` to 0 so
+ * the next edit opens a fresh stack item, while everything in between always
+ * coalesces regardless of timing. This makes "type a burst, then undo it as a
+ * unit" reliable without changing any behavior the tests assert: a run that
+ * happened to stay under the 500ms window already grouped the same way.
+ *
+ * No-op outside collab, where `advanceHistoryClock` already drives a
+ * deterministic clock.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+export async function freezeCollabUndoGrouping(page) {
+  if (!IS_COLLAB) {
+    return;
+  }
+  // Collab connects asynchronously, so the UndoManager may not be published the
+  // instant the editor mounts — poll until it is, then disable the capture
+  // window in place. The predicate's mutation is intentional and idempotent: it
+  // returns true (ending the poll) only on the tick it runs.
+  await getPageOrFrame(page).waitForFunction(() => {
+    const editor = document.querySelector(
+      '[data-lexical-editor="true"]',
+    )?.__lexicalEditor;
+    const undoManager = editor?.[Symbol.for('@lexical/yjs/UndoManager')];
+    if (!undoManager) {
+      return false;
+    }
+    undoManager.captureTimeout = Infinity;
+    return true;
+  });
+}
+
 // Fair time for the browser to process a newly inserted image
 export async function sleepInsertImage(count = 1) {
   return await sleep(1000 * count);


### PR DESCRIPTION
## Description

The "Undo with collaboration on" test intermittently failed on webkit (and is racy on all browsers) with a partial undo: e.g. after undoing the "hello world again" burst the middle paragraph still showed "hello world aga", or after undoing the checklist a list item or "a" remained, instead of the expected empty paragraph.

Root cause: in collab, @lexical/history is disabled in favor of the Yjs UndoManager, which coalesces consecutive local edits into one undo stack item only while each lands within captureTimeout (500ms) of the previous, measured with Date.now(). Unlike the local-history clock that advanceHistoryClock drives, that timer is not injectable, so under CI load a stall longer than the window silently splits a single logical edit group across multiple stack items. The test issues one undo() per group and asserts the whole group reverts, so a split leaves a partial revert.

Fix: add freezeCollabUndoGrouping(), which sets the UndoManager's captureTimeout to Infinity for the edited frame. Grouping is then driven solely by explicit boundaries -- advanceHistoryClock's stopCapturing() and the stopCapturing() the UndoManager runs automatically after every undo/redo (both reset lastChange to 0). Edits in between always coalesce regardless of timing, so a burst reverts as a unit. This does not change any asserted behavior: a run that happened to stay under the 500ms window already grouped the same way.

## Test plan

Test changes only