### PR TITLE
[Breaking Changes][lexical] Refactor: Port node classes to the $config() protocol

### DIFF
--- a/examples/node-replacement/src/nodes/CustomParagraphNode.ts
+++ b/examples/node-replacement/src/nodes/CustomParagraphNode.ts
@@ -5,22 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {
-  $applyNodeReplacement,
-  type EditorConfig,
-  ParagraphNode,
-  type SerializedParagraphNode,
-} from 'lexical';
+import {$applyNodeReplacement, type EditorConfig, ParagraphNode} from 'lexical';
 
 export class CustomParagraphNode extends ParagraphNode {
-  static getType() {
-    return 'custom-paragraph';
-  }
-  static clone(node: CustomParagraphNode): CustomParagraphNode {
-    return new CustomParagraphNode(node.__key);
-  }
-  static importJSON(json: SerializedParagraphNode): CustomParagraphNode {
-    return $createCustomParagraphNode().updateFromJSON(json);
+  $config() {
+    return this.config('custom-paragraph', {extends: ParagraphNode});
   }
   createDOM(config: EditorConfig) {
     const el = super.createDOM(config);

--- a/examples/react-rich/src/App.tsx
+++ b/examples/react-rich/src/App.tsx
@@ -82,9 +82,19 @@ const getExtraStyles = (element: HTMLElement): string => {
 const constructImportMap = (): DOMConversionMap => {
   const importMap: DOMConversionMap = {};
 
+  // With the $config() protocol a node's static methods (including importDOM)
+  // are generated on first static access rather than declared up front, so read
+  // getType() to ensure TextNode.importDOM is populated before we wrap its
+  // importers here (this runs before any editor, and therefore registration,
+  // exists).
+  TextNode.getType();
+  const importDOMFn = TextNode.importDOM;
+
   // Wrap all TextNode importers with a function that also imports
   // the custom styles implemented by the playground
-  for (const [tag, fn] of Object.entries(TextNode.importDOM() || {})) {
+  for (const [tag, fn] of Object.entries(
+    importDOMFn ? importDOMFn() || {} : {},
+  )) {
     importMap[tag] = importNode => {
       const importer = fn(importNode);
       if (!importer) {

--- a/examples/vanilla-js-plugin/src/emoji-plugin/EmojiNode.ts
+++ b/examples/vanilla-js-plugin/src/emoji-plugin/EmojiNode.ts
@@ -28,8 +28,8 @@ const BASE_EMOJI_URI = new URL(`@emoji-datasource-facebook/`, import.meta.url)
 export class EmojiNode extends TextNode {
   __unifiedID: string;
 
-  static getType(): string {
-    return 'emoji';
+  $config() {
+    return this.config('emoji', {extends: TextNode});
   }
 
   static clone(node: EmojiNode): EmojiNode {

--- a/packages/lexical-code-core/flow/LexicalCodeCore.js.flow
+++ b/packages/lexical-code-core/flow/LexicalCodeCore.js.flow
@@ -54,9 +54,7 @@ declare export function $isCodeHighlightNode(
 
 declare export class CodeHighlightNode extends TextNode {
   __highlightType: ?string;
-  constructor(text: string, highlightType?: string, key?: NodeKey): void;
-  static getType(): string;
-  static clone(node: CodeHighlightNode): CodeHighlightNode;
+  constructor(text?: string, highlightType?: string, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   setFormat(format: number): this;
 }
@@ -99,9 +97,7 @@ declare export function $isCodeNode(
 
 declare export class CodeNode extends ElementNode {
   __language: string | null | void;
-  static getType(): string;
-  static clone(node: CodeNode): CodeNode;
-  constructor(language: ?string, key?: NodeKey): void;
+  constructor(language?: ?string, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   insertNewAfter(
     selection: RangeSelection,

--- a/packages/lexical-code-core/src/CodeHighlightNode.ts
+++ b/packages/lexical-code-core/src/CodeHighlightNode.ts
@@ -44,16 +44,8 @@ export class CodeHighlightNode extends TextNode {
     this.__highlightType = highlightType;
   }
 
-  static getType(): string {
-    return 'code-highlight';
-  }
-
-  static clone(node: CodeHighlightNode): CodeHighlightNode {
-    return new CodeHighlightNode(
-      node.__text,
-      node.__highlightType || undefined,
-      node.__key,
-    );
+  $config() {
+    return this.config('code-highlight', {extends: TextNode});
   }
 
   afterCloneFrom(prevNode: this): void {
@@ -105,12 +97,6 @@ export class CodeHighlightNode extends TextNode {
       }
     }
     return update;
-  }
-
-  static importJSON(
-    serializedNode: SerializedCodeHighlightNode,
-  ): CodeHighlightNode {
-    return $createCodeHighlightNode().updateFromJSON(serializedNode);
   }
 
   updateFromJSON(

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -21,7 +21,6 @@ import {
   $isTabNode,
   $isTextNode,
   addClassNamesToElement,
-  type DOMConversionMap,
   type DOMConversionOutput,
   type DOMExportOutput,
   type EditorConfig,
@@ -87,15 +86,80 @@ export class CodeNode extends ElementNode {
   /** @internal */
   __isSyntaxHighlightSupported: boolean;
 
-  static getType(): string {
-    return 'code';
+  $config() {
+    return this.config('code', {
+      extends: ElementNode,
+      importDOM: {
+        // Typically <pre> is used for code blocks, and <code> for inline code styles
+        // but if it's a multi line <code> we'll create a block. Pass through to
+        // inline format handled by TextNode otherwise.
+        code: (node: Node) => {
+          const isMultiLine =
+            node.textContent != null &&
+            (/\r?\n/.test(node.textContent) || hasChildDOMNodeTag(node, 'BR'));
+
+          return isMultiLine
+            ? {
+                conversion: $convertPreElement,
+                priority: 1,
+              }
+            : null;
+        },
+        div: () => ({
+          conversion: $convertDivElement,
+          priority: 1,
+        }),
+        pre: () => ({
+          conversion: $convertPreElement,
+          priority: 0,
+        }),
+        table: (node: Node) => {
+          const table = node;
+          // domNode is a <table> since we matched it by nodeName
+          if (isGitHubCodeTable(table as HTMLTableElement)) {
+            return {
+              conversion: $convertTableElement,
+              priority: 3,
+            };
+          }
+          return null;
+        },
+        td: (node: Node) => {
+          // element is a <td> since we matched it by nodeName
+          const td = node as HTMLTableCellElement;
+          const table: HTMLTableElement | null = td.closest('table');
+
+          if (isGitHubCodeCell(td) || (table && isGitHubCodeTable(table))) {
+            // Return a no-op if it's a table cell in a code table, but not a code line.
+            // Otherwise it'll fall back to the T
+            return {
+              conversion: convertCodeNoop,
+              priority: 3,
+            };
+          }
+
+          return null;
+        },
+        tr: (node: Node) => {
+          // element is a <tr> since we matched it by nodeName
+          const tr = node as HTMLTableCellElement;
+          const table: HTMLTableElement | null = tr.closest('table');
+          if (table && isGitHubCodeTable(table)) {
+            return {
+              conversion: convertCodeNoop,
+              priority: 3,
+            };
+          }
+          return null;
+        },
+      },
+    });
   }
 
-  static clone(node: CodeNode): CodeNode {
-    return new CodeNode(node.__language, node.__key);
-  }
-
-  constructor(language?: string | null | undefined, key?: NodeKey) {
+  // `language` carries an explicit `undefined` default so the constructor
+  // reports zero required arguments and `$config` can synthesize the static
+  // `clone` from the no-argument constructor.
+  constructor(language: string | null | undefined = undefined, key?: NodeKey) {
     super(key);
     this.__language = language || undefined;
     this.__isSyntaxHighlightSupported = false;
@@ -204,77 +268,6 @@ export class CodeNode extends ElementNode {
       setDOMStyleFromCSS(element.style, style);
     }
     return {element};
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      // Typically <pre> is used for code blocks, and <code> for inline code styles
-      // but if it's a multi line <code> we'll create a block. Pass through to
-      // inline format handled by TextNode otherwise.
-      code: (node: Node) => {
-        const isMultiLine =
-          node.textContent != null &&
-          (/\r?\n/.test(node.textContent) || hasChildDOMNodeTag(node, 'BR'));
-
-        return isMultiLine
-          ? {
-              conversion: $convertPreElement,
-              priority: 1,
-            }
-          : null;
-      },
-      div: () => ({
-        conversion: $convertDivElement,
-        priority: 1,
-      }),
-      pre: () => ({
-        conversion: $convertPreElement,
-        priority: 0,
-      }),
-      table: (node: Node) => {
-        const table = node;
-        // domNode is a <table> since we matched it by nodeName
-        if (isGitHubCodeTable(table as HTMLTableElement)) {
-          return {
-            conversion: $convertTableElement,
-            priority: 3,
-          };
-        }
-        return null;
-      },
-      td: (node: Node) => {
-        // element is a <td> since we matched it by nodeName
-        const td = node as HTMLTableCellElement;
-        const table: HTMLTableElement | null = td.closest('table');
-
-        if (isGitHubCodeCell(td) || (table && isGitHubCodeTable(table))) {
-          // Return a no-op if it's a table cell in a code table, but not a code line.
-          // Otherwise it'll fall back to the T
-          return {
-            conversion: convertCodeNoop,
-            priority: 3,
-          };
-        }
-
-        return null;
-      },
-      tr: (node: Node) => {
-        // element is a <tr> since we matched it by nodeName
-        const tr = node as HTMLTableCellElement;
-        const table: HTMLTableElement | null = tr.closest('table');
-        if (table && isGitHubCodeTable(table)) {
-          return {
-            conversion: convertCodeNoop,
-            priority: 3,
-          };
-        }
-        return null;
-      },
-    };
-  }
-
-  static importJSON(serializedNode: SerializedCodeNode): CodeNode {
-    return $createCodeNode().updateFromJSON(serializedNode);
   }
 
   updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedCodeNode>): this {

--- a/packages/lexical-code-core/src/FlatStructureUtils.ts
+++ b/packages/lexical-code-core/src/FlatStructureUtils.ts
@@ -21,6 +21,7 @@ import {
   type RangeSelection,
   type SiblingCaret,
   type TabNode,
+  type TextNode,
   tokenizeRawText,
 } from 'lexical';
 
@@ -30,11 +31,15 @@ import {
   type CodeHighlightNode,
 } from './CodeHighlightNode';
 
-function $getLastMatchingCodeNode<D extends CaretDirection>(
-  anchor: CodeHighlightNode | TabNode | LineBreakNode,
-  direction: D,
-): CodeHighlightNode | TabNode | LineBreakNode {
-  let matchingNode: CodeHighlightNode | TabNode | LineBreakNode = anchor;
+// The anchor is generic (rather than the narrower
+// `CodeHighlightNode | TabNode | LineBreakNode`) because callers may have only
+// narrowed as far as TextNode; the matched siblings are always
+// CodeHighlightNode/TabNode, and an unmatched anchor is returned unchanged.
+function $getLastMatchingCodeNode<
+  T extends TextNode | LineBreakNode,
+  D extends CaretDirection,
+>(anchor: T, direction: D): T | CodeHighlightNode | TabNode {
+  let matchingNode: T | CodeHighlightNode | TabNode = anchor;
   for (
     let caret: null | SiblingCaret<LexicalNode, D> = $getSiblingCaret(
       anchor,
@@ -48,15 +53,15 @@ function $getLastMatchingCodeNode<D extends CaretDirection>(
   return matchingNode;
 }
 
-export function $getFirstCodeNodeOfLine(
-  anchor: CodeHighlightNode | TabNode | LineBreakNode,
-): CodeHighlightNode | TabNode | LineBreakNode {
+export function $getFirstCodeNodeOfLine<T extends TextNode | LineBreakNode>(
+  anchor: T,
+): T | CodeHighlightNode | TabNode {
   return $getLastMatchingCodeNode(anchor, 'previous');
 }
 
-export function $getLastCodeNodeOfLine(
-  anchor: CodeHighlightNode | TabNode | LineBreakNode,
-): CodeHighlightNode | TabNode | LineBreakNode {
+export function $getLastCodeNodeOfLine<T extends TextNode | LineBreakNode>(
+  anchor: T,
+): T | CodeHighlightNode | TabNode {
   return $getLastMatchingCodeNode(anchor, 'next');
 }
 

--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -40,9 +40,7 @@ declare export function $isCodeHighlightNode(
 
 declare export class CodeHighlightNode extends TextNode {
   __highlightType: ?string;
-  constructor(text: string, highlightType?: string, key?: NodeKey): void;
-  static getType(): string;
-  static clone(node: CodeHighlightNode): CodeHighlightNode;
+  constructor(text?: string, highlightType?: string, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   setFormat(format: number): this;
 }
@@ -95,9 +93,7 @@ declare export function $isCodeNode(
 
 declare export class CodeNode extends ElementNode {
   __language: string | null | void;
-  static getType(): string;
-  static clone(node: CodeNode): CodeNode;
-  constructor(language: ?string, key?: NodeKey): void;
+  constructor(language?: ?string, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   insertNewAfter(
     selection: RangeSelection,

--- a/packages/lexical-extension/flow/LexicalExtension.js.flow
+++ b/packages/lexical-extension/flow/LexicalExtension.js.flow
@@ -139,8 +139,6 @@ declare export function getPeerDependencyFromEditorOrThrow<
 
 export type SerializedHorizontalRuleNode = SerializedLexicalNode;
 declare export class HorizontalRuleNode extends DecoratorNode<React.Node> {
-  static getType(): string;
-  static clone(node: HorizontalRuleNode): HorizontalRuleNode;
   createDOM(): HTMLElement;
   getTextContent(): '\n';
   updateDOM(): false;

--- a/packages/lexical-extension/src/HorizontalRuleExtension.ts
+++ b/packages/lexical-extension/src/HorizontalRuleExtension.ts
@@ -23,7 +23,6 @@ import {
   createCommand,
   DecoratorNode,
   defineExtension,
-  type DOMConversionMap,
   type DOMConversionOutput,
   type DOMExportOutput,
   type EditorConfig,
@@ -62,27 +61,20 @@ export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('INSERT_HORIZONTAL_RULE_COMMAND');
 
 export class HorizontalRuleNode extends DecoratorNode<unknown> {
-  static getType(): string {
-    return 'horizontalrule';
-  }
-
-  static clone(node: HorizontalRuleNode): HorizontalRuleNode {
-    return new HorizontalRuleNode(node.__key);
-  }
-
-  static importJSON(
-    serializedNode: SerializedHorizontalRuleNode,
-  ): HorizontalRuleNode {
-    return $createHorizontalRuleNode().updateFromJSON(serializedNode);
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      hr: () => ({
-        conversion: $convertHorizontalRuleElement,
-        priority: 0,
-      }),
-    };
+  $config() {
+    // `extends` is intentionally left to the runtime default (the prototype
+    // parent) rather than declared explicitly: the deprecated
+    // `@lexical/react` HorizontalRuleNode subclasses this one and reuses the
+    // same 'horizontalrule' type, so both `$config()` overrides must infer a
+    // matching shape.
+    return this.config('horizontalrule', {
+      importDOM: {
+        hr: () => ({
+          conversion: $convertHorizontalRuleElement,
+          priority: 0,
+        }),
+      },
+    });
   }
 
   exportDOM(): DOMExportOutput {

--- a/packages/lexical-hashtag/flow/LexicalHashtag.js.flow
+++ b/packages/lexical-hashtag/flow/LexicalHashtag.js.flow
@@ -18,10 +18,8 @@ import type {
 import {TextNode} from 'lexical';
 
 declare export class HashtagNode extends TextNode {
-  static getType(): string;
-  static clone(node: HashtagNode): HashtagNode;
   static importJSON(serializedNode: SerializedTextNode): HashtagNode;
-  constructor(text: string, key?: NodeKey): void;
+  constructor(text?: string, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   canInsertTextBefore(): boolean;
   isTextEntity(): true;

--- a/packages/lexical-hashtag/src/LexicalHashtagNode.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagNode.ts
@@ -11,28 +11,19 @@ import {
   addClassNamesToElement,
   type EditorConfig,
   type LexicalNode,
-  type SerializedTextNode,
   TextNode,
 } from 'lexical';
 
 /** @noInheritDoc */
 export class HashtagNode extends TextNode {
-  static getType(): string {
-    return 'hashtag';
-  }
-
-  static clone(node: HashtagNode): HashtagNode {
-    return new HashtagNode(node.__text, node.__key);
+  $config() {
+    return this.config('hashtag', {extends: TextNode});
   }
 
   createDOM(config: EditorConfig): HTMLElement {
     const element = super.createDOM(config);
     addClassNamesToElement(element, config.theme.hashtag);
     return element;
-  }
-
-  static importJSON(serializedNode: SerializedTextNode): HashtagNode {
-    return $createHashtagNode().updateFromJSON(serializedNode);
   }
 
   canInsertTextBefore(): boolean {

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -38,11 +38,8 @@ declare export class LinkNode extends ElementNode {
   __target: null | string;
   __rel: null | string;
   __title: null | string;
-  static getType(): string;
-  static clone(node: LinkNode): LinkNode;
-  constructor(url: string, attributes?: LinkAttributes, key?: NodeKey): void;
+  constructor(url?: string, attributes?: LinkAttributes, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
-  static importDOM(): DOMConversionMap | null;
   exportJSON(): SerializedLinkNode;
   getURL(): string;
   setURL(url: string): void;
@@ -74,9 +71,6 @@ export type SerializedAutoLinkNode = {
   ...
 };
 declare export class AutoLinkNode extends LinkNode {
-  static getType(): string;
-  // $FlowFixMe[incompatible-type] clone method inheritance
-  static clone(node: AutoLinkNode): AutoLinkNode;
   insertNewAfter(
     selection: RangeSelection,
     restoreSelection?: boolean,

--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -28,7 +28,6 @@ import {
   addClassNamesToElement,
   type BaseSelection,
   createCommand,
-  type DOMConversionMap,
   type DOMConversionOutput,
   type EditorConfig,
   ElementNode,
@@ -83,16 +82,16 @@ export class LinkNode extends ElementNode {
   /** @internal */
   __title: null | string;
 
-  static getType(): string {
-    return 'link';
-  }
-
-  static clone(node: LinkNode): LinkNode {
-    return new LinkNode(
-      node.__url,
-      {rel: node.__rel, target: node.__target, title: node.__title},
-      node.__key,
-    );
+  $config() {
+    return this.config('link', {
+      extends: ElementNode,
+      importDOM: {
+        a: () => ({
+          conversion: $convertAnchorElement,
+          priority: 1,
+        }),
+      },
+    });
   }
 
   constructor(
@@ -153,19 +152,6 @@ export class LinkNode extends ElementNode {
   ): boolean {
     this.updateLinkDOM(prevNode, anchor, config);
     return false;
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      a: (node: Node) => ({
-        conversion: $convertAnchorElement,
-        priority: 1,
-      }),
-    };
-  }
-
-  static importJSON(serializedNode: SerializedLinkNode): LinkNode {
-    return $createLinkNode().updateFromJSON(serializedNode);
   }
 
   updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedLinkNode>): this {
@@ -521,21 +507,8 @@ export class AutoLinkNode extends LinkNode {
     this.__isUnlinked = prevNode.__isUnlinked;
   }
 
-  static getType(): string {
-    return 'autolink';
-  }
-
-  static clone(node: AutoLinkNode): AutoLinkNode {
-    return new AutoLinkNode(
-      node.__url,
-      {
-        isUnlinked: node.__isUnlinked,
-        rel: node.__rel,
-        target: node.__target,
-        title: node.__title,
-      },
-      node.__key,
-    );
+  $config() {
+    return this.config('autolink', {extends: LinkNode});
   }
 
   shouldMergeAdjacentLink(_otherLink: LinkNode): boolean {
@@ -571,21 +544,12 @@ export class AutoLinkNode extends LinkNode {
     );
   }
 
-  static importJSON(serializedNode: SerializedAutoLinkNode): AutoLinkNode {
-    return $createAutoLinkNode().updateFromJSON(serializedNode);
-  }
-
   updateFromJSON(
     serializedNode: LexicalUpdateJSON<SerializedAutoLinkNode>,
   ): this {
     return super
       .updateFromJSON(serializedNode)
       .setIsUnlinked(serializedNode.isUnlinked || false);
-  }
-
-  static importDOM(): null {
-    // TODO: Should link node should handle the import over autolink?
-    return null;
   }
 
   exportJSON(): SerializedAutoLinkNode {

--- a/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts
@@ -14,6 +14,7 @@ import {
   type SerializedAutoLinkNode,
 } from '@lexical/link';
 import {
+  $cloneWithProperties,
   $createParagraphNode,
   $createRangeSelection,
   $getRoot,
@@ -79,7 +80,7 @@ describe('LexicalAutoAutoLinkNode tests', () => {
       await editor.update(() => {
         const autoLinkNode = new AutoLinkNode('/');
 
-        const clone = AutoLinkNode.clone(autoLinkNode);
+        const clone = $cloneWithProperties(autoLinkNode);
 
         expect(clone).not.toBe(autoLinkNode);
         expect(clone).toStrictEqual(autoLinkNode);

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -14,7 +14,7 @@ import {
   $toggleLink,
   formatUrl,
   LinkExtension,
-  LinkNode,
+  type LinkNode,
   type SerializedLinkNode,
 } from '@lexical/link';
 import {$createMarkNode, $isMarkNode} from '@lexical/mark';
@@ -24,6 +24,7 @@ import {
   RichTextExtension,
 } from '@lexical/rich-text';
 import {
+  $cloneWithProperties,
   $createLineBreakNode,
   $createParagraphNode,
   $createRangeSelection,
@@ -82,7 +83,7 @@ describe('LexicalLinkNode tests', () => {
       await editor.update(() => {
         const linkNode = $createLinkNode('/');
 
-        const linkNodeClone = LinkNode.clone(linkNode);
+        const linkNodeClone = $cloneWithProperties(linkNode);
 
         expect(linkNodeClone).not.toBe(linkNode);
         expect(linkNodeClone).toStrictEqual(linkNode);

--- a/packages/lexical-mark/flow/LexicalMark.js.flow
+++ b/packages/lexical-mark/flow/LexicalMark.js.flow
@@ -24,9 +24,7 @@ export type SerializedMarkNode = SerializedElementNode & {
 declare export class MarkNode extends ElementNode {
   __ids: string[];
 
-  // $FlowFixMe[incompatible-variance]
-  static clone(node: this): MarkNode;
-  constructor(ids: string[], key?: NodeKey): void;
+  constructor(ids?: string[], key?: NodeKey): void;
 
   hasID(id: string): boolean;
   getIDs(): string[];

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -37,25 +37,13 @@ export class MarkNode extends ElementNode {
   /** @internal */
   __ids: readonly string[];
 
-  static getType(): string {
-    return 'mark';
-  }
-
-  static clone(node: MarkNode): MarkNode {
-    return new MarkNode(node.__ids, node.__key);
+  $config() {
+    return this.config('mark', {extends: ElementNode});
   }
 
   afterCloneFrom(prevNode: this): void {
     super.afterCloneFrom(prevNode);
     this.__ids = prevNode.__ids;
-  }
-
-  static importDOM(): null {
-    return null;
-  }
-
-  static importJSON(serializedNode: SerializedMarkNode): MarkNode {
-    return $createMarkNode().updateFromJSON(serializedNode);
   }
 
   updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedMarkNode>): this {

--- a/packages/lexical-overflow/flow/LexicalOverflow.js.flow
+++ b/packages/lexical-overflow/flow/LexicalOverflow.js.flow
@@ -17,8 +17,6 @@ import type {
 } from 'lexical';
 import {ElementNode} from 'lexical';
 declare export class OverflowNode extends ElementNode {
-  static getType(): string;
-  static clone(node: OverflowNode): OverflowNode;
   constructor(key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   insertNewAfter(selection: RangeSelection): null | LexicalNode;

--- a/packages/lexical-playground/src/nodes/EmojiNode.tsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.tsx
@@ -26,8 +26,8 @@ export type SerializedEmojiNode = Spread<
 export class EmojiNode extends TextNode {
   __className: string;
 
-  static getType(): string {
-    return 'emoji';
+  $config() {
+    return this.config('emoji', {extends: TextNode});
   }
 
   static clone(node: EmojiNode): EmojiNode {

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -35,12 +35,8 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
   __equation: string;
   __inline: boolean;
 
-  static getType(): string {
-    return 'equation';
-  }
-
-  static clone(node: EquationNode): EquationNode {
-    return new EquationNode(node.__equation, node.__inline, node.__key);
+  $config() {
+    return this.config('equation', {extends: DecoratorNode});
   }
 
   constructor(equation: string = '', inline?: boolean, key?: NodeKey) {

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -38,17 +38,8 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
   __width: Dimension;
   __height: Dimension;
 
-  static getType(): string {
-    return 'excalidraw';
-  }
-
-  static clone(node: ExcalidrawNode): ExcalidrawNode {
-    return new ExcalidrawNode(
-      node.__data,
-      node.__width,
-      node.__height,
-      node.__key,
-    );
+  $config() {
+    return this.config('excalidraw', {extends: DecoratorNode});
   }
 
   static importJSON(serializedNode: SerializedExcalidrawNode): ExcalidrawNode {

--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -65,8 +65,8 @@ export type SerializedFigmaNode = Spread<
 export class FigmaNode extends DecoratorBlockNode {
   __id: string;
 
-  static getType(): string {
-    return 'figma';
+  $config() {
+    return this.config('figma', {extends: DecoratorBlockNode});
   }
 
   static clone(node: FigmaNode): FigmaNode {

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -135,8 +135,8 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
   // Captions cannot yet be used within editor cells
   __captionsEnabled: boolean;
 
-  static getType(): string {
-    return 'image';
+  $config() {
+    return this.config('image', {extends: DecoratorNode});
   }
 
   static clone(node: ImageNode): ImageNode {

--- a/packages/lexical-playground/src/nodes/KeywordNode.ts
+++ b/packages/lexical-playground/src/nodes/KeywordNode.ts
@@ -20,16 +20,8 @@ import {
 export type SerializedKeywordNode = SerializedTextNode;
 
 export class KeywordNode extends TextNode {
-  static getType(): string {
-    return 'keyword';
-  }
-
-  static clone(node: KeywordNode): KeywordNode {
-    return new KeywordNode(node.__text, node.__key);
-  }
-
-  static importJSON(serializedNode: SerializedKeywordNode): KeywordNode {
-    return $createKeywordNode().updateFromJSON(serializedNode);
+  $config() {
+    return this.config('keyword', {extends: TextNode});
   }
 
   createDOM(config: EditorConfig): HTMLElement {

--- a/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
@@ -33,8 +33,8 @@ export class LayoutContainerNode extends ElementNode {
     this.__templateColumns = templateColumns;
   }
 
-  static getType(): string {
-    return 'layout-container';
+  $config() {
+    return this.config('layout-container', {extends: ElementNode});
   }
 
   static clone(node: LayoutContainerNode): LayoutContainerNode {

--- a/packages/lexical-playground/src/nodes/LayoutItemNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutItemNode.ts
@@ -26,12 +26,8 @@ export function $isEmptyLayoutItemNode(node: LexicalNode): boolean {
 }
 
 export class LayoutItemNode extends ElementNode {
-  static getType(): string {
-    return 'layout-item';
-  }
-
-  static clone(node: LayoutItemNode): LayoutItemNode {
-    return new LayoutItemNode(node.__key);
+  $config() {
+    return this.config('layout-item', {extends: ElementNode});
   }
 
   createDOM(config: EditorConfig): HTMLElement {
@@ -57,10 +53,6 @@ export class LayoutItemNode extends ElementNode {
       return true;
     }
     return false;
-  }
-
-  static importJSON(serializedNode: SerializedLayoutItemNode): LayoutItemNode {
-    return $createLayoutItemNode().updateFromJSON(serializedNode);
   }
 
   isShadowRoot(): boolean {

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -28,8 +28,8 @@ const mentionBackgroundColor = 'rgba(24, 119, 232, 0.2)';
 export class MentionNode extends TextNode {
   __mention: string;
 
-  static getType(): string {
-    return 'mention';
+  $config() {
+    return this.config('mention', {extends: TextNode});
   }
 
   static clone(node: MentionNode): MentionNode {

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -62,16 +62,8 @@ function PageBreakComponent({nodeKey}: {nodeKey: NodeKey}) {
 }
 
 export class PageBreakNode extends DecoratorNode<JSX.Element> {
-  static getType(): string {
-    return 'page-break';
-  }
-
-  static clone(node: PageBreakNode): PageBreakNode {
-    return new PageBreakNode(node.__key);
-  }
-
-  static importJSON(serializedNode: SerializedPageBreakNode): PageBreakNode {
-    return $createPageBreakNode().updateFromJSON(serializedNode);
+  $config() {
+    return this.config('page-break', {extends: DecoratorNode});
   }
 
   createDOM(): HTMLElement {

--- a/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
+++ b/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
@@ -11,18 +11,13 @@ import {
   addClassNamesToElement,
   type EditorConfig,
   type LexicalNode,
-  type SerializedTextNode,
   TextNode,
 } from 'lexical';
 
 /** @noInheritDoc */
 export class SpecialTextNode extends TextNode {
-  static getType(): string {
-    return 'specialText';
-  }
-
-  static clone(node: SpecialTextNode): SpecialTextNode {
-    return new SpecialTextNode(node.__text, node.__key);
+  $config() {
+    return this.config('specialText', {extends: TextNode});
   }
 
   createDOM(config: EditorConfig): HTMLElement {
@@ -41,10 +36,6 @@ export class SpecialTextNode extends TextNode {
     addClassNamesToElement(dom, config.theme.specialText);
 
     return false;
-  }
-
-  static importJSON(serializedNode: SerializedTextNode): SpecialTextNode {
-    return $createSpecialTextNode().updateFromJSON(serializedNode);
   }
 
   isTextEntity(): true {

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -78,8 +78,8 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
   __color: StickyNoteColor;
   __caption: LexicalEditorWithDispose;
 
-  static getType(): string {
-    return 'sticky';
+  $config() {
+    return this.config('sticky', {extends: DecoratorNode});
   }
 
   static clone(node: StickyNode): StickyNode {

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -121,8 +121,8 @@ export type SerializedTweetNode = Spread<
 export class TweetNode extends DecoratorBlockNode {
   __id: string;
 
-  static getType(): string {
-    return 'tweet';
+  $config() {
+    return this.config('tweet', {extends: DecoratorBlockNode});
   }
 
   static clone(node: TweetNode): TweetNode {

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -68,8 +68,8 @@ export type SerializedYouTubeNode = Spread<
 export class YouTubeNode extends DecoratorBlockNode {
   __id: string;
 
-  static getType(): string {
-    return 'youtube';
+  $config() {
+    return this.config('youtube', {extends: DecoratorBlockNode});
   }
 
   static clone(node: YouTubeNode): YouTubeNode {

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
@@ -41,8 +41,8 @@ export class CollapsibleContainerNode extends ElementNode {
     this.__open = open;
   }
 
-  static getType(): string {
-    return 'collapsible-container';
+  $config() {
+    return this.config('collapsible-container', {extends: ElementNode});
   }
 
   static clone(node: CollapsibleContainerNode): CollapsibleContainerNode {

--- a/packages/lexical-react/flow/LexicalHorizontalRuleNode.js.flow
+++ b/packages/lexical-react/flow/LexicalHorizontalRuleNode.js.flow
@@ -11,8 +11,6 @@ import type {LexicalNode, LexicalCommand, SerializedLexicalNode} from 'lexical';
 import {DecoratorNode} from 'lexical';
 export type SerializedHorizontalRuleNode = SerializedLexicalNode;
 declare export class HorizontalRuleNode extends DecoratorNode<React.Node> {
-  static getType(): string;
-  static clone(node: HorizontalRuleNode): HorizontalRuleNode;
   createDOM(): HTMLElement;
   getTextContent(): '\n';
   updateDOM(): false;

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -19,7 +19,6 @@ import {
   addClassNamesToElement,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
-  type DOMConversionMap,
   type DOMConversionOutput,
   getComposedEventTarget,
   mergeRegister,
@@ -82,27 +81,19 @@ function HorizontalRuleComponent({nodeKey}: {nodeKey: NodeKey}) {
  * @deprecated A pure Lexical implementation is available in `@lexical/extension` as HorizontalRuleExtension
  */
 export class HorizontalRuleNode extends BaseHorizontalRuleNode {
-  static getType(): string {
-    return 'horizontalrule';
-  }
-
-  static clone(node: HorizontalRuleNode): HorizontalRuleNode {
-    return new HorizontalRuleNode(node.__key);
-  }
-
-  static importJSON(
-    serializedNode: SerializedHorizontalRuleNode,
-  ): HorizontalRuleNode {
-    return $createHorizontalRuleNode().updateFromJSON(serializedNode);
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      hr: () => ({
-        conversion: $convertHorizontalRuleElement,
-        priority: 0,
-      }),
-    };
+  $config() {
+    // `extends` is left to the runtime default (the prototype parent,
+    // BaseHorizontalRuleNode) so this deprecated subclass infers a `$config()`
+    // shape compatible with the base node it reuses the 'horizontalrule' type
+    // from.
+    return this.config('horizontalrule', {
+      importDOM: {
+        hr: () => ({
+          conversion: $convertHorizontalRuleElement,
+          priority: 0,
+        }),
+      },
+    });
   }
 
   decorate(): JSX.Element {

--- a/packages/lexical-rich-text/flow/LexicalRichText.js.flow
+++ b/packages/lexical-rich-text/flow/LexicalRichText.js.flow
@@ -25,8 +25,6 @@ import {ElementNode} from 'lexical';
 
 declare export var DRAG_DROP_PASTE: LexicalCommand<File[]>;
 declare export class QuoteNode extends ElementNode {
-  static getType(): string;
-  static clone(node: QuoteNode): QuoteNode;
   constructor(key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   insertNewAfter(
@@ -46,12 +44,9 @@ declare export function $isQuoteNode(
 export type HeadingTagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 declare export class HeadingNode extends ElementNode {
   __tag: HeadingTagType;
-  static getType(): string;
-  static clone(node: HeadingNode): HeadingNode;
-  constructor(tag: HeadingTagType, key?: NodeKey): void;
+  constructor(tag?: HeadingTagType, key?: NodeKey): void;
   getTag(): HeadingTagType;
   createDOM(config: EditorConfig): HTMLElement;
-  static importDOM(): DOMConversionMap | null;
   insertNewAfter(
     selection: RangeSelection,
     restoreSelection?: boolean,

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -86,7 +86,6 @@ import {
   DELETE_CHARACTER_COMMAND,
   DELETE_LINE_COMMAND,
   DELETE_WORD_COMMAND,
-  type DOMConversionMap,
   type DOMConversionOutput,
   type DOMExportOutput,
   DRAGOVER_COMMAND,
@@ -177,17 +176,15 @@ export const quoteShadowRootState = /* @__PURE__ */ createState('shadowRoot', {
 
 /** @noInheritDoc */
 export class QuoteNode extends ElementNode {
-  static getType(): string {
-    return 'quote';
-  }
-
-  static clone(node: QuoteNode): QuoteNode {
-    return new QuoteNode(node.__key);
-  }
-
   $config() {
     return this.config('quote', {
       extends: ElementNode,
+      importDOM: {
+        blockquote: () => ({
+          conversion: $convertBlockquoteElement,
+          priority: 0,
+        }),
+      },
       stateConfigs: [{flat: true, stateConfig: quoteShadowRootState}],
     });
   }
@@ -224,15 +221,6 @@ export class QuoteNode extends ElementNode {
     return false;
   }
 
-  static importDOM(): DOMConversionMap | null {
-    return {
-      blockquote: (node: Node) => ({
-        conversion: $convertBlockquoteElement,
-        priority: 0,
-      }),
-    };
-  }
-
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const {element} = super.exportDOM(editor);
 
@@ -257,12 +245,12 @@ export class QuoteNode extends ElementNode {
     };
   }
 
-  static importJSON(serializedNode: SerializedQuoteNode): QuoteNode {
-    return $createQuoteNode().updateFromJSON(serializedNode);
-  }
-
   exportJSON(): SerializedQuoteNode {
     return super.exportJSON();
+  }
+
+  static importJSON(serializedNode: SerializedQuoteNode): QuoteNode {
+    return $createQuoteNode().updateFromJSON(serializedNode);
   }
 
   // Mutation
@@ -322,12 +310,43 @@ export class HeadingNode extends ElementNode {
   /** @internal */
   __tag: HeadingTagType;
 
-  static getType(): string {
-    return 'heading';
-  }
-
-  static clone(node: HeadingNode): HeadingNode {
-    return new HeadingNode(node.__tag, node.__key);
+  $config() {
+    return this.config('heading', {
+      extends: ElementNode,
+      importDOM: {
+        h1: () => ({conversion: $convertHeadingElement, priority: 0}),
+        h2: () => ({conversion: $convertHeadingElement, priority: 0}),
+        h3: () => ({conversion: $convertHeadingElement, priority: 0}),
+        h4: () => ({conversion: $convertHeadingElement, priority: 0}),
+        h5: () => ({conversion: $convertHeadingElement, priority: 0}),
+        h6: () => ({conversion: $convertHeadingElement, priority: 0}),
+        p: (node: Node) => {
+          // domNode is a <p> since we matched it by nodeName
+          const paragraph = node as HTMLParagraphElement;
+          const firstChild = paragraph.firstChild;
+          if (firstChild !== null && isGoogleDocsTitle(firstChild)) {
+            return {
+              conversion: () => ({node: null}),
+              priority: 3,
+            };
+          }
+          return null;
+        },
+        span: (node: Node) => {
+          if (isGoogleDocsTitle(node)) {
+            return {
+              conversion: () => {
+                return {
+                  node: $createHeadingNode('h1'),
+                };
+              },
+              priority: 3,
+            };
+          }
+          return null;
+        },
+      },
+    });
   }
 
   afterCloneFrom(prevNode: this): void {
@@ -368,60 +387,6 @@ export class HeadingNode extends ElementNode {
     return prevNode.__tag !== this.__tag;
   }
 
-  static importDOM(): DOMConversionMap | null {
-    return {
-      h1: (node: Node) => ({
-        conversion: $convertHeadingElement,
-        priority: 0,
-      }),
-      h2: (node: Node) => ({
-        conversion: $convertHeadingElement,
-        priority: 0,
-      }),
-      h3: (node: Node) => ({
-        conversion: $convertHeadingElement,
-        priority: 0,
-      }),
-      h4: (node: Node) => ({
-        conversion: $convertHeadingElement,
-        priority: 0,
-      }),
-      h5: (node: Node) => ({
-        conversion: $convertHeadingElement,
-        priority: 0,
-      }),
-      h6: (node: Node) => ({
-        conversion: $convertHeadingElement,
-        priority: 0,
-      }),
-      p: (node: Node) => {
-        // domNode is a <p> since we matched it by nodeName
-        const paragraph = node as HTMLParagraphElement;
-        const firstChild = paragraph.firstChild;
-        if (firstChild !== null && isGoogleDocsTitle(firstChild)) {
-          return {
-            conversion: () => ({node: null}),
-            priority: 3,
-          };
-        }
-        return null;
-      },
-      span: (node: Node) => {
-        if (isGoogleDocsTitle(node)) {
-          return {
-            conversion: (domNode: Node) => {
-              return {
-                node: $createHeadingNode('h1'),
-              };
-            },
-            priority: 3,
-          };
-        }
-        return null;
-      },
-    };
-  }
-
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const {element} = super.exportDOM(editor);
 
@@ -444,12 +409,6 @@ export class HeadingNode extends ElementNode {
     return {
       element,
     };
-  }
-
-  static importJSON(serializedNode: SerializedHeadingNode): HeadingNode {
-    return $createHeadingNode(serializedNode.tag).updateFromJSON(
-      serializedNode,
-    );
   }
 
   updateFromJSON(

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -47,8 +47,6 @@ declare export class TableCellNode extends ElementNode {
   __headerState: TableCellHeaderState;
   __width?: number;
   __backgroundColor: null | string;
-  static getType(): string;
-  static clone(node: TableCellNode): TableCellNode;
   constructor(
     headerState?: TableCellHeaderState,
     colSpan?: number,
@@ -97,8 +95,6 @@ export type TableMapValueType = {
 export type TableMapType = TableMapValueType[][];
 
 declare export class TableNode extends ElementNode {
-  static getType(): string;
-  static clone(node: TableNode): TableNode;
   constructor(key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   insertNewAfter(selection: RangeSelection): null | ParagraphNode | TableNode;
@@ -139,8 +135,6 @@ declare export function $getTableAndElementByKey(
  */
 
 declare export class TableRowNode extends ElementNode {
-  static getType(): string;
-  static clone(node: TableRowNode): TableRowNode;
   constructor(height?: ?number, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   setHeight(height: number): ?number;

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -14,7 +14,6 @@ import {
   $isLineBreakNode,
   $isTextNode,
   addClassNamesToElement,
-  type DOMConversionMap,
   type DOMConversionOutput,
   type DOMExportOutput,
   type EditorConfig,
@@ -68,17 +67,20 @@ export class TableCellNode extends ElementNode {
   /** @internal */
   __verticalAlign?: undefined | string;
 
-  static getType(): string {
-    return 'tablecell';
-  }
-
-  static clone(node: TableCellNode): TableCellNode {
-    return new TableCellNode(
-      node.__headerState,
-      node.__colSpan,
-      node.__width,
-      node.__key,
-    );
+  $config() {
+    return this.config('tablecell', {
+      extends: ElementNode,
+      importDOM: {
+        td: () => ({
+          conversion: $convertTableCellNodeElement,
+          priority: 0,
+        }),
+        th: () => ({
+          conversion: $convertTableCellNodeElement,
+          priority: 0,
+        }),
+      },
+    });
   }
 
   afterCloneFrom(node: this): void {
@@ -89,23 +91,6 @@ export class TableCellNode extends ElementNode {
     this.__colSpan = node.__colSpan;
     this.__headerState = node.__headerState;
     this.__width = node.__width;
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      td: (node: Node) => ({
-        conversion: $convertTableCellNodeElement,
-        priority: 0,
-      }),
-      th: (node: Node) => ({
-        conversion: $convertTableCellNodeElement,
-        priority: 0,
-      }),
-    };
-  }
-
-  static importJSON(serializedNode: SerializedTableCellNode): TableCellNode {
-    return $createTableCellNode().updateFromJSON(serializedNode);
   }
 
   updateFromJSON(

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -17,7 +17,6 @@ import {
   $getNearestNodeFromDOMNode,
   addClassNamesToElement,
   type BaseSelection,
-  type DOMConversionMap,
   type DOMConversionOutput,
   type DOMExportOutput,
   type EditorConfig,
@@ -176,13 +175,25 @@ export function setScrollableTablesActive(
 /** @noInheritDoc */
 export class TableNode extends ElementNode {
   /** @internal */
-  __rowStriping: boolean;
-  __frozenColumnCount: number;
-  __frozenRowCount: number;
-  __colWidths?: readonly number[];
+  __rowStriping: boolean = false;
+  __frozenColumnCount: number = 0;
+  __frozenRowCount: number = 0;
+  // Initialized unconditionally (not `__colWidths?: ...`) so a freshly
+  // constructed instance always has the own property — `@lexical/yjs` derives a
+  // node's syncable properties from `Object.keys(new Klass())`, so an
+  // uninitialized optional field would silently drop out of collab sync.
+  __colWidths: readonly number[] | undefined = undefined;
 
-  static getType(): string {
-    return 'table';
+  $config() {
+    return this.config('table', {
+      extends: ElementNode,
+      importDOM: {
+        table: () => ({
+          conversion: $convertTableElement,
+          priority: 1,
+        }),
+      },
+    });
   }
 
   getColWidths(): readonly number[] | undefined {
@@ -198,29 +209,12 @@ export class TableNode extends ElementNode {
     return self;
   }
 
-  static clone(node: TableNode): TableNode {
-    return new TableNode(node.__key);
-  }
-
   afterCloneFrom(prevNode: this) {
     super.afterCloneFrom(prevNode);
     this.__colWidths = prevNode.__colWidths;
     this.__rowStriping = prevNode.__rowStriping;
     this.__frozenColumnCount = prevNode.__frozenColumnCount;
     this.__frozenRowCount = prevNode.__frozenRowCount;
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      table: (_node: Node) => ({
-        conversion: $convertTableElement,
-        priority: 1,
-      }),
-    };
-  }
-
-  static importJSON(serializedNode: SerializedTableNode): TableNode {
-    return $createTableNode().updateFromJSON(serializedNode);
   }
 
   updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedTableNode>): this {
@@ -230,14 +224,6 @@ export class TableNode extends ElementNode {
       .setFrozenColumns(serializedNode.frozenColumnCount || 0)
       .setFrozenRows(serializedNode.frozenRowCount || 0)
       .setColWidths(serializedNode.colWidths);
-  }
-
-  constructor(key?: NodeKey) {
-    super(key);
-    this.__rowStriping = false;
-    this.__frozenColumnCount = 0;
-    this.__frozenRowCount = 0;
-    this.__colWidths = undefined;
   }
 
   exportJSON(): SerializedTableNode {

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -12,7 +12,6 @@ import {
   $getDocument,
   addClassNamesToElement,
   type BaseSelection,
-  type DOMConversionMap,
   type DOMConversionOutput,
   type EditorConfig,
   ElementNode,
@@ -38,30 +37,21 @@ export class TableRowNode extends ElementNode {
   /** @internal */
   __height?: number;
 
-  static getType(): string {
-    return 'tablerow';
-  }
-
-  static clone(node: TableRowNode): TableRowNode {
-    return new TableRowNode(node.__height, node.__key);
+  $config() {
+    return this.config('tablerow', {
+      extends: ElementNode,
+      importDOM: {
+        tr: () => ({
+          conversion: $convertTableRowElement,
+          priority: 0,
+        }),
+      },
+    });
   }
 
   afterCloneFrom(prevNode: this): void {
     super.afterCloneFrom(prevNode);
     this.__height = prevNode.__height;
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      tr: (node: Node) => ({
-        conversion: $convertTableRowElement,
-        priority: 0,
-      }),
-    };
-  }
-
-  static importJSON(serializedNode: SerializedTableRowNode): TableRowNode {
-    return $createTableRowNode().updateFromJSON(serializedNode);
   }
 
   updateFromJSON(
@@ -72,7 +62,9 @@ export class TableRowNode extends ElementNode {
       .setHeight(serializedNode.height);
   }
 
-  constructor(height?: number, key?: NodeKey) {
+  // `height` carries an explicit `undefined` default so the constructor reports
+  // zero required arguments and `$config` can synthesize the static `clone`.
+  constructor(height: number | undefined = undefined, key?: NodeKey) {
     super(key);
     this.__height = height;
   }

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -11,10 +11,10 @@ import {
   $createTableCellNode,
   $isTableCellNode,
   TableCellHeaderStates,
-  TableCellNode,
 } from '@lexical/table';
 import {$createTextNode, $getRoot, type DOMConversionOutput} from 'lexical';
 import {
+  $runDOMConversion,
   expectHtmlToBeEqual,
   html,
   initializeUnitTest,
@@ -220,22 +220,14 @@ describe('LexicalTableCellNode tests', () => {
       });
     }, 15000);
 
-    // Simulates the Lexical Paste Engine finding and running the converter
-    const convertHTMLTag = (element: HTMLElement) => {
-      const importDOMMap = TableCellNode.importDOM();
-
-      // look up tag name (e.g., 'th') in the import map
-      const handler = importDOMMap![element.tagName.toLowerCase()];
-      if (!handler) {
-        throw new Error(`No handler found for tag ${element.tagName}`);
-      }
-
-      const specs = handler(element);
-      if (!specs) {
-        throw new Error(`Handler returned null for tag ${element.tagName}`);
-      }
-      return specs.conversion(element);
-    };
+    // Simulates the Lexical Paste Engine finding and running the converter by
+    // driving the real DOM-import machinery (the editor's registered conversion
+    // cache, the path the paste engine actually uses) rather than reaching into
+    // TableCellNode.importDOM() directly. The element is converted in place so
+    // the cell's row/table position is visible to the conversion.
+    const $convertHTMLTag = (
+      element: HTMLElement,
+    ): DOMConversionOutput | null => $runDOMConversion(testEnv.editor, element);
 
     const expectTableCellNode = (result: DOMConversionOutput | null) => {
       const node = result?.node;
@@ -259,7 +251,7 @@ describe('LexicalTableCellNode tests', () => {
         const th = document.createElement('th');
         th.setAttribute('scope', 'col');
 
-        const result = convertHTMLTag(th);
+        const result = $convertHTMLTag(th);
 
         const node = expectTableCellNode(result);
 
@@ -274,7 +266,7 @@ describe('LexicalTableCellNode tests', () => {
         const th = document.createElement('th');
         th.setAttribute('scope', 'row');
 
-        const result = convertHTMLTag(th);
+        const result = $convertHTMLTag(th);
 
         const node = expectTableCellNode(result);
 
@@ -292,7 +284,7 @@ describe('LexicalTableCellNode tests', () => {
         tr.appendChild(th);
         table.appendChild(tr);
 
-        const result = convertHTMLTag(th);
+        const result = $convertHTMLTag(th);
 
         const node = expectTableCellNode(result);
 
@@ -313,7 +305,7 @@ describe('LexicalTableCellNode tests', () => {
         tr.appendChild(td);
         table.appendChild(tr);
 
-        const result = convertHTMLTag(th);
+        const result = $convertHTMLTag(th);
         const node = expectTableCellNode(result);
 
         // First row, first column → BOTH
@@ -339,7 +331,7 @@ describe('LexicalTableCellNode tests', () => {
         table.appendChild(tr1);
         table.appendChild(tr2);
 
-        const result = convertHTMLTag(th2);
+        const result = $convertHTMLTag(th2);
         const node = expectTableCellNode(result);
 
         // Non-first row, first column → COLUMN
@@ -362,7 +354,7 @@ describe('LexicalTableCellNode tests', () => {
         table.appendChild(thead);
 
         // Second th in thead → ROW (not first column, so only ROW from first row)
-        const result = convertHTMLTag(th2);
+        const result = $convertHTMLTag(th2);
         const node = expectTableCellNode(result);
 
         expect(node.getHeaderStyles()).toBe(TableCellHeaderStates.ROW);
@@ -376,7 +368,7 @@ describe('LexicalTableCellNode tests', () => {
         const td = document.createElement('td');
         td.style.backgroundColor = '#F4B084';
 
-        const result = convertHTMLTag(td);
+        const result = $convertHTMLTag(td);
         const node = expectTableCellNode(result);
 
         // Browsers normalize hex to rgb when set via .style
@@ -390,7 +382,7 @@ describe('LexicalTableCellNode tests', () => {
       await editor.update(() => {
         const td = document.createElement('td');
 
-        const result = convertHTMLTag(td);
+        const result = $convertHTMLTag(td);
         const node = expectTableCellNode(result);
 
         expect(node.getBackgroundColor()).toBeNull();
@@ -404,7 +396,7 @@ describe('LexicalTableCellNode tests', () => {
         const td = document.createElement('td');
         td.style.color = 'blue';
 
-        const result = convertHTMLTag(td);
+        const result = $convertHTMLTag(td);
         expectTableCellNode(result);
 
         // The after callback propagates td color to child TextNodes
@@ -421,7 +413,7 @@ describe('LexicalTableCellNode tests', () => {
         const td = document.createElement('td');
         td.style.color = 'blue';
 
-        const result = convertHTMLTag(td);
+        const result = $convertHTMLTag(td);
         expectTableCellNode(result);
 
         const textNode = $createTextNode('Hello');

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -553,9 +553,12 @@ export function $syncPropertiesFromYjs(
         writableNode = lexicalNode.getWritable();
       }
 
-      writableNode[property as string & keyof typeof writableNode] =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        nextValue as any;
+      // Generic property writer. `property` is never a read-only node field
+      // here (e.g. `__type` is intrinsic and, being equal on both sides, is
+      // filtered out by the `prevValue !== nextValue` guard above), so cast
+      // through a mutable record to write it.
+      (writableNode as unknown as Record<string, unknown>)[property] =
+        nextValue;
     }
   }
 }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -487,6 +487,7 @@ declare export class LexicalNode {
   static getType(): string;
   static clone(data: $FlowFixMe): LexicalNode;
   static importDOM(): DOMConversionMap | null;
+  static importJSON(serializedNode: $FlowFixMe): LexicalNode;
   constructor(key?: NodeKey): void;
   exportDOM(editor: LexicalEditor): DOMExportOutput;
   exportJSON(): SerializedLexicalNode;
@@ -782,9 +783,7 @@ declare export class TextNode extends LexicalNode {
   __style: string;
   __mode: 0 | 1 | 2 | 3;
   __detail: number;
-  static getType(): string;
-  static clone(node: $FlowFixMe): TextNode;
-  constructor(text: string, key?: NodeKey): void;
+  constructor(text?: string, key?: NodeKey): void;
   getTopLevelElement(): ElementNode | null;
   getTopLevelElementOrThrow(): ElementNode;
   getFormat(): number;
@@ -858,10 +857,7 @@ declare export function $isTabNode(
 ): node is TabNode;
 
 declare export class TabNode extends TextNode {
-  static getType(): string;
-  static clone(node: TabNode): TabNode;
   constructor(key?: NodeKey): void;
-  static importDOM(): DOMConversionMap | null;
   static importJSON(serializedTabNode: SerializedTabNode): TabNode;
   exportJSON(): SerializedTabNode;
 }
@@ -871,8 +867,6 @@ declare export class TabNode extends TextNode {
  */
 
 declare export class LineBreakNode extends LexicalNode {
-  static getType(): string;
-  static clone(node: LineBreakNode): LineBreakNode;
   constructor(key?: NodeKey): void;
   getTextContent(): '\n';
   createDOM(): HTMLElement;
@@ -894,8 +888,7 @@ declare export function $isLineBreakNode(
 
 declare export class RootNode extends ElementNode {
   __cachedText: null | string;
-  static getType(): string;
-  static clone(): RootNode;
+  static importJSON(serializedNode: SerializedRootNode): RootNode;
   constructor(): void;
   getTextContent(): string;
   select(_anchorOffset?: number, _focusOffset?: number): RangeSelection;
@@ -1125,8 +1118,6 @@ declare export function $isLexicalNode(
  * LexicalParagraphNode
  */
 declare export class ParagraphNode extends ElementNode {
-  static getType(): string;
-  static clone(node: ParagraphNode): ParagraphNode;
   constructor(key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   insertNewAfter(

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -715,7 +715,9 @@ export class LexicalNode {
   /** @internal Allow us to look up the type including static props */
   declare ['constructor']: KlassConstructor<typeof LexicalNode>;
   /** @internal */
-  __type: string;
+  // `__type` is assigned once, in the constructor, and is never valid to
+  // mutate afterward.
+  readonly __type: string;
   /** @internal */
   //@ts-ignore We set the key in the constructor.
   __key: string;

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -30,6 +30,8 @@ import {
   createEditor,
   type CreateEditorArgs,
   DecoratorNode,
+  type DOMConversion,
+  type DOMConversionOutput,
   type EditorState,
   type EditorThemeClasses,
   ElementNode,
@@ -605,4 +607,37 @@ export function prettifyHtml(s: string): string {
     ...prettierConfig,
     parser: 'html',
   });
+}
+
+/**
+ * Locate and run the DOM importer for `element` through the editor's registered
+ * conversion cache — the same machinery `@lexical/html`'s paste path consults
+ * via `getConversionFunction` — and return its {@link DOMConversionOutput}.
+ *
+ * Prefer this over calling a node's static `importDOM()` directly: it exercises
+ * the real registration (priority resolution, dedup, and any `HTMLConfig`
+ * import overrides) instead of one class's raw map, and it runs the conversion
+ * on `element` in place so logic that inspects the element's DOM ancestors
+ * (e.g. a table cell reading its row/table position) sees the real context.
+ */
+export function $runDOMConversion(
+  editor: LexicalEditor,
+  element: HTMLElement,
+): DOMConversionOutput | null {
+  let match: DOMConversion | null = null;
+  const conversions = editor._htmlConversions.get(
+    element.tagName.toLowerCase(),
+  );
+  if (conversions !== undefined) {
+    for (const conversion of conversions) {
+      const candidate = conversion(element);
+      if (
+        candidate !== null &&
+        (match === null || (match.priority || 0) <= (candidate.priority || 0))
+      ) {
+        match = candidate;
+      }
+    }
+  }
+  return match !== null ? match.conversion(element) : null;
 }

--- a/packages/lexical/src/nodes/ArtificialNode.ts
+++ b/packages/lexical/src/nodes/ArtificialNode.ts
@@ -13,8 +13,8 @@ import {ElementNode} from './LexicalElementNode';
 // TODO: Cleanup ArtificialNode__DO_NOT_USE #5966
 /** @internal */
 export class ArtificialNode__DO_NOT_USE extends ElementNode {
-  static getType(): string {
-    return 'artificial';
+  $config() {
+    return this.config('artificial', {extends: ElementNode});
   }
 
   createDOM(config: EditorConfig): HTMLElement {

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -9,10 +9,8 @@
 import type {KlassConstructor} from '../LexicalEditor';
 
 import {
-  type DOMConversionMap,
   type DOMConversionOutput,
   LexicalNode,
-  type NodeKey,
   type SerializedLexicalNode,
 } from '../LexicalNode';
 import {
@@ -28,16 +26,21 @@ export type SerializedLineBreakNode = SerializedLexicalNode;
 export class LineBreakNode extends LexicalNode {
   /** @internal */
   declare ['constructor']: KlassConstructor<typeof LineBreakNode>;
-  static getType(): string {
-    return 'linebreak';
-  }
 
-  static clone(node: LineBreakNode): LineBreakNode {
-    return new LineBreakNode(node.__key);
-  }
-
-  constructor(key?: NodeKey) {
-    super(key);
+  $config() {
+    return this.config('linebreak', {
+      importDOM: {
+        br: (node: Node) => {
+          if (isOnlyChildInBlockNode(node) || isLastChildInBlockNode(node)) {
+            return null;
+          }
+          return {
+            conversion: $convertLineBreakElement,
+            priority: 0,
+          };
+        },
+      },
+    });
   }
 
   getTextContent(): '\n' {
@@ -54,26 +57,6 @@ export class LineBreakNode extends LexicalNode {
 
   isInline(): true {
     return true;
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      br: (node: Node) => {
-        if (isOnlyChildInBlockNode(node) || isLastChildInBlockNode(node)) {
-          return null;
-        }
-        return {
-          conversion: $convertLineBreakElement,
-          priority: 0,
-        };
-      },
-    };
-  }
-
-  static importJSON(
-    serializedLineBreakNode: SerializedLineBreakNode,
-  ): LineBreakNode {
-    return $createLineBreakNode().updateFromJSON(serializedLineBreakNode);
   }
 }
 

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -13,7 +13,6 @@ import type {
   Spread,
 } from '../LexicalEditor';
 import type {
-  DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
   LexicalNode,
@@ -50,12 +49,16 @@ export class ParagraphNode extends ElementNode {
   /** @internal */
   declare ['constructor']: KlassConstructor<typeof ParagraphNode>;
 
-  static getType(): string {
-    return 'paragraph';
-  }
-
-  static clone(node: ParagraphNode): ParagraphNode {
-    return new ParagraphNode(node.__key);
+  $config() {
+    return this.config('paragraph', {
+      extends: ElementNode,
+      importDOM: {
+        p: () => ({
+          conversion: $convertParagraphElement,
+          priority: 0,
+        }),
+      },
+    });
   }
 
   // View
@@ -77,15 +80,6 @@ export class ParagraphNode extends ElementNode {
     return false;
   }
 
-  static importDOM(): DOMConversionMap | null {
-    return {
-      p: (node: Node) => ({
-        conversion: $convertParagraphElement,
-        priority: 0,
-      }),
-    };
-  }
-
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const {element} = super.exportDOM(editor);
 
@@ -103,10 +97,6 @@ export class ParagraphNode extends ElementNode {
     return {
       element,
     };
-  }
-
-  static importJSON(serializedNode: SerializedParagraphNode): ParagraphNode {
-    return $createParagraphNode().updateFromJSON(serializedNode);
   }
 
   exportJSON(): SerializedParagraphNode {

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -29,12 +29,8 @@ export class RootNode extends ElementNode {
   /** @internal */
   __cachedText: null | string;
 
-  static getType(): string {
-    return 'root';
-  }
-
-  static clone(): RootNode {
-    return new RootNode();
+  $config() {
+    return this.config('root', {extends: ElementNode});
   }
 
   constructor() {

--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -7,7 +7,7 @@
  */
 
 import type {EditorConfig} from '../LexicalEditor';
-import type {DOMConversionMap, LexicalNode, NodeKey} from '../LexicalNode';
+import type {LexicalNode, NodeKey} from '../LexicalNode';
 
 import invariant from '@lexical/internal/invariant';
 
@@ -24,21 +24,16 @@ export type SerializedTabNode = SerializedTextNode;
 
 /** @noInheritDoc */
 export class TabNode extends TextNode {
-  static getType(): string {
-    return 'tab';
+  $config() {
+    return this.config('tab', {extends: TextNode});
   }
 
-  static clone(node: TabNode): TabNode {
-    return new TabNode(node.__key);
-  }
-
-  constructor(key?: NodeKey) {
+  // `key` carries an explicit `undefined` default (rather than the usual `?`)
+  // so the constructor reports zero required arguments, which lets `$config`
+  // synthesize the static `clone` by invoking the no-argument constructor.
+  constructor(key: NodeKey | undefined = undefined) {
     super('\t', key);
     this.__detail = IS_UNMERGEABLE;
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return null;
   }
 
   createDOM(config: EditorConfig): HTMLElement {
@@ -50,10 +45,6 @@ export class TabNode extends TextNode {
       domClassList.add(...classNames);
     }
     return dom;
-  }
-
-  static importJSON(serializedTabNode: SerializedTabNode): TabNode {
-    return $createTabNode().updateFromJSON(serializedTabNode);
   }
 
   /**

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -38,7 +38,6 @@ import {
   TEXT_TYPE_TO_MODE,
 } from '../LexicalConstants';
 import {
-  type DOMConversionMap,
   type DOMConversionOutput,
   type DOMExportOutput,
   LexicalNode,
@@ -341,12 +340,59 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
     return true;
   }
 
-  static getType(): string {
-    return 'text';
-  }
-
-  static clone(node: TextNode): TextNode {
-    return new TextNode(node.__text, node.__key);
+  $config() {
+    return this.config('text', {
+      importDOM: {
+        '#text': () => ({
+          conversion: $convertTextDOMNode,
+          priority: 0,
+        }),
+        b: () => ({
+          conversion: convertBringAttentionToElement,
+          priority: 0,
+        }),
+        code: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+        em: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+        i: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+        mark: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+        s: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+        span: () => ({
+          conversion: convertSpanElement,
+          priority: 0,
+        }),
+        strong: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+        sub: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+        sup: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+        u: () => ({
+          conversion: convertTextFormatElement,
+          priority: 0,
+        }),
+      },
+    });
   }
 
   afterCloneFrom(prevNode: this): void {
@@ -605,63 +651,6 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
       setDOMStyleFromCSS(dom.style, nextStyle, prevStyle);
     }
     return false;
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      '#text': () => ({
-        conversion: $convertTextDOMNode,
-        priority: 0,
-      }),
-      b: () => ({
-        conversion: convertBringAttentionToElement,
-        priority: 0,
-      }),
-      code: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-      em: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-      i: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-      mark: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-      s: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-      span: () => ({
-        conversion: convertSpanElement,
-        priority: 0,
-      }),
-      strong: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-      sub: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-      sup: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-      u: () => ({
-        conversion: convertTextFormatElement,
-        priority: 0,
-      }),
-    };
-  }
-
-  static importJSON(serializedNode: SerializedTextNode): TextNode {
-    return $createTextNode().updateFromJSON(serializedNode);
   }
 
   updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedTextNode>): this {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
@@ -15,7 +15,11 @@ import {
 } from 'lexical';
 import {describe, expect, test} from 'vitest';
 
-import {initializeUnitTest, invariant} from '../../../__tests__/utils';
+import {
+  $runDOMConversion,
+  initializeUnitTest,
+  invariant,
+} from '../../../__tests__/utils';
 
 const editorConfig = Object.freeze({
   namespace: '',
@@ -151,18 +155,11 @@ describe('LexicalParagraphNode tests', () => {
     test('ParagraphNode.importDOM handles both CSS text-align and legacy align attribute', async () => {
       const {editor} = testEnv;
 
-      const convertParagraph = (element: HTMLElement) => {
-        const importDOMMap = ParagraphNode.importDOM();
-        const handler = importDOMMap![element.tagName.toLowerCase()];
-        if (!handler) {
-          throw new Error(`No handler found for tag: ${element.tagName}`);
-        }
-        const specs = handler(element);
-        if (!specs) {
-          return null;
-        }
-        return specs.conversion(element);
-      };
+      // Drive the real DOM-import machinery (the editor's registered conversion
+      // cache) instead of reaching into ParagraphNode.importDOM() directly.
+      const $convertParagraph = (
+        element: HTMLElement,
+      ): DOMConversionOutput | null => $runDOMConversion(editor, element);
 
       const expectParagraphNode = (result: DOMConversionOutput | null) => {
         const node = result ? result.node : null;
@@ -183,14 +180,14 @@ describe('LexicalParagraphNode tests', () => {
         const pAlign = document.createElement('p');
         pAlign.setAttribute('align', 'right');
 
-        const nodeAlign = expectParagraphNode(convertParagraph(pAlign));
+        const nodeAlign = expectParagraphNode($convertParagraph(pAlign));
         expect(nodeAlign.getFormatType()).toBe('right');
 
         // Case 2: Modern <p style="text-align: center">
         const pStyle = document.createElement('p');
         pStyle.style.textAlign = 'center';
 
-        const nodeStyle = expectParagraphNode(convertParagraph(pStyle));
+        const nodeStyle = expectParagraphNode($convertParagraph(pStyle));
         expect(nodeStyle.getFormatType()).toBe('center');
 
         // Case 3: CSS takes priority over Attribute
@@ -199,7 +196,7 @@ describe('LexicalParagraphNode tests', () => {
         pConflict.setAttribute('align', 'right');
         pConflict.style.textAlign = 'left';
 
-        const nodeConflict = expectParagraphNode(convertParagraph(pConflict));
+        const nodeConflict = expectParagraphNode($convertParagraph(pConflict));
         expect(nodeConflict.getFormatType()).toBe('left');
 
         // Case 4: Invalid align attribute is ignored
@@ -207,7 +204,7 @@ describe('LexicalParagraphNode tests', () => {
         const pInvalid = document.createElement('p');
         pInvalid.setAttribute('align', 'super-weird-stuff');
 
-        const nodeInvalid = expectParagraphNode(convertParagraph(pInvalid));
+        const nodeInvalid = expectParagraphNode($convertParagraph(pInvalid));
         // Should NOT be 'super-weird-stuff' or undefined
         expect(nodeInvalid.getFormatType()).toBe('');
       });

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
@@ -6,6 +6,7 @@
  *
  */
 import {
+  $cloneWithProperties,
   $createParagraphNode,
   $createTextNode,
   $getRoot,
@@ -91,7 +92,7 @@ describe('LexicalRootNode tests', () => {
     });
 
     test('RootNode.clone()', async () => {
-      const rootNodeClone = (rootNode.constructor as typeof RootNode).clone();
+      const rootNodeClone = $cloneWithProperties(rootNode);
 
       expect(rootNodeClone).not.toBe(rootNode);
       expect(rootNodeClone).toStrictEqual(rootNode);


### PR DESCRIPTION
## Breaking Changes

Note that these changes only affect *callers* of static methods of the built-in node classes. It is still completely supported to *implement* these static methods on your own node classes, but we of course recommend that you upgrade to the `$config` protocol as it's more concise and offers more features.

All base classes now use the `$config` protocol which will widen their types static methods, which are technically public API but were really only intended for use directly by the editor (e.g. `ParagraphNode.importDOM()` or `ParagraphNode.clone()` shouldn't appear in user code).

Classes using the `$config` protocol don't directly implement these static methods, their trivial implementations are generated on first call to `getStaticNodeConfig`. This happens automatically during editor construction, but may happen earlier.

It's fine to keep calling these static methods directly, no behavior or type change:
- `NodeClass.getType()`

You should avoid calling these static methods directly because they are not intended as callable API surface (other than maybe in tests). Their behavior hasn't changed but the types have widened:

- `NodeClass.importJSON()` - Use higher-level functions to parse serialized nodes such as `LexicalEditor.parseEditorState` or `$generateNodesFromSerializedNodes`
- `NodeClass.importDOM()` - You should consider migrating to [DOMImportExtension](https://lexical.dev/docs/serialization/dom-import) and/or use importDOM indirectly via `$generateNodesFromDOM`

Refactor direct calls, the implementation is present but the behavior has likely changed:

- `NodeClass.clone()` - Use [$cloneWithProperties](https://lexical.dev/docs/api/modules/lexical#clonewithproperties) instead. This is present at runtime with a wider type, but only does a trivial construction. The companion `afterCloneFrom` instance method does all of state propagation.

No longer present on refactored classes, do not call:

- `NodeClass.transform()` - This was an `@internal` API, classes that used these have had their transforms moved to the `$config` data structure and they are *not* injected as a static method. It will be deprecated at some point, you can use extensions to register transforms as well as `$transform` in your `$config`.

## Description

The `$config()` protocol (added in #8645) lets a node declare its type, cloning, serialization, and DOM-import behavior from a single `$config()` instance method; `getStaticNodeConfig` then synthesizes the corresponding static methods (`getType`, `clone`, `importJSON`, `importDOM`) at runtime. This PR ports the node classes to `$config()` and removes the now-redundant boilerplate statics, moving each node's `importDOM` map into the `$config` `importDOM` option while leaving `updateFromJSON`/`exportJSON`/`createDOM`/`updateDOM` in place. It intentionally does **not** adopt the separate JSON-schema serialization work - serialization is unchanged.

Ported across `lexical` (TextNode, TabNode, LineBreakNode, ParagraphNode, RootNode, ArtificialNode), `@lexical/rich-text` (Heading, Quote), `@lexical/link` (Link, AutoLink), `@lexical/mark`, `@lexical/hashtag`, `@lexical/table` (Table, Row, Cell), `@lexical/code` (CodeNode, CodeHighlightNode), `@lexical/react` and `@lexical/extension` HorizontalRule, the playground nodes, and the examples. Decorator nodes whose constructors take required arguments keep a minimal `clone`/`importJSON` (they must construct with arguments). The base `LexicalNode` and the fixtures that exist to verify the legacy static-method path are left as-is.

- Because a `$config`-based node records its own `type` via the protocol's accessor, the structurally-identical `TabNode` stays nominally distinct from `TextNode` without the statics it previously relied on, so guards like `$isTabNode()` keep narrowing correctly.
- Nodes relying on the synthesized `clone` need a zero-argument constructor, so key-only/leading parameters were given explicit defaults (or redundant pure-delegation constructors were removed) so `Node.length === 0`.
- Fixed code that relied on `TextNode` being incorrectly assignable to `TabNode`: `$getFirstCodeNodeOfLine` is now generic over its anchor type.
- `__type` is now `readonly` (it is only ever assigned once, in the constructor); `@lexical/yjs`'s generic property writer casts through a mutable record accordingly (it never actually writes `__type`, which is intrinsic and filtered out by its equal-value guard).

Tests:
- Clone tests use the public `$cloneWithProperties` helper instead of manually pairing `clone()` with `afterCloneFrom()`.
- DOM-conversion tests use a new shared `$runDOMConversion` util that drives the editor's registered conversion cache (the real paste path) instead of a node's static `importDOM()`.

## Test plan

New unit tests