### PR TITLE
[*] Chore: make CLAUDE.md a symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Agent Instructions
-
-For detailed architectural guidance, build commands, and development workflows, see **[AGENTS.md](./AGENTS.md)**.
+AGENTS.md


### PR DESCRIPTION
## Description

`CLAUDE.md` currently just points readers to `AGENTS.md`. This replaces it with a symlink (`CLAUDE.md` → `AGENTS.md`, git mode `120000`) so Claude Code reads a single source of truth and the two files can't drift.

This follows up on review feedback in #8634, where @etrepum suggested a symlink rather than duplicating guidance across both files. Splitting it into its own PR so it can be evaluated independently of the backwards-compatibility doc change.

**Caveat:** this is a git symlink. It resolves transparently on macOS/Linux. On Windows checkouts without `core.symlinks=true` it will materialize as a small text file containing the string `AGENTS.md` rather than the file contents. If that tradeoff isn't worth it for a repo with diverse contributor environments, happy to close this — no strong opinion.

## Test plan

- `git ls-files -s CLAUDE.md` reports mode `120000` (symlink).
- On macOS/Linux, `cat CLAUDE.md` resolves to the contents of `AGENTS.md`.
- No other files changed.