### PR TITLE
docs: link no-build vanilla quick start

### DIFF
--- a/packages/lexical-website/docs/getting-started/quick-start.md
+++ b/packages/lexical-website/docs/getting-started/quick-start.md
@@ -7,6 +7,15 @@ sidebar_position: 1
 This section covers how to use Lexical, independently of any framework or library. For those intending to use Lexical in their React applications,
 it's advisable to [check out the Getting Started with React page](../getting-started/react.md).
 
+If you want to try Lexical in the browser without setting up TypeScript, npm, or
+a bundler first, see the [browser-only ESM playground](https://playground.lexical.dev/esm/).
+It uses an HTML import map and regular `<script type="module">` tags; the
+complete source lives in
+[`packages/lexical-playground/esm`](https://github.com/facebook/lexical/tree/main/packages/lexical-playground/esm).
+For a framework-free editor built with Lexical Extensions, see the
+[Extension: Vanilla Tailwind](https://lexical.dev/gallery#extension-vanilla-tailwind)
+gallery example.
+
 ### Creating an editor and using it
 
 When you work with Lexical, you normally work with a single editor instance. An editor instance can be thought of as the one responsible


### PR DESCRIPTION
## Summary
- Point the Vanilla JS quick start at the existing browser-only ESM playground
- Link the source directory for the import-map based HTML example
- Surface the framework-free Extension: Vanilla Tailwind gallery example

Refs #5840

## Test plan
- `git diff --check`
- `npx --yes prettier --check packages/lexical-website/docs/getting-started/quick-start.md`
- `curl -fsSL --max-time 15 https://playground.lexical.dev/esm/` and verified the expected ESM playground title

Not run: `pnpm -C packages/lexical-website run build`, because this fresh clone has no dependencies installed and local Corepack fails before resolving `pnpm@10.34.1` with `Cannot find matching keyid`.