### PR TITLE
[lexical] Bug Fix: delete atomic token/segmented nodes on Android IME backspace

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -825,12 +825,36 @@ function $handleBeforeInput(event: InputEvent): boolean {
           isSelectionAnchorSameAsFocus &&
           !hasSelectedAllTextInNode &&
           selectedNodeCanInsertTextAfter;
-        // Check if selection is collapsed and if the previous node is a decorator node
-        // If so, the browser will not be able to handle the deletion
+        // Check if selection is collapsed and if the previous node is one the
+        // browser cannot atomically delete. If so, let Lexical handle the
+        // deletion instead of deferring to the browser.
+        //
+        // This covers two cases:
+        //   1. DecoratorNodes - the browser has no concept of these, so a
+        //      native deleteContentBackward leaves them untouched.
+        //   2. Token / segmented TextNodes (e.g. mentions, hashtags) - these
+        //      are meant to be deleted as a single unit. Some Android IMEs
+        //      (notably Microsoft SwiftKey, which fires keydown with
+        //      keyCode 229) issue a deleteContentBackward that the browser
+        //      walks character-by-character. Because the node is atomic, the
+        //      browser ends up skipping over it entirely and nothing is
+        //      deleted. Routing these through Lexical's DELETE_CHARACTER_COMMAND
+        //      removes the whole token as expected.
         if (shouldLetBrowserHandleDelete && selection.isCollapsed()) {
-          shouldLetBrowserHandleDelete = !$isDecoratorNode(
-            $getAdjacentNode(selection.anchor, true),
-          );
+          // Find the node the caret would delete into (backward). When the
+          // caret sits at the start of a node, that's the previous sibling;
+          // otherwise it's the node the caret is currently inside.
+          const anchorPoint = selection.anchor;
+          const anchorOwnNode = anchorPoint.getNode();
+          const nodeBeforeCaret =
+            anchorPoint.type === 'text' && anchorPoint.offset > 0
+              ? anchorOwnNode
+              : $getAdjacentNode(anchorPoint, true);
+          const isAtomicNode =
+            $isDecoratorNode(nodeBeforeCaret) ||
+            ($isTextNode(nodeBeforeCaret) &&
+              (nodeBeforeCaret.isToken() || nodeBeforeCaret.isSegmented()));
+          shouldLetBrowserHandleDelete = !isAtomicNode;
         }
         if (!shouldLetBrowserHandleDelete) {
           dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);

--- a/packages/lexical/src/__tests__/unit/LexicalAndroidIMEDeleteToken.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalAndroidIMEDeleteToken.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Regression test for an Android IME backspace bug (Microsoft SwiftKey).
+ *
+ * On Android, certain IMEs (notably Microsoft SwiftKey) fire keydown with
+ * keyCode 229 / key "Unidentified" instead of a real "Backspace", so the
+ * KEY_BACKSPACE_COMMAND keydown path never runs. Deletion instead arrives as
+ * a `beforeinput` event with inputType `deleteContentBackward`.
+ *
+ * For ordinary text on Android Chrome, Lexical lets the browser perform the
+ * deletion (`shouldLetBrowserHandleDelete`). But when the node immediately
+ * before a collapsed cursor is an atomic unit — a DecoratorNode, or a token /
+ * segmented TextNode such as a mention — the browser's native delete walks
+ * character-by-character and skips over the atomic node, so nothing is
+ * deleted (the reported SwiftKey bug).
+ *
+ * The fix extends the "don't let the browser handle it" guard to cover token
+ * and segmented TextNodes in addition to DecoratorNodes, so Lexical dispatches
+ * DELETE_CHARACTER_COMMAND and removes the whole token.
+ *
+ * These tests assert on whether DELETE_CHARACTER_COMMAND is dispatched (i.e.
+ * Lexical owns the delete) rather than on the post-delete text content: the
+ * collapsed-selection delete path ultimately calls the native
+ * `Selection.modify`, which jsdom does not implement, so the end-to-end
+ * deletion cannot run in this environment. The dispatch decision is exactly
+ * the behavior this fix changes.
+ */
+
+import {registerRichText} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getRoot,
+  $setSelection,
+  COMMAND_PRIORITY_CRITICAL,
+  DELETE_CHARACTER_COMMAND,
+  LexicalEditor,
+  TextNode,
+} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+// Make LexicalEvents.ts observe an Android Chrome environment.
+vi.mock('lexical/src/environment', () => ({
+  CAN_USE_BEFORE_INPUT: true,
+  CAN_USE_DOM: true,
+  IS_ANDROID: true,
+  IS_ANDROID_CHROME: true,
+  IS_APPLE: false,
+  IS_APPLE_WEBKIT: false,
+  IS_CHROME: true,
+  IS_FIREFOX: false,
+  IS_IOS: false,
+  IS_SAFARI: false,
+}));
+
+function createDeleteContentBackwardEvent(): InputEvent {
+  const event = new InputEvent('beforeinput', {
+    bubbles: true,
+    cancelable: true,
+    inputType: 'deleteContentBackward',
+  });
+  // jsdom InputEvent does not expose getTargetRanges; patch it manually.
+  Object.defineProperty(event, 'getTargetRanges', {
+    value: () => [],
+  });
+  return event;
+}
+
+describe('Android IME deleteContentBackward — atomic node before cursor', () => {
+  let container: HTMLDivElement;
+  let editor: LexicalEditor;
+  let deleteCharacterCount: number;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('data-lexical-editor', 'true');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    editor = createTestEditor();
+    registerRichText(editor);
+    editor.setRootElement(container);
+
+    deleteCharacterCount = 0;
+    editor.registerCommand(
+      DELETE_CHARACTER_COMMAND,
+      () => {
+        deleteCharacterCount++;
+        // Returning true marks the command handled and prevents the default
+        // rich-text handler (which would call the unsupported Selection.modify)
+        // from running in jsdom.
+        return true;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+  });
+
+  afterEach(() => {
+    editor.setRootElement(null);
+    document.body.removeChild(container);
+  });
+
+  // Places a collapsed cursor at the END of `node` (the atomic candidate),
+  // mirroring the reconciled selection state when backspacing right after the
+  // node. A trailing plain TextNode is appended so the paragraph is realistic.
+  function setupCursorAfter(makeNode: () => TextNode): void {
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const node = makeNode();
+        const after = $createTextNode(' x');
+        paragraph.append(node, after);
+        $getRoot().clear().append(paragraph);
+
+        const sel = $createRangeSelection();
+        const offset = node.getTextContentSize();
+        sel.anchor.set(node.getKey(), offset, 'text');
+        sel.focus.set(node.getKey(), offset, 'text');
+        $setSelection(sel);
+      },
+      {discrete: true},
+    );
+  }
+
+  test('Lexical handles delete when the cursor is right after a segmented token (mention)', () => {
+    setupCursorAfter(() => $createTextNode('@alice').setMode('segmented'));
+    container.dispatchEvent(createDeleteContentBackwardEvent());
+    expect(deleteCharacterCount).toBe(1);
+  });
+
+  test('Lexical handles delete when the cursor is right after a token-mode TextNode', () => {
+    setupCursorAfter(() => $createTextNode('#hashtag').setMode('token'));
+    container.dispatchEvent(createDeleteContentBackwardEvent());
+    expect(deleteCharacterCount).toBe(1);
+  });
+
+  test('browser handles delete when the cursor is inside plain text', () => {
+    setupCursorAfter(() => $createTextNode('plain'));
+    container.dispatchEvent(createDeleteContentBackwardEvent());
+    // Plain text is deletable natively, so Lexical defers to the browser and
+    // does NOT dispatch DELETE_CHARACTER_COMMAND.
+    expect(deleteCharacterCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

On Android, some IMEs — notably **Microsoft SwiftKey** — fire `keydown` with `keyCode === 229` / `key === "Unidentified"` instead of a real `"Backspace"`. As a result, Lexical's `KEY_BACKSPACE_COMMAND` keydown path never runs, and the deletion instead arrives as a `beforeinput` event with `inputType === "deleteContentBackward"`.

For Android Chrome, `$handleBeforeInput` defers that deletion to the browser (`shouldLetBrowserHandleDelete`), opting out **only** when the node immediately before the collapsed caret is a `DecoratorNode`. Token / segmented `TextNode`s (e.g. mentions, hashtags) were not covered, so the browser performed the delete natively, walked over the atomic node character-by-character, and skipped it entirely. The practical symptom: when you tag a person in a post and press backspace to delete the tag, **nothing happens** — the token can only be removed by selecting it and deleting the selection.

### Fix

Extend the opt-out so Lexical (not the browser) handles the delete when the node before the caret is atomic — a `DecoratorNode` **or** a token / segmented `TextNode`. The node-before-caret is resolved whether the caret sits at the start of a node (its previous sibling) or inside a node at its end (the reconciled state right after the token). When the adjacent node is atomic, Lexical dispatches `DELETE_CHARACTER_COMMAND`, which already removes the whole segment/token correctly.

This is a small, internal change to a single Android-only branch:
- No public API, exports, or types change.
- The `Backspace`-keydown path (hardware/most keyboards) is untouched.
- Decorator-before-cursor and plain-text behavior are unchanged; only the token/segmented case flips from "browser skips it" to "Lexical deletes it".

## Test plan

### Automated

New unit test `packages/lexical/src/__tests__/unit/LexicalAndroidIMEDeleteToken.test.ts` (mocks an Android Chrome environment and dispatches a `deleteContentBackward` `beforeinput`):
- Cursor after a **segmented** token (mention) → Lexical dispatches `DELETE_CHARACTER_COMMAND`.
- Cursor after a **token-mode** `TextNode` → Lexical dispatches `DELETE_CHARACTER_COMMAND`.
- Cursor inside **plain text** → Lexical defers to the browser (no `DELETE_CHARACTER_COMMAND`).

> Note: the assertions check the dispatch decision rather than post-delete text, because the collapsed-selection delete path ultimately calls the native `Selection.modify`, which jsdom does not implement.

The full `packages/lexical` core unit suite passes (577 tests), including the existing `LexicalIosKoreanIME` IME tests. Prettier and ESLint are clean.

### Manual (Android)

1. On an Android device using Microsoft SwiftKey, open an editor with mention/token nodes (e.g. the playground with the Mentions plugin).
2. Type a mention so it becomes a token, then press **Backspace** with the caret right after it.

#### Before
The token is skipped and cannot be deleted with backspace (only by selecting + deleting).

#### After
Backspace deletes the whole token, matching the behavior with default keyboards.
