### PR TITLE
[lexical] Extend the $config() protocol with accessor-based nominal typing

### DIFF
--- a/packages/lexical-website/docs/concepts/nodes.mdx
+++ b/packages/lexical-website/docs/concepts/nodes.mdx
@@ -815,3 +815,93 @@ export function $isVideoNode(
 Using `useDecorators`, `PlainTextPlugin` and `RichTextPlugin` executes `React.createPortal(reactDecorator, element)` for each `DecoratorNode`,
 where the `reactDecorator` is what is returned by `DecoratorNode.prototype.decorate`,
 and the `element` is an `HTMLElement` returned by `DecoratorNode.prototype.createDOM`.
+
+### Sharing `$config` across an abstract base class
+
+A concrete node records its string `type` in `$config`. An abstract base class
+has no concrete `type` of its own, but it can still declare configuration that
+is shared with all of its concrete subclasses — for example a `$transform`, or
+required [NodeState](/docs/concepts/node-state) — by keying its `$config` with a
+well-known symbol instead of a string. By convention this is
+`Symbol.for(<ClassName>)`:
+
+```ts
+import {ElementNode} from 'lexical';
+
+// Abstract base — it has no concrete node `type` of its own.
+export class BaseBoxNode extends ElementNode {
+  $config() {
+    return this.config(Symbol.for('BaseBoxNode'), {
+      extends: ElementNode,
+      // Registered for this class and every subclass.
+      $transform: (node: BaseBoxNode): void => {
+        // ...
+      },
+    });
+  }
+}
+
+// Concrete subclass — inherits the shared $transform.
+export class RedBoxNode extends BaseBoxNode {
+  $config() {
+    return this.config('red-box', {extends: BaseBoxNode});
+  }
+
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+}
+```
+
+The descriptive, globally-registered symbol keeps the configuration easy to find
+in a debugger and can never collide with a real node `type`.
+
+### Nominal typing for structurally-identical nodes
+
+TypeScript's type system is _structural_: two classes with the same members are
+mutually assignable even when one is declared as a subclass of the other. So a
+node subclass that adds no type-distinguishable members over its base — for
+example a node that only overrides methods with identical signatures — is
+structurally identical to its base, despite being a distinct class. The built-in
+`TabNode` (which extends `TextNode`) is one such node. Because the two are
+structurally identical, TypeScript considers `TextNode` assignable to `TabNode`,
+so without a nominal distinction the negative branch of an `instanceof`-style
+type guard like `$isTabNode()` would collapse to `never`:
+
+```ts
+import {$isTabNode, type TextNode} from 'lexical';
+
+function $example(node: TextNode) {
+  if ($isTabNode(node)) {
+    return;
+  }
+  // `node` is correctly narrowed to `TextNode` here.
+  node.getFormat();
+}
+```
+
+You get this distinction automatically by declaring the superclass with
+`extends` in `$config` — which is exactly what `TabNode` does:
+
+```ts
+import {TextNode} from 'lexical';
+
+export class TabNode extends TextNode {
+  $config() {
+    // highlight-next-line
+    return this.config('tab', {extends: TextNode});
+  }
+}
+```
+
+Lexical records each node's own `type` in the `$config` return type along the
+`extends` chain. That makes the classes nominally distinct: the base is no
+longer assignable to the subclass (so the guard narrows correctly) while the
+subclass remains assignable to the base. It works at every level of the
+hierarchy — a subclass of `TabNode` is likewise distinct from `TabNode` — it is
+type-only with no runtime cost, and there is nothing to declare on the class
+beyond the `extends` you already provide.

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -101,11 +101,16 @@ export type SerializedLexicalNode = {
  */
 export interface StaticNodeConfigValue<
   T extends LexicalNode,
-  Type extends string,
+  Type extends string | symbol,
 > {
   /**
    * The exact type of T.getType(), e.g. 'text' - the method itself must
    * have a more generic 'string' type to be compatible wtih subclassing.
+   *
+   * For a concrete node this is its string `type`. An abstract base class is
+   * keyed in {@link BaseStaticNodeConfig} by a symbol (it has no concrete node
+   * `type`), so `Type` is widened to `string | symbol`; the `type` field is
+   * never populated for a symbol-keyed config.
    */
   readonly type?: Type;
   /**
@@ -170,9 +175,20 @@ export interface StaticNodeConfigValue<
 /**
  * This is the type of LexicalNode.$config() that can be
  * overridden by subclasses.
+ *
+ * Concrete nodes are keyed by their string `type`. An abstract base class
+ * (such as ElementNode or DecoratorNode) has no concrete node `type`, so when
+ * it needs to declare configuration that is shared with its concrete
+ * subclasses (for example required {@link RequiredNodeStateConfig} state or a
+ * `$transform`) it is keyed instead by a well-known symbol, by convention
+ * `Symbol.for(<NodeClassName>)` (e.g. `Symbol.for('ElementNode')`). The
+ * descriptive, globally-registered symbol keeps the config easy to find in a
+ * debugger and can never collide with a real node `type`.
  */
 export type BaseStaticNodeConfig = {
-  readonly [K in string]?: StaticNodeConfigValue<LexicalNode, string>;
+  readonly [K in string | symbol]?:
+    | undefined
+    | StaticNodeConfigValue<LexicalNode, K>;
 };
 
 /**
@@ -194,15 +210,75 @@ export type AnyStaticNodeConfigValue = StaticNodeConfigValue<any, any>;
 /**
  * @internal
  *
+ * Type-only key under which a {@link StaticNodeConfigRecord} carries the node's
+ * own (most-derived) `type` as a nullary accessor `() => Type`.
+ *
+ * TypeScript's type system is structural, so a node subclass that adds no
+ * type-distinguishable members over its base (e.g. {@link TabNode} over
+ * {@link TextNode}, which only overrides methods with identical signatures) is
+ * structurally identical to that base despite being a distinct class — the
+ * negative branch of an `instanceof`-style guard like `$isTabNode()` would
+ * otherwise collapse to `never` because TypeScript concludes the base is also
+ * assignable to the subclass.
+ *
+ * Encoding the type as a *function* (rather than a bare `Type`) lets the
+ * accessor accumulate down the `extends` chain by intersection: a subclass'
+ * record is `ParentRecord & {[STATIC_NODE_TYPE]: () => OwnType}`, so the key
+ * holds `(() => ParentType) & (() => OwnType)`. TypeScript resolves an
+ * intersection of call signatures as an overload set, which has two effects:
+ *
+ * - {@link GetStaticNodeType} reads `ReturnType<...>`, which selects the *last*
+ *   overload — the most-derived own `type` — rather than a union of the chain.
+ * - A node stays assignable to each of its ancestors (the intersection
+ *   satisfies every `() => AncestorType`) while an ancestor is not assignable
+ *   to it (it lacks the `() => OwnType` signature), so guards narrow correctly
+ *   at every level of the hierarchy — not just one.
+ *
+ * This keeps the node classes themselves nominally distinguishable along their
+ * real hierarchy; it is not a cross-cutting trait marker. The accessor is never
+ * read at runtime — `config()` does not set this key — so it is `declare`-only
+ * and carries no runtime cost. It is `@internal` (surfaced via the
+ * {@link StaticNodeTypeAccessor} interface so that inferred `$config()` return
+ * types remain nameable in generated declaration files) and a node never
+ * references it. Distinction is automatic for any node that declares its
+ * `extends`; a subclass adds nothing by hand.
+ */
+export declare const STATIC_NODE_TYPE: unique symbol;
+
+/**
+ * @internal
+ *
+ * Carries a node's own `type` under the {@link STATIC_NODE_TYPE} accessor. This
+ * is an `interface` (rather than an inline object type) on purpose: it is never
+ * inlined in generated declaration files, so a subclass' `$config()` return type
+ * references it by name (`StaticNodeTypeAccessor<'tab'>`) and the symbol key
+ * stays encapsulated here rather than leaking — unnamed — into every node's
+ * `.d.ts`.
+ */
+export interface StaticNodeTypeAccessor<Type extends string> {
+  readonly [STATIC_NODE_TYPE]: () => Type;
+}
+
+/**
+ * @internal
+ *
  * This is the more specific type than BaseStaticNodeConfig that a subclass
- * should return from $config()
+ * should return from $config().
+ *
+ * A node that declares its `extends` accumulates the configuration of its
+ * superclass and records its own `type` under {@link STATIC_NODE_TYPE}, so that
+ * it is nominally distinct from — yet still assignable to — that superclass.
  */
 export type StaticNodeConfigRecord<
   Type extends string,
   Config extends AnyStaticNodeConfigValue,
-> = BaseStaticNodeConfig & {
-  readonly [K in Type]?: Config;
-};
+> = Config extends {
+  extends: abstract new (...args: never) => infer Inst extends LexicalNode;
+}
+  ? ReturnType<Inst[typeof PROTOTYPE_CONFIG_METHOD]> & {
+      readonly [K in Type]?: Config;
+    } & StaticNodeTypeAccessor<Type>
+  : BaseStaticNodeConfig & {readonly [K in Type]?: Config};
 
 /**
  * Extract the type from a node based on its $config
@@ -214,12 +290,16 @@ export type StaticNodeConfigRecord<
  * ```
  */
 export type GetStaticNodeType<T extends LexicalNode> =
-  ReturnType<T[typeof PROTOTYPE_CONFIG_METHOD]> extends StaticNodeConfig<
-    T,
-    infer Type
-  >
-    ? Type
-    : string;
+  ReturnType<T[typeof PROTOTYPE_CONFIG_METHOD]> extends {
+    readonly [STATIC_NODE_TYPE]: infer Accessor extends () => string;
+  }
+    ? ReturnType<Accessor>
+    : ReturnType<T[typeof PROTOTYPE_CONFIG_METHOD]> extends StaticNodeConfig<
+          T,
+          infer Type
+        >
+      ? Type
+      : string;
 
 /**
  * The most precise type we can infer for the JSON that will
@@ -551,15 +631,33 @@ export class LexicalNode {
    * This is a convenience method for $config that
    * aids in type inference. See {@link LexicalNode.$config}
    * for example usage.
+   *
+   * An abstract base class that has no concrete node `type` may pass a
+   * well-known symbol (by convention `Symbol.for(<NodeClassName>)`) instead of
+   * a string `type` to declare configuration shared with its subclasses.
    */
+  config<Config extends StaticNodeConfigValue<this, string>>(
+    type: symbol,
+    config: Config,
+  ): BaseStaticNodeConfig;
   config<Type extends string, Config extends StaticNodeConfigValue<this, Type>>(
     type: Type,
     config: Config,
-  ): StaticNodeConfigRecord<Type, Config> {
+  ): StaticNodeConfigRecord<Type, Config>;
+  config(
+    type: string | symbol,
+    config: AnyStaticNodeConfigValue,
+  ): BaseStaticNodeConfig {
     const parentKlass =
       config.extends || Object.getPrototypeOf(this.constructor);
-    Object.assign(config, {extends: parentKlass, type});
-    return {[type]: config} as StaticNodeConfigRecord<Type, Config>;
+    Object.assign(config, {extends: parentKlass});
+    // A concrete node records its string `type`; an abstract base class is
+    // keyed by a well-known symbol (e.g. Symbol.for('ElementNode')) and has no
+    // concrete node `type`.
+    if (typeof type === 'string') {
+      Object.assign(config, {type});
+    }
+    return {[type]: config} as BaseStaticNodeConfig;
   }
 
   /**
@@ -1237,7 +1335,9 @@ export class LexicalNode {
    * See [Serialization & Deserialization](https://lexical.dev/docs/concepts/serialization#lexical---html).
    *
    * */
-  static importJSON(_serializedNode: SerializedLexicalNode): LexicalNode {
+  static importJSON(
+    _serializedNode: SerializedLexicalNode & Record<string, unknown>,
+  ): LexicalNode {
     invariant(
       false,
       'LexicalNode: Node %s does not implement .importJSON().',

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -262,12 +262,48 @@ export interface StaticNodeTypeAccessor<Type extends string> {
 /**
  * @internal
  *
+ * Type-only key under which a {@link StaticNodeConfigRecord} carries the node's
+ * own configuration (the value passed to {@link LexicalNode.config}) as a
+ * nullary accessor `() => Config`.
+ *
+ * This mirrors {@link STATIC_NODE_TYPE}: encoding the config as a *function*
+ * lets it accumulate down the `extends` chain by call-signature intersection so
+ * that `ReturnType<...>` resolves the most-derived own config. It exists so that
+ * an abstract base class keyed by a symbol — which has no string `type` to index
+ * the record by — can still expose its own config to the state-config
+ * collectors, and so that such a base's symbol-keyed `$config()` return remains
+ * a valid override of an accessor-bearing superclass `$config()` (it inherits
+ * the superclass record, hence that record's {@link STATIC_NODE_TYPE} accessor).
+ * Never read at runtime — `config()` does not set this key — so it is
+ * `declare`-only and carries no runtime cost.
+ */
+export declare const STATIC_NODE_CONFIG: unique symbol;
+
+/**
+ * @internal
+ *
+ * Carries a node's own config under the {@link STATIC_NODE_CONFIG} accessor.
+ * Like {@link StaticNodeTypeAccessor} this is a named `interface` so the symbol
+ * key stays encapsulated and inferred `$config()` return types remain nameable
+ * in generated declaration files.
+ */
+export interface StaticNodeConfigAccessor<
+  Config extends AnyStaticNodeConfigValue,
+> {
+  readonly [STATIC_NODE_CONFIG]: () => Config;
+}
+
+/**
+ * @internal
+ *
  * This is the more specific type than BaseStaticNodeConfig that a subclass
  * should return from $config().
  *
  * A node that declares its `extends` accumulates the configuration of its
- * superclass and records its own `type` under {@link STATIC_NODE_TYPE}, so that
- * it is nominally distinct from — yet still assignable to — that superclass.
+ * superclass and records its own `type` under {@link STATIC_NODE_TYPE} and its
+ * own config under {@link STATIC_NODE_CONFIG}, so that it is nominally distinct
+ * from — yet still assignable to — that superclass, and so the state-config
+ * collectors can read its own config without indexing by `type`.
  */
 export type StaticNodeConfigRecord<
   Type extends string,
@@ -277,8 +313,29 @@ export type StaticNodeConfigRecord<
 }
   ? ReturnType<Inst[typeof PROTOTYPE_CONFIG_METHOD]> & {
       readonly [K in Type]?: Config;
-    } & StaticNodeTypeAccessor<Type>
+    } & StaticNodeTypeAccessor<Type> &
+      StaticNodeConfigAccessor<Config>
   : BaseStaticNodeConfig & {readonly [K in Type]?: Config};
+
+/**
+ * @internal
+ *
+ * The record returned by {@link LexicalNode.config} for an abstract base class
+ * keyed by a symbol. Unlike {@link StaticNodeConfigRecord} it records no string
+ * `type` and adds no {@link STATIC_NODE_TYPE} accessor (an abstract base has no
+ * concrete node type), but it does inherit its superclass record and expose its
+ * own config under {@link STATIC_NODE_CONFIG}. Inheriting the superclass record
+ * is what keeps the override valid when the superclass is a concrete node whose
+ * `$config()` return already carries a {@link STATIC_NODE_TYPE} accessor.
+ */
+export type AbstractStaticNodeConfigRecord<
+  Config extends AnyStaticNodeConfigValue,
+> = Config extends {
+  extends: abstract new (...args: never) => infer Inst extends LexicalNode;
+}
+  ? ReturnType<Inst[typeof PROTOTYPE_CONFIG_METHOD]> &
+      StaticNodeConfigAccessor<Config>
+  : BaseStaticNodeConfig & StaticNodeConfigAccessor<Config>;
 
 /**
  * Extract the type from a node based on its $config
@@ -300,6 +357,24 @@ export type GetStaticNodeType<T extends LexicalNode> =
         >
       ? Type
       : string;
+
+/**
+ * @internal
+ *
+ * A node's own config (the value it passed to {@link LexicalNode.config}), read
+ * from the {@link STATIC_NODE_CONFIG} accessor, or `never` for a node whose
+ * `$config()` does not set that accessor (a legacy node, or one whose record
+ * uses the {@link BaseStaticNodeConfig} fallback). Unlike indexing the record by
+ * a resolved string `type`, this also resolves the own config of an abstract
+ * base class keyed by a symbol.
+ */
+export type GetStaticNodeOwnConfig<T extends LexicalNode> =
+  ReturnType<T[typeof PROTOTYPE_CONFIG_METHOD]> extends {
+    readonly [STATIC_NODE_CONFIG]: infer Accessor extends
+      () => AnyStaticNodeConfigValue;
+  }
+    ? ReturnType<Accessor>
+    : never;
 
 /**
  * The most precise type we can infer for the JSON that will
@@ -639,7 +714,7 @@ export class LexicalNode {
   config<Config extends StaticNodeConfigValue<this, string>>(
     type: symbol,
     config: Config,
-  ): BaseStaticNodeConfig;
+  ): AbstractStaticNodeConfigRecord<Config>;
   config<Type extends string, Config extends StaticNodeConfigValue<this, Type>>(
     type: Type,
     config: Config,

--- a/packages/lexical/src/LexicalNodeState.ts
+++ b/packages/lexical/src/LexicalNodeState.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {AnyStaticNodeConfigValue, GetStaticNodeType} from './LexicalNode';
+
 import invariant from '@lexical/internal/invariant';
 
 import {
@@ -17,7 +19,6 @@ import {
   NODE_STATE_KEY,
   type SerializedLexicalNode,
   type Spread,
-  type StaticNodeConfigRecord,
 } from '.';
 import {PROTOTYPE_CONFIG_METHOD} from './LexicalConstants';
 import {errorOnReadOnly} from './LexicalUpdates';
@@ -104,22 +105,37 @@ export type CollectStateJSON<
   {[K in keyof Tuple]: RequiredNodeStateConfigJSON<Tuple[K], Flat>}[number]
 >;
 
+// Read the node's own config out of its $config() record. The record is keyed
+// by the node's own `type`, so we resolve that type first (see
+// {@link GetStaticNodeType}) and index by it rather than reverse-inferring
+// through the StaticNodeConfigRecord shape, which accumulates ancestor keys.
+// The own type is read through a mapped type (`{[P in Type]: ...}[Type]`) so
+// that the indexed access resolves against the concrete key literal rather than
+// the record's broad string index signature when `T` is still generic.
 type GetStaticNodeConfig<T extends LexicalNode> =
-  ReturnType<T[typeof PROTOTYPE_CONFIG_METHOD]> extends infer Record
-    ? Record extends StaticNodeConfigRecord<infer Type, infer Config>
-      ? Config & {readonly type: Type}
-      : never
+  GetStaticNodeType<T> extends infer Type extends string
+    ? string extends Type
+      ? never
+      : {
+            [P in Type]: NonNullable<
+              ReturnType<T[typeof PROTOTYPE_CONFIG_METHOD]>[P]
+            >;
+          }[Type] extends infer Config extends AnyStaticNodeConfigValue
+        ? Config & {readonly type: Type}
+        : never
     : never;
 type GetStaticNodeConfigs<T extends LexicalNode> =
   GetStaticNodeConfig<T> extends infer OwnConfig
-    ? OwnConfig extends never
+    ? // `[X] extends [never]` checks for never without distributing (a naked
+      // `never` would otherwise collapse the whole conditional to never). A node
+      // with no $config — e.g. a legacy node keyed only by static getType() —
+      // yields never here and contributes no state configs.
+      [OwnConfig] extends [never]
       ? []
       : OwnConfig extends {extends: Klass<infer Parent>}
-        ? GetStaticNodeConfig<Parent> extends infer ParentNodeConfig
-          ? ParentNodeConfig extends never
-            ? [OwnConfig]
-            : [OwnConfig, ...GetStaticNodeConfigs<Parent>]
-          : OwnConfig
+        ? [GetStaticNodeConfig<Parent>] extends [never]
+          ? [OwnConfig]
+          : [OwnConfig, ...GetStaticNodeConfigs<Parent>]
         : [OwnConfig]
     : [];
 

--- a/packages/lexical/src/LexicalNodeState.ts
+++ b/packages/lexical/src/LexicalNodeState.ts
@@ -6,7 +6,11 @@
  *
  */
 
-import type {AnyStaticNodeConfigValue, GetStaticNodeType} from './LexicalNode';
+import type {
+  AnyStaticNodeConfigValue,
+  GetStaticNodeOwnConfig,
+  GetStaticNodeType,
+} from './LexicalNode';
 
 import invariant from '@lexical/internal/invariant';
 
@@ -105,15 +109,20 @@ export type CollectStateJSON<
   {[K in keyof Tuple]: RequiredNodeStateConfigJSON<Tuple[K], Flat>}[number]
 >;
 
-// Read the node's own config out of its $config() record. The record is keyed
-// by the node's own `type`, so we resolve that type first (see
-// {@link GetStaticNodeType}) and index by it rather than reverse-inferring
-// through the StaticNodeConfigRecord shape, which accumulates ancestor keys.
-// The own type is read through a mapped type (`{[P in Type]: ...}[Type]`) so
-// that the indexed access resolves against the concrete key literal rather than
-// the record's broad string index signature when `T` is still generic.
-type GetStaticNodeConfig<T extends LexicalNode> =
-  GetStaticNodeType<T> extends infer Type extends string
+// Read a node's own config out of its $config() record. Preferentially read it
+// from the STATIC_NODE_CONFIG accessor (see {@link GetStaticNodeOwnConfig}),
+// which resolves the most-derived own config directly — including for an
+// abstract base class keyed by a symbol, which has no string `type` to index by.
+// A record produced by the {@link BaseStaticNodeConfig} fallback (a node that
+// declares no `extends`, or a legacy node) sets no accessor; for those we fall
+// back to resolving the own `type` (see {@link GetStaticNodeType}) and indexing
+// by it. The own type is read through a mapped type (`{[P in Type]: ...}[Type]`)
+// so that the indexed access resolves against the concrete key literal rather
+// than the record's broad string index signature when `T` is still generic.
+type GetStaticNodeConfig<T extends LexicalNode> = [
+  GetStaticNodeOwnConfig<T>,
+] extends [never]
+  ? GetStaticNodeType<T> extends infer Type extends string
     ? string extends Type
       ? never
       : {
@@ -123,6 +132,10 @@ type GetStaticNodeConfig<T extends LexicalNode> =
           }[Type] extends infer Config extends AnyStaticNodeConfigValue
         ? Config & {readonly type: Type}
         : never
+    : never
+  : GetStaticNodeOwnConfig<T> extends infer Config extends
+        AnyStaticNodeConfigValue
+    ? Config & {readonly type: GetStaticNodeType<T>}
     : never;
 type GetStaticNodeConfigs<T extends LexicalNode> =
   GetStaticNodeConfig<T> extends infer OwnConfig

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -2398,7 +2398,9 @@ function isAbstractNodeClass(klass: Klass<LexicalNode>): boolean {
 /** @internal */
 export function getStaticNodeConfig(klass: Klass<LexicalNode>): {
   ownNodeType: undefined | string;
-  ownNodeConfig: undefined | StaticNodeConfigValue<LexicalNode, string>;
+  ownNodeConfig:
+    | undefined
+    | StaticNodeConfigValue<LexicalNode, string | symbol>;
 } {
   const nodeConfigRecord =
     PROTOTYPE_CONFIG_METHOD in klass.prototype
@@ -2409,15 +2411,33 @@ export function getStaticNodeConfig(klass: Klass<LexicalNode>): {
     !isAbstract && hasOwnStaticMethod(klass, 'getType')
       ? klass.getType()
       : undefined;
-  let ownNodeConfig: undefined | StaticNodeConfigValue<LexicalNode, string>;
+  let ownNodeConfig:
+    | undefined
+    | StaticNodeConfigValue<LexicalNode, string | symbol>;
   let ownNodeType = nodeType;
   if (nodeConfigRecord) {
     if (nodeType) {
       ownNodeConfig = nodeConfigRecord[nodeType];
     } else {
+      // No static getType(): derive the type and config from the $config
+      // record. The common case is a concrete node keyed by its string `type`.
       for (const [k, v] of Object.entries(nodeConfigRecord)) {
         ownNodeType = k;
         ownNodeConfig = v;
+      }
+      // Fall back to a well-known symbol key (e.g. Symbol.for('ElementNode'))
+      // for an abstract base class that has no concrete node type, using the
+      // first symbol whose value is a config record.
+      if (!ownNodeConfig) {
+        for (const symbolKey of Object.getOwnPropertySymbols(
+          nodeConfigRecord,
+        )) {
+          const symbolConfig = nodeConfigRecord[symbolKey];
+          if (symbolConfig) {
+            ownNodeConfig = symbolConfig;
+            break;
+          }
+        }
       }
     }
   }

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -11,11 +11,13 @@ import {
   $create,
   $createLineBreakNode,
   $createRangeSelection,
+  $createTabNode,
   $getRoot,
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
   $isRangeSelection,
+  $isTabNode,
   $setSelection,
   createEditor,
   DecoratorNode,
@@ -27,6 +29,7 @@ import {
   RangeSelection,
   SerializedLexicalNode,
   SerializedTextNode,
+  TabNode,
   TextNode,
 } from 'lexical';
 import {
@@ -35,6 +38,7 @@ import {
   beforeEach,
   describe,
   expect,
+  expectTypeOf,
   test,
   vi,
 } from 'vitest';
@@ -100,7 +104,17 @@ class InlineDecoratorNode extends DecoratorNode<string> {
 
 describe('LexicalNode tests', () => {
   beforeAll(() => {
-    vi.spyOn(LexicalNode, 'getType').mockImplementation(() => 'node');
+    // Give the abstract base a concrete type for `new LexicalNode()` tests, but
+    // delegate for subclasses: now that ported nodes derive their type from
+    // `$config` (instead of their own static `getType`), they reach this base
+    // method until `getStaticNodeConfig` injects their own, so it must resolve
+    // the real type rather than collapsing every subclass to 'node'.
+    const realGetType = LexicalNode.getType;
+    vi.spyOn(LexicalNode, 'getType').mockImplementation(function (
+      this: typeof LexicalNode,
+    ) {
+      return this === LexicalNode ? 'node' : realGetType.call(this);
+    });
   });
   afterAll(() => {
     vi.restoreAllMocks();
@@ -2082,5 +2096,87 @@ describe('LexicalNode.$config() without registration', () => {
         'correct-custom-decorator',
       );
     }
+  });
+
+  test('abstract base class declares shared $config under a Symbol key', () => {
+    // An abstract base class has no concrete node `type`, so it publishes the
+    // configuration it shares with its subclasses (here a $transform) under a
+    // well-known symbol rather than a string key. getStaticNodeConfig must
+    // resolve that symbol-keyed config so the transform is collected for the
+    // concrete subclass.
+    const transformed: string[] = [];
+    class AbstractBaseNode extends ElementNode {
+      $config() {
+        return this.config(Symbol.for('AbstractBaseNode'), {
+          $transform: (node: AbstractBaseNode) => {
+            transformed.push(node.getType());
+          },
+        });
+      }
+    }
+    class ConcreteChildNode extends AbstractBaseNode {
+      $config() {
+        return this.config('concrete-child-node', {extends: AbstractBaseNode});
+      }
+      createDOM(): HTMLElement {
+        return document.createElement('div');
+      }
+    }
+    // The abstract base must not be assigned a concrete type or static methods.
+    expect(() => AbstractBaseNode.getType()).toThrow(
+      /does not implement \.getType/,
+    );
+
+    const editor = createEditor({
+      nodes: [ConcreteChildNode],
+      onError(err) {
+        throw err;
+      },
+    });
+    editor.update(
+      () => {
+        $getRoot().append(new ConcreteChildNode());
+      },
+      {discrete: true},
+    );
+
+    expect(ConcreteChildNode.getType()).toEqual('concrete-child-node');
+    expect(transformed).toEqual(['concrete-child-node']);
+  });
+
+  test('a structurally-identical subclass stays narrowable', () => {
+    // TabNode adds nothing structural over TextNode (it only overrides methods
+    // with identical signatures). The $config protocol accumulates a node's own
+    // type under STATIC_NODE_TYPE, which keeps the two distinct so $isTabNode()
+    // narrows a TextNode correctly instead of collapsing the negative branch to
+    // `never` (which TypeScript would do if the base were assignable back to the
+    // subclass).
+    const $narrowFromTextNode = (node: TextNode): string => {
+      if ($isTabNode(node)) {
+        expectTypeOf(node).toEqualTypeOf<TabNode>();
+        return node.getType();
+      }
+      // This assertion fails to compile if the negative branch collapsed to
+      // `never` instead of staying `TextNode`.
+      expectTypeOf(node).toEqualTypeOf<TextNode>();
+      return node.getType();
+    };
+
+    const editor = createEditor({
+      onError(err) {
+        throw err;
+      },
+    });
+    editor.update(
+      () => {
+        const tab = $createTabNode();
+        const text = $createTextNode('x');
+        expect($isTabNode(tab)).toBe(true);
+        expect($isTabNode(text)).toBe(false);
+        expect($narrowFromTextNode(text)).toBe('text');
+        expect($narrowFromTextNode(tab)).toBe('tab');
+      },
+      {discrete: true},
+    );
   });
 });

--- a/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
@@ -8,6 +8,7 @@
 
 import {
   $copyNode,
+  $create,
   $createParagraphNode,
   $createTextNode,
   $getRoot,
@@ -15,15 +16,18 @@ import {
   $getStateChange,
   $isParagraphNode,
   $setState,
+  createEditor,
   createState,
+  ElementNode,
   LexicalExportJSON,
   NODE_STATE_KEY,
   type NodeStateJSON,
   ParagraphNode,
   RootNode,
+  type SerializedElementNode,
   StateValueOrUpdater,
 } from 'lexical';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect, expectTypeOf, test} from 'vitest';
 
 import {nodeStatesAreEquivalent} from '../../LexicalNodeState';
 import {initializeUnitTest, invariant} from '../utils';
@@ -112,6 +116,64 @@ type _TestExtraStateNodeExportJSON = Expect<
 
 function $createStateNode() {
   return new StateNode();
+}
+
+// ===========================================================================
+// Interleaved abstract/concrete $config hierarchy:
+//   ElementNode -> InterleaveParagraph (concrete) -> InterleaveAbstract
+//   (abstract, Symbol-keyed) -> InterleaveConcrete (concrete)
+// A required flat state is declared at each level below ElementNode, and the
+// abstract base also registers a $transform. Before the accessor-based config
+// fix:
+//   - InterleaveAbstract.$config did not type-check as an override of the
+//     accessor-bearing InterleaveParagraph.$config, and
+//   - NodeStateJSON<InterleaveConcrete> truncated at the Symbol-keyed base to
+//     just {icState}, dropping iaState and ipState even though the runtime
+//     registered and serialized all three.
+// ===========================================================================
+const ipState = createState('ipState', {
+  parse: v => (typeof v === 'number' ? v : 0),
+});
+const iaState = createState('iaState', {
+  parse: v => (typeof v === 'number' ? v : 0),
+});
+const icState = createState('icState', {
+  parse: v => (typeof v === 'number' ? v : 0),
+});
+const interleaveTransforms: string[] = [];
+
+class InterleaveParagraph extends ElementNode {
+  $config() {
+    return this.config('interleave-paragraph', {
+      extends: ElementNode,
+      stateConfigs: [{flat: true, stateConfig: ipState}],
+    });
+  }
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+  updateDOM(): false {
+    return false;
+  }
+}
+class InterleaveAbstract extends InterleaveParagraph {
+  $config() {
+    return this.config(Symbol.for('InterleaveAbstract'), {
+      $transform: (node: InterleaveAbstract) => {
+        interleaveTransforms.push(node.getType());
+      },
+      extends: InterleaveParagraph,
+      stateConfigs: [{flat: true, stateConfig: iaState}],
+    });
+  }
+}
+class InterleaveConcrete extends InterleaveAbstract {
+  $config() {
+    return this.config('interleave-concrete', {
+      extends: InterleaveAbstract,
+      stateConfigs: [{flat: true, stateConfig: icState}],
+    });
+  }
 }
 
 describe('LexicalNode state', () => {
@@ -727,4 +789,64 @@ describe('LexicalNode state', () => {
       theme: {},
     },
   );
+});
+
+describe('$config interleaved abstract/concrete classes', () => {
+  test('serializes, transforms, and types every interleaved level’s state', () => {
+    interleaveTransforms.length = 0;
+    const editor = createEditor({
+      nodes: [InterleaveConcrete],
+      onError: err => {
+        throw err;
+      },
+    });
+    editor.update(
+      () => {
+        const node = $setState(
+          $setState(
+            $setState($create(InterleaveConcrete), ipState, 1),
+            iaState,
+            2,
+          ),
+          icState,
+          3,
+        );
+        $getRoot().append(node);
+        const json = node.exportJSON();
+
+        // Value: every interleaved level's flat state was serialized — the
+        // concrete ancestor's (ipState), the Symbol-keyed abstract base's
+        // (iaState) and the concrete leaf's (icState).
+        expect(json).toMatchObject({
+          iaState: 2,
+          icState: 3,
+          ipState: 1,
+          type: 'interleave-concrete',
+        });
+
+        // Type: exportJSON()'s return stays the generic serialized type (it must,
+        // to remain compatible with subclassing) — the precise per-node JSON is
+        // described by NodeStateJSON, which now collects every interleaved
+        // level's flat state. Before the fix this truncated at the Symbol-keyed
+        // base to just {icState}.
+        expectTypeOf(json).toEqualTypeOf<SerializedElementNode>();
+        expectTypeOf<
+          keyof Omit<NodeStateJSON<InterleaveConcrete>, typeof NODE_STATE_KEY>
+        >().toEqualTypeOf<'ipState' | 'iaState' | 'icState'>();
+        expectTypeOf<
+          NodeStateJSON<InterleaveConcrete>['ipState']
+        >().toEqualTypeOf<number | undefined>();
+        expectTypeOf<
+          NodeStateJSON<InterleaveConcrete>['iaState']
+        >().toEqualTypeOf<number | undefined>();
+        expectTypeOf<
+          NodeStateJSON<InterleaveConcrete>['icState']
+        >().toEqualTypeOf<number | undefined>();
+      },
+      {discrete: true},
+    );
+    // The abstract base's $transform ran for the concrete leaf (transforms fire
+    // during reconciliation once the node is part of the document).
+    expect(interleaveTransforms).toContain('interleave-concrete');
+  });
 });

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -208,6 +208,7 @@ export type {
   StaticNodeConfig,
   StaticNodeConfigRecord,
   StaticNodeConfigValue,
+  StaticNodeTypeAccessor,
 } from './LexicalNode';
 export {$isLexicalNode, buildImportMap} from './LexicalNode';
 export {

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -188,6 +188,7 @@ export {$isEditorState} from './LexicalEditorState';
 export type {EventHandler} from './LexicalEvents';
 export {stopLexicalPropagation} from './LexicalEvents';
 export type {
+  AbstractStaticNodeConfigRecord,
   BaseStaticNodeConfig,
   DOMChildConversion,
   DOMConversion,
@@ -206,6 +207,7 @@ export type {
   NodeMap,
   SerializedLexicalNode,
   StaticNodeConfig,
+  StaticNodeConfigAccessor,
   StaticNodeConfigRecord,
   StaticNodeConfigValue,
   StaticNodeTypeAccessor,


### PR DESCRIPTION
## Description

This is the additive, minimally invasive half of the $config() work, split out so its backwards compatibility can be audited independently of the node-class refactor that follows. No existing node class is changed here: every change extends the $config() protocol, its supporting types and runtime, the documentation, and the tests. Existing classes keep their hand-written statics and are unaffected.

Protocol changes (additive):
- Abstract base classes have no concrete node `type`, so they can now declare configuration shared with their subclasses (e.g. a `$transform` or required NodeState) under a well-known `Symbol.for(<ClassName>)` key, which `getStaticNodeConfig` resolves via `Object.getOwnPropertySymbols`. `BaseStaticNodeConfig` becomes a single mapped type over `string | symbol`, and `StaticNodeConfigValue`'s `Type` parameter is widened to `string | symbol` (a symbol-keyed config never populates the string `type` field).
- TypeScript is structural, so a node subclass that adds no type-distinguishable members over its base (e.g. `TabNode` over `TextNode`, which only overrides methods with identical signatures) is indistinguishable from it, collapsing the negative branch of guards like `$isTabNode()` to `never`. A node that declares its `extends` now records its own `type` in the `$config` return type under an internal, type-only `() => Type` accessor that accumulates down the `extends` chain by call-signature intersection: the base is no longer assignable to the subclass (so guards narrow correctly) while the subclass stays assignable to the base, and the distinction holds at every level of the hierarchy. The accessor key lives behind an `@internal` `StaticNodeTypeAccessor` interface so inferred `$config()` return types stay nameable in generated `.d.ts`. `GetStaticNodeConfig` reads a node's own config out of the now-accumulating record by indexing its resolved own `type`.
- The default `LexicalNode.importJSON` parameter is widened to `SerializedLexicalNode & Record<string, unknown>` so a node relying on the synthesized `importJSON` accepts its own richer serialized shape — extra subclass fields and all — without a cast.

Tests:
- Coverage for the abstract-class Symbol `$config` mechanism, `importJSON()` and `clone()` with no boilerplate, and a narrowing regression test asserting that `$isTabNode()`'s negative branch on a `TextNode` stays `TextNode` rather than collapsing to `never`.

Docs:
- `concepts/nodes.mdx`: declaring shared `$config` on an abstract base class under a `Symbol.for(...)` key, and the automatic nominal typing that distinguishes structurally-identical nodes once they declare `extends`.

A full implementation that includes the refactoring of classes is in #8640

## Test plan

New unit tests