### PR TITLE
[lexical] Bug Fix: use ShadowRoot selection for editor roots

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -109,7 +109,7 @@ import {
   dispatchCommand,
   doesContainSurrogatePair,
   getAnchorTextFromDOM,
-  getDOMSelection,
+  getDOMSelectionForEditor,
   getDOMSelectionFromTarget,
   getEditorPropertyFromDOMNode,
   getEditorsToPropagate,
@@ -230,7 +230,7 @@ function $shouldPreventDefaultAndInsertText(
   const focus = selection.focus;
   const anchorNode = anchor.getNode();
   const editor = getActiveEditor();
-  const domSelection = getDOMSelection(getWindow(editor));
+  const domSelection = getDOMSelectionForEditor(editor);
   const domAnchorNode = domSelection !== null ? domSelection.anchorNode : null;
   const anchorKey = anchor.key;
   const backingAnchorElement = editor.getElementByKey(anchorKey);
@@ -502,7 +502,7 @@ function $updateSelectionFormatStyleFromElementNode(
 function onClick(event: PointerEvent, editor: LexicalEditor): void {
   updateEditorSync(editor, () => {
     const selection = $getSelection();
-    const domSelection = getDOMSelection(getWindow(editor));
+    const domSelection = getDOMSelectionForEditor(editor);
     const lastSelection = $getPreviousSelection();
 
     if (domSelection) {
@@ -1113,7 +1113,7 @@ function $handleInput(event: InputEvent): boolean {
     }
     const anchor = selection.anchor;
     const anchorNode = anchor.getNode();
-    const domSelection = getDOMSelection(getWindow(editor));
+    const domSelection = getDOMSelectionForEditor(editor);
     if (domSelection === null) {
       return true;
     }
@@ -1250,7 +1250,7 @@ function $onCompositionEndImpl(editor: LexicalEditor, data?: string): void {
         textNode.nodeValue !== null &&
         $isTextNode(node)
       ) {
-        const domSelection = getDOMSelection(getWindow(editor));
+        const domSelection = getDOMSelectionForEditor(editor);
         let anchorOffset = null;
         let focusOffset = null;
 

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -25,7 +25,7 @@ import {
   $getNodeByKey,
   $getNodeFromDOMNode,
   $updateTextNodeFromDOMContent,
-  getDOMSelection,
+  getDOMSelectionForEditor,
   getNodeKeyFromDOMNode,
   getParentElement,
   getWindow,
@@ -81,7 +81,7 @@ function $handleTextMutation(
   node: TextNode,
   editor: LexicalEditor,
 ): void {
-  const domSelection = getDOMSelection(getWindow(editor));
+  const domSelection = getDOMSelectionForEditor(editor);
   let anchorOffset = null;
   let focusOffset = null;
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -84,10 +84,9 @@ import {
   $isTokenOrTab,
   $setCompositionKey,
   doesContainSurrogatePair,
-  getDOMSelection,
+  getDOMSelectionForEditor,
   getElementByKeyOrThrow,
   getNodeKeyFromDOMNode,
-  getWindow,
   INTERNAL_$isBlock,
   isDOMCapturingSelection,
   isHTMLElement,
@@ -1588,7 +1587,7 @@ export class RangeSelection implements BaseSelection {
     const collapse = alter === 'move';
 
     const editor = getActiveEditor();
-    const domSelection = getDOMSelection(getWindow(editor));
+    const domSelection = getDOMSelectionForEditor(editor);
 
     if (!domSelection) {
       return;
@@ -2673,7 +2672,7 @@ export function $internalCreateSelection(
 ): null | BaseSelection {
   const currentEditorState = editor.getEditorState();
   const lastSelection = currentEditorState._selection;
-  const domSelection = getDOMSelection(getWindow(editor));
+  const domSelection = getDOMSelectionForEditor(editor);
 
   if ($isRangeSelection(lastSelection) || lastSelection == null) {
     return $internalCreateRangeSelection(

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -53,12 +53,11 @@ import {
 import {
   $getCompositionKey,
   $updateDOMBlockCursorElement,
-  getDOMSelection,
+  getDOMSelectionForEditor,
   getEditorPropertyFromDOMNode,
   getEditorStateTextContent,
   getEditorsToPropagate,
   getRegisteredNodeOrThrow,
-  getWindow,
   isLexicalEditor,
   removeDOMBlockCursorElement,
   scheduleMicroTask,
@@ -648,9 +647,7 @@ export function $commitPendingUpdates(
   // Reconciliation has finished. Now update selection and trigger listeners.
   // ======
 
-  const domSelection = shouldSkipDOM
-    ? null
-    : getDOMSelection(getWindow(editor));
+  const domSelection = shouldSkipDOM ? null : getDOMSelectionForEditor(editor);
 
   // Attempt to update the DOM selection, including focusing of the root element,
   // and scroll into view if needed.

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -746,7 +746,7 @@ export function $updateSelectedTextFromDOM(
   data?: string,
 ): void {
   // Update the text content with the latest composition text
-  const domSelection = getDOMSelection(getWindow(editor));
+  const domSelection = getDOMSelectionForEditor(editor);
   if (domSelection === null) {
     return;
   }
@@ -1833,6 +1833,35 @@ export function $updateDOMBlockCursorElement(
  */
 export function getDOMSelection(targetWindow: null | Window): null | Selection {
   return !CAN_USE_DOM ? null : (targetWindow || window).getSelection();
+}
+
+/**
+ * Returns the selection for the editor root. When an editor is mounted inside a
+ * ShadowRoot, browsers may project window.getSelection() outside of that shadow
+ * tree, so prefer the root's native selection when available.
+ */
+export function getDOMSelectionForEditor(
+  editor: LexicalEditor,
+): null | Selection {
+  const rootElement = editor._rootElement;
+  if (CAN_USE_DOM && rootElement !== null) {
+    const rootNode = rootElement.getRootNode();
+    if (rootNode !== rootElement.ownerDocument) {
+      const getSelection = (
+        rootNode as {
+          getSelection?: () => null | Selection;
+        }
+      ).getSelection;
+
+      if (typeof getSelection === 'function') {
+        const selection = getSelection.call(rootNode);
+        if (selection !== null) {
+          return selection;
+        }
+      }
+    }
+  }
+  return getDOMSelection(getWindow(editor));
 }
 
 /**

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -34,6 +34,7 @@ import {
   emptyFunction,
   generateRandomKey,
   getCachedTypeToNodeMap,
+  getDOMSelectionForEditor,
   getTextDirection,
   isArray,
   isExactShortcutMatch,
@@ -152,6 +153,76 @@ describe('LexicalUtils tests', () => {
           ),
         ).toBe(true);
       });
+    });
+
+    test('getDOMSelectionForEditor() uses ShadowRoot selection when available', () => {
+      const editor = createEditor({
+        namespace: 'test',
+        onError: vi.fn(),
+      });
+      const host = document.createElement('div');
+      const rootElement = document.createElement('div');
+      const shadowRoot = host.attachShadow({mode: 'open'});
+      const shadowSelection = window.getSelection()!;
+      const shadowGetSelection = vi.fn(() => shadowSelection);
+      const windowGetSelection = vi.spyOn(window, 'getSelection');
+
+      Object.defineProperty(shadowRoot, 'getSelection', {
+        configurable: true,
+        value: shadowGetSelection,
+      });
+
+      document.body.appendChild(host);
+      shadowRoot.appendChild(rootElement);
+      editor.setRootElement(rootElement);
+      shadowGetSelection.mockClear();
+      windowGetSelection.mockClear();
+
+      try {
+        expect(getDOMSelectionForEditor(editor)).toBe(shadowSelection);
+        expect(shadowGetSelection).toHaveBeenCalledTimes(1);
+        expect(windowGetSelection).not.toHaveBeenCalled();
+      } finally {
+        editor.setRootElement(null);
+        document.body.removeChild(host);
+        windowGetSelection.mockRestore();
+      }
+    });
+
+    test('getDOMSelectionForEditor() falls back when ShadowRoot selection is null', () => {
+      const editor = createEditor({
+        namespace: 'test',
+        onError: vi.fn(),
+      });
+      const host = document.createElement('div');
+      const rootElement = document.createElement('div');
+      const shadowRoot = host.attachShadow({mode: 'open'});
+      const windowSelection = window.getSelection()!;
+      const shadowGetSelection = vi.fn(() => null);
+      const windowGetSelection = vi
+        .spyOn(window, 'getSelection')
+        .mockReturnValue(windowSelection);
+
+      Object.defineProperty(shadowRoot, 'getSelection', {
+        configurable: true,
+        value: shadowGetSelection,
+      });
+
+      document.body.appendChild(host);
+      shadowRoot.appendChild(rootElement);
+      editor.setRootElement(rootElement);
+      shadowGetSelection.mockClear();
+      windowGetSelection.mockClear();
+
+      try {
+        expect(getDOMSelectionForEditor(editor)).toBe(windowSelection);
+        expect(shadowGetSelection).toHaveBeenCalledTimes(1);
+        expect(windowGetSelection).toHaveBeenCalledTimes(1);
+      } finally {
+        editor.setRootElement(null);
+        document.body.removeChild(host);
+        windowGetSelection.mockRestore();
+      }
     });
 
     test('getTextDirection()', () => {


### PR DESCRIPTION
## Description

Editors mounted inside a ShadowRoot currently still read selection through `window.getSelection()` in several editor-scoped paths. In Chrome, that can return a selection outside the shadow tree while the actual caret is inside the editor, so updates can be applied at the wrong text position.

This adds an internal `getDOMSelectionForEditor(editor)` helper that prefers `ShadowRoot.getSelection()` when the editor root is mounted in a shadow root, then falls back to the existing window selection path. Editor-owned DOM selection reads now use that helper.

Related to #7790

## Test plan

### Before

Added focused unit coverage for ShadowRoot selection reads in `LexicalUtils.test.ts`.

### After

- `pnpm vitest --project unit --no-watch packages/lexical/src/__tests__/unit/LexicalUtils.test.ts`
- `pnpm exec eslint packages/lexical/src/LexicalEvents.ts packages/lexical/src/LexicalMutations.ts packages/lexical/src/LexicalSelection.ts packages/lexical/src/LexicalUpdates.ts packages/lexical/src/LexicalUtils.ts packages/lexical/src/__tests__/unit/LexicalUtils.test.ts`
- `pnpm run tsc`
- `pnpm run build`