### PR TITLE
[Breaking Change][lexical][*] Chore: deprecate unsafe type parameters on node traversal methods

### DIFF
--- a/packages/lexical-code-core/src/FlatStructureUtils.ts
+++ b/packages/lexical-code-core/src/FlatStructureUtils.ts
@@ -122,16 +122,18 @@ export function $getStartOfCodeInLine(
 
   while (true) {
     if (nodeOffset === 0) {
-      node = node.getPreviousSibling();
-      if (node === null) {
+      const prevSibling: LexicalNode | null = node.getPreviousSibling();
+      if (prevSibling === null) {
+        node = null;
         break;
       }
       invariant(
-        $isCodeHighlightNode(node) ||
-          $isTabNode(node) ||
-          $isLineBreakNode(node),
+        $isCodeHighlightNode(prevSibling) ||
+          $isTabNode(prevSibling) ||
+          $isLineBreakNode(prevSibling),
         'Expected a valid Code Node: CodeHighlightNode, TabNode, LineBreakNode',
       );
+      node = prevSibling;
       if ($isLineBreakNode(node)) {
         last = {
           node,

--- a/packages/lexical-code-core/src/FlatStructureUtils.ts
+++ b/packages/lexical-code-core/src/FlatStructureUtils.ts
@@ -122,8 +122,8 @@ export function $getStartOfCodeInLine(
 
   while (true) {
     if (nodeOffset === 0) {
-      // The annotation is necessary to break a circular inference through
-      // the loop back-edge (TS7022)
+      // Annotation breaks a circular inference through the loop (TS7022),
+      // remove when the deprecated generic signatures from #8661 are removed
       const prevSibling: LexicalNode | null = node.getPreviousSibling();
       if (prevSibling === null) {
         node = null;

--- a/packages/lexical-code-core/src/FlatStructureUtils.ts
+++ b/packages/lexical-code-core/src/FlatStructureUtils.ts
@@ -122,6 +122,8 @@ export function $getStartOfCodeInLine(
 
   while (true) {
     if (nodeOffset === 0) {
+      // The annotation is necessary to break a circular inference through
+      // the loop back-edge (TS7022)
       const prevSibling: LexicalNode | null = node.getPreviousSibling();
       if (prevSibling === null) {
         node = null;

--- a/packages/lexical-code-prism/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-prism/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type {CodeHighlightNode, CodeNode} from '@lexical/code';
-import type {LexicalCommand, LineBreakNode, TabNode} from 'lexical';
+import type {CodeNode} from '@lexical/code';
+import type {LexicalCommand, LexicalNode} from 'lexical';
 
 import {$createCodeNode, $isCodeNode} from '@lexical/code';
 import {CodeIndentExtension} from '@lexical/code-core';
@@ -151,11 +151,7 @@ describe('LexicalCodeNode tests', () => {
                   selLast -= 1;
                 }
 
-                let matching:
-                  | null
-                  | LineBreakNode
-                  | TabNode
-                  | CodeHighlightNode = codeNode.getFirstChild();
+                let matching: null | LexicalNode = codeNode.getFirstChild();
                 let parentIndex = 0;
                 let offset = 0;
                 while (

--- a/packages/lexical-code-prism/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-prism/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -7,7 +7,7 @@
  */
 
 import type {CodeNode} from '@lexical/code';
-import type {LexicalCommand, LexicalNode} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 import {$createCodeNode, $isCodeNode} from '@lexical/code';
 import {CodeIndentExtension} from '@lexical/code-core';
@@ -151,7 +151,7 @@ describe('LexicalCodeNode tests', () => {
                   selLast -= 1;
                 }
 
-                let matching: null | LexicalNode = codeNode.getFirstChild();
+                let matching = codeNode.getFirstChild();
                 let parentIndex = 0;
                 let offset = 0;
                 while (

--- a/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type {CodeHighlightNode, CodeNode} from '@lexical/code';
-import type {LexicalCommand, LineBreakNode, TabNode} from 'lexical';
+import type {CodeNode} from '@lexical/code';
+import type {LexicalCommand, LexicalNode} from 'lexical';
 
 import {
   $createCodeNode,
@@ -187,11 +187,7 @@ describe('LexicalCodeNode tests', () => {
                   selLast -= 1;
                 }
 
-                let matching:
-                  | null
-                  | LineBreakNode
-                  | TabNode
-                  | CodeHighlightNode = codeNode.getFirstChild();
+                let matching: null | LexicalNode = codeNode.getFirstChild();
                 let parentIndex = 0;
                 let offset = 0;
                 while (

--- a/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -7,7 +7,7 @@
  */
 
 import type {CodeNode} from '@lexical/code';
-import type {LexicalCommand, LexicalNode} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 import {
   $createCodeNode,
@@ -187,7 +187,7 @@ describe('LexicalCodeNode tests', () => {
                   selLast -= 1;
                 }
 
-                let matching: null | LexicalNode = codeNode.getFirstChild();
+                let matching = codeNode.getFirstChild();
                 let parentIndex = 0;
                 let offset = 0;
                 while (

--- a/packages/lexical-extension/src/__tests__/unit/ClickAfterLastBlock.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/ClickAfterLastBlock.test.ts
@@ -101,7 +101,7 @@ describe('ClickAfterLastBlockExtension', () => {
     editor.read(() => {
       const rootNode = $getRoot();
       expect(rootNode.getChildrenSize()).toBe(3);
-      const lastChild: LexicalNode | null = rootNode.getLastChild();
+      const lastChild = rootNode.getLastChild();
       assert(
         lastChild !== null && $isParagraphNode(lastChild),
         'last child after click should be an empty paragraph',

--- a/packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts
@@ -51,12 +51,12 @@ describe('Link', () => {
     using editor = buildEditorFromExtensions(extension);
     editor.update(
       () => {
-        const textNode: TextNode = $getRoot().getLastDescendant()!;
+        const textNode = $getRoot().getLastDescendant() as TextNode;
         textNode.select(0);
         expect($isLinkNode(textNode.getParent())).toBe(false);
         $toggleLink('https://lexical.dev/');
         expect($isLinkNode(textNode.getParent())).toBe(true);
-        let linkNode: LinkNode = textNode.getParent()!;
+        let linkNode = textNode.getParent() as LinkNode;
         expect(linkNode.getURL()).toBe('https://lexical.dev/');
         expect(linkNode.getTarget()).toBe(null);
         expect($getRoot().getTextContent()).toBe('Hello');
@@ -69,7 +69,7 @@ describe('Link', () => {
           title: 'title',
           url: 'https://lexical.dev/',
         });
-        linkNode = textNode.getParent()!;
+        linkNode = textNode.getParent() as LinkNode;
         expect(linkNode.getURL()).toBe('https://lexical.dev/');
         expect(linkNode.getTarget()).toBe('_blank');
         expect(linkNode.getRel()).toBe('noopener');

--- a/packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts
@@ -19,7 +19,6 @@ import {
   $toggleLink,
   AutoLinkNode,
   LinkExtension,
-  LinkNode,
 } from '@lexical/link';
 import {RichTextExtension} from '@lexical/rich-text';
 import {
@@ -33,7 +32,6 @@ import {
   configExtension,
   LexicalEditorWithDispose,
   PASTE_COMMAND,
-  TextNode,
 } from 'lexical';
 import {assert, describe, expect, it} from 'vitest';
 
@@ -51,12 +49,14 @@ describe('Link', () => {
     using editor = buildEditorFromExtensions(extension);
     editor.update(
       () => {
-        const textNode = $getRoot().getLastDescendant() as TextNode;
+        const textNode = $getRoot().getLastDescendant();
+        assert($isTextNode(textNode), 'Expected a TextNode');
         textNode.select(0);
         expect($isLinkNode(textNode.getParent())).toBe(false);
         $toggleLink('https://lexical.dev/');
         expect($isLinkNode(textNode.getParent())).toBe(true);
-        let linkNode = textNode.getParent() as LinkNode;
+        let linkNode = textNode.getParent();
+        assert($isLinkNode(linkNode), 'Expected a LinkNode');
         expect(linkNode.getURL()).toBe('https://lexical.dev/');
         expect(linkNode.getTarget()).toBe(null);
         expect($getRoot().getTextContent()).toBe('Hello');
@@ -69,7 +69,8 @@ describe('Link', () => {
           title: 'title',
           url: 'https://lexical.dev/',
         });
-        linkNode = textNode.getParent() as LinkNode;
+        linkNode = textNode.getParent();
+        assert($isLinkNode(linkNode), 'Expected a LinkNode');
         expect(linkNode.getURL()).toBe('https://lexical.dev/');
         expect(linkNode.getTarget()).toBe('_blank');
         expect(linkNode.getRel()).toBe('noopener');
@@ -108,8 +109,8 @@ describe('Link', () => {
         assert($isParagraphNode(p), 'Expecting a ParagraphNode in the root');
         const children = p.getChildren();
         expect(children.length).toBe(1);
-        expect($isLinkNode(children[0])).toBe(true);
-        const link = children[0] as LinkNode;
+        const link = children[0];
+        assert($isLinkNode(link), 'Expected a LinkNode');
         expect(link.getURL()).toBe('https://lexical.dev/');
         expect(link.getTarget()).toBe('_blank');
         expect(link.getRel()).toBe('noreferrer');

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -7,7 +7,7 @@
  */
 
 import type {ListItemNode} from './LexicalListItemNode';
-import type {LexicalCommand, LexicalEditor} from 'lexical';
+import type {ElementNode, LexicalCommand, LexicalEditor} from 'lexical';
 
 import {Signal} from '@lexical/extension';
 import {
@@ -404,7 +404,7 @@ function findCheckListItemSibling(
   backward: boolean,
 ): ListItemNode | null {
   let sibling = backward ? node.getPreviousSibling() : node.getNextSibling();
-  let parent: ListItemNode | null = node;
+  let parent: ElementNode | null = node;
 
   // Going up in a tree to get non-null sibling
   while (sibling == null && $isListItemNode(parent)) {

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -369,9 +369,8 @@ export function $handleIndent(listItemNode: ListItemNode): void {
 
   const parent = listItemNode.getParent();
 
-  // We can cast both of the below `isNestedListNode` only returns a boolean type instead of a user-defined type guards
-  const nextSibling = listItemNode.getNextSibling() as ListItemNode;
-  const previousSibling = listItemNode.getPreviousSibling() as ListItemNode;
+  const nextSibling = listItemNode.getNextSibling();
+  const previousSibling = listItemNode.getPreviousSibling();
   // if there are nested lists on either side, merge them all together.
 
   if (isNestedListNode(nextSibling) && isNestedListNode(previousSibling)) {

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -370,10 +370,8 @@ export function $handleIndent(listItemNode: ListItemNode): void {
   const parent = listItemNode.getParent();
 
   // We can cast both of the below `isNestedListNode` only returns a boolean type instead of a user-defined type guards
-  const nextSibling =
-    listItemNode.getNextSibling<ListItemNode>() as ListItemNode;
-  const previousSibling =
-    listItemNode.getPreviousSibling<ListItemNode>() as ListItemNode;
+  const nextSibling = listItemNode.getNextSibling() as ListItemNode;
+  const previousSibling = listItemNode.getPreviousSibling() as ListItemNode;
   // if there are nested lists on either side, merge them all together.
 
   if (isNestedListNode(nextSibling) && isNestedListNode(previousSibling)) {

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {LexicalNode, Spread} from 'lexical';
+import type {ElementNode, LexicalNode, Spread} from 'lexical';
 
 import invariant from '@lexical/internal/invariant';
 import {$findMatchingParent} from '@lexical/utils';
@@ -46,13 +46,14 @@ export function $getListDepth(listNode: ListNode): number {
  * @returns The ListNode found.
  */
 export function $getTopListNode(listItem: LexicalNode): ListNode {
-  let list = listItem.getParent<ListNode>();
+  const parentList = listItem.getParent();
 
-  if (!$isListNode(list)) {
+  if (!$isListNode(parentList)) {
     invariant(false, 'A ListItemNode must have a ListNode for a parent.');
   }
 
-  let parent: ListNode | null = list;
+  let list: ListNode = parentList;
+  let parent: ElementNode | null = parentList;
 
   while (parent !== null) {
     parent = parent.getParent();
@@ -77,7 +78,7 @@ export function $isLastItemInList(listItem: ListItemNode): boolean {
   if ($isListNode(firstChild)) {
     return false;
   }
-  let parent: ListItemNode | null = listItem;
+  let parent: ElementNode | null = listItem;
 
   while (parent !== null) {
     if ($isListItemNode(parent)) {

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -13,7 +13,7 @@ import type {
   TextMatchTransformer,
   Transformer,
 } from './MarkdownTransformers';
-import type {ElementNode, LexicalEditor, TextNode} from 'lexical';
+import type {ElementNode, LexicalEditor, LexicalNode, TextNode} from 'lexical';
 
 import {$isCodeNode} from '@lexical/code-core';
 import invariant from '@lexical/internal/invariant';
@@ -263,12 +263,9 @@ function $runTextFormatTransformers(
 
     // Go through text node siblings and search for opening tag
     // if haven't found it within the same text node as closing tag
-    let sibling: TextNode | null = openNode;
+    let sibling: LexicalNode | null = openNode;
 
-    while (
-      openTagStartIndex < 0 &&
-      (sibling = sibling.getPreviousSibling<TextNode>())
-    ) {
+    while (openTagStartIndex < 0 && (sibling = sibling.getPreviousSibling())) {
       if ($isLineBreakNode(sibling)) {
         break;
       }

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -587,7 +587,7 @@ function CommentsPanelList({
               editor.update(
                 () => {
                   const markNodeKey = Array.from(markNodeKeys)[0];
-                  const markNode = $getNodeByKey<MarkNode>(markNodeKey);
+                  const markNode = $getNodeByKey(markNodeKey);
                   if ($isMarkNode(markNode)) {
                     markNode.selectStart();
                   }
@@ -773,7 +773,7 @@ export default function CommentPlugin({
           setTimeout(() => {
             editor.update(() => {
               for (const key of markNodeKeys) {
-                const node: null | MarkNode = $getNodeByKey(key);
+                const node = $getNodeByKey(key);
                 if ($isMarkNode(node)) {
                   node.deleteID(id);
                   if (node.getIDs().length === 0) {
@@ -861,7 +861,7 @@ export default function CommentPlugin({
         mutations => {
           editor.getEditorState().read(() => {
             for (const [key, mutation] of mutations) {
-              const node: null | MarkNode = $getNodeByKey(key);
+              const node = $getNodeByKey(key);
               let ids: NodeKey[] = [];
 
               if (mutation === 'destroyed') {

--- a/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import type {ElementNode, LexicalCommand, LexicalNode, NodeKey} from 'lexical';
+import type {LexicalCommand, NodeKey} from 'lexical';
 
 import {defineImportRule, DOMImportExtension, sel} from '@lexical/html';
 import {
@@ -79,9 +79,9 @@ const $fillLayoutItemIfEmpty = (node: LayoutItemNode) => {
 };
 
 const $removeIsolatedLayoutItem = (node: LayoutItemNode): boolean => {
-  const parent = node.getParent<ElementNode>();
+  const parent = node.getParent();
   if (!$isLayoutContainerNode(parent)) {
-    const children = node.getChildren<LexicalNode>();
+    const children = node.getChildren();
     for (const child of children) {
       node.insertBefore(child);
     }
@@ -150,7 +150,7 @@ export const LayoutExtension = defineExtension({
         UPDATE_LAYOUT_COMMAND,
         ({template, nodeKey}) => {
           editor.update(() => {
-            const container = $getNodeByKey<LexicalNode>(nodeKey);
+            const container = $getNodeByKey(nodeKey);
 
             if (!$isLayoutContainerNode(container)) {
               return;
@@ -170,7 +170,7 @@ export const LayoutExtension = defineExtension({
               }
             } else if (itemsCount < prevItemsCount) {
               for (let i = prevItemsCount - 1; i >= itemsCount; i--) {
-                const layoutItem = container.getChildAtIndex<LexicalNode>(i);
+                const layoutItem = container.getChildAtIndex(i);
 
                 if ($isLayoutItemNode(layoutItem)) {
                   layoutItem.remove();
@@ -197,7 +197,7 @@ export const LayoutExtension = defineExtension({
         }
       }),
       editor.registerNodeTransform(LayoutContainerNode, node => {
-        const children = node.getChildren<LexicalNode>();
+        const children = node.getChildren();
         if (!children.every($isLayoutItemNode)) {
           for (const child of children) {
             node.insertBefore(child);

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -239,7 +239,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
 
           let height = tableRow.getHeight();
           if (height === undefined) {
-            const rowCells = tableRow.getChildren<TableCellNode>();
+            const rowCells = tableRow.getChildren().filter($isTableCellNode);
             height = Math.min(
               ...rowCells.map(
                 // eslint-disable-next-line react-hooks/immutability

--- a/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
@@ -130,8 +130,8 @@ export default function TableFitNestedTablePlugin(): null {
         const modifiedTables = new Set<TableNode>();
         for (const [nodeKey, mutation] of nodeMutations) {
           if (mutation === 'created' || mutation === 'updated') {
-            const tableNode = $getNodeByKey<TableNode>(nodeKey);
-            if (tableNode) {
+            const tableNode = $getNodeByKey(nodeKey);
+            if ($isTableNode(tableNode)) {
               modifiedTables.add(tableNode);
             }
           }

--- a/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
@@ -151,7 +151,7 @@ export function VersionsPlugin({id}: {id: string}) {
             if (mutation === 'destroyed') {
               continue;
             }
-            const node = $getNodeByKeyOrThrow<TextNode>(nodeKey);
+            const node = $getNodeByKeyOrThrow(nodeKey);
             const ychange = $getYChangeState<User>(node);
             const element = editor.getElementByKey(nodeKey);
             if (!ychange || !element) {

--- a/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
@@ -207,8 +207,8 @@ export function TableOfContentsPlugin({children}: Props): JSX.Element {
         editor.getEditorState().read(() => {
           for (const [nodeKey, mutation] of mutatedNodes) {
             if (mutation === 'created') {
-              const newHeading = $getNodeByKey<HeadingNode>(nodeKey);
-              if (newHeading !== null) {
+              const newHeading = $getNodeByKey(nodeKey);
+              if ($isHeadingNode(newHeading)) {
                 const prevHeading = $getPreviousHeading(newHeading);
                 currentTableOfContents = $insertHeadingIntoTableOfContents(
                   prevHeading,
@@ -222,8 +222,8 @@ export function TableOfContentsPlugin({children}: Props): JSX.Element {
                 currentTableOfContents,
               );
             } else if (mutation === 'updated') {
-              const newHeading = $getNodeByKey<HeadingNode>(nodeKey);
-              if (newHeading !== null) {
+              const newHeading = $getNodeByKey(nodeKey);
+              if ($isHeadingNode(newHeading)) {
                 const prevHeading = $getPreviousHeading(newHeading);
                 currentTableOfContents = $updateHeadingPosition(
                   prevHeading,

--- a/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
@@ -14,6 +14,7 @@ import {
   $isTextNode,
   $setSelection,
   BaseSelection,
+  ElementNode,
   LexicalNode,
 } from 'lexical';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
@@ -52,12 +53,12 @@ const $createSelectionByPath = ({
   const selection = $createRangeSelection();
   const root = $getRoot();
 
-  const anchorNode = anchorPath.reduce(
-    (node, index) => node.getChildAtIndex(index)!,
+  const anchorNode = anchorPath.reduce<LexicalNode>(
+    (node, index) => (node as ElementNode).getChildAtIndex(index)!,
     root,
   );
-  const focusNode = focusPath.reduce(
-    (node, index) => node.getChildAtIndex(index)!,
+  const focusNode = focusPath.reduce<LexicalNode>(
+    (node, index) => (node as ElementNode).getChildAtIndex(index)!,
     root,
   );
 

--- a/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
@@ -11,13 +11,13 @@ import {
   $createRangeSelection,
   $createTextNode,
   $getRoot,
+  $isElementNode,
   $isTextNode,
   $setSelection,
   BaseSelection,
-  ElementNode,
   LexicalNode,
 } from 'lexical';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, assert, beforeEach, describe, expect, it} from 'vitest';
 
 import {
   connectClients,
@@ -53,14 +53,14 @@ const $createSelectionByPath = ({
   const selection = $createRangeSelection();
   const root = $getRoot();
 
-  const anchorNode = anchorPath.reduce<LexicalNode>(
-    (node, index) => (node as ElementNode).getChildAtIndex(index)!,
-    root,
-  );
-  const focusNode = focusPath.reduce<LexicalNode>(
-    (node, index) => (node as ElementNode).getChildAtIndex(index)!,
-    root,
-  );
+  const $reduceChildAtIndex = (node: LexicalNode, index: number) => {
+    assert($isElementNode(node), 'Expected an ElementNode in the path');
+    const child = node.getChildAtIndex(index);
+    assert(child !== null, 'Expected a child at the path index');
+    return child;
+  };
+  const anchorNode = anchorPath.reduce<LexicalNode>($reduceChildAtIndex, root);
+  const focusNode = focusPath.reduce<LexicalNode>($reduceChildAtIndex, root);
 
   selection.anchor.set(
     anchorNode.getKey(),

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -139,16 +139,19 @@ export function $trimTextContentFromAnchor(
 
   while (remaining > 0 && currentNode !== null) {
     if ($isElementNode(currentNode)) {
+      // Annotation breaks a circular inference through the loop (TS7022)
       const lastDescendant: null | LexicalNode =
         currentNode.getLastDescendant();
       if (lastDescendant !== null) {
         currentNode = lastDescendant;
       }
     }
+    // Annotation breaks a circular inference through the loop (TS7022)
     let nextNode: LexicalNode | null = currentNode.getPreviousSibling();
     let additionalElementWhitespace = 0;
     if (nextNode === null) {
       let parent: LexicalNode | null = currentNode.getParentOrThrow();
+      // Annotation breaks a circular inference through the loop (TS7022)
       let parentSibling: LexicalNode | null = parent.getPreviousSibling();
 
       while (parentSibling === null) {

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -139,19 +139,22 @@ export function $trimTextContentFromAnchor(
 
   while (remaining > 0 && currentNode !== null) {
     if ($isElementNode(currentNode)) {
-      // Annotation breaks a circular inference through the loop (TS7022)
+      // Annotation breaks a circular inference through the loop (TS7022),
+      // remove when the deprecated generic signatures from #8661 are removed
       const lastDescendant: null | LexicalNode =
         currentNode.getLastDescendant();
       if (lastDescendant !== null) {
         currentNode = lastDescendant;
       }
     }
-    // Annotation breaks a circular inference through the loop (TS7022)
+    // Annotation breaks a circular inference through the loop (TS7022),
+    // remove when the deprecated generic signatures from #8661 are removed
     let nextNode: LexicalNode | null = currentNode.getPreviousSibling();
     let additionalElementWhitespace = 0;
     if (nextNode === null) {
       let parent: LexicalNode | null = currentNode.getParentOrThrow();
-      // Annotation breaks a circular inference through the loop (TS7022)
+      // Annotation breaks a circular inference through the loop (TS7022),
+      // remove when the deprecated generic signatures from #8661 are removed
       let parentSibling: LexicalNode | null = parent.getPreviousSibling();
 
       while (parentSibling === null) {

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -140,7 +140,7 @@ export function $trimTextContentFromAnchor(
   while (remaining > 0 && currentNode !== null) {
     if ($isElementNode(currentNode)) {
       const lastDescendant: null | LexicalNode =
-        currentNode.getLastDescendant<LexicalNode>();
+        currentNode.getLastDescendant();
       if (lastDescendant !== null) {
         currentNode = lastDescendant;
       }

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -150,7 +150,8 @@ function $removeParentEmptyElements(startingNode: ElementNode): void {
 
   while (node !== null && !$isRootOrShadowRoot(node)) {
     const latest = node.getLatest();
-    // Annotation breaks a circular inference through the loop (TS7022)
+    // Annotation breaks a circular inference through the loop (TS7022),
+    // remove when the deprecated generic signatures from #8661 are removed
     const parentNode: ElementNode | null = node.getParent();
 
     if (latest.getChildrenSize() === 0) {

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -150,7 +150,7 @@ function $removeParentEmptyElements(startingNode: ElementNode): void {
 
   while (node !== null && !$isRootOrShadowRoot(node)) {
     const latest = node.getLatest();
-    const parentNode: ElementNode | null = node.getParent<ElementNode>();
+    const parentNode: ElementNode | null = node.getParent();
 
     if (latest.getChildrenSize() === 0) {
       node.remove(true);
@@ -283,7 +283,10 @@ export function $wrapNodesImpl(
 
   let targetIsPrevSibling = false;
   while (target !== null) {
-    const prevSibling = target.getPreviousSibling<ElementNode>();
+    // The previous sibling is not necessarily an ElementNode, but this
+    // pre-existing cast preserves the historical behavior of treating it
+    // as the wrap target regardless of its actual type.
+    const prevSibling = target.getPreviousSibling() as ElementNode | null;
 
     if (prevSibling !== null) {
       target = prevSibling;

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -150,6 +150,7 @@ function $removeParentEmptyElements(startingNode: ElementNode): void {
 
   while (node !== null && !$isRootOrShadowRoot(node)) {
     const latest = node.getLatest();
+    // Annotation breaks a circular inference through the loop (TS7022)
     const parentNode: ElementNode | null = node.getParent();
 
     if (latest.getChildrenSize() === 0) {

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -275,20 +275,18 @@ export function $wrapNodesImpl(
   // either insertAfter/insertBefore/append the corresponding
   // elements to. This is made more complicated due to nested
   // structures.
-  let target = $isElementNode(firstNode)
+  const firstNodeBlock = $isElementNode(firstNode)
     ? firstNode
     : firstNode.getParentOrThrow();
-
-  if (target.isInline()) {
-    target = target.getParentOrThrow();
-  }
+  let target: LexicalNode = firstNodeBlock.isInline()
+    ? firstNodeBlock.getParentOrThrow()
+    : firstNodeBlock;
 
   let targetIsPrevSibling = false;
   while (target !== null) {
-    // The previous sibling is not necessarily an ElementNode, but this
-    // pre-existing cast preserves the historical behavior of treating it
-    // as the wrap target regardless of its actual type.
-    const prevSibling = target.getPreviousSibling() as ElementNode | null;
+    // Annotation breaks a circular inference through the loop (TS7022),
+    // remove when the deprecated generic signatures from #8661 are removed
+    const prevSibling: LexicalNode | null = target.getPreviousSibling();
 
     if (prevSibling !== null) {
       target = prevSibling;
@@ -389,7 +387,10 @@ export function $wrapNodesImpl(
         }
       }
     } else {
-      const firstChild = target.getFirstChild();
+      // Capture the narrowed type, the reassignment of target below would
+      // otherwise widen it back to LexicalNode
+      const rootTarget = target;
+      const firstChild = rootTarget.getFirstChild();
 
       if ($isElementNode(firstChild)) {
         target = firstChild;
@@ -397,11 +398,11 @@ export function $wrapNodesImpl(
 
       if (firstChild === null) {
         if (wrappingElement) {
-          target.append(wrappingElement);
+          rootTarget.append(wrappingElement);
         } else {
           for (let i = 0; i < elements.length; i++) {
             const element = elements[i];
-            target.append(element);
+            rootTarget.append(element);
             lastElement = element;
           }
         }

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -601,7 +601,7 @@ export class TableNode extends ElementNode {
   }
 
   getColumnCount(): number {
-    const firstRow = this.getFirstChild<TableRowNode>();
+    const firstRow = this.getFirstChild() as TableRowNode | null;
     if (!firstRow) {
       return 0;
     }

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -38,7 +38,7 @@ import {
 import {PIXEL_VALUE_REG_EXP} from './constants';
 import {$isTableCellNode, type TableCellNode} from './LexicalTableCellNode';
 import {TableDOMCell, TableDOMTable} from './LexicalTableObserver';
-import {$isTableRowNode, type TableRowNode} from './LexicalTableRowNode';
+import {$isTableRowNode} from './LexicalTableRowNode';
 import {
   $getNearestTableCellInTableFromDOMNode,
   getTable,
@@ -601,8 +601,8 @@ export class TableNode extends ElementNode {
   }
 
   getColumnCount(): number {
-    const firstRow = this.getFirstChild() as TableRowNode | null;
-    if (!firstRow) {
+    const firstRow = this.getFirstChild();
+    if (!$isTableRowNode(firstRow)) {
       return 0;
     }
 

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -425,9 +425,10 @@ export class TableObserver {
   }
 
   $getAnchorTableCell(): TableCellNode | null {
-    return this.anchorCellNodeKey
-      ? ($getNodeByKey(this.anchorCellNodeKey) as TableCellNode | null)
+    const node = this.anchorCellNodeKey
+      ? $getNodeByKey(this.anchorCellNodeKey)
       : null;
+    return $isTableCellNode(node) ? node : null;
   }
   $getAnchorTableCellOrThrow(): TableCellNode {
     const anchorTableCell = this.$getAnchorTableCell();
@@ -439,9 +440,10 @@ export class TableObserver {
   }
 
   $getFocusTableCell(): TableCellNode | null {
-    return this.focusCellNodeKey
-      ? ($getNodeByKey(this.focusCellNodeKey) as TableCellNode | null)
+    const node = this.focusCellNodeKey
+      ? $getNodeByKey(this.focusCellNodeKey)
       : null;
+    return $isTableCellNode(node) ? node : null;
   }
 
   $getFocusTableCellOrThrow(): TableCellNode {

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -426,7 +426,7 @@ export class TableObserver {
 
   $getAnchorTableCell(): TableCellNode | null {
     return this.anchorCellNodeKey
-      ? $getNodeByKey(this.anchorCellNodeKey)
+      ? ($getNodeByKey(this.anchorCellNodeKey) as TableCellNode | null)
       : null;
   }
   $getAnchorTableCellOrThrow(): TableCellNode {
@@ -439,7 +439,9 @@ export class TableObserver {
   }
 
   $getFocusTableCell(): TableCellNode | null {
-    return this.focusCellNodeKey ? $getNodeByKey(this.focusCellNodeKey) : null;
+    return this.focusCellNodeKey
+      ? ($getNodeByKey(this.focusCellNodeKey) as TableCellNode | null)
+      : null;
   }
 
   $getFocusTableCellOrThrow(): TableCellNode {

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -328,7 +328,9 @@ function $handleTableClick(
   };
 
   tableObserver.pointerType = event.pointerType;
-  const tableNode = $getNodeByKeyOrThrow<TableNode>(tableObserver.tableNodeKey);
+  const tableNode = $getNodeByKeyOrThrow(
+    tableObserver.tableNodeKey,
+  ) as TableNode;
   const prevSelection = $getPreviousSelection();
   // We can't trust Firefox to do the right thing with the selection and
   // we don't have a proper state machine to do this "correctly" but
@@ -893,9 +895,9 @@ export function $handleTableSelectionChangeCommand(
     $isRangeSelection(selection) &&
     selection.isCollapsed()
   ) {
-    const tableNode = $getNodeByKeyOrThrow<TableNode>(
+    const tableNode = $getNodeByKeyOrThrow(
       shouldCheckSelectionForTable,
-    );
+    ) as TableNode;
     const anchor = selection.anchor.getNode();
     const firstRow = tableNode.getFirstChild();
     const anchorCell = $findCellNode(anchor);
@@ -931,7 +933,7 @@ export function $handleTableSelectionChangeCommand(
   const tableNodesAndObservers = Array.from(
     tableObservers.observers.entries(),
   ).map(([tableKey, [tableObserver]]) => ({
-    tableNode: $getNodeByKeyOrThrow<TableNode>(tableKey),
+    tableNode: $getNodeByKeyOrThrow(tableKey) as TableNode,
     tableObserver,
   }));
   for (const {tableNode, tableObserver} of tableNodesAndObservers) {
@@ -1076,7 +1078,7 @@ function $fixTableSelectionForSelectedTable(
   if (!selection.is(prevSelection)) {
     return;
   }
-  const tableNode = $getNodeByKeyOrThrow<TableNode>(selection.tableKey);
+  const tableNode = $getNodeByKeyOrThrow(selection.tableKey) as TableNode;
   // if selection goes outside of the table we need to change it to Range selection
   const domSelection = getDOMSelection(editorWindow);
   if (domSelection && domSelection.anchorNode && domSelection.focusNode) {

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -26,6 +26,7 @@ import type {
   LexicalCommand,
   LexicalEditor,
   LexicalNode,
+  NodeKey,
   PointCaret,
   RangeSelection,
   SiblingCaret,
@@ -109,6 +110,12 @@ import {
 } from './LexicalTableUtils';
 
 const LEXICAL_ELEMENT_KEY = '__lexicalTableSelection';
+
+function $getTableNodeByKeyOrThrow(key: NodeKey): TableNode {
+  const tableNode = $getNodeByKeyOrThrow(key);
+  invariant($isTableNode(tableNode), 'Expected TableNode for key %s', key);
+  return tableNode;
+}
 
 const isPointerDownOnEvent = (event: PointerEvent) => {
   return (event.buttons & 1) === 1;
@@ -328,9 +335,7 @@ function $handleTableClick(
   };
 
   tableObserver.pointerType = event.pointerType;
-  const tableNode = $getNodeByKeyOrThrow(
-    tableObserver.tableNodeKey,
-  ) as TableNode;
+  const tableNode = $getTableNodeByKeyOrThrow(tableObserver.tableNodeKey);
   const prevSelection = $getPreviousSelection();
   // We can't trust Firefox to do the right thing with the selection and
   // we don't have a proper state machine to do this "correctly" but
@@ -895,9 +900,7 @@ export function $handleTableSelectionChangeCommand(
     $isRangeSelection(selection) &&
     selection.isCollapsed()
   ) {
-    const tableNode = $getNodeByKeyOrThrow(
-      shouldCheckSelectionForTable,
-    ) as TableNode;
+    const tableNode = $getTableNodeByKeyOrThrow(shouldCheckSelectionForTable);
     const anchor = selection.anchor.getNode();
     const firstRow = tableNode.getFirstChild();
     const anchorCell = $findCellNode(anchor);
@@ -933,7 +936,7 @@ export function $handleTableSelectionChangeCommand(
   const tableNodesAndObservers = Array.from(
     tableObservers.observers.entries(),
   ).map(([tableKey, [tableObserver]]) => ({
-    tableNode: $getNodeByKeyOrThrow(tableKey) as TableNode,
+    tableNode: $getTableNodeByKeyOrThrow(tableKey),
     tableObserver,
   }));
   for (const {tableNode, tableObserver} of tableNodesAndObservers) {
@@ -1078,7 +1081,7 @@ function $fixTableSelectionForSelectedTable(
   if (!selection.is(prevSelection)) {
     return;
   }
-  const tableNode = $getNodeByKeyOrThrow(selection.tableKey) as TableNode;
+  const tableNode = $getTableNodeByKeyOrThrow(selection.tableKey);
   // if selection goes outside of the table we need to change it to Range selection
   const domSelection = getDOMSelection(editorWindow);
   if (domSelection && domSelection.anchorNode && domSelection.focusNode) {

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -186,7 +186,7 @@ export function $insertTableRow(
 
   if ($isTableRowNode(targetRowNode)) {
     for (let r = 0; r < rowCount; r++) {
-      const tableRowCells = targetRowNode.getChildren<TableCellNode>();
+      const tableRowCells = targetRowNode.getChildren();
       const tableColumnCount = tableRowCells.length;
       const newTableRowNode = $createTableRowNode();
 
@@ -631,9 +631,10 @@ export function $deleteTableRowAtSelection(): void {
   }
   const columnCount = gridMap[0].length;
   const nextRow = gridMap[focusEndRow + 1];
-  const nextRowNode: null | TableRowNode = grid.getChildAtIndex(
+  // The children of a TableNode are TableRowNodes by construction
+  const nextRowNode = grid.getChildAtIndex(
     focusEndRow + 1,
-  );
+  ) as null | TableRowNode;
   for (let row = focusEndRow; row >= anchorStartRow; row--) {
     for (let column = columnCount - 1; column >= 0; column--) {
       const {
@@ -1336,7 +1337,8 @@ export function $getTableCellNodeRect(tableCellNode: TableCellNode): {
   colSpan: number;
 } | null {
   const [cellNode, , gridNode] = $getNodeTriplet(tableCellNode);
-  const rows = gridNode.getChildren<TableRowNode>();
+  // The children of a TableNode are TableRowNodes by construction
+  const rows = gridNode.getChildren() as Array<TableRowNode>;
   const rowCount = rows.length;
   const columnCount = rows[0].getChildren().length;
 
@@ -1348,7 +1350,7 @@ export function $getTableCellNodeRect(tableCellNode: TableCellNode): {
 
   for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
     const row = rows[rowIndex];
-    const cells = row.getChildren<TableCellNode>();
+    const cells = row.getChildren() as Array<TableCellNode>;
     let columnIndex = 0;
 
     for (let cellIndex = 0; cellIndex < cells.length; cellIndex++) {

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -631,10 +631,7 @@ export function $deleteTableRowAtSelection(): void {
   }
   const columnCount = gridMap[0].length;
   const nextRow = gridMap[focusEndRow + 1];
-  // The children of a TableNode are TableRowNodes by construction
-  const nextRowNode = grid.getChildAtIndex(
-    focusEndRow + 1,
-  ) as null | TableRowNode;
+  const nextRowNode = grid.getChildAtIndex(focusEndRow + 1);
   for (let row = focusEndRow; row >= anchorStartRow; row--) {
     for (let column = columnCount - 1; column >= 0; column--) {
       const {
@@ -670,7 +667,7 @@ export function $deleteTableRowAtSelection(): void {
         // Handle overflow only once
         row === focusEndRow
       ) {
-        invariant(nextRowNode !== null, 'Expected nextRowNode not to be null');
+        invariant($isTableRowNode(nextRowNode), 'Expected a TableRowNode');
         let insertAfterCell: null | TableCellNode = null;
         for (let columnIndex = 0; columnIndex < column; columnIndex++) {
           const currentCellMap = nextRow[columnIndex];
@@ -1337,8 +1334,7 @@ export function $getTableCellNodeRect(tableCellNode: TableCellNode): {
   colSpan: number;
 } | null {
   const [cellNode, , gridNode] = $getNodeTriplet(tableCellNode);
-  // The children of a TableNode are TableRowNodes by construction
-  const rows = gridNode.getChildren() as Array<TableRowNode>;
+  const rows = gridNode.getChildren().filter($isTableRowNode);
   const rowCount = rows.length;
   const columnCount = rows[0].getChildren().length;
 
@@ -1350,7 +1346,7 @@ export function $getTableCellNodeRect(tableCellNode: TableCellNode): {
 
   for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
     const row = rows[rowIndex];
-    const cells = row.getChildren() as Array<TableCellNode>;
+    const cells = row.getChildren().filter($isTableCellNode);
     let columnIndex = 0;
 
     for (let cellIndex = 0; cellIndex < cells.length; cellIndex++) {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -115,10 +115,11 @@ describe('LexicalUtils#splitNode', () => {
 
         let nodeToSplit: ElementNode = $getRoot();
         for (const index of testCase.splitPath) {
-          nodeToSplit = nodeToSplit.getChildAtIndex(index)!;
-          if (!$isElementNode(nodeToSplit)) {
+          const child = nodeToSplit.getChildAtIndex(index)!;
+          if (!$isElementNode(child)) {
             throw new Error('Expected node to be element');
           }
+          nodeToSplit = child;
         }
 
         $splitNode(nodeToSplit, testCase.splitOffset);

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -417,8 +417,8 @@ export function registerNestedElementResolver<N extends ElementNode>(
       }
     }
 
-    let parentNode: N | null = node;
-    let childNode = node;
+    let parentNode: ElementNode | null = node;
+    let childNode: ElementNode = node;
 
     while (parentNode !== null) {
       childNode = parentNode;

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -624,7 +624,7 @@ export function $moveSelectionToPreviousNode(
   }
   // Get previous node
   const prevNodeKey = anchorNode.__prev;
-  let prevNode: ElementNode | null = null;
+  let prevNode: LexicalNode | null = null;
   if (prevNodeKey) {
     prevNode = $getNodeByKey(prevNodeKey);
   }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -490,15 +490,57 @@ declare export class LexicalNode {
   isSelected(): boolean;
   getKey(): NodeKey;
   getIndexWithinParent(): number;
+  getParent(): ElementNode | null;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getParent<T extends ElementNode>(): T | null;
+  getParentOrThrow(): ElementNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getParentOrThrow<T extends ElementNode>(): T;
   getTopLevelElement(): DecoratorNode<unknown> | ElementNode | null;
   getTopLevelElementOrThrow(): DecoratorNode<unknown> | ElementNode;
+  getParents(): Array<ElementNode>;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getParents<T extends ElementNode>(): Array<T>;
   getParentKeys(): Array<NodeKey>;
+  getPreviousSibling(): LexicalNode | null;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getPreviousSibling<T extends LexicalNode>(): T | null;
+  getPreviousSiblings(): Array<LexicalNode>;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getPreviousSiblings<T extends LexicalNode>(): Array<T>;
+  getNextSibling(): LexicalNode | null;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getNextSibling<T extends LexicalNode>(): T | null;
+  getNextSiblings(): Array<LexicalNode>;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getNextSiblings<T extends LexicalNode>(): Array<T>;
   getCommonAncestor<T extends ElementNode>(node: LexicalNode): T | null;
   is(object: ?LexicalNode): boolean;
@@ -852,20 +894,79 @@ declare export class ElementNode extends LexicalNode {
   getFormat(): number;
   getFormatType(): ElementFormatType;
   getIndent(): number;
+  getChildren(): Array<LexicalNode>;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getChildren<T extends LexicalNode>(): Array<T>;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getChildren<T extends Array<LexicalNode>>(): T;
   getChildrenKeys(): Array<NodeKey>;
   getChildrenSize(): number;
   isEmpty(): boolean;
   isDirty(): boolean;
   getAllTextNodes(): Array<TextNode>;
+  getFirstDescendant(): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getFirstDescendant<T extends LexicalNode>(): null | T;
+  getLastDescendant(): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getLastDescendant<T extends LexicalNode>(): null | T;
+  getDescendantByIndex(index: number): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getDescendantByIndex<T extends LexicalNode>(index: number): null | T;
+  getFirstChild(): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getFirstChild<T extends LexicalNode>(): null | T;
+  getFirstChildOrThrow(): LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getFirstChildOrThrow<T extends LexicalNode>(): T;
+  getLastChild(): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getLastChild<T extends LexicalNode>(): null | T;
+  getLastChildOrThrow(): LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getLastChildOrThrow<T extends LexicalNode>(): T;
+  getChildAtIndex(index: number): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
   getChildAtIndex<T extends LexicalNode>(index: number): null | T;
   getTextContent(): string;
   getDirection(): 'ltr' | 'rtl' | null;
@@ -1013,7 +1114,22 @@ declare export function getNearestEditorFromDOMNode(
 declare export function $getNearestNodeFromDOMNode(
   startingDOM: Node,
 ): LexicalNode | null;
+declare export function $getNodeByKey(
+  key: NodeKey,
+  _editorState?: EditorState,
+): LexicalNode | null;
+/**
+ * @deprecated The type parameter is an unchecked and unsafe cast and
+ * will be removed in a future release. Call this function without a type
+ * argument and narrow the result with a type guard instead.
+ */
 declare export function $getNodeByKey<N extends LexicalNode>(key: NodeKey): N | null;
+declare export function $getNodeByKeyOrThrow(key: NodeKey): LexicalNode;
+/**
+ * @deprecated The type parameter is an unchecked and unsafe cast and
+ * will be removed in a future release. Call this function without a type
+ * argument and narrow the result with a type guard instead.
+ */
 declare export function $getNodeByKeyOrThrow<N extends LexicalNode>(key: NodeKey): N;
 declare export function $getRoot(): RootNode;
 declare export function $isLeafNode<T = unknown>(

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -947,19 +947,35 @@ export class LexicalNode {
   /**
    * Returns the parent of this node, or null if none is found.
    */
-  getParent<T extends ElementNode>(): T | null {
+  getParent(): ElementNode | null;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `node.getParent() as T | null`, and will be removed
+   * in a future release. Call this method without a type argument and
+   * narrow the result with a type guard instead.
+   */
+  getParent<T extends ElementNode>(): T | null;
+  getParent(): ElementNode | null {
     const parent = this.getLatest().__parent;
     if (parent === null) {
       return null;
     }
-    return $getNodeByKey<T>(parent);
+    return $getNodeByKey<ElementNode>(parent);
   }
 
   /**
    * Returns the parent of this node, or throws if none is found.
    */
-  getParentOrThrow<T extends ElementNode>(): T {
-    const parent = this.getParent<T>();
+  getParentOrThrow(): ElementNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `node.getParentOrThrow() as T`, and will be removed
+   * in a future release. Call this method without a type argument and
+   * narrow the result with a type guard instead.
+   */
+  getParentOrThrow<T extends ElementNode>(): T;
+  getParentOrThrow(): ElementNode {
+    const parent = this.getParent();
     if (parent === null) {
       invariant(false, 'Expected node %s to have a parent.', this.__key);
     }
@@ -1039,10 +1055,18 @@ export class LexicalNode {
    * before this one in the same parent.
    *
    */
-  getPreviousSibling<T extends LexicalNode>(): T | null {
+  getPreviousSibling(): LexicalNode | null;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `node.getPreviousSibling() as T | null`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the result with a type guard instead.
+   */
+  getPreviousSibling<T extends LexicalNode>(): T | null;
+  getPreviousSibling(): LexicalNode | null {
     const self = this.getLatest();
     const prevKey = self.__prev;
-    return prevKey === null ? null : $getNodeByKey<T>(prevKey);
+    return prevKey === null ? null : $getNodeByKey(prevKey);
   }
 
   /**
@@ -1050,13 +1074,21 @@ export class LexicalNode {
    * this one and the first child of it's parent, inclusive.
    *
    */
-  getPreviousSiblings<T extends LexicalNode>(): Array<T> {
-    const siblings: Array<T> = [];
+  getPreviousSiblings(): Array<LexicalNode>;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `node.getPreviousSiblings() as Array<T>`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the results with a type guard instead.
+   */
+  getPreviousSiblings<T extends LexicalNode>(): Array<T>;
+  getPreviousSiblings(): Array<LexicalNode> {
+    const siblings: Array<LexicalNode> = [];
     const parent = this.getParent();
     if (parent === null) {
       return siblings;
     }
-    let node: null | T = parent.getFirstChild();
+    let node: null | LexicalNode = parent.getFirstChild();
     while (node !== null) {
       if (node.is(this)) {
         break;
@@ -1072,10 +1104,18 @@ export class LexicalNode {
    * after this one in the same parent
    *
    */
-  getNextSibling<T extends LexicalNode>(): T | null {
+  getNextSibling(): LexicalNode | null;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `node.getNextSibling() as T | null`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the result with a type guard instead.
+   */
+  getNextSibling<T extends LexicalNode>(): T | null;
+  getNextSibling(): LexicalNode | null {
     const self = this.getLatest();
     const nextKey = self.__next;
-    return nextKey === null ? null : $getNodeByKey<T>(nextKey);
+    return nextKey === null ? null : $getNodeByKey(nextKey);
   }
 
   /**
@@ -1083,9 +1123,17 @@ export class LexicalNode {
    * one and the last child of it's parent, inclusive.
    *
    */
-  getNextSiblings<T extends LexicalNode>(): Array<T> {
-    const siblings: Array<T> = [];
-    let node: null | T = this.getNextSibling();
+  getNextSiblings(): Array<LexicalNode>;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `node.getNextSiblings() as Array<T>`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the results with a type guard instead.
+   */
+  getNextSiblings<T extends LexicalNode>(): Array<T>;
+  getNextSiblings(): Array<LexicalNode> {
+    const siblings: Array<LexicalNode> = [];
+    let node: null | LexicalNode = this.getNextSibling();
     while (node !== null) {
       siblings.push(node);
       node = node.getNextSibling();

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -857,7 +857,8 @@ export class LexicalNode {
         return true;
       }
 
-      // Annotation breaks a circular inference through the loop (TS7022)
+      // Annotation breaks a circular inference through the loop (TS7022),
+      // remove when the deprecated generic signatures from #8661 are removed
       const node: LexicalNode | null = $getNodeByKey(nodeKey);
 
       if (node === null) {
@@ -992,7 +993,8 @@ export class LexicalNode {
   getTopLevelElement(): ElementNode | DecoratorNode<unknown> | null {
     let node: ElementNode | this | null = this;
     while (node !== null) {
-      // Annotation breaks a circular inference through the loop (TS7022)
+      // Annotation breaks a circular inference through the loop (TS7022),
+      // remove when the deprecated generic signatures from #8661 are removed
       const parent: ElementNode | null = node.getParent();
       if ($isRootOrShadowRoot(parent)) {
         invariant(

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -857,6 +857,7 @@ export class LexicalNode {
         return true;
       }
 
+      // Annotation breaks a circular inference through the loop (TS7022)
       const node: LexicalNode | null = $getNodeByKey(nodeKey);
 
       if (node === null) {
@@ -991,6 +992,7 @@ export class LexicalNode {
   getTopLevelElement(): ElementNode | DecoratorNode<unknown> | null {
     let node: ElementNode | this | null = this;
     while (node !== null) {
+      // Annotation breaks a circular inference through the loop (TS7022)
       const parent: ElementNode | null = node.getParent();
       if ($isRootOrShadowRoot(parent)) {
         invariant(
@@ -1052,9 +1054,8 @@ export class LexicalNode {
   }
 
   /**
-   * Returns the "previous" siblings - that is, the node that comes
-   * before this one in the same parent.
-   *
+   * Returns the node before this one in the same parent, or null
+   * if there is no such node.
    */
   getPreviousSibling(): LexicalNode | null;
   /**
@@ -1071,9 +1072,8 @@ export class LexicalNode {
   }
 
   /**
-   * Returns the "previous" siblings - that is, the nodes that come between
-   * this one and the first child of it's parent, inclusive.
-   *
+   * Returns all nodes before this one in the same parent,
+   * in document order.
    */
   getPreviousSiblings(): Array<LexicalNode>;
   /**
@@ -1089,7 +1089,7 @@ export class LexicalNode {
     if (parent === null) {
       return siblings;
     }
-    let node: null | LexicalNode = parent.getFirstChild();
+    let node = parent.getFirstChild();
     while (node !== null) {
       if (node.is(this)) {
         break;
@@ -1101,9 +1101,8 @@ export class LexicalNode {
   }
 
   /**
-   * Returns the "next" siblings - that is, the node that comes
-   * after this one in the same parent
-   *
+   * Returns the node after this one in the same parent, or null
+   * if there is no such node.
    */
   getNextSibling(): LexicalNode | null;
   /**
@@ -1120,9 +1119,8 @@ export class LexicalNode {
   }
 
   /**
-   * Returns all "next" siblings - that is, the nodes that come between this
-   * one and the last child of it's parent, inclusive.
-   *
+   * Returns all nodes after this one in the same parent,
+   * in document order.
    */
   getNextSiblings(): Array<LexicalNode>;
   /**
@@ -1134,7 +1132,7 @@ export class LexicalNode {
   getNextSiblings<T extends LexicalNode>(): Array<T>;
   getNextSiblings(): Array<LexicalNode> {
     const siblings: Array<LexicalNode> = [];
-    let node: null | LexicalNode = this.getNextSibling();
+    let node = this.getNextSibling();
     while (node !== null) {
       siblings.push(node);
       node = node.getNextSibling();

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -960,7 +960,8 @@ export class LexicalNode {
     if (parent === null) {
       return null;
     }
-    return $getNodeByKey<ElementNode>(parent);
+    // Cast: a parent key always refers to an ElementNode
+    return $getNodeByKey(parent) as ElementNode | null;
   }
 
   /**
@@ -1304,7 +1305,8 @@ export class LexicalNode {
     if ($isEphemeral(this)) {
       return this;
     }
-    const latest = $getNodeByKey<this>(this.__key);
+    // Cast: the nodeMap entry for this key is always the same node class
+    const latest = $getNodeByKey(this.__key) as this | null;
     if (latest === null) {
       invariant(
         false,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -867,11 +867,12 @@ export class RangeSelection implements BaseSelection {
         (!firstNodeParent.canInsertTextAfter() &&
           firstNode.getNextSibling() === null))
     ) {
-      let nextSibling = firstNode.getNextSibling<TextNode>();
+      const candidateNextSibling = firstNode.getNextSibling();
+      let nextSibling: TextNode;
       if (
-        !$isTextNode(nextSibling) ||
-        !nextSibling.canInsertTextBefore() ||
-        $isTokenOrSegmented(nextSibling)
+        !$isTextNode(candidateNextSibling) ||
+        !candidateNextSibling.canInsertTextBefore() ||
+        $isTokenOrSegmented(candidateNextSibling)
       ) {
         nextSibling = $createTextNode();
         nextSibling.setFormat(format);
@@ -881,6 +882,8 @@ export class RangeSelection implements BaseSelection {
         } else {
           firstNode.insertAfter(nextSibling);
         }
+      } else {
+        nextSibling = candidateNextSibling;
       }
       nextSibling.select(0, 0);
       firstNode = nextSibling;
@@ -896,8 +899,12 @@ export class RangeSelection implements BaseSelection {
         (!firstNodeParent.canInsertTextBefore() &&
           firstNode.getPreviousSibling() === null))
     ) {
-      let prevSibling = firstNode.getPreviousSibling<TextNode>();
-      if (!$isTextNode(prevSibling) || $isTokenOrSegmented(prevSibling)) {
+      const candidatePrevSibling = firstNode.getPreviousSibling();
+      let prevSibling: TextNode;
+      if (
+        !$isTextNode(candidatePrevSibling) ||
+        $isTokenOrSegmented(candidatePrevSibling)
+      ) {
         prevSibling = $createTextNode();
         prevSibling.setFormat(format);
         if (!firstNodeParent.canInsertTextBefore()) {
@@ -905,6 +912,8 @@ export class RangeSelection implements BaseSelection {
         } else {
           firstNode.insertBefore(prevSibling);
         }
+      } else {
+        prevSibling = candidatePrevSibling;
       }
       prevSibling.select();
       firstNode = prevSibling;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -534,12 +534,30 @@ export function $getCompositionKey(): null | NodeKey {
   return editor._compositionKey;
 }
 
+/**
+ * Returns the node with the given key from the active EditorState
+ * (or the given EditorState), or null if it does not exist.
+ */
+export function $getNodeByKey(
+  key: NodeKey,
+  _editorState?: EditorState,
+): LexicalNode | null;
+/**
+ * @deprecated The type parameter is an unchecked and unsafe cast,
+ * equivalent to `$getNodeByKey(key) as T | null`, and will be removed
+ * in a future release. Call this function without a type argument and
+ * narrow the result with a type guard instead.
+ */
 export function $getNodeByKey<T extends LexicalNode>(
   key: NodeKey,
   _editorState?: EditorState,
-): T | null {
+): T | null;
+export function $getNodeByKey(
+  key: NodeKey,
+  _editorState?: EditorState,
+): LexicalNode | null {
   const editorState = _editorState || getActiveEditorState();
-  const node = editorState._nodeMap.get(key) as T;
+  const node = editorState._nodeMap.get(key);
   if (node === undefined) {
     return null;
   }
@@ -1708,8 +1726,20 @@ export function errorOnInsertTextNodeOnRoot(
   }
 }
 
-export function $getNodeByKeyOrThrow<N extends LexicalNode>(key: NodeKey): N {
-  const node = $getNodeByKey<N>(key);
+/**
+ * Returns the node with the given key from the active EditorState,
+ * or throws if it does not exist.
+ */
+export function $getNodeByKeyOrThrow(key: NodeKey): LexicalNode;
+/**
+ * @deprecated The type parameter is an unchecked and unsafe cast,
+ * equivalent to `$getNodeByKeyOrThrow(key) as N`, and will be removed
+ * in a future release. Call this function without a type argument and
+ * narrow the result with a type guard instead.
+ */
+export function $getNodeByKeyOrThrow<N extends LexicalNode>(key: NodeKey): N;
+export function $getNodeByKeyOrThrow(key: NodeKey): LexicalNode {
+  const node = $getNodeByKey(key);
   if (node === null) {
     invariant(
       false,

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
@@ -47,8 +47,8 @@ describe('LexicalEditorState tests', () => {
 
       editor.getEditorState().read(() => {
         root = $getRoot();
-        paragraph = root.getFirstChild()!;
-        text = paragraph.getFirstChild()!;
+        paragraph = root.getFirstChild() as ParagraphNode;
+        text = paragraph.getFirstChild() as TextNode;
       });
 
       expect(root).toEqual({

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
@@ -11,10 +11,12 @@ import {
   $createTextNode,
   $getEditor,
   $getRoot,
+  $isParagraphNode,
+  $isTextNode,
   ParagraphNode,
   TextNode,
 } from 'lexical';
-import {describe, expect, test} from 'vitest';
+import {assert, describe, expect, test} from 'vitest';
 
 import {EditorState} from '../../LexicalEditorState';
 import {$createRootNode, RootNode} from '../../nodes/LexicalRootNode';
@@ -47,8 +49,12 @@ describe('LexicalEditorState tests', () => {
 
       editor.getEditorState().read(() => {
         root = $getRoot();
-        paragraph = root.getFirstChild() as ParagraphNode;
-        text = paragraph.getFirstChild() as TextNode;
+        const firstChild = root.getFirstChild();
+        assert($isParagraphNode(firstChild), 'Expected a ParagraphNode');
+        paragraph = firstChild;
+        const firstGrandchild = firstChild.getFirstChild();
+        assert($isTextNode(firstGrandchild), 'Expected a TextNode');
+        text = firstGrandchild;
       });
 
       expect(root).toEqual({

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -12,6 +12,8 @@ import {
   $createLineBreakNode,
   $createRangeSelection,
   $createTabNode,
+  $getNodeByKey,
+  $getNodeByKeyOrThrow,
   $getRoot,
   $getSelection,
   $isDecoratorNode,
@@ -2212,6 +2214,12 @@ describe('LexicalNode.$config() without registration', () => {
       expectTypeOf(
         element.getDescendantByIndex(0),
       ).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(
+        $getNodeByKey(node.getKey()),
+      ).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(
+        $getNodeByKeyOrThrow(node.getKey()),
+      ).toEqualTypeOf<LexicalNode>();
       // The deprecated generic overloads remain callable so that existing
       // code continues to compile during migration.
       expectTypeOf(
@@ -2220,6 +2228,12 @@ describe('LexicalNode.$config() without registration', () => {
       expectTypeOf(
         element.getFirstChild<TextNode>(),
       ).toEqualTypeOf<TextNode | null>();
+      expectTypeOf(
+        $getNodeByKey<TextNode>(node.getKey()),
+      ).toEqualTypeOf<TextNode | null>();
+      expectTypeOf(
+        $getNodeByKeyOrThrow<TextNode>(node.getKey()),
+      ).toEqualTypeOf<TextNode>();
       // The type parameter is no longer inferred from the contextual type,
       // so this implicit unchecked cast is a compile error.
       // @ts-expect-error - getFirstChild() returns LexicalNode | null

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -2179,4 +2179,68 @@ describe('LexicalNode.$config() without registration', () => {
       {discrete: true},
     );
   });
+
+  test('traversal methods return base node types unless explicitly cast', () => {
+    // The type parameters on the traversal methods are deprecated unchecked
+    // casts. Calls without a type argument must resolve to the base node
+    // types rather than inferring the type parameter from context.
+    const $checkTraversalTypes = (node: LexicalNode, element: ElementNode) => {
+      expectTypeOf(node.getParent()).toEqualTypeOf<ElementNode | null>();
+      expectTypeOf(node.getParentOrThrow()).toEqualTypeOf<ElementNode>();
+      expectTypeOf(
+        node.getPreviousSibling(),
+      ).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(node.getNextSibling()).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(node.getPreviousSiblings()).toEqualTypeOf<
+        Array<LexicalNode>
+      >();
+      expectTypeOf(node.getNextSiblings()).toEqualTypeOf<Array<LexicalNode>>();
+      expectTypeOf(element.getChildren()).toEqualTypeOf<Array<LexicalNode>>();
+      expectTypeOf(
+        element.getChildAtIndex(0),
+      ).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(element.getFirstChild()).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(element.getFirstChildOrThrow()).toEqualTypeOf<LexicalNode>();
+      expectTypeOf(element.getLastChild()).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(element.getLastChildOrThrow()).toEqualTypeOf<LexicalNode>();
+      expectTypeOf(
+        element.getFirstDescendant(),
+      ).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(
+        element.getLastDescendant(),
+      ).toEqualTypeOf<LexicalNode | null>();
+      expectTypeOf(
+        element.getDescendantByIndex(0),
+      ).toEqualTypeOf<LexicalNode | null>();
+      // The deprecated generic overloads remain callable so that existing
+      // code continues to compile during migration.
+      expectTypeOf(
+        node.getParent<ParagraphNode>(),
+      ).toEqualTypeOf<ParagraphNode | null>();
+      expectTypeOf(
+        element.getFirstChild<TextNode>(),
+      ).toEqualTypeOf<TextNode | null>();
+      // The type parameter is no longer inferred from the contextual type,
+      // so this implicit unchecked cast is a compile error.
+      // @ts-expect-error - getFirstChild() returns LexicalNode | null
+      const child: TextNode | null = element.getFirstChild();
+      return child;
+    };
+
+    const editor = createEditor({
+      onError(err) {
+        throw err;
+      },
+    });
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('x');
+        paragraph.append(text);
+        $getRoot().append(paragraph);
+        expect($checkTraversalTypes(text, paragraph)).toBe(text);
+      },
+      {discrete: true},
+    );
+  });
 });

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -161,7 +161,7 @@ export class ElementNode extends LexicalNode {
   getChildren<T extends LexicalNode>(): Array<T>;
   getChildren(): Array<LexicalNode> {
     const children: Array<LexicalNode> = [];
-    let child: LexicalNode | null = this.getFirstChild();
+    let child = this.getFirstChild();
     while (child !== null) {
       children.push(child);
       child = child.getNextSibling();
@@ -170,7 +170,7 @@ export class ElementNode extends LexicalNode {
   }
   getChildrenKeys(): Array<NodeKey> {
     const children: Array<NodeKey> = [];
-    let child: LexicalNode | null = this.getFirstChild();
+    let child = this.getFirstChild();
     while (child !== null) {
       children.push(child.__key);
       child = child.getNextSibling();
@@ -196,7 +196,7 @@ export class ElementNode extends LexicalNode {
   }
   getAllTextNodes(): Array<TextNode> {
     const textNodes = [];
-    let child: LexicalNode | null = this.getFirstChild();
+    let child = this.getFirstChild();
     while (child !== null) {
       if ($isTextNode(child)) {
         textNodes.push(child);
@@ -222,7 +222,7 @@ export class ElementNode extends LexicalNode {
    */
   getFirstDescendant<T extends LexicalNode>(): null | T;
   getFirstDescendant(): null | LexicalNode {
-    let node: null | LexicalNode = this.getFirstChild();
+    let node = this.getFirstChild();
     while ($isElementNode(node)) {
       const child = node.getFirstChild();
       if (child === null) {
@@ -245,7 +245,7 @@ export class ElementNode extends LexicalNode {
    */
   getLastDescendant<T extends LexicalNode>(): null | T;
   getLastDescendant(): null | LexicalNode {
-    let node: null | LexicalNode = this.getLastChild();
+    let node = this.getLastChild();
     while ($isElementNode(node)) {
       const child = node.getLastChild();
       if (child === null) {

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -148,9 +148,20 @@ export class ElementNode extends LexicalNode {
     const self = this.getLatest();
     return self.__indent;
   }
-  getChildren<T extends LexicalNode>(): Array<T> {
-    const children: Array<T> = [];
-    let child: T | null = this.getFirstChild();
+  /**
+   * Returns the children of this node, in document order.
+   */
+  getChildren(): Array<LexicalNode>;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getChildren() as Array<T>`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the results with a type guard instead.
+   */
+  getChildren<T extends LexicalNode>(): Array<T>;
+  getChildren(): Array<LexicalNode> {
+    const children: Array<LexicalNode> = [];
+    let child: LexicalNode | null = this.getFirstChild();
     while (child !== null) {
       children.push(child);
       child = child.getNextSibling();
@@ -198,10 +209,22 @@ export class ElementNode extends LexicalNode {
     }
     return textNodes;
   }
-  getFirstDescendant<T extends LexicalNode>(): null | T {
-    let node = this.getFirstChild<T>();
+  /**
+   * Returns the deepest first descendant of this node,
+   * or null if it has no children.
+   */
+  getFirstDescendant(): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getFirstDescendant() as T | null`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the result with a type guard instead.
+   */
+  getFirstDescendant<T extends LexicalNode>(): null | T;
+  getFirstDescendant(): null | LexicalNode {
+    let node: null | LexicalNode = this.getFirstChild();
     while ($isElementNode(node)) {
-      const child = node.getFirstChild<T>();
+      const child = node.getFirstChild();
       if (child === null) {
         break;
       }
@@ -209,10 +232,22 @@ export class ElementNode extends LexicalNode {
     }
     return node;
   }
-  getLastDescendant<T extends LexicalNode>(): null | T {
-    let node = this.getLastChild<T>();
+  /**
+   * Returns the deepest last descendant of this node,
+   * or null if it has no children.
+   */
+  getLastDescendant(): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getLastDescendant() as T | null`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the result with a type guard instead.
+   */
+  getLastDescendant<T extends LexicalNode>(): null | T;
+  getLastDescendant(): null | LexicalNode {
+    let node: null | LexicalNode = this.getLastChild();
     while ($isElementNode(node)) {
-      const child = node.getLastChild<T>();
+      const child = node.getLastChild();
       if (child === null) {
         break;
       }
@@ -220,8 +255,20 @@ export class ElementNode extends LexicalNode {
     }
     return node;
   }
-  getDescendantByIndex<T extends LexicalNode>(index: number): null | T {
-    const children = this.getChildren<T>();
+  /**
+   * Returns the deepest descendant corresponding to the child at the given
+   * index, or null if this node has no children.
+   */
+  getDescendantByIndex(index: number): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getDescendantByIndex(index) as T | null`, and
+   * will be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
+  getDescendantByIndex<T extends LexicalNode>(index: number): null | T;
+  getDescendantByIndex(index: number): null | LexicalNode {
+    const children = this.getChildren();
     const childrenLength = children.length;
     // For non-empty element nodes, we resolve its descendant
     // (either a leaf node or the bottom-most element)
@@ -240,36 +287,92 @@ export class ElementNode extends LexicalNode {
       null
     );
   }
-  getFirstChild<T extends LexicalNode>(): null | T {
+  /**
+   * Returns the first child of this node, or null if it has no children.
+   */
+  getFirstChild(): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getFirstChild() as T | null`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the result with a type guard instead.
+   */
+  getFirstChild<T extends LexicalNode>(): null | T;
+  getFirstChild(): null | LexicalNode {
     const self = this.getLatest();
     const firstKey = self.__first;
-    return firstKey === null ? null : $getNodeByKey<T>(firstKey);
+    return firstKey === null ? null : $getNodeByKey(firstKey);
   }
-  getFirstChildOrThrow<T extends LexicalNode>(): T {
-    const firstChild = this.getFirstChild<T>();
+  /**
+   * Returns the first child of this node, or throws if it has no children.
+   */
+  getFirstChildOrThrow(): LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getFirstChildOrThrow() as T`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the result with a type guard instead.
+   */
+  getFirstChildOrThrow<T extends LexicalNode>(): T;
+  getFirstChildOrThrow(): LexicalNode {
+    const firstChild = this.getFirstChild();
     if (firstChild === null) {
       invariant(false, 'Expected node %s to have a first child.', this.__key);
     }
     return firstChild;
   }
-  getLastChild<T extends LexicalNode>(): null | T {
+  /**
+   * Returns the last child of this node, or null if it has no children.
+   */
+  getLastChild(): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getLastChild() as T | null`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the result with a type guard instead.
+   */
+  getLastChild<T extends LexicalNode>(): null | T;
+  getLastChild(): null | LexicalNode {
     const self = this.getLatest();
     const lastKey = self.__last;
-    return lastKey === null ? null : $getNodeByKey<T>(lastKey);
+    return lastKey === null ? null : $getNodeByKey(lastKey);
   }
-  getLastChildOrThrow<T extends LexicalNode>(): T {
-    const lastChild = this.getLastChild<T>();
+  /**
+   * Returns the last child of this node, or throws if it has no children.
+   */
+  getLastChildOrThrow(): LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getLastChildOrThrow() as T`, and will be
+   * removed in a future release. Call this method without a type argument
+   * and narrow the result with a type guard instead.
+   */
+  getLastChildOrThrow<T extends LexicalNode>(): T;
+  getLastChildOrThrow(): LexicalNode {
+    const lastChild = this.getLastChild();
     if (lastChild === null) {
       invariant(false, 'Expected node %s to have a last child.', this.__key);
     }
     return lastChild;
   }
-  getChildAtIndex<T extends LexicalNode>(index: number): null | T {
+  /**
+   * Returns the child of this node at the given index, or null if
+   * the index is out of range.
+   */
+  getChildAtIndex(index: number): null | LexicalNode;
+  /**
+   * @deprecated The type parameter is an unchecked and unsafe cast,
+   * equivalent to `element.getChildAtIndex(index) as T | null`, and will
+   * be removed in a future release. Call this method without a type
+   * argument and narrow the result with a type guard instead.
+   */
+  getChildAtIndex<T extends LexicalNode>(index: number): null | T;
+  getChildAtIndex(index: number): null | LexicalNode {
     const size = this.getChildrenSize();
-    let node: null | T;
+    let node: null | LexicalNode;
     let i;
     if (index < size / 2) {
-      node = this.getFirstChild<T>();
+      node = this.getFirstChild();
       i = 0;
       while (node !== null && i <= index) {
         if (i === index) {
@@ -280,7 +383,7 @@ export class ElementNode extends LexicalNode {
       }
       return null;
     }
-    node = this.getLastChild<T>();
+    node = this.getLastChild();
     i = size - 1;
     while (node !== null && i >= index) {
       if (i === index) {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -345,7 +345,7 @@ describe('LexicalElementNode tests', () => {
 
     beforeEach(async () => {
       await update(() => {
-        block = $getRoot().getFirstChildOrThrow();
+        block = $getRoot().getFirstChildOrThrow() as ElementNode;
       });
     });
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -12,6 +12,7 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
   createEditor,
   ElementNode,
@@ -22,7 +23,15 @@ import {
 import * as React from 'react';
 import {act, createRef, useEffect} from 'react';
 import {createRoot} from 'react-dom/client';
-import {afterEach, beforeEach, describe, expect, it, test} from 'vitest';
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  test,
+} from 'vitest';
 
 import {
   $createTestElementNode,
@@ -345,7 +354,9 @@ describe('LexicalElementNode tests', () => {
 
     beforeEach(async () => {
       await update(() => {
-        block = $getRoot().getFirstChildOrThrow() as ElementNode;
+        const firstChild = $getRoot().getFirstChildOrThrow();
+        assert($isElementNode(firstChild), 'Expected an ElementNode');
+        block = firstChild;
       });
     });
 


### PR DESCRIPTION
## Breaking Change

This is a types-only change to the API but some unsafe inference will require changes to the call sites to pass the type check. For example, this unsafe code would pass type checks before but fail after this PR:

```ts
const node: ParagraphNode | null = $getRoot().getFirstChild();
```

A direct port of this unsafe code would use a cast (no safety or correctness difference):

```ts
const node = $getRoot().getFirstChild() as ParagraphNode | null;
```

To write safe code, you must use a guard for runtime narrowing. For example:

```ts
const node = $getRoot().getFirstChild();
if ($isParagraphNode(node)) {
  // node is narrowed to ParagraphNode in this branch
}
```

Existing code that explicitly uses a type argument to do an unsafe cast will still work, but that usage is deprecated and will be removed in some future version of lexical (e.g. `$getRoot().getFirstChild<ParagraphNode>()` is now deprecated).

## Description

The zero-argument generics on the LexicalNode and ElementNode traversal methods (getParent(OrThrow), getPreviousSibling(s), getNextSibling(s), getChildren, getFirstChild(OrThrow), getLastChild(OrThrow), getChildAtIndex, getFirstDescendant, getLastDescendant, and getDescendantByIndex) were implicit unchecked casts: there is no inference site, so the only sound type argument is the constraint itself and any other instantiation is equivalent to an unchecked cast.

Each method is now declared as an overload pair: a documented non-generic signature that returns the base type (LexicalNode or ElementNode | null as appropriate), plus the old generic signature marked `@deprecated` so existing call sites keep compiling but get flagged in editors and in the generated API documentation. The deprecated overloads can be removed in a future release.

The type parameter is no longer inferred from the contextual (assignment) type, so call sites that relied on that implicit cast now fail to compile and must narrow with a type guard or use an explicit cast; all such call sites in the repo have been migrated, with no intended runtime behavior changes.

## Test plan

- [x] Manually verify that the deprecations show up in QA with the VSCode language server, and that the deprecations don't show up for call sites without the explicit generic. This PR doesn't fix all use sites.
