### PR TITLE
[lexical] Feature: add onWarn editor hook and route cascade guard through it

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -343,6 +343,7 @@ export interface CreateEditorArgs {
   namespace?: string;
   nodes?: ReadonlyArray<LexicalNodeConfig>;
   onError?: ErrorHandler;
+  onWarn?: ErrorHandler;
   parentEditor?: LexicalEditor;
   editable?: boolean;
   theme?: EditorThemeClasses;
@@ -1000,6 +1001,8 @@ export class LexicalEditor {
   /** @internal */
   _onError: ErrorHandler;
   /** @internal */
+  _onWarn: ErrorHandler;
+  /** @internal */
   _htmlConversions: DOMConversionCache;
   /** @internal */
   _window: null | Window;
@@ -1068,6 +1071,7 @@ export class LexicalEditor {
     this._key = createUID();
 
     this._onError = onError;
+    this._onWarn = createEditorArgs?.onWarn || console.warn;
     this._htmlConversions = htmlConversions;
     this._editable = editable;
     this._headless = parentEditor !== null && parentEditor._headless;

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1071,7 +1071,8 @@ export class LexicalEditor {
     this._key = createUID();
 
     this._onError = onError;
-    this._onWarn = createEditorArgs?.onWarn || console.warn;
+    this._onWarn =
+      (createEditorArgs && createEditorArgs.onWarn) || console.warn;
     this._htmlConversions = htmlConversions;
     this._editable = editable;
     this._headless = parentEditor !== null && parentEditor._headless;

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -879,15 +879,23 @@ function $triggerEnqueuedUpdates(editor: LexicalEditor): void {
     editor._updates = [];
     editor._cascadeCount = 0;
     // The cascade has already been broken above by clearing the update queue,
-    // so this is a recoverable internal guard rather than a fatal error. Use
-    // devInvariant so it throws loudly in development but only warns in
-    // production, instead of routing a recovered condition through _onError
-    // (typically console.error) and reporting it as an uncaught error.
-    devInvariant(
-      false,
-      'One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition. Editor namespace: %s',
-      editor._config.namespace,
-    );
+    // so this is a recoverable internal guard rather than a fatal error. Route
+    // through _onWarn so embedders can capture telemetry (e.g. FBLOGGER) while
+    // keeping default OSS behavior as console.warn. In __DEV__ we still throw
+    // loudly via devInvariant for immediate developer feedback.
+    if (__DEV__) {
+      devInvariant(
+        false,
+        'One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition. Editor namespace: %s',
+        editor._config.namespace,
+      );
+    } else {
+      editor._onWarn(
+        new Error(
+          `One or more update listeners are endlessly enqueueing more updates. May have encountered infinite recursion caused by update listeners that trigger additional updates without a stop condition. Editor namespace: ${editor._config.namespace}`,
+        ),
+      );
+    }
     return;
   }
   const queuedUpdate = queuedUpdates.shift();


### PR DESCRIPTION
## Description

Add an optional `onWarn` hook to `CreateEditorArgs` that mirrors `onError` but at warning severity. The hook defaults to `console.warn`, preserving existing OSS behavior.

The update-recursion guard in `$triggerEnqueuedUpdates` (cascade count > 99) now routes through `editor._onWarn` in production instead of a raw `console.warn` via `devInvariant`. In development (`__DEV__`), it still throws loudly via `devInvariant` for immediate developer feedback.

This allows embedders to wire `onWarn` to their own telemetry systems (e.g. structured logging) without the warning being lost to the browser console. It complements #8631 which downgraded this from an error to a warning — this PR ensures the warning remains capturable.

### Why a separate hook rather than reusing `onError`

#8631 deliberately moved this off `_onError` because routing a recovered condition through the error handler (typically `console.error`) reported it as an uncaught error, and prior history (#8596) showed routing through `onError` could freeze the editor. A dedicated `onWarn` keeps the severity separation clean.

### Changes

1. **`LexicalEditor.ts`**: Add `onWarn?: ErrorHandler` to `CreateEditorArgs`; add `_onWarn: ErrorHandler` field on `LexicalEditor` class, defaulting to `console.warn`.
2. **`LexicalUpdates.ts`**: In the `_cascadeCount > 99` branch of `$triggerEnqueuedUpdates`, call `editor._onWarn(new Error(...))` in production; retain `devInvariant` throw in `__DEV__`.

Closes: N/A (feature request from internal sync)

## Test plan

### Automated
- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Existing test suite unaffected (hook is additive, default behavior unchanged)

### Manual verification
- Without `onWarn`: behavior identical to before (cascade guard logs to `console.warn`)
- With `onWarn: (err) => myLogger.warn(err)`: embedder receives the Error object for structured telemetry