### PR TITLE
[Breaking Changes][*] Refactor: Register DOMImportExtension rules implicitly via node extensions and make tree-shaking annotations effective

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,20 @@ For E2E testing workflow:
 - `pnpm run tsc` - Run TypeScript compiler
 - `pnpm run ci-check` - Run all checks (TypeScript, Flow, Prettier, ESLint)
 
+### Tree-shaking annotations
+
+Module-scope calls to the side-effect-free factories (`defineExtension`,
+`configExtension`, `safeCast`, `createCommand`, `createState`,
+`defineImportRule`, etc.) must be annotated with `/* @__PURE__ */` so
+bundlers can drop unused definitions from application bundles. This is
+enforced (with an autofixer) by the
+`@lexical/internal/require-pure-annotation` ESLint rule — run
+`pnpm run lint:fix` (also run by the pre-commit hook) to insert the
+annotations automatically. When adding a new factory of this kind,
+annotate its definition with `@__NO_SIDE_EFFECTS__` and add its name to
+the rule's default list in
+`packages/lexical-eslint-plugin-internal/src/rules/require-pure-annotation.js`.
+
 ## High-Level Architecture
 
 ### Core Concepts

--- a/dev-examples/dom-import/README.md
+++ b/dev-examples/dom-import/README.md
@@ -1,20 +1,26 @@
 # DOMImportExtension example
 
 A reduced rich-text editor focused on demonstrating the new
-`DOMImportExtension` import pipeline:
+`DOMImportExtension` import pipeline. Each node-providing extension
+registers its own import rules, so listing the runtime extensions is
+all the configuration the pipeline needs —
+`ClipboardDOMImportExtension` is the only import-specific dependency:
 
-- **Rich text** — paragraphs, headings, quotes (`RichTextExtension` +
-  `RichTextImportExtension`).
-- **Lists** — bullet / numbered / check-list (`ListExtension` +
-  `ListImportExtension`).
-- **Tables** (`TableExtension` + `TableImportExtension`).
-- **Links** (`LinkImportExtension`).
+- **Rich text** — paragraphs, headings, quotes (`RichTextExtension`,
+  which also registers the `<h1>`–`<h6>` / `<blockquote>` import
+  rules and the shared `CoreImportExtension` baseline).
+- **Lists** — bullet / numbered / check-list (`ListExtension`).
+- **Tables** (`TableExtension`).
+- **Links** (`LinkExtension`).
+- **Horizontal rules** (`HorizontalRuleExtension` — the `<hr>` rule
+  ships with `CoreImportExtension`, gated on the node being
+  registered).
 - **Code blocks with Shiki highlighting** (`CodeShikiExtension`
   registers `CodeNode` / `CodeHighlightNode` and wires Shiki up as
-  the syntax-highlighting tokenizer; `CodeImportExtension` adds the
-  import rules — `<pre>`, multi-line `<code>`, GitHub raw-file-view
-  code tables, monospace `<div>`, and the VS Code paste
-  consolidation preprocess).
+  the syntax-highlighting tokenizer; the underlying `CodeExtension`
+  brings the import rules — `<pre>`, multi-line `<code>`, GitHub
+  raw-file-view code tables, monospace `<div>`, and the VS Code
+  paste consolidation preprocess).
 - **Markdown shortcuts** — type `# `, `* `, `1. `, `> `, ``` ``` ```, etc.
   to convert on the fly.
 - **MS Word paste** — a preprocess detects the

--- a/dev-examples/dom-import/src/App.tsx
+++ b/dev-examples/dom-import/src/App.tsx
@@ -7,7 +7,6 @@
  */
 
 import {ClipboardDOMImportExtension} from '@lexical/clipboard';
-import {CodeImportExtension} from '@lexical/code-core';
 import {CodeShikiExtension} from '@lexical/code-shiki';
 import {
   AutoFocusExtension,
@@ -16,20 +15,12 @@ import {
   TabIndentationExtension,
 } from '@lexical/extension';
 import {HistoryExtension} from '@lexical/history';
-import {
-  CoreImportExtension,
-  HorizontalRuleImportExtension,
-} from '@lexical/html';
-import {LinkExtension, LinkImportExtension} from '@lexical/link';
-import {
-  CheckListExtension,
-  ListExtension,
-  ListImportExtension,
-} from '@lexical/list';
+import {LinkExtension} from '@lexical/link';
+import {CheckListExtension, ListExtension} from '@lexical/list';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
-import {RichTextExtension, RichTextImportExtension} from '@lexical/rich-text';
-import {TableExtension, TableImportExtension} from '@lexical/table';
+import {RichTextExtension} from '@lexical/rich-text';
+import {TableExtension} from '@lexical/table';
 import {defineExtension} from 'lexical';
 
 import ExampleTheme from './ExampleTheme';
@@ -62,14 +53,6 @@ const editorExtension = defineExtension({
     CodeShikiExtension,
     MarkdownShortcutsExtension,
     ToolbarExtension,
-    // DOMImportExtension pipeline — rules contributed per node package.
-    CoreImportExtension,
-    RichTextImportExtension,
-    ListImportExtension,
-    LinkImportExtension,
-    TableImportExtension,
-    HorizontalRuleImportExtension,
-    CodeImportExtension,
     // Word-only overlay, installed conditionally by a preprocess.
     WordPasteExtension,
     // Route real `text/html` pastes through the DOMImportExtension

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -403,6 +403,19 @@ export default [
     },
   },
 
+  // Override: Package sources - require /* @__PURE__ */ annotations on
+  // module-scope calls to the side-effect-free lexical factories
+  // (defineExtension, createCommand, defineImportRule, ...) so bundlers
+  // can tree-shake unused definitions. The pre-commit `eslint --fix`
+  // inserts them automatically. Not applied to tests (never bundled).
+  {
+    files: ['packages/**/src/**'],
+    ignores: ['packages/**/src/__tests__/**'],
+    rules: {
+      '@lexical/internal/require-pure-annotation': ERROR,
+    },
+  },
+
   // Override: Tests - allow imports from self
   {
     files: ['packages/**/__tests__/**'],

--- a/packages/lexical-clipboard/src/ClipboardImportExtension.ts
+++ b/packages/lexical-clipboard/src/ClipboardImportExtension.ts
@@ -13,6 +13,7 @@ import {
   $generateNodesFromDOM,
   $generateNodesFromDOMViaExtension,
   contextValue,
+  CoreImportExtension,
   ImportSource,
   ImportSourceDataTransfer,
 } from '@lexical/html';
@@ -481,9 +482,14 @@ export const ClipboardImportExtension = defineExtension({
  * Drop-in extension that routes `text/html` clipboard pastes and drops
  * through the {@link DOMImportExtension} pipeline (rules, schemas,
  * preprocessors, overlays) instead of the legacy
- * {@link $generateNodesFromDOM}. Add to your extension dependencies along
- * with the per-package import extensions you want active
- * ({@link CoreImportExtension}, {@link RichTextImportExtension}, etc.).
+ * {@link $generateNodesFromDOM}. Node-providing extensions
+ * (`RichTextExtension`, `ListExtension`, `LinkExtension`,
+ * `TableExtension`, `CodeExtension`, …) register their own import rules,
+ * so adding this extension to an editor built from them is all it takes
+ * to activate the pipeline for pastes. {@link CoreImportExtension} (the
+ * paragraph/text/inline-format baseline) is a dependency of this
+ * extension, so even an editor with no rule-contributing node extensions
+ * gets sensible text handling.
  *
  * The original {@link DataTransfer} and `'paste'` source kind are forwarded
  * into the import context so rules and preprocessors can read them via
@@ -496,13 +502,12 @@ export const ClipboardImportExtension = defineExtension({
  * ```ts
  * import {defineExtension} from 'lexical';
  * import {ClipboardDOMImportExtension} from '@lexical/clipboard';
- * import {CoreImportExtension, RichTextImportExtension} from '@lexical/html';
+ * import {RichTextExtension} from '@lexical/rich-text';
  *
  * defineExtension({
  *   name: 'app',
  *   dependencies: [
- *     CoreImportExtension,
- *     RichTextImportExtension,
+ *     RichTextExtension,
  *     ClipboardDOMImportExtension,
  *   ],
  * });
@@ -510,6 +515,7 @@ export const ClipboardImportExtension = defineExtension({
  */
 export const ClipboardDOMImportExtension = defineExtension({
   dependencies: [
+    CoreImportExtension,
     configExtension(ClipboardImportExtension, {
       $importMimeType: {
         'text/html': [

--- a/packages/lexical-clipboard/src/ClipboardImportExtension.ts
+++ b/packages/lexical-clipboard/src/ClipboardImportExtension.ts
@@ -440,14 +440,14 @@ export function $getImportOutput(): ClipboardImportOutput {
  * });
  * ```
  */
-export const ClipboardImportExtension = defineExtension({
+export const ClipboardImportExtension = /* @__PURE__ */ defineExtension({
   build: (_editor, config): ClipboardImportOutput => ({
     $importMimeType: config.$importMimeType,
     $insertDataTransfer: (dataTransfer, selection) =>
       $runImport(config, dataTransfer, selection),
     priority: config.priority,
   }),
-  config: safeCast<ClipboardImportConfig>({
+  config: /* @__PURE__ */ safeCast<ClipboardImportConfig>({
     $importMimeType: DEFAULT_IMPORT_MIME_TYPE,
     priority: DEFAULT_IMPORT_MIME_TYPE_PRIORITY,
   }),
@@ -513,10 +513,10 @@ export const ClipboardImportExtension = defineExtension({
  * });
  * ```
  */
-export const ClipboardDOMImportExtension = defineExtension({
+export const ClipboardDOMImportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
     CoreImportExtension,
-    configExtension(ClipboardImportExtension, {
+    /* @__PURE__ */ configExtension(ClipboardImportExtension, {
       $importMimeType: {
         'text/html': [
           (html, selection, _$next, dataTransfer) => {

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -923,11 +923,11 @@ export function $exportMimeTypeFromSelection(
  * });
  * ```
  */
-export const GetClipboardDataExtension = defineExtension({
+export const GetClipboardDataExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     return config.$exportMimeType;
   },
-  config: safeCast<GetClipboardDataConfig>({
+  config: /* @__PURE__ */ safeCast<GetClipboardDataConfig>({
     $exportMimeType: DEFAULT_EXPORT_MIME_TYPE,
   }),
   mergeConfig(config, partial) {

--- a/packages/lexical-code-core/src/CodeExtension.ts
+++ b/packages/lexical-code-core/src/CodeExtension.ts
@@ -26,13 +26,13 @@ import {$exitCodeNodeOnEnter, CodeNode} from './CodeNode';
 /**
  * Add code blocks to the editor (syntax highlighting provided separately)
  */
-export const CodeExtension = defineExtension({
+export const CodeExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
     // DOMImportExtension support for the nodes registered here. Inert
     // unless the editor routes HTML through the pipeline (e.g. via
     // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
     CoreImportExtension,
-    configExtension(DOMImportExtension, {
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
       preprocess: [$installVscodeCodePasteOverlay],
       rules: CodeImportRules,
     }),
@@ -64,7 +64,7 @@ export const CodeExtension = defineExtension({
  * {@link CodeImportRules} (and `CoreImportExtension`) itself — depend on
  * it directly instead.
  */
-export const CodeImportExtension = defineExtension({
+export const CodeImportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [CodeExtension],
   name: '@lexical/code/Import',
 });

--- a/packages/lexical-code-core/src/CodeExtension.ts
+++ b/packages/lexical-code-core/src/CodeExtension.ts
@@ -6,21 +6,37 @@
  *
  */
 
+import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
 import {
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_LOW,
+  configExtension,
   defineExtension,
   KEY_ENTER_COMMAND,
 } from 'lexical';
 
 import {CodeHighlightNode} from './CodeHighlightNode';
+import {
+  $installVscodeCodePasteOverlay,
+  CodeImportRules,
+} from './CodeImportExtension';
 import {$exitCodeNodeOnEnter, CodeNode} from './CodeNode';
 
 /**
  * Add code blocks to the editor (syntax highlighting provided separately)
  */
 export const CodeExtension = defineExtension({
+  dependencies: [
+    // DOMImportExtension support for the nodes registered here. Inert
+    // unless the editor routes HTML through the pipeline (e.g. via
+    // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
+    CoreImportExtension,
+    configExtension(DOMImportExtension, {
+      preprocess: [$installVscodeCodePasteOverlay],
+      rules: CodeImportRules,
+    }),
+  ],
   name: '@lexical/code',
   nodes: () => [CodeNode, CodeHighlightNode],
   register(editor) {
@@ -37,4 +53,18 @@ export const CodeExtension = defineExtension({
       COMMAND_PRIORITY_LOW,
     );
   },
+});
+
+/**
+ * Bundles {@link CodeImportRules} together with the runtime
+ * {@link CodeExtension}.
+ *
+ * @experimental
+ * @deprecated {@link CodeExtension} now registers
+ * {@link CodeImportRules} (and `CoreImportExtension`) itself — depend on
+ * it directly instead.
+ */
+export const CodeImportExtension = defineExtension({
+  dependencies: [CodeExtension],
+  name: '@lexical/code/Import',
 });

--- a/packages/lexical-code-core/src/CodeImportExtension.ts
+++ b/packages/lexical-code-core/src/CodeImportExtension.ts
@@ -9,23 +9,18 @@
 import type {DOMPreprocessFn} from '@lexical/html';
 
 import {
-  CoreImportExtension,
   defineImportRule,
   defineOverlayRules,
-  DOMImportExtension,
   ImportOverlays,
   sel,
 } from '@lexical/html';
 import {
   $generateNodesFromRawText,
-  configExtension,
-  defineExtension,
   isDOMDocumentNode,
   isDOMTextNode,
   isHTMLElement,
 } from 'lexical';
 
-import {CodeExtension} from './CodeExtension';
 import {$createCodeNode} from './CodeNode';
 
 const LANGUAGE_DATA_ATTRIBUTE = 'data-language';
@@ -371,6 +366,12 @@ const GitHubCodeCellByClassRule = defineImportRule({
  * registered before the generic `<table>` / `<tr>` / `<td>` rules so
  * they win dispatch.
  *
+ * Registered by {@link CodeExtension} itself (together with
+ * `CoreImportExtension` and the {@link $installVscodeCodePasteOverlay}
+ * preprocess), so any editor that uses the code extension can import
+ * these shapes through the `DOMImportExtension` pipeline without further
+ * configuration.
+ *
  * @experimental
  */
 export const CodeImportRules = [
@@ -381,23 +382,3 @@ export const CodeImportRules = [
   PreRule,
   DivRule,
 ];
-
-/**
- * Bundles {@link CodeImportRules} (plus {@link CoreImportExtension}) into
- * a single dependency. The legacy {@link CodeNode.importDOM} continues to
- * work in parallel; depend on this extension to opt into the new
- * pipeline.
- *
- * @experimental
- */
-export const CodeImportExtension = defineExtension({
-  dependencies: [
-    CoreImportExtension,
-    CodeExtension,
-    configExtension(DOMImportExtension, {
-      preprocess: [$installVscodeCodePasteOverlay],
-      rules: CodeImportRules,
-    }),
-  ],
-  name: '@lexical/code/Import',
-});

--- a/packages/lexical-code-core/src/CodeImportExtension.ts
+++ b/packages/lexical-code-core/src/CodeImportExtension.ts
@@ -54,7 +54,7 @@ function isMonospaceDescendant(node: HTMLElement): boolean {
  * the cost of these rules is never paid against unrelated `<tr>` /
  * `<td>` pastes.
  */
-const GitHubCodeTableOverlayRules = defineOverlayRules([
+const GitHubCodeTableOverlayRules = /* @__PURE__ */ defineOverlayRules([
   defineImportRule({
     $import: (ctx, el) => ctx.$importChildren(el),
     match: sel.tag('tr', 'td'),
@@ -62,7 +62,7 @@ const GitHubCodeTableOverlayRules = defineOverlayRules([
   }),
 ]);
 
-const PreRule = defineImportRule({
+const PreRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => [
     $createCodeNode(el.getAttribute(LANGUAGE_DATA_ATTRIBUTE)).splice(
       0,
@@ -80,7 +80,7 @@ const PreRule = defineImportRule({
  * defers to the inline-format rule from `CoreImportExtension` so it
  * becomes a TextNode with IS_CODE.
  */
-const MultilineCodeRule = defineImportRule({
+const MultilineCodeRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el, $next) => {
     const text = el.textContent || '';
     const isMultiLine = /\r?\n/.test(text) || el.querySelector('br') !== null;
@@ -206,7 +206,7 @@ function looksLikeVscodePaste(root: ParentNode): boolean {
  * around per-line `<div>`s and `<br>`s. Emits a single CodeNode whose
  * text is the wrapper's lines joined by `\n`.
  */
-const VscodeWrapperRule = defineImportRule({
+const VscodeWrapperRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, el, $next) => {
     if (!isMonospacePreElement(el) || isMonospaceDescendant(el)) {
       return $next();
@@ -234,7 +234,7 @@ const VscodeWrapperRule = defineImportRule({
  * subsequent sibling in the same run, the prev-sibling check below
  * returns `[]` so the run is only emitted once.
  */
-const VscodeLineRunRule = defineImportRule({
+const VscodeLineRunRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, el, $next) => {
     if (!isMonospacePreElement(el) || isMonospaceDescendant(el)) {
       return $next();
@@ -265,7 +265,7 @@ const VscodeLineRunRule = defineImportRule({
   name: '@lexical/code/vscode-line-run',
 });
 
-const VscodeCodePasteOverlay = defineOverlayRules([
+const VscodeCodePasteOverlay = /* @__PURE__ */ defineOverlayRules([
   VscodeWrapperRule,
   VscodeLineRunRule,
 ]);
@@ -313,7 +313,7 @@ export const $installVscodeCodePasteOverlay: DOMPreprocessFn = (
  * wrapper just unwrap so their text content flows into the surrounding
  * CodeNode.
  */
-const DivRule = defineImportRule({
+const DivRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el, $next) => {
     if (isMonospaceElement(el)) {
       return [$createCodeNode().splice(0, 0, ctx.$importChildren(el))];
@@ -335,7 +335,7 @@ const DivRule = defineImportRule({
  * subtree unwrap unconditionally — without paying the predicate cost
  * on every other `<tr>` / `<td>` paste elsewhere.
  */
-const GitHubCodeTableRule = defineImportRule({
+const GitHubCodeTableRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => [
     $createCodeNode().splice(
       0,
@@ -353,7 +353,7 @@ const GitHubCodeTableRule = defineImportRule({
  * descendant text flows up into whatever context the cell is in. The
  * class is part of the selector itself, so no runtime guard.
  */
-const GitHubCodeCellByClassRule = defineImportRule({
+const GitHubCodeCellByClassRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => ctx.$importChildren(el),
   match: sel.tag('td').classAll('js-file-line'),
   name: '@lexical/code/github-code-cell-by-class',

--- a/packages/lexical-code-core/src/CodeImportExtension.ts
+++ b/packages/lexical-code-core/src/CodeImportExtension.ts
@@ -55,7 +55,7 @@ function isMonospaceDescendant(node: HTMLElement): boolean {
  * `<td>` pastes.
  */
 const GitHubCodeTableOverlayRules = /* @__PURE__ */ defineOverlayRules([
-  defineImportRule({
+  /* @__PURE__ */ defineImportRule({
     $import: (ctx, el) => ctx.$importChildren(el),
     match: sel.tag('tr', 'td'),
     name: '@lexical/code/github-code-table/unwrap',

--- a/packages/lexical-code-core/src/CodeIndentation.ts
+++ b/packages/lexical-code-core/src/CodeIndentation.ts
@@ -677,9 +677,9 @@ export interface CodeIndentConfig {
  * Code blocks without syntax highlighting can use this extension on its
  * own.
  */
-export const CodeIndentExtension = defineExtension({
+export const CodeIndentExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<CodeIndentConfig>({
+  config: /* @__PURE__ */ safeCast<CodeIndentConfig>({
     disabled: false,
     escapeWithArrows: false,
     tabSize: undefined,

--- a/packages/lexical-code-core/src/__tests__/unit/CodeImportExtension.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeImportExtension.test.ts
@@ -12,6 +12,7 @@ import {
   getExtensionDependencyFromEditor,
 } from '@lexical/extension';
 import {DOMImportExtension} from '@lexical/html';
+import {$isTableNode, TableExtension} from '@lexical/table';
 import {JSDOM} from 'jsdom';
 import {
   $getEditor,
@@ -28,7 +29,10 @@ import {$isCodeNode, CodeNode} from '../../CodeNode';
 function buildEditor() {
   return buildEditorFromExtensions(
     defineExtension({
-      dependencies: [CodeExtension, CodeImportExtension],
+      // CodeExtension registers its own import rules (and the shared
+      // CoreImportExtension baseline) — no dedicated import extension
+      // required.
+      dependencies: [CodeExtension],
       name: 'code-host',
     }),
   );
@@ -128,6 +132,34 @@ describe('CodeImportExtension', () => {
     });
   });
 
+  test('GitHub raw-file-view table still wins when TableExtension is present', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        // Table listed before Code, like a typical app config: rules
+        // merge in dependency order, so CodeExtension's class-restricted
+        // <table> rule out-prioritizes TableExtension's generic one.
+        dependencies: [TableExtension, CodeExtension],
+        name: 'table-code-host',
+      }),
+    );
+    importInto(
+      editor,
+      [
+        '<table class="js-file-line-container">',
+        '<tr><td class="js-file-line">line 1</td></tr>',
+        '</table>',
+        '<table><tr><td>plain</td></tr></table>',
+      ].join(''),
+    );
+    editor.read(() => {
+      const [code, table] = $getRoot().getChildren();
+      assert($isCodeNode(code), 'expected CodeNode for the GitHub table');
+      expect(code.getTextContent()).toContain('line 1');
+      assert($isTableNode(table), 'expected TableNode for the plain table');
+      expect(table.getTextContent()).toContain('plain');
+    });
+  });
+
   test('plain <table> falls through (no CodeNode)', () => {
     using editor = buildEditor();
     importInto(editor, '<table><tr><td>a</td></tr></table>');
@@ -137,6 +169,21 @@ describe('CodeImportExtension', () => {
         !$isCodeNode(root.getFirstChild()),
         'plain table should not become a CodeNode',
       );
+    });
+  });
+
+  test('deprecated CodeImportExtension alias still imports <pre>', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [CodeImportExtension],
+        name: 'code-alias-host',
+      }),
+    );
+    importInto(editor, '<pre data-language="ts">const x = 1;</pre>');
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isCodeNode(node), 'expected CodeNode');
+      expect(node.getLanguage()).toBe('ts');
     });
   });
 });

--- a/packages/lexical-code-core/src/index.ts
+++ b/packages/lexical-code-core/src/index.ts
@@ -6,13 +6,13 @@
  *
  */
 
-export {CodeExtension} from './CodeExtension';
+export {CodeExtension, CodeImportExtension} from './CodeExtension';
 export {
   $createCodeHighlightNode,
   $isCodeHighlightNode,
   CodeHighlightNode,
 } from './CodeHighlightNode';
-export {CodeImportExtension, CodeImportRules} from './CodeImportExtension';
+export {CodeImportRules} from './CodeImportExtension';
 export {
   type CodeIndentConfig,
   CodeIndentExtension,

--- a/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
@@ -441,9 +441,9 @@ export interface CodePrismConfig {
  * and the related keyboard handlers are activated automatically. Set
  * `tabSize` on `CodeIndentExtension` to enable space-indent outdent.
  */
-export const CodePrismExtension = defineExtension({
+export const CodePrismExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<CodePrismConfig>({
+  config: /* @__PURE__ */ safeCast<CodePrismConfig>({
     disabled: false,
     tokenizer: PrismTokenizer,
   }),

--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -458,9 +458,9 @@ export interface CodeShikiConfig {
  * and the related keyboard handlers are activated automatically. Set
  * `tabSize` on `CodeIndentExtension` to enable space-indent outdent.
  */
-export const CodeShikiExtension = defineExtension({
+export const CodeShikiExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<CodeShikiConfig>({
+  config: /* @__PURE__ */ safeCast<CodeShikiConfig>({
     disabled: false,
     tokenizer: ShikiTokenizer,
   }),
@@ -495,8 +495,8 @@ export type CodeHighlighterShikiConfig = Tokenizer;
  * `configExtension(CodeHighlighterShikiExtension, customTokenizer)`
  * continue to work without modification.
  */
-export const CodeHighlighterShikiExtension = defineExtension({
-  config: safeCast<CodeHighlighterShikiConfig>(ShikiTokenizer),
+export const CodeHighlighterShikiExtension = /* @__PURE__ */ defineExtension({
+  config: /* @__PURE__ */ safeCast<CodeHighlighterShikiConfig>(ShikiTokenizer),
   dependencies: [CodeShikiExtension],
   init: (editorConfig, config, state) => {
     // Forward the flat Tokenizer config to CodeShikiExtension's `tokenizer`

--- a/packages/lexical-dragon/src/index.ts
+++ b/packages/lexical-dragon/src/index.ts
@@ -135,9 +135,11 @@ export interface DragonConfig {
  * Add Dragon speech to text input support to the editor, via the
  * \@lexical/dragon module.
  */
-export const DragonExtension = defineExtension({
+export const DragonExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config, state) => namedSignals(config),
-  config: safeCast<DragonConfig>({disabled: typeof window === 'undefined'}),
+  config: /* @__PURE__ */ safeCast<DragonConfig>({
+    disabled: typeof window === 'undefined',
+  }),
   name: '@lexical/dragon',
   register: (editor, config, state) =>
     effect(() =>

--- a/packages/lexical-eslint-plugin-internal/src/__tests__/unit/require-pure-annotation.test.ts
+++ b/packages/lexical-eslint-plugin-internal/src/__tests__/unit/require-pure-annotation.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {RuleTester} from 'eslint';
+import {describe, expect, it} from 'vitest';
+
+import plugin from '../../index.js';
+import rule from '../../rules/require-pure-annotation.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+describe('require-pure-annotation', () => {
+  it('is exported by the plugin with a fixer', () => {
+    expect(plugin.rules['require-pure-annotation']).toBe(rule);
+    expect(rule.meta!.fixable).toBe('code');
+  });
+
+  it('passes RuleTester', () => {
+    ruleTester.run('require-pure-annotation', rule, {
+      invalid: [
+        {
+          code: `export const MyExtension = defineExtension({name: 'my'});`,
+          errors: [{messageId: 'missingPureAnnotation'}],
+          output: `export const MyExtension = /* @__PURE__ */ defineExtension({name: 'my'});`,
+        },
+        {
+          // Initializer on its own line.
+          code: `export const MY_COMMAND =\n  createCommand('MY_COMMAND');`,
+          errors: [{messageId: 'missingPureAnnotation'}],
+          output: `export const MY_COMMAND =\n  /* @__PURE__ */ createCommand('MY_COMMAND');`,
+        },
+        {
+          // An unannotated argument-position call pins the (annotated)
+          // enclosing call, so it is required too.
+          code: `export const E = /* @__PURE__ */ defineExtension({config: safeCast({a: 1}), name: 'e'});`,
+          errors: [{messageId: 'missingPureAnnotation'}],
+          output: `export const E = /* @__PURE__ */ defineExtension({config: /* @__PURE__ */ safeCast({a: 1}), name: 'e'});`,
+        },
+        {
+          // Module-scope call nested in an array.
+          code: `const deps = [configExtension(Other, {x: 1})];\nexport default deps;`,
+          errors: [{messageId: 'missingPureAnnotation'}],
+          output: `const deps = [/* @__PURE__ */ configExtension(Other, {x: 1})];\nexport default deps;`,
+        },
+        {
+          // Custom function list replaces the default.
+          code: `const x = myFactory();`,
+          errors: [{messageId: 'missingPureAnnotation'}],
+          options: [{functions: ['myFactory']}],
+          output: `const x = /* @__PURE__ */ myFactory();`,
+        },
+      ],
+      valid: [
+        {
+          code: `export const MyExtension = /* @__PURE__ */ defineExtension({name: 'my'});`,
+        },
+        {
+          // Terser-style # sigil is accepted.
+          code: `export const MY_COMMAND = /* #__PURE__ */ createCommand('MY_COMMAND');`,
+        },
+        {
+          // Calls deferred inside function bodies don't affect
+          // tree-shaking of the module's top-level statements.
+          code: `export function makeCommand() { return createCommand('LATE'); }`,
+        },
+        {
+          code: `export const lazy = () => defineImportRule({name: 'r'});`,
+        },
+        {
+          // Unlisted functions are not the rule's business.
+          code: `const x = someOtherFactory({});`,
+        },
+        {
+          // Custom function list replaces the default.
+          code: `const x = defineExtension({name: 'n'});`,
+          options: [{functions: ['myFactory']}],
+        },
+      ],
+    });
+  });
+});

--- a/packages/lexical-eslint-plugin-internal/src/index.js
+++ b/packages/lexical-eslint-plugin-internal/src/index.js
@@ -8,13 +8,18 @@
 
 import noImportsFromSelf from './rules/no-imports-from-self.js';
 import noOptionalChaining from './rules/no-optional-chaining.js';
+import requirePureAnnotation from './rules/require-pure-annotation.js';
 
 const rules = {
   'no-imports-from-self': noImportsFromSelf,
   'no-optional-chaining': noOptionalChaining,
+  'require-pure-annotation': requirePureAnnotation,
 };
 
 // Legacy config format (ESLint 7-8)
+// Note: require-pure-annotation is deliberately not part of the default
+// configs — it only applies to package sources (never tests), so the
+// root eslint.config.mjs enables it with its own files scope.
 const legacyAll = {
   rules: {
     '@lexical/internal/no-imports-from-self': 'error',

--- a/packages/lexical-eslint-plugin-internal/src/rules/require-pure-annotation.js
+++ b/packages/lexical-eslint-plugin-internal/src/rules/require-pure-annotation.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * The factory functions whose definitions are annotated with
+ * `@__NO_SIDE_EFFECTS__`. That annotation is only honored by esbuild for
+ * calls in the same file as the definition (and not at all by
+ * webpack/terser), so every module-scope call site must carry its own
+ * `\/* @__PURE__ *\/` annotation for bundlers to tree-shake unused
+ * extension/command/rule definitions out of application bundles.
+ *
+ * Argument-position calls (e.g. `configExtension` / `safeCast` inside a
+ * `defineExtension` config) matter too: a pure call is only removable
+ * when its arguments are also side-effect-free, so one unannotated
+ * nested call pins the entire enclosing definition.
+ */
+const DEFAULT_FUNCTIONS = [
+  'configExtension',
+  'createCommand',
+  'createContextState',
+  'createImportState',
+  'createRenderState',
+  'createState',
+  'declarePeerDependency',
+  'defineExtension',
+  'defineImportRule',
+  'defineOverlayRules',
+  'domOverride',
+  'safeCast',
+];
+
+const PURE_ANNOTATION = /[#@]__PURE__/;
+
+/**
+ * True when the call is evaluated during module initialization (not
+ * deferred inside a function body), which is the only place the
+ * annotation affects tree-shaking. Class fields and static blocks are
+ * rare enough for these factories that they are not required either.
+ *
+ * @param {import('eslint').Rule.Node} node
+ * @returns {boolean}
+ */
+function isModuleScopeEvaluation(node) {
+  for (let parent = node.parent; parent; parent = parent.parent) {
+    switch (parent.type) {
+      case 'FunctionDeclaration':
+      case 'FunctionExpression':
+      case 'ArrowFunctionExpression':
+      case 'PropertyDefinition':
+      case 'StaticBlock':
+        return false;
+      default:
+        break;
+    }
+  }
+  return true;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const [options] = context.options;
+    const functions = new Set(
+      (options && options.functions) || DEFAULT_FUNCTIONS,
+    );
+
+    return {
+      CallExpression(node) {
+        const {callee} = node;
+        if (callee.type !== 'Identifier' || !functions.has(callee.name)) {
+          return;
+        }
+        if (!isModuleScopeEvaluation(node)) {
+          return;
+        }
+        const comments = sourceCode.getCommentsBefore(node);
+        const last = comments[comments.length - 1];
+        if (last && PURE_ANNOTATION.test(last.value)) {
+          return;
+        }
+        context.report({
+          data: {name: callee.name},
+          fix(fixer) {
+            return fixer.insertTextBefore(node, '/* @__PURE__ */ ');
+          },
+          messageId: 'missingPureAnnotation',
+          node: callee,
+        });
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description:
+        'require /* @__PURE__ */ annotations on module-scope calls to the' +
+        ' side-effect-free lexical factories so bundlers can tree-shake' +
+        ' unused definitions',
+      recommended: true,
+    },
+    fixable: 'code',
+    messages: {
+      missingPureAnnotation:
+        'Module-scope call to {{name}} must be annotated with' +
+        ' /* @__PURE__ */ so bundlers can drop the result when unused' +
+        " (esbuild and webpack do not honor the definition's" +
+        ' @__NO_SIDE_EFFECTS__ across files, and an unannotated' +
+        ' argument-position call pins the enclosing definition).',
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          functions: {
+            items: {type: 'string'},
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+};
+
+export default rule;

--- a/packages/lexical-extension/src/AutoFocusExtension.ts
+++ b/packages/lexical-extension/src/AutoFocusExtension.ts
@@ -28,11 +28,11 @@ export interface AutoFocusConfig {
  * An Extension to focus the LexicalEditor when the root element is set
  * (typically only when the editor is first created).
  */
-export const AutoFocusExtension = defineExtension({
+export const AutoFocusExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config, state) => {
     return namedSignals(config);
   },
-  config: safeCast<AutoFocusConfig>({
+  config: /* @__PURE__ */ safeCast<AutoFocusConfig>({
     defaultSelection: 'rootEnd',
     disabled: false,
   }),

--- a/packages/lexical-extension/src/ClearEditorExtension.ts
+++ b/packages/lexical-extension/src/ClearEditorExtension.ts
@@ -57,11 +57,13 @@ export function registerClearEditor(
 /**
  * An extension to provide an implementation of {@link CLEAR_EDITOR_COMMAND}
  */
-export const ClearEditorExtension = defineExtension({
+export const ClearEditorExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     return namedSignals(config);
   },
-  config: safeCast<ClearEditorConfig>({$onClear: $defaultOnClear}),
+  config: /* @__PURE__ */ safeCast<ClearEditorConfig>({
+    $onClear: $defaultOnClear,
+  }),
   name: '@lexical/extension/ClearEditor',
   register(editor, config, state) {
     const {$onClear} = state.getOutput();

--- a/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
+++ b/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
@@ -130,9 +130,9 @@ function shouldClaimClick(
  *
  * Closes #8544.
  */
-export const ClickAfterLastBlockExtension = defineExtension({
+export const ClickAfterLastBlockExtension = /* @__PURE__ */ defineExtension({
   build: (_editor, config): ClickAfterLastBlockOutput => namedSignals(config),
-  config: safeCast<ClickAfterLastBlockConfig>({
+  config: /* @__PURE__ */ safeCast<ClickAfterLastBlockConfig>({
     $shouldInsertAfter: $defaultShouldInsertAfter,
     disabled: false,
   }),

--- a/packages/lexical-extension/src/DecoratorTextExtension.ts
+++ b/packages/lexical-extension/src/DecoratorTextExtension.ts
@@ -37,7 +37,7 @@ export type SerializedDecoratorTextNode = Spread<
   SerializedLexicalNode
 >;
 
-const formatState = createState('format', {
+const formatState = /* @__PURE__ */ createState('format', {
   parse: value => (typeof value === 'number' ? value : 0),
 });
 
@@ -192,7 +192,7 @@ const DEFAULT_TAG_NAME_TO_FORMAT: {[key: string]: TextFormatType} = {
  * An extension for DecoratorTextNode that sets the format for the node and CSS classes for the DOM container.
  * The base class is always set, and the focus class is set when the node is selected.
  */
-export const DecoratorTextExtension = defineExtension({
+export const DecoratorTextExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/extension/DecoratorText',
   nodes: () => [DecoratorTextNode],
   register(editor, config, state) {

--- a/packages/lexical-extension/src/EditorStateExtension.ts
+++ b/packages/lexical-extension/src/EditorStateExtension.ts
@@ -12,7 +12,7 @@ import {watchedSignal} from './watchedSignal';
 /**
  * An extension to provide the current EditorState as a signal
  */
-export const EditorStateExtension = defineExtension({
+export const EditorStateExtension = /* @__PURE__ */ defineExtension({
   build(editor) {
     return watchedSignal(
       () => editor.getEditorState(),

--- a/packages/lexical-extension/src/HorizontalRuleExtension.ts
+++ b/packages/lexical-extension/src/HorizontalRuleExtension.ts
@@ -46,7 +46,7 @@ import {batch, effect, ReadonlySignal, Signal, signal} from './signals';
 export type SerializedHorizontalRuleNode = SerializedLexicalNode;
 
 export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> =
-  createCommand('INSERT_HORIZONTAL_RULE_COMMAND');
+  /* @__PURE__ */ createCommand('INSERT_HORIZONTAL_RULE_COMMAND');
 
 export class HorizontalRuleNode extends DecoratorNode<unknown> {
   static getType(): string {
@@ -134,7 +134,7 @@ function $toggleNodeSelection(
  * An extension for HorizontalRuleNode that provides an implementation that
  * works without any React dependency.
  */
-export const HorizontalRuleExtension = defineExtension({
+export const HorizontalRuleExtension = /* @__PURE__ */ defineExtension({
   dependencies: [EditorStateExtension, NodeSelectionExtension],
   name: '@lexical/extension/HorizontalRule',
   nodes: () => [HorizontalRuleNode],

--- a/packages/lexical-extension/src/IMEExtension.ts
+++ b/packages/lexical-extension/src/IMEExtension.ts
@@ -48,7 +48,7 @@ import {effect, type Signal, signal} from './signals';
  *   new TextNode.
  *
  */
-export const IMEExtension = defineExtension({
+export const IMEExtension = /* @__PURE__ */ defineExtension({
   build(_editor: LexicalEditor): {
     compositionKey: Signal<null | NodeKey>;
     composingTextNode: Signal<null | TextNode>;

--- a/packages/lexical-extension/src/InitialStateExtension.ts
+++ b/packages/lexical-extension/src/InitialStateExtension.ts
@@ -48,8 +48,8 @@ export interface InitialStateConfig {
  * but you should not call `editor.setRootElement` earlier than
  * this phase to avoid rendering an empty editor first.
  */
-export const InitialStateExtension = defineExtension({
-  config: safeCast<InitialStateConfig>({
+export const InitialStateExtension = /* @__PURE__ */ defineExtension({
+  config: /* @__PURE__ */ safeCast<InitialStateConfig>({
     setOptions: HISTORY_MERGE_OPTIONS,
     updateOptions: HISTORY_MERGE_OPTIONS,
   }),

--- a/packages/lexical-extension/src/NestedEditorExtension.ts
+++ b/packages/lexical-extension/src/NestedEditorExtension.ts
@@ -23,10 +23,10 @@ function $defaultGetParentEditor() {
   return editor;
 }
 
-export const NestedEditorExtension = defineExtension({
+export const NestedEditorExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) =>
     namedSignals({inheritEditableFromParent: config.inheritEditableFromParent}),
-  config: safeCast<NestedEditorConfig>({
+  config: /* @__PURE__ */ safeCast<NestedEditorConfig>({
     $getParentEditor: $defaultGetParentEditor,
     inheritEditableFromParent: false,
   }),

--- a/packages/lexical-extension/src/NodeSelectionExtension.ts
+++ b/packages/lexical-extension/src/NodeSelectionExtension.ts
@@ -27,7 +27,7 @@ const EMPTY_SET = new Set<NodeKey>();
  * currently selected or not. A framework independent
  * alternative to {@link useLexicalNodeSelection}.
  */
-export const NodeSelectionExtension = defineExtension({
+export const NodeSelectionExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     const editorStateStore = state.getDependency(EditorStateExtension).output;
     const watchedNodeStore = signal({

--- a/packages/lexical-extension/src/NormalizeInlineElementsExtension.ts
+++ b/packages/lexical-extension/src/NormalizeInlineElementsExtension.ts
@@ -40,30 +40,32 @@ function deleteEmptyInline(node: LexicalNode) {
  * the plugin API with the option to disable it, but it may be removed
  * in the future and integrated into the core
  */
-export const NormalizeInlineElementsExtension = defineExtension({
-  build: (editor, config, state) => namedSignals(config),
-  config: safeCast<NormalizeInlineElementsConfig>({
-    disabled: false,
-  }),
-  name: '@lexical/NormalizeInlineElements',
-  register: (editor, config, state) => {
-    const stores = state.getOutput();
-    return effect(() => {
-      if (!stores.disabled.value) {
-        const disposeTransformers: VoidFunction[] = [];
-        for (const {klass, transforms} of editor._nodes.values()) {
-          if (
-            klass.prototype instanceof ElementNode &&
-            klass.prototype.isInline !== ElementNode.prototype.isInline
-          ) {
-            transforms.add(deleteEmptyInline);
-            disposeTransformers.push(() =>
-              transforms.delete(deleteEmptyInline),
-            );
+export const NormalizeInlineElementsExtension = /* @__PURE__ */ defineExtension(
+  {
+    build: (editor, config, state) => namedSignals(config),
+    config: /* @__PURE__ */ safeCast<NormalizeInlineElementsConfig>({
+      disabled: false,
+    }),
+    name: '@lexical/NormalizeInlineElements',
+    register: (editor, config, state) => {
+      const stores = state.getOutput();
+      return effect(() => {
+        if (!stores.disabled.value) {
+          const disposeTransformers: VoidFunction[] = [];
+          for (const {klass, transforms} of editor._nodes.values()) {
+            if (
+              klass.prototype instanceof ElementNode &&
+              klass.prototype.isInline !== ElementNode.prototype.isInline
+            ) {
+              transforms.add(deleteEmptyInline);
+              disposeTransformers.push(() =>
+                transforms.delete(deleteEmptyInline),
+              );
+            }
           }
+          return () => disposeTransformers.forEach(fn => fn());
         }
-        return () => disposeTransformers.forEach(fn => fn());
-      }
-    });
+      });
+    },
   },
-});
+);

--- a/packages/lexical-extension/src/NormalizeTripleClickSelectionExtension.ts
+++ b/packages/lexical-extension/src/NormalizeTripleClickSelectionExtension.ts
@@ -150,61 +150,62 @@ function $fixFocusOverselection() {
  * be called from other places and it can be replaced or wrapped with
  * different functionality.
  */
-export const NormalizeTripleClickSelectionExtension = defineExtension({
-  build: (editor, config, state): NormalizeTripleClickSelectionOutput =>
-    namedSignals(config),
-  config: safeCast<NormalizeTripleClickSelectionConfig>({
-    $fixFocusOverselection,
-    dateNow: Date.now,
-    disabled: false,
-    thresholdMsec: 100,
-  }),
-  name: '@lexical/NormalizeTripleClickSelection',
-  register: (editor, config, state) =>
-    effect(() => {
-      const stores = state.getOutput();
-      if (stores.disabled.value) {
-        return;
-      }
-      return editor.registerRootListener(rootElement => {
-        if (!rootElement) {
+export const NormalizeTripleClickSelectionExtension =
+  /* @__PURE__ */ defineExtension({
+    build: (editor, config, state): NormalizeTripleClickSelectionOutput =>
+      namedSignals(config),
+    config: /* @__PURE__ */ safeCast<NormalizeTripleClickSelectionConfig>({
+      $fixFocusOverselection,
+      dateNow: Date.now,
+      disabled: false,
+      thresholdMsec: 100,
+    }),
+    name: '@lexical/NormalizeTripleClickSelection',
+    register: (editor, config, state) =>
+      effect(() => {
+        const stores = state.getOutput();
+        if (stores.disabled.value) {
           return;
         }
-        let lastTripleClick = 0;
-        const refreshTripleClick = (event: null | MouseEvent) => {
-          if (event ? event.detail === 3 : lastTripleClick > 0) {
-            const now = stores.dateNow.peek()();
-            lastTripleClick =
-              (event && event.type === 'mousedown') ||
-              now - lastTripleClick <= stores.thresholdMsec.peek()
-                ? now
-                : 0;
+        return editor.registerRootListener(rootElement => {
+          if (!rootElement) {
+            return;
           }
-          return lastTripleClick;
-        };
-        return mergeRegister(
-          editor.registerCommand(
-            SELECTION_CHANGE_COMMAND,
-            () => {
-              if (refreshTripleClick(null)) {
-                lastTripleClick = 0;
-                stores.$fixFocusOverselection.peek()();
-              }
-              return false;
-            },
-            COMMAND_PRIORITY_BEFORE_CRITICAL,
-          ),
-          (() => {
-            const events = ['mouseup', 'mousedown'] as const;
-            events.forEach(v =>
-              rootElement.addEventListener(v, refreshTripleClick, true),
-            );
-            return () =>
+          let lastTripleClick = 0;
+          const refreshTripleClick = (event: null | MouseEvent) => {
+            if (event ? event.detail === 3 : lastTripleClick > 0) {
+              const now = stores.dateNow.peek()();
+              lastTripleClick =
+                (event && event.type === 'mousedown') ||
+                now - lastTripleClick <= stores.thresholdMsec.peek()
+                  ? now
+                  : 0;
+            }
+            return lastTripleClick;
+          };
+          return mergeRegister(
+            editor.registerCommand(
+              SELECTION_CHANGE_COMMAND,
+              () => {
+                if (refreshTripleClick(null)) {
+                  lastTripleClick = 0;
+                  stores.$fixFocusOverselection.peek()();
+                }
+                return false;
+              },
+              COMMAND_PRIORITY_BEFORE_CRITICAL,
+            ),
+            (() => {
+              const events = ['mouseup', 'mousedown'] as const;
               events.forEach(v =>
-                rootElement.removeEventListener(v, refreshTripleClick, true),
+                rootElement.addEventListener(v, refreshTripleClick, true),
               );
-          })(),
-        );
-      });
-    }),
-});
+              return () =>
+                events.forEach(v =>
+                  rootElement.removeEventListener(v, refreshTripleClick, true),
+                );
+            })(),
+          );
+        });
+      }),
+  });

--- a/packages/lexical-extension/src/SelectionAlwaysOnDisplayExtension.ts
+++ b/packages/lexical-extension/src/SelectionAlwaysOnDisplayExtension.ts
@@ -21,19 +21,20 @@ export interface SelectionAlwaysOnDisplayConfig {
  * An extension that highlights selected content in the Lexical editor
  * even when the editor is not currently focused.
  */
-export const SelectionAlwaysOnDisplayExtension = defineExtension({
-  build: (editor, config, state) => namedSignals(config),
-  config: safeCast<SelectionAlwaysOnDisplayConfig>({
-    disabled: false,
-    onReposition: undefined,
-  }),
-  name: '@lexical/utils/SelectionAlwaysOnDisplay',
-  register: (editor, config, state) => {
-    const stores = state.getOutput();
-    return effect(() => {
-      if (!stores.disabled.value) {
-        return selectionAlwaysOnDisplay(editor, stores.onReposition.value);
-      }
-    });
-  },
-});
+export const SelectionAlwaysOnDisplayExtension =
+  /* @__PURE__ */ defineExtension({
+    build: (editor, config, state) => namedSignals(config),
+    config: /* @__PURE__ */ safeCast<SelectionAlwaysOnDisplayConfig>({
+      disabled: false,
+      onReposition: undefined,
+    }),
+    name: '@lexical/utils/SelectionAlwaysOnDisplay',
+    register: (editor, config, state) => {
+      const stores = state.getOutput();
+      return effect(() => {
+        if (!stores.disabled.value) {
+          return selectionAlwaysOnDisplay(editor, stores.onReposition.value);
+        }
+      });
+    },
+  });

--- a/packages/lexical-extension/src/TabIndentationExtension.ts
+++ b/packages/lexical-extension/src/TabIndentationExtension.ts
@@ -146,11 +146,11 @@ export interface TabIndentationConfig {
  * recommend using this plugin as it could negatively affect accessibility for keyboard
  * users, causing focus to become trapped within the editor.
  */
-export const TabIndentationExtension = defineExtension({
+export const TabIndentationExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     return namedSignals(config);
   },
-  config: safeCast<TabIndentationConfig>({
+  config: /* @__PURE__ */ safeCast<TabIndentationConfig>({
     $canIndent: $defaultCanIndent,
     disabled: false,
     maxIndent: null,

--- a/packages/lexical-extension/src/WatchEditableExtension.ts
+++ b/packages/lexical-extension/src/WatchEditableExtension.ts
@@ -17,7 +17,7 @@ import {watchedSignal} from './watchedSignal';
  * `effect`/`computed` to react to editability changes without subscribing
  * through React (or any other framework).
  */
-export const WatchEditableExtension = defineExtension({
+export const WatchEditableExtension = /* @__PURE__ */ defineExtension({
   build(editor) {
     return watchedSignal(
       () => editor.isEditable(),

--- a/packages/lexical-hashtag/src/LexicalHashtagExtension.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagExtension.ts
@@ -295,7 +295,7 @@ export interface HashtagConfig {
 /**
  * Add `#hashtag` support to the editor
  */
-export const HashtagExtension = defineExtension({
+export const HashtagExtension = /* @__PURE__ */ defineExtension({
   config: defaultHashtagConfig,
   name: '@lexical/hashtag/Hashtag',
   nodes: () => [HashtagNode],

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -688,7 +688,7 @@ export interface HistoryExtensionOutput {
  * Registers necessary listeners to manage undo/redo history stack and related
  * editor commands, via the \@lexical/history module.
  */
-export const HistoryExtension = defineExtension({
+export const HistoryExtension = /* @__PURE__ */ defineExtension({
   build: (
     editor,
     {delay, createInitialHistoryState, disabled, maxDepth, now},
@@ -710,7 +710,7 @@ export const HistoryExtension = defineExtension({
       ...state.getInitResult(),
     };
   },
-  config: safeCast<HistoryConfig>({
+  config: /* @__PURE__ */ safeCast<HistoryConfig>({
     createInitialHistoryState: createEmptyHistoryState,
     delay: 300,
     disabled: typeof window === 'undefined',
@@ -780,18 +780,18 @@ export interface SharedHistoryConfig {
  * editor commands, via the \@lexical/history module, only if the parent editor
  * has a history plugin implementation.
  */
-export const SharedHistoryExtension = defineExtension({
+export const SharedHistoryExtension = /* @__PURE__ */ defineExtension({
   build: (editor, {disabled, parentEditor}) =>
     namedSignals({
       disabled,
       parentEditor: parentEditor || editor._parentEditor,
     }),
-  config: safeCast<SharedHistoryConfig>({
+  config: /* @__PURE__ */ safeCast<SharedHistoryConfig>({
     disabled: false,
     parentEditor: null,
   }),
   dependencies: [
-    configExtension(HistoryExtension, {
+    /* @__PURE__ */ configExtension(HistoryExtension, {
       disabled: true,
     }),
   ],

--- a/packages/lexical-html/src/DOMRenderExtension.ts
+++ b/packages/lexical-html/src/DOMRenderExtension.ts
@@ -35,7 +35,7 @@ interface DOMRenderInitResult {
  * editor. This is highly experimental and subject to change from one version
  * to the next.
  **/
-export const DOMRenderExtension = defineExtension<
+export const DOMRenderExtension = /* @__PURE__ */ defineExtension<
   DOMRenderConfig,
   typeof DOMRenderExtensionName,
   DOMRenderExtensionOutput,

--- a/packages/lexical-html/src/RenderContext.ts
+++ b/packages/lexical-html/src/RenderContext.ts
@@ -50,13 +50,19 @@ export function createRenderState<V>(
  * Render context state that is true if the export was initiated from the root of the document.
  * @experimental
  */
-export const RenderContextRoot = createRenderState('root', Boolean);
+export const RenderContextRoot = /* @__PURE__ */ createRenderState(
+  'root',
+  Boolean,
+);
 
 /**
  * Render context state that is true if this is an export operation ($generateHtmlFromNodes).
  * @experimental
  */
-export const RenderContextExport = createRenderState('isExport', Boolean);
+export const RenderContextExport = /* @__PURE__ */ createRenderState(
+  'isExport',
+  Boolean,
+);
 
 function getDefaultRenderContext(
   editor: LexicalEditor,

--- a/packages/lexical-html/src/__tests__/unit/HorizontalRuleImportExtension.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/HorizontalRuleImportExtension.test.ts
@@ -10,6 +10,7 @@ import {
   $isHorizontalRuleNode,
   buildEditorFromExtensions,
   getExtensionDependencyFromEditor,
+  HorizontalRuleExtension,
 } from '@lexical/extension';
 import {
   CoreImportExtension,
@@ -30,9 +31,10 @@ import {assert, describe, expect, test} from 'vitest';
 function buildEditor() {
   return buildEditorFromExtensions(
     defineExtension({
-      // Leaf importer extensions no longer pull `CoreImportExtension`
-      // in by themselves — the application is expected to add it once.
-      dependencies: [CoreImportExtension, HorizontalRuleImportExtension],
+      // The `<hr>` rule ships with `CoreImportRules`, gated on
+      // `HorizontalRuleNode` registration — no dedicated import
+      // extension required.
+      dependencies: [CoreImportExtension, HorizontalRuleExtension],
       name: 'hr-host',
     }),
   );
@@ -76,6 +78,38 @@ describe('HorizontalRuleImportExtension', () => {
       assert($isParagraphNode(children[2]), 'expected paragraph');
       expect(children[0].getTextContent()).toBe('before');
       expect(children[2].getTextContent()).toBe('after');
+    });
+  });
+
+  test('<hr> is dropped when HorizontalRuleNode is not registered', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [CoreImportExtension],
+        name: 'hr-gated-host',
+      }),
+    );
+    importInto(editor, '<p>before</p><hr><p>after</p>');
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(2);
+      assert($isParagraphNode(children[0]), 'expected paragraph');
+      assert($isParagraphNode(children[1]), 'expected paragraph');
+      expect(children[0].getTextContent()).toBe('before');
+      expect(children[1].getTextContent()).toBe('after');
+    });
+  });
+
+  test('deprecated HorizontalRuleImportExtension alias still imports <hr>', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [HorizontalRuleImportExtension],
+        name: 'hr-alias-host',
+      }),
+    );
+    importInto(editor, '<hr>');
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isHorizontalRuleNode(node), 'expected HorizontalRuleNode');
     });
   });
 });

--- a/packages/lexical-html/src/import/CoreImportExtension.ts
+++ b/packages/lexical-html/src/import/CoreImportExtension.ts
@@ -12,11 +12,14 @@ import {DOMImportExtension} from './DOMImportExtension';
 
 /**
  * Bundles {@link CoreImportRules} into a {@link DOMImportExtension}-aware
- * extension. Depend on this from your editor (directly or via richer
- * extensions like `RichTextImportExtension`) to get the equivalent of the
- * legacy core `importDOM` behavior for `<p>`, `<span>`, `<b>`,
- * `<strong>`, `<em>`, `<i>`, `<code>`, `<mark>`, `<s>`, `<sub>`, `<sup>`,
- * `<u>`, `<br>`, and `#text`.
+ * extension. Node-providing extensions that contribute import rules
+ * (`RichTextExtension`, `ListExtension`, `LinkExtension`,
+ * `TableExtension`, `CodeExtension`, …) depend on this themselves, so
+ * most editors get it implicitly; depend on it directly to get the
+ * equivalent of the legacy core `importDOM` behavior for `<p>`,
+ * `<span>`, `<b>`, `<strong>`, `<em>`, `<i>`, `<code>`, `<mark>`,
+ * `<s>`, `<sub>`, `<sup>`, `<u>`, `<br>`, and `#text` (plus `<hr>`
+ * when `HorizontalRuleNode` is registered).
  *
  * @experimental
  */

--- a/packages/lexical-html/src/import/CoreImportExtension.ts
+++ b/packages/lexical-html/src/import/CoreImportExtension.ts
@@ -23,7 +23,11 @@ import {DOMImportExtension} from './DOMImportExtension';
  *
  * @experimental
  */
-export const CoreImportExtension = defineExtension({
-  dependencies: [configExtension(DOMImportExtension, {rules: CoreImportRules})],
+export const CoreImportExtension = /* @__PURE__ */ defineExtension({
+  dependencies: [
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: CoreImportRules,
+    }),
+  ],
   name: '@lexical/html/CoreImport',
 });

--- a/packages/lexical-html/src/import/DOMImportExtension.ts
+++ b/packages/lexical-html/src/import/DOMImportExtension.ts
@@ -102,7 +102,7 @@ function $runPreprocessStack(
  *
  * @experimental
  */
-export const DefaultHoistRule = defineImportRule({
+export const DefaultHoistRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => ctx.$importChildren(el),
   match: selBase.any(),
   name: '@lexical/html/default-hoist',
@@ -120,7 +120,7 @@ export const DefaultHoistRule = defineImportRule({
  * The legacy `$generateNodesFromDOM` continues to work in parallel; the
  * intent is to migrate node packages over to this extension incrementally.
  */
-export const DOMImportExtension = defineExtension<
+export const DOMImportExtension = /* @__PURE__ */ defineExtension<
   DOMImportConfig,
   typeof DOMImportExtensionName,
   DOMImportExtensionOutput,

--- a/packages/lexical-html/src/import/HorizontalRuleImportExtension.ts
+++ b/packages/lexical-html/src/import/HorizontalRuleImportExtension.ts
@@ -32,7 +32,7 @@ export const HorizontalRuleImportRules = [HorizontalRuleRule];
  * registered — depend on `HorizontalRuleExtension` (plus any extension
  * that brings in `CoreImportExtension`) directly instead.
  */
-export const HorizontalRuleImportExtension = defineExtension({
+export const HorizontalRuleImportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [HorizontalRuleExtension, CoreImportExtension],
   name: '@lexical/html/HorizontalRuleImport',
 });

--- a/packages/lexical-html/src/import/HorizontalRuleImportExtension.ts
+++ b/packages/lexical-html/src/import/HorizontalRuleImportExtension.ts
@@ -6,47 +6,33 @@
  *
  */
 
-import {
-  $createHorizontalRuleNode,
-  HorizontalRuleExtension,
-} from '@lexical/extension';
-import {configExtension, defineExtension} from 'lexical';
+import {HorizontalRuleExtension} from '@lexical/extension';
+import {defineExtension} from 'lexical';
 
-import {defineImportRule} from './defineImportRule';
-import {DOMImportExtension} from './DOMImportExtension';
-import {selBase} from './sel';
-
-const HorizontalRuleRule = defineImportRule({
-  $import: () => [$createHorizontalRuleNode()],
-  match: selBase.tag('hr'),
-  name: '@lexical/html/hr',
-});
+import {CoreImportExtension} from './CoreImportExtension';
+import {HorizontalRuleRule} from './coreImportRules';
 
 /**
- * Import rules for {@link HorizontalRuleNode}.
+ * Import rules for {@link HorizontalRuleNode}. The `<hr>` rule is part of
+ * {@link CoreImportRules} (gated on `HorizontalRuleNode` registration), so
+ * this array exists only for backwards compatibility and introspection.
  *
  * @experimental
  */
 export const HorizontalRuleImportRules = [HorizontalRuleRule];
 
 /**
- * Bundles {@link HorizontalRuleImportRules} together with the runtime
- * {@link HorizontalRuleExtension}. The application is expected to
- * already have `CoreImportExtension` (or some equivalent) in its
- * dependency graph — the core/text/paragraph/inline-format rules are a
- * shared baseline, not something this leaf importer should re-declare.
- *
- * Lives in `@lexical/html` (not `@lexical/extension`) because
- * {@link DOMImportExtension} itself is in `@lexical/html`, and
- * `@lexical/extension` is upstream of `@lexical/html` in the dependency
- * graph.
+ * Bundles the runtime {@link HorizontalRuleExtension} together with
+ * {@link CoreImportExtension}, whose {@link CoreImportRules} include the
+ * registration-gated `<hr>` rule.
  *
  * @experimental
+ * @deprecated The `<hr>` import rule now ships with
+ * {@link CoreImportRules} and activates whenever `HorizontalRuleNode` is
+ * registered — depend on `HorizontalRuleExtension` (plus any extension
+ * that brings in `CoreImportExtension`) directly instead.
  */
 export const HorizontalRuleImportExtension = defineExtension({
-  dependencies: [
-    HorizontalRuleExtension,
-    configExtension(DOMImportExtension, {rules: HorizontalRuleImportRules}),
-  ],
+  dependencies: [HorizontalRuleExtension, CoreImportExtension],
   name: '@lexical/html/HorizontalRuleImport',
 });

--- a/packages/lexical-html/src/import/ImportContext.ts
+++ b/packages/lexical-html/src/import/ImportContext.ts
@@ -82,7 +82,10 @@ export type ImportSourceKind = 'paste' | 'unknown';
  * @experimental
  */
 export const ImportSource: ImportStateConfig<ImportSourceKind> =
-  createImportState<ImportSourceKind>('importSource', () => 'unknown');
+  /* @__PURE__ */ createImportState<ImportSourceKind>(
+    'importSource',
+    () => 'unknown',
+  );
 
 /**
  * Built-in import-context state holding the {@link DataTransfer} the
@@ -108,7 +111,7 @@ export const ImportSource: ImportStateConfig<ImportSourceKind> =
  * @experimental
  */
 export const ImportSourceDataTransfer: ImportStateConfig<DataTransfer | null> =
-  createImportState<DataTransfer | null>(
+  /* @__PURE__ */ createImportState<DataTransfer | null>(
     'importSourceDataTransfer',
     () => null,
   );
@@ -122,10 +125,8 @@ export const ImportSourceDataTransfer: ImportStateConfig<DataTransfer | null> =
  *
  * @experimental
  */
-export const ImportTextFormat: ImportStateConfig<number> = createImportState(
-  'textFormat',
-  () => 0,
-);
+export const ImportTextFormat: ImportStateConfig<number> =
+  /* @__PURE__ */ createImportState('textFormat', () => 0);
 
 /**
  * Built-in import-context state holding a parsed CSS-style record
@@ -239,10 +240,13 @@ export function defaultIsInline(node: Node): boolean {
  * @experimental
  */
 export const ImportWhitespaceConfig: ImportStateConfig<WhitespaceImportConfig> =
-  createImportState<WhitespaceImportConfig>('whitespaceConfig', () => ({
-    isInline: defaultIsInline,
-    preservesWhitespace: defaultPreservesWhitespace,
-  }));
+  /* @__PURE__ */ createImportState<WhitespaceImportConfig>(
+    'whitespaceConfig',
+    () => ({
+      isInline: defaultIsInline,
+      preservesWhitespace: defaultPreservesWhitespace,
+    }),
+  );
 
 /**
  * Built-in session slot for runtime overlay rules that should be in

--- a/packages/lexical-html/src/import/ImportContext.ts
+++ b/packages/lexical-html/src/import/ImportContext.ts
@@ -146,7 +146,7 @@ export const ImportTextFormat: ImportStateConfig<number> =
  */
 export const ImportTextStyle: ImportStateConfig<
   Readonly<Record<string, string>>
-> = createImportState<Readonly<Record<string, string>>>(
+> = /* @__PURE__ */ createImportState<Readonly<Record<string, string>>>(
   'textStyle',
   () => ({}),
 );
@@ -268,7 +268,7 @@ export const ImportWhitespaceConfig: ImportStateConfig<WhitespaceImportConfig> =
  */
 export const ImportOverlays: ImportStateConfig<
   readonly CompiledOverlayRules[]
-> = createImportState<readonly CompiledOverlayRules[]>(
+> = /* @__PURE__ */ createImportState<readonly CompiledOverlayRules[]>(
   'importOverlays',
   () => [],
 );

--- a/packages/lexical-html/src/import/coreImportRules.ts
+++ b/packages/lexical-html/src/import/coreImportRules.ts
@@ -225,7 +225,7 @@ function applyFormatOverride(format: number, ov: FormatOverride): number {
  * - `<span style="text-decoration: none">` strip inherited underline /
  *   line-through.
  */
-const InlineFormatRule = defineImportRule({
+const InlineFormatRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const inherited = ctx.get(ImportTextFormat);
     const tagDefault = TAG_DEFAULT_STYLE[el.nodeName];
@@ -407,7 +407,7 @@ function $applyTextStyle(
  * collapse whitespace using the same neighbor-aware rules as the legacy
  * `$convertTextDOMNode`.
  */
-const TextRule = defineImportRule({
+const TextRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const format = ctx.get(ImportTextFormat);
     const style = ctx.get(ImportTextStyle);
@@ -439,13 +439,13 @@ const TextRule = defineImportRule({
  * a higher-priority `<style>` rule to capture stylesheet text into the
  * import session for later use.
  */
-const IgnoreScriptStyleRule = defineImportRule({
+const IgnoreScriptStyleRule = /* @__PURE__ */ defineImportRule({
   $import: () => [],
   match: sel.tag('script', 'style'),
   name: '@lexical/html/script-style-ignore',
 });
 
-const LineBreakRule = defineImportRule({
+const LineBreakRule = /* @__PURE__ */ defineImportRule({
   // Mirror the legacy LineBreakNode.importDOM filter: stray `<br>` that
   // are the sole or trailing child of a block parent (e.g. Apple's
   // `<br class="Apple-interchange-newline">` clipboard sentinel, or the
@@ -464,7 +464,7 @@ const LineBreakRule = defineImportRule({
  * `<p>` rule. Re-applies format, indent, direction, and the legacy
  * `align` attribute fallback.
  */
-const ParagraphRule = defineImportRule({
+const ParagraphRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const p = $createParagraphNode();
     $setFormatFromDOM(p, el);
@@ -501,7 +501,7 @@ const ParagraphRule = defineImportRule({
  *
  * @internal
  */
-export const HorizontalRuleRule = defineImportRule({
+export const HorizontalRuleRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, _el, $next) =>
     $getEditor().hasNode(HorizontalRuleNode)
       ? [$createHorizontalRuleNode()]
@@ -540,7 +540,7 @@ export const HorizontalRuleRule = defineImportRule({
  * `ParagraphNode` intermediate, and there is no need for a marker node
  * to distinguish them.
  */
-const TransparentBlockRule = defineImportRule({
+const TransparentBlockRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el, $next) => {
     if (!isBlockDomNode(el)) {
       // Inline element with no dedicated rule — let the inline rules (or

--- a/packages/lexical-html/src/import/coreImportRules.ts
+++ b/packages/lexical-html/src/import/coreImportRules.ts
@@ -6,10 +6,15 @@
  *
  */
 import {
+  $createHorizontalRuleNode,
+  HorizontalRuleNode,
+} from '@lexical/extension';
+import {
   $createLineBreakNode,
   $createParagraphNode,
   $createTextNode,
   $generateNodesFromRawText,
+  $getEditor,
   $isTextNode,
   $setDirectionFromDOM,
   $setFormatFromDOM,
@@ -481,6 +486,31 @@ const ParagraphRule = defineImportRule({
 });
 
 /**
+ * `<hr>` rule, gated on {@link HorizontalRuleNode} registration so it
+ * mirrors the legacy `importDOM` contract (a node's conversions are only
+ * active when the node itself is registered). It lives here rather than
+ * next to `HorizontalRuleExtension` because `@lexical/extension`
+ * is upstream of `@lexical/html` in the package graph and cannot define
+ * import rules — this is the one node-providing extension whose import
+ * support cannot be implied by depending on it.
+ *
+ * Registered ahead of {@link TransparentBlockRule}: `<hr>` matches
+ * `isBlockDomNode`, so the wildcard block rule would otherwise consume
+ * it. When `HorizontalRuleNode` is not registered, `$next()` restores
+ * the old behavior (the childless element vanishes).
+ *
+ * @internal
+ */
+export const HorizontalRuleRule = defineImportRule({
+  $import: (_ctx, _el, $next) =>
+    $getEditor().hasNode(HorizontalRuleNode)
+      ? [$createHorizontalRuleNode()]
+      : $next(),
+  match: sel.tag('hr'),
+  name: '@lexical/html/hr',
+});
+
+/**
  * Transparent block-container rule for any unconverted block-level DOM
  * element — `<div>`, but also `<section>`, `<article>`, `<header>`,
  * `<figure>`, … (everything {@link isBlockDomNode} recognizes via the
@@ -529,15 +559,17 @@ const TransparentBlockRule = defineImportRule({
 /**
  * Rules covering the {@link ParagraphNode}, {@link TextNode},
  * {@link LineBreakNode}, and {@link TabNode} cases that the legacy
- * `importDOM` machinery in `@lexical/lexical` handled. Intended to be
- * registered as a dependency of every editor that uses
- * {@link DOMImportExtension}.
+ * `importDOM` machinery in `@lexical/lexical` handled, plus the
+ * registration-gated `<hr>` rule for {@link HorizontalRuleNode} (see
+ * {@link HorizontalRuleRule}). Intended to be registered as a dependency
+ * of every editor that uses {@link DOMImportExtension}.
  *
  * @experimental
  */
 export const CoreImportRules = [
   IgnoreScriptStyleRule,
   ParagraphRule,
+  HorizontalRuleRule,
   TransparentBlockRule,
   TextRule,
   LineBreakRule,

--- a/packages/lexical-link/src/ClickableLinkExtension.ts
+++ b/packages/lexical-link/src/ClickableLinkExtension.ts
@@ -129,11 +129,14 @@ export function registerClickableLink(
  * selection to change instead of opening a link. This extension can be used to
  * restore the default behavior, e.g. when the editor is not editable.
  */
-export const ClickableLinkExtension = defineExtension({
+export const ClickableLinkExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     return namedSignals(config);
   },
-  config: safeCast<ClickableLinkConfig>({disabled: false, newTab: false}),
+  config: /* @__PURE__ */ safeCast<ClickableLinkConfig>({
+    disabled: false,
+    newTab: false,
+  }),
   dependencies: [LinkExtension],
   name: '@lexical/link/ClickableLink',
   register(editor, config, state) {

--- a/packages/lexical-link/src/LexicalAutoLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalAutoLinkExtension.ts
@@ -620,7 +620,7 @@ export function registerAutoLink(
  * The given `matchers` and `changeHandlers` will be merged by
  * concatenating the configured arrays.
  */
-export const AutoLinkExtension = defineExtension({
+export const AutoLinkExtension = /* @__PURE__ */ defineExtension({
   config: defaultConfig,
   dependencies: [LinkExtension],
   mergeConfig(config, overrides) {

--- a/packages/lexical-link/src/LexicalLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalLinkExtension.ts
@@ -144,7 +144,7 @@ export function registerLink(
  * listener to wrap selected nodes in a link when a
  * URL is pasted and `validateUrl` is defined.
  */
-export const LinkExtension = defineExtension({
+export const LinkExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     return namedSignals(config);
   },
@@ -154,7 +154,9 @@ export const LinkExtension = defineExtension({
     // unless the editor routes HTML through the pipeline (e.g. via
     // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
     CoreImportExtension,
-    configExtension(DOMImportExtension, {rules: LinkImportRules}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: LinkImportRules,
+    }),
   ],
   mergeConfig(config, overrides) {
     const merged = shallowMergeConfig(config, overrides);
@@ -182,7 +184,7 @@ export const LinkExtension = defineExtension({
  * {@link LinkImportRules} (and `CoreImportExtension`) itself — depend on
  * it directly instead.
  */
-export const LinkImportExtension = defineExtension({
+export const LinkImportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [LinkExtension],
   name: '@lexical/link/Import',
 });

--- a/packages/lexical-link/src/LexicalLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalLinkExtension.ts
@@ -7,6 +7,7 @@
  */
 
 import {effect, namedSignals, NamedSignalsOutput} from '@lexical/extension';
+import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
 import {mergeRegister, objectKlassEquals} from '@lexical/utils';
 import {
   $getSelection,
@@ -15,6 +16,7 @@ import {
   $isTextNode,
   COMMAND_PRIORITY_EDITOR,
   COMMAND_PRIORITY_LOW,
+  configExtension,
   defineExtension,
   LexicalEditor,
   PASTE_COMMAND,
@@ -28,6 +30,7 @@ import {
   LinkNode,
   TOGGLE_LINK_COMMAND,
 } from './LexicalLinkNode';
+import {LinkImportRules} from './LinkImportExtension';
 
 export interface LinkConfig {
   /**
@@ -146,6 +149,13 @@ export const LinkExtension = defineExtension({
     return namedSignals(config);
   },
   config: defaultProps,
+  dependencies: [
+    // DOMImportExtension support for the nodes registered here. Inert
+    // unless the editor routes HTML through the pipeline (e.g. via
+    // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
+    CoreImportExtension,
+    configExtension(DOMImportExtension, {rules: LinkImportRules}),
+  ],
   mergeConfig(config, overrides) {
     const merged = shallowMergeConfig(config, overrides);
     if (config.attributes) {
@@ -161,4 +171,18 @@ export const LinkExtension = defineExtension({
   register(editor, config, state) {
     return registerLink(editor, state.getOutput());
   },
+});
+
+/**
+ * Bundles {@link LinkImportRules} together with the runtime
+ * {@link LinkExtension}.
+ *
+ * @experimental
+ * @deprecated {@link LinkExtension} now registers
+ * {@link LinkImportRules} (and `CoreImportExtension`) itself — depend on
+ * it directly instead.
+ */
+export const LinkImportExtension = defineExtension({
+  dependencies: [LinkExtension],
+  name: '@lexical/link/Import',
 });

--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -610,7 +610,7 @@ export function $isAutoLinkNode(
 
 export const TOGGLE_LINK_COMMAND: LexicalCommand<
   string | ({url: string} & LinkAttributes) | null
-> = createCommand('TOGGLE_LINK_COMMAND');
+> = /* @__PURE__ */ createCommand('TOGGLE_LINK_COMMAND');
 
 function $getPointNode(point: Point, offset: number): LexicalNode | null {
   if (point.type === 'element') {

--- a/packages/lexical-link/src/LinkImportExtension.ts
+++ b/packages/lexical-link/src/LinkImportExtension.ts
@@ -10,7 +10,7 @@ import {$distributeInlineWrapper, defineImportRule, sel} from '@lexical/html';
 
 import {$createLinkNode} from './LexicalLinkNode';
 
-const AnchorRule = defineImportRule({
+const AnchorRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     if (!el.textContent && el.children.length === 0) {
       return [];

--- a/packages/lexical-link/src/LinkImportExtension.ts
+++ b/packages/lexical-link/src/LinkImportExtension.ts
@@ -6,15 +6,8 @@
  *
  */
 
-import {
-  $distributeInlineWrapper,
-  defineImportRule,
-  DOMImportExtension,
-  sel,
-} from '@lexical/html';
-import {configExtension, defineExtension} from 'lexical';
+import {$distributeInlineWrapper, defineImportRule, sel} from '@lexical/html';
 
-import {LinkExtension} from './LexicalLinkExtension';
 import {$createLinkNode} from './LexicalLinkNode';
 
 const AnchorRule = defineImportRule({
@@ -45,23 +38,11 @@ const AnchorRule = defineImportRule({
 /**
  * Import rules for {@link LinkNode}.
  *
- * @experimental
- */
-export const LinkImportRules = [AnchorRule];
-
-/**
- * Bundles {@link LinkImportRules} together with the runtime
- * {@link LinkExtension}. The application is expected to already have
- * `CoreImportExtension` (or some equivalent) in its dependency graph —
- * the core/text/paragraph/inline-format rules are a shared baseline,
- * not something this leaf importer should re-declare.
+ * Registered by {@link LinkExtension} itself (together with
+ * `CoreImportExtension`), so any editor that uses the link extension can
+ * import `<a>` through the `DOMImportExtension` pipeline without further
+ * configuration.
  *
  * @experimental
  */
-export const LinkImportExtension = defineExtension({
-  dependencies: [
-    LinkExtension,
-    configExtension(DOMImportExtension, {rules: LinkImportRules}),
-  ],
-  name: '@lexical/link/Import',
-});
+export const LinkImportRules = [AnchorRule];

--- a/packages/lexical-link/src/__tests__/unit/LinkImportExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkImportExtension.test.ts
@@ -10,14 +10,14 @@ import {
   buildEditorFromExtensions,
   getExtensionDependencyFromEditor,
 } from '@lexical/extension';
-import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
-import {$isLinkNode, LinkImportExtension, LinkNode} from '@lexical/link';
+import {DOMImportExtension} from '@lexical/html';
 import {
-  $isHeadingNode,
-  HeadingNode,
-  QuoteNode,
-  RichTextImportExtension,
-} from '@lexical/rich-text';
+  $isLinkNode,
+  LinkExtension,
+  LinkImportExtension,
+  LinkNode,
+} from '@lexical/link';
+import {$isHeadingNode, RichTextExtension} from '@lexical/rich-text';
 import {JSDOM} from 'jsdom';
 import {
   $getEditor,
@@ -32,11 +32,11 @@ import {assert, describe, expect, test} from 'vitest';
 function buildEditor() {
   return buildEditorFromExtensions(
     defineExtension({
-      // Leaf importer extensions no longer pull `CoreImportExtension`
-      // in by themselves — the application is expected to add it once.
-      dependencies: [CoreImportExtension, LinkImportExtension],
+      // LinkExtension registers its own import rules (and the shared
+      // CoreImportExtension baseline) — no dedicated import extension
+      // required.
+      dependencies: [LinkExtension],
       name: 'link-host',
-      nodes: [LinkNode],
     }),
   );
 }
@@ -103,19 +103,27 @@ describe('LinkImportExtension', () => {
       expect(para.getTextContent()).toBe('beforeafter');
     });
   });
+
+  test('deprecated LinkImportExtension alias still imports <a>', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [LinkImportExtension],
+        name: 'link-alias-host',
+      }),
+    );
+    importInto(editor, '<p><a href="https://example.com">click</a></p>');
+    editor.read(() => {
+      expect($firstLink().getURL()).toBe('https://example.com');
+    });
+  });
 });
 
 describe('LinkImportExtension — block children lifted out of inline parent', () => {
   function buildRichEditor() {
     return buildEditorFromExtensions(
       defineExtension({
-        dependencies: [
-          CoreImportExtension,
-          LinkImportExtension,
-          RichTextImportExtension,
-        ],
+        dependencies: [LinkExtension, RichTextExtension],
         name: 'rich-link-host',
-        nodes: [LinkNode, HeadingNode, QuoteNode],
       }),
     );
   }

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -21,7 +21,11 @@ export {
   type LinkMatcher,
   registerAutoLink,
 } from './LexicalAutoLinkExtension';
-export {LinkExtension, registerLink} from './LexicalLinkExtension';
+export {
+  LinkExtension,
+  LinkImportExtension,
+  registerLink,
+} from './LexicalLinkExtension';
 export {
   $createAutoLinkNode,
   $createLinkNode,
@@ -37,7 +41,7 @@ export {
   type SerializedLinkNode,
   TOGGLE_LINK_COMMAND,
 } from './LexicalLinkNode';
-export {LinkImportExtension, LinkImportRules} from './LinkImportExtension';
+export {LinkImportRules} from './LinkImportExtension';
 
 /** @deprecated renamed to {@link $toggleLink} by @lexical/eslint-plugin rules-of-lexical */
 export const toggleLink = $toggleLink;

--- a/packages/lexical-list/src/LexicalListExtension.ts
+++ b/packages/lexical-list/src/LexicalListExtension.ts
@@ -30,11 +30,11 @@ export interface ListConfig {
  * Configures {@link ListNode}, {@link ListItemNode} and registers
  * the strict indent transform if `hasStrictIndent` is true (default false).
  */
-export const ListExtension = defineExtension({
+export const ListExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     return namedSignals(config);
   },
-  config: safeCast<ListConfig>({
+  config: /* @__PURE__ */ safeCast<ListConfig>({
     hasStrictIndent: false,
     shouldPreserveNumbering: false,
   }),
@@ -43,7 +43,9 @@ export const ListExtension = defineExtension({
     // unless the editor routes HTML through the pipeline (e.g. via
     // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
     CoreImportExtension,
-    configExtension(DOMImportExtension, {rules: ListImportRules}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: ListImportRules,
+    }),
   ],
   name: '@lexical/list/List',
   nodes: () => [ListNode, ListItemNode],
@@ -73,9 +75,9 @@ export interface CheckListConfig {
  * {@link ListItemNode} with a `INSERT_CHECK_LIST_COMMAND` listener and
  * the expected keyboard and mouse interactions for checkboxes.
  */
-export const CheckListExtension = defineExtension({
+export const CheckListExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<CheckListConfig>({
+  config: /* @__PURE__ */ safeCast<CheckListConfig>({
     disableTakeFocusOnClick: false,
   }),
   dependencies: [ListExtension],
@@ -93,7 +95,7 @@ export const CheckListExtension = defineExtension({
  * {@link ListImportRules} (and `CoreImportExtension`) itself — depend on
  * it directly instead.
  */
-export const ListImportExtension = defineExtension({
+export const ListImportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [ListExtension],
   name: '@lexical/list/Import',
 });

--- a/packages/lexical-list/src/LexicalListExtension.ts
+++ b/packages/lexical-list/src/LexicalListExtension.ts
@@ -7,12 +7,14 @@
  */
 
 import {effect, namedSignals} from '@lexical/extension';
+import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
 import {mergeRegister} from '@lexical/utils';
-import {defineExtension, safeCast} from 'lexical';
+import {configExtension, defineExtension, safeCast} from 'lexical';
 
 import {registerCheckList} from './checkList';
 import {ListItemNode} from './LexicalListItemNode';
 import {ListNode} from './LexicalListNode';
+import {ListImportRules} from './ListImportExtension';
 import {registerList, registerListStrictIndentTransform} from './registerList';
 
 export interface ListConfig {
@@ -36,6 +38,13 @@ export const ListExtension = defineExtension({
     hasStrictIndent: false,
     shouldPreserveNumbering: false,
   }),
+  dependencies: [
+    // DOMImportExtension support for the nodes registered here. Inert
+    // unless the editor routes HTML through the pipeline (e.g. via
+    // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
+    CoreImportExtension,
+    configExtension(DOMImportExtension, {rules: ListImportRules}),
+  ],
   name: '@lexical/list/List',
   nodes: () => [ListNode, ListItemNode],
   register(editor, config, state) {
@@ -73,4 +82,18 @@ export const CheckListExtension = defineExtension({
   name: '@lexical/list/CheckList',
   register: (editor, config, state) =>
     registerCheckList(editor, state.getOutput()),
+});
+
+/**
+ * Bundles {@link ListImportRules} together with the runtime
+ * {@link ListExtension}.
+ *
+ * @experimental
+ * @deprecated {@link ListExtension} now registers
+ * {@link ListImportRules} (and `CoreImportExtension`) itself — depend on
+ * it directly instead.
+ */
+export const ListImportExtension = defineExtension({
+  dependencies: [ListExtension],
+  name: '@lexical/list/Import',
 });

--- a/packages/lexical-list/src/ListImportExtension.ts
+++ b/packages/lexical-list/src/ListImportExtension.ts
@@ -12,7 +12,6 @@ import {
   $isBlockLevel,
   $propagateTextAlignToBlockChildren,
   defineImportRule,
-  DOMImportExtension,
   isElementOfTag,
   sel,
 } from '@lexical/html';
@@ -22,12 +21,9 @@ import {
   $isParagraphNode,
   $setDirectionFromDOM,
   $setFormatFromDOM,
-  configExtension,
-  defineExtension,
   type LexicalNode,
 } from 'lexical';
 
-import {ListExtension} from './LexicalListExtension';
 import {
   $createListItemNode,
   $isListItemNode,
@@ -289,6 +285,11 @@ export const ListSchema: ChildSchema = {
  * Import rules for {@link ListNode} and {@link ListItemNode}, including
  * GitHub task-list and Joplin checkbox heuristics.
  *
+ * Registered by {@link ListExtension} itself (together with
+ * `CoreImportExtension`), so any editor that uses the list extension can
+ * import these tags through the `DOMImportExtension` pipeline without
+ * further configuration.
+ *
  * @experimental
  */
 export const ListImportRules = [
@@ -300,20 +301,3 @@ export const ListImportRules = [
   ListRule,
   ListItemRule,
 ];
-
-/**
- * Bundles {@link ListImportRules} together with the runtime
- * {@link ListExtension}. The application is expected to already have
- * `CoreImportExtension` (or some equivalent) in its dependency graph —
- * the core/text/paragraph/inline-format rules are a shared baseline,
- * not something this leaf importer should re-declare.
- *
- * @experimental
- */
-export const ListImportExtension = defineExtension({
-  dependencies: [
-    ListExtension,
-    configExtension(DOMImportExtension, {rules: ListImportRules}),
-  ],
-  name: '@lexical/list/Import',
-});

--- a/packages/lexical-list/src/ListImportExtension.ts
+++ b/packages/lexical-list/src/ListImportExtension.ts
@@ -68,7 +68,7 @@ function $normalizeListChildren(children: LexicalNode[]): ListItemNode[] {
   return out;
 }
 
-const ListRule = defineImportRule({
+const ListRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     let node;
     if (isElementOfTag(el, 'ol')) {
@@ -179,7 +179,7 @@ function $flattenListItemBlocks(children: LexicalNode[]): LexicalNode[] {
   return out;
 }
 
-const ListItemRule = defineImportRule({
+const ListItemRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const ariaChecked = el.getAttribute('aria-checked');
     const checked =
@@ -234,7 +234,7 @@ function $buildChecklistItem(
   ];
 }
 
-const TaskListItemRule = defineImportRule({
+const TaskListItemRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el, $next) => {
     const input = el.querySelector(':scope > input[type="checkbox"]');
     if (!input) {
@@ -246,7 +246,7 @@ const TaskListItemRule = defineImportRule({
   name: '@lexical/list/li-task-list-item',
 });
 
-const JoplinChecklistItemRule = defineImportRule({
+const JoplinChecklistItemRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el, $next) => {
     const wrapper = el.querySelector(':scope > .checkbox-wrapper');
     if (!wrapper) {

--- a/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
@@ -10,16 +10,15 @@ import {
   buildEditorFromExtensions,
   configExtension,
   getExtensionDependencyFromEditor,
+  HorizontalRuleExtension,
 } from '@lexical/extension';
 import {
-  CoreImportExtension,
   createImportState,
   defineImportRule,
   defineOverlayRules,
   type DOMImportContext,
   DOMImportExtension,
   type DOMPreprocessFn,
-  HorizontalRuleImportExtension,
   ImportOverlays,
   InlineSchema,
   sel,
@@ -29,6 +28,7 @@ import {
   $createListNode,
   $isListItemNode,
   $isListNode,
+  ListExtension,
   ListImportExtension,
   ListItemNode,
   ListNode,
@@ -48,11 +48,11 @@ import {assert, describe, expect, test} from 'vitest';
 function buildEditor() {
   return buildEditorFromExtensions(
     defineExtension({
-      // Leaf importer extensions no longer pull `CoreImportExtension`
-      // in by themselves — the application is expected to add it once.
-      dependencies: [CoreImportExtension, ListImportExtension],
+      // ListExtension registers its own import rules (and the shared
+      // CoreImportExtension baseline) — no dedicated import extension
+      // required.
+      dependencies: [ListExtension],
       name: 'list-host',
-      nodes: [ListNode, ListItemNode],
     }),
   );
 }
@@ -149,6 +149,19 @@ describe('ListImportExtension', () => {
       expect(items.some(i => i.getTextContent().includes('real item'))).toBe(
         true,
       );
+    });
+  });
+
+  test('deprecated ListImportExtension alias still imports lists', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [ListImportExtension],
+        name: 'list-alias-host',
+      }),
+    );
+    importInto(editor, '<ul><li>a</li></ul>');
+    editor.read(() => {
+      expect($items($rootList()).map(i => i.getTextContent())).toEqual(['a']);
     });
   });
 });
@@ -330,14 +343,12 @@ function buildWordPasteEditor() {
   return buildEditorFromExtensions(
     defineExtension({
       dependencies: [
-        CoreImportExtension,
-        ListImportExtension,
+        ListExtension,
         configExtension(DOMImportExtension, {
           preprocess: [$installWordOverlay],
         }),
       ],
       name: 'word-paste-host',
-      nodes: [ListNode, ListItemNode],
     }),
   );
 }
@@ -497,13 +508,8 @@ describe('ListItemNode block flattening', () => {
   test('treats a non-paragraph block (<hr>) as a boundary, not inline content', () => {
     using editor = buildEditorFromExtensions(
       defineExtension({
-        dependencies: [
-          CoreImportExtension,
-          HorizontalRuleImportExtension,
-          ListImportExtension,
-        ],
+        dependencies: [HorizontalRuleExtension, ListExtension],
         name: 'list-hr-host',
-        nodes: [ListNode, ListItemNode],
       }),
     );
     importInto(editor, '<ul><li>x<hr />y</li></ul>');

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -38,9 +38,8 @@ import {$insertList} from './formatList';
 import {$isListItemNode} from './LexicalListItemNode';
 import {$isListNode} from './LexicalListNode';
 
-export const INSERT_CHECK_LIST_COMMAND: LexicalCommand<void> = createCommand(
-  'INSERT_CHECK_LIST_COMMAND',
-);
+export const INSERT_CHECK_LIST_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('INSERT_CHECK_LIST_COMMAND');
 
 /**
  * Registers the checklist plugin with the editor.

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -33,12 +33,9 @@ export {
   CheckListExtension,
   type ListConfig,
   ListExtension,
-} from './LexicalListExtension';
-export {
   ListImportExtension,
-  ListImportRules,
-  ListSchema,
-} from './ListImportExtension';
+} from './LexicalListExtension';
+export {ListImportRules, ListSchema} from './ListImportExtension';
 export {
   INSERT_ORDERED_LIST_COMMAND,
   INSERT_UNORDERED_LIST_COMMAND,

--- a/packages/lexical-list/src/registerList.ts
+++ b/packages/lexical-list/src/registerList.ts
@@ -35,13 +35,11 @@ export const UPDATE_LIST_START_COMMAND: LexicalCommand<{
   newStart: number;
 }> = createCommand('UPDATE_LIST_START_COMMAND');
 export const INSERT_UNORDERED_LIST_COMMAND: LexicalCommand<void> =
-  createCommand('INSERT_UNORDERED_LIST_COMMAND');
-export const INSERT_ORDERED_LIST_COMMAND: LexicalCommand<void> = createCommand(
-  'INSERT_ORDERED_LIST_COMMAND',
-);
-export const REMOVE_LIST_COMMAND: LexicalCommand<void> = createCommand(
-  'REMOVE_LIST_COMMAND',
-);
+  /* @__PURE__ */ createCommand('INSERT_UNORDERED_LIST_COMMAND');
+export const INSERT_ORDERED_LIST_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('INSERT_ORDERED_LIST_COMMAND');
+export const REMOVE_LIST_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('REMOVE_LIST_COMMAND');
 
 export interface RegisterListOptions {
   restoreNumbering?: boolean;

--- a/packages/lexical-list/src/registerList.ts
+++ b/packages/lexical-list/src/registerList.ts
@@ -33,7 +33,7 @@ import {$getListDepth} from './utils';
 export const UPDATE_LIST_START_COMMAND: LexicalCommand<{
   listNodeKey: NodeKey;
   newStart: number;
-}> = createCommand('UPDATE_LIST_START_COMMAND');
+}> = /* @__PURE__ */ createCommand('UPDATE_LIST_START_COMMAND');
 export const INSERT_UNORDERED_LIST_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('INSERT_UNORDERED_LIST_COMMAND');
 export const INSERT_ORDERED_LIST_COMMAND: LexicalCommand<void> =

--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -160,7 +160,7 @@ export function $getMarkIDs(
 /**
  * Configures {@link MarkNode}
  */
-export const MarkExtension = defineExtension({
+export const MarkExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/mark',
   nodes: () => [MarkNode],
 });

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -282,12 +282,12 @@ const TAG_END_REGEX = /^<\/[a-z_][\w-]*\s*>/i;
 const ENDS_WITH = (regex: RegExp) =>
   new RegExp(`(?:${regex.source})$`, regex.flags);
 
-export const listMarkerState = createState('mdListMarker', {
+export const listMarkerState = /* @__PURE__ */ createState('mdListMarker', {
   parse: v => (typeof v === 'string' && /^[-*+]$/.test(v) ? v : '-'),
   resetOnCopyNode: true,
 });
 
-export const codeFenceState = createState('mdCodeFence', {
+export const codeFenceState = /* @__PURE__ */ createState('mdCodeFence', {
   parse: val => {
     if (typeof val === 'string' && /^`{3,}$/.test(val)) {
       return val;
@@ -299,15 +299,18 @@ export const codeFenceState = createState('mdCodeFence', {
 
 export type MarkdownHardLineBreak = string;
 
-export const hardLineBreakState = createState('mdHardLineBreak', {
-  parse: (val): MarkdownHardLineBreak => {
-    if (typeof val === 'string' && /^(\\| {2,})$/.test(val)) {
-      return val;
-    }
-    return '';
+export const hardLineBreakState = /* @__PURE__ */ createState(
+  'mdHardLineBreak',
+  {
+    parse: (val): MarkdownHardLineBreak => {
+      if (typeof val === 'string' && /^(\\| {2,})$/.test(val)) {
+        return val;
+      }
+      return '';
+    },
+    resetOnCopyNode: true,
   },
-  resetOnCopyNode: true,
-});
+);
 
 export function parseMarkdownHardLineBreak(
   line: string,

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -70,7 +70,7 @@ export function $isOverflowNode(
 /**
  * Configures {@link OverflowNode}
  */
-export const OverflowExtension = defineExtension({
+export const OverflowExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/overflow',
   nodes: () => [OverflowNode],
 });

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -434,7 +434,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
 /**
  * An extension to register \@lexical/plain-text behavior
  */
-export const PlainTextExtension = defineExtension({
+export const PlainTextExtension = /* @__PURE__ */ defineExtension({
   conflictsWith: ['@lexical/rich-text'],
   dependencies: [
     DragonExtension,

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -38,6 +38,7 @@ import {
   $createQuoteNode,
   RichTextExtension,
 } from '@lexical/rich-text';
+import {TableExtension} from '@lexical/table';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -55,10 +56,7 @@ import Editor from './Editor';
 import {registerSettingsSynchronization} from './hooks/useSynchronizeSettings';
 import logo from './images/logo.svg';
 import {KeywordsExtension} from './nodes/KeywordNode';
-import {
-  PlaygroundImportExtension,
-  PlaygroundRichTextImportExtension,
-} from './nodes/PlaygroundImportExtension';
+import {PlaygroundImportExtension} from './nodes/PlaygroundImportExtension';
 import PlaygroundNodes from './nodes/PlaygroundNodes';
 import {PlaygroundDOMRenderExtension} from './PlaygroundDOMRenderExtension';
 import {AutocompleteExtension} from './plugins/AutocompleteExtension';
@@ -185,10 +183,11 @@ const PlaygroundRichTextExtension = defineExtension({
         code: {arrow: true, click: true, enter: true, onlyAtBoundary: true},
       },
     }),
-    // Rich-text-only DOM importers (rich-text/list/table/code/hr); kept out of
+    // Each node extension below registers its own DOM-import rules, so the
+    // rich-text importer set tracks this node set automatically (kept out of
     // the always-on PlaygroundImportExtension so plain-text mode doesn't pull
-    // in RichTextExtension (which conflicts with PlainTextExtension).
-    PlaygroundRichTextImportExtension,
+    // in RichTextExtension, which conflicts with PlainTextExtension).
+    TableExtension,
     ImagesExtension,
     HorizontalRuleExtension,
     PageBreakExtension,
@@ -240,10 +239,9 @@ const AppExtension = defineExtension({
     configExtension(AutocompleteExtension, {disabled: true}),
     configExtension(VisibleNonPrintingExtension, {disabled: true}),
     // DOMImportExtension pipeline — `PlaygroundImportExtension` bundles
-    // the shared `CoreImportExtension` baseline, every per-package
-    // import extension (rich-text, list, link, table, code, hr), the
-    // playground-specific inline-style overlay and the
-    // `ClipboardDOMImportExtension` paste handler.
+    // the shared `CoreImportExtension` baseline, the playground-specific
+    // inline-style overlay and the `ClipboardDOMImportExtension` paste
+    // handler. Per-node import rules ride along with each node extension.
     PlaygroundImportExtension,
     // Replaces the legacy `buildHTMLConfig().export` overrides.
     PlaygroundDOMRenderExtension,

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -176,9 +176,9 @@ function $prepopulatedRichText() {
 }
 
 // These are only enabled for rich-text mode
-const PlaygroundRichTextExtension = defineExtension({
+const PlaygroundRichTextExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(RichTextExtension, {
+    /* @__PURE__ */ configExtension(RichTextExtension, {
       escapeFormatTriggers: {
         code: {arrow: true, click: true, enter: true, onlyAtBoundary: true},
       },
@@ -197,7 +197,9 @@ const PlaygroundRichTextExtension = defineExtension({
     TabFocusExtension,
     CollapsibleExtension,
     CodeHighlightExtension,
-    configExtension(ListExtension, {shouldPreserveNumbering: false}),
+    /* @__PURE__ */ configExtension(ListExtension, {
+      shouldPreserveNumbering: false,
+    }),
     CheckListExtension,
     PlaygroundMarkdownShortcutsExtension,
     PageBreakExtension,
@@ -210,7 +212,7 @@ const PlaygroundRichTextExtension = defineExtension({
   name: '@lexical/playground/RichText',
 });
 
-const AppExtension = defineExtension({
+const AppExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
     AutoFocusExtension,
     ClearEditorExtension,
@@ -227,17 +229,19 @@ const AppExtension = defineExtension({
     DragDropPasteExtension,
     EmojisExtension,
     MentionsExtension,
-    configExtension(LinkExtension, {validateUrl}),
+    /* @__PURE__ */ configExtension(LinkExtension, {validateUrl}),
     PlaygroundAutoLinkExtension,
     ClickableLinkExtension,
     SelectionAlwaysOnDisplayExtension,
     TerseExportExtension,
-    configExtension(ClickAfterLastBlockExtension, {
+    /* @__PURE__ */ configExtension(ClickAfterLastBlockExtension, {
       $shouldInsertAfter: node =>
         $defaultShouldInsertAfter(node) || $isCodeNode(node),
     }),
-    configExtension(AutocompleteExtension, {disabled: true}),
-    configExtension(VisibleNonPrintingExtension, {disabled: true}),
+    /* @__PURE__ */ configExtension(AutocompleteExtension, {disabled: true}),
+    /* @__PURE__ */ configExtension(VisibleNonPrintingExtension, {
+      disabled: true,
+    }),
     // DOMImportExtension pipeline — `PlaygroundImportExtension` bundles
     // the shared `CoreImportExtension` baseline, the playground-specific
     // inline-style overlay and the `ClipboardDOMImportExtension` paste
@@ -285,7 +289,7 @@ function buildExtensionFromSettings(settings: DynamicSettings) {
         : $prepopulatedRichText,
     dependencies: [
       AppExtension,
-      configExtension(HistoryExtension, {disabled: isCollab}),
+      /* @__PURE__ */ configExtension(HistoryExtension, {disabled: isCollab}),
       isRichText ? PlaygroundRichTextExtension : PlainTextExtension,
     ],
     name: '@lexical/playground/dynamic-config',

--- a/packages/lexical-playground/src/PlaygroundDOMRenderExtension.ts
+++ b/packages/lexical-playground/src/PlaygroundDOMRenderExtension.ts
@@ -21,11 +21,11 @@ import {
  * `<p>` for a `<div role="paragraph">` (carrying over all attributes) so
  * the resulting HTML stays well-formed.
  */
-export const PlaygroundDOMRenderExtension = defineExtension({
+export const PlaygroundDOMRenderExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMRenderExtension, {
+    /* @__PURE__ */ configExtension(DOMRenderExtension, {
       overrides: [
-        domOverride([ParagraphNode], {
+        /* @__PURE__ */ domOverride([ParagraphNode], {
           $exportDOM: (node, $next, editor) => {
             const output = $next();
             if (

--- a/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeNode.tsx
+++ b/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeNode.tsx
@@ -58,7 +58,7 @@ export type SerializedDateTimeNode = Spread<
   SerializedDecoratorTextNode
 >;
 
-const dateTimeState = createState('dateTime', {
+const dateTimeState = /* @__PURE__ */ createState('dateTime', {
   parse: v => new Date(v as string),
   unparse: v => v.toISOString(),
 });

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -64,7 +64,7 @@ type ImageStatus =
 const imageCache = new Map<string, Promise<ImageStatus> | ImageStatus>();
 
 export const RIGHT_CLICK_IMAGE_COMMAND: LexicalCommand<MouseEvent> =
-  createCommand('RIGHT_CLICK_IMAGE_COMMAND');
+  /* @__PURE__ */ createCommand('RIGHT_CLICK_IMAGE_COMMAND');
 
 function DisableCaptionOnBlur({
   setShowCaption,

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -53,7 +53,7 @@ import {KeywordsExtension} from './KeywordNode';
 
 const ImageComponent = React.lazy(() => import('./ImageComponent'));
 
-const CaptionEditorExtension = defineExtension({
+const CaptionEditorExtension = /* @__PURE__ */ defineExtension({
   // Skip the default empty-paragraph initializer. In collab mode
   // CollaborationPlugin's bootstrap only runs `initializeEditor` when
   // the Lexical root is empty, so a pre-seeded paragraph would prevent
@@ -72,7 +72,7 @@ const CaptionEditorExtension = defineExtension({
     LinkExtension,
     KeywordsExtension,
     EmojisExtension,
-    configExtension(ReactExtension, {
+    /* @__PURE__ */ configExtension(ReactExtension, {
       contentEditable: (
         <ContentEditable
           placeholder="Enter a caption..."

--- a/packages/lexical-playground/src/nodes/KeywordNode.ts
+++ b/packages/lexical-playground/src/nodes/KeywordNode.ts
@@ -82,7 +82,7 @@ function getKeywordMatch(text: string) {
   };
 }
 
-export const KeywordsExtension = defineExtension({
+export const KeywordsExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/LexicalKeywords',
   nodes: () => [KeywordNode],
   register(editor) {

--- a/packages/lexical-playground/src/nodes/PlaygroundImportExtension.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundImportExtension.ts
@@ -66,7 +66,7 @@ function $appendStyleToTextDescendants(
  * style of every TextNode descendant produced by the lower-priority
  * `InlineFormatRule`.
  */
-const PlaygroundInlineStyleRule = defineImportRule({
+const PlaygroundInlineStyleRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, el, $next) => {
     const extraStyle = getPlaygroundExtraStyles(el);
     const result = $next();
@@ -118,12 +118,14 @@ export const PlaygroundImportRules = [PlaygroundInlineStyleRule];
  * mode, and plain-text mode never pulls in `RichTextExtension` (which
  * *conflicts* with `PlainTextExtension`).
  */
-export const PlaygroundImportExtension = defineExtension({
+export const PlaygroundImportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
     CoreImportExtension,
     LinkExtension,
     ClipboardDOMImportExtension,
-    configExtension(DOMImportExtension, {rules: PlaygroundImportRules}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: PlaygroundImportRules,
+    }),
   ],
   name: '@lexical/playground/Import',
 });

--- a/packages/lexical-playground/src/nodes/PlaygroundImportExtension.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundImportExtension.ts
@@ -9,18 +9,13 @@
 import type {LexicalNode} from 'lexical';
 
 import {ClipboardDOMImportExtension} from '@lexical/clipboard';
-import {CodeImportExtension} from '@lexical/code-core';
 import {
   CoreImportExtension,
   defineImportRule,
   DOMImportExtension,
-  HorizontalRuleImportExtension,
   sel,
 } from '@lexical/html';
-import {LinkImportExtension} from '@lexical/link';
-import {ListImportExtension} from '@lexical/list';
-import {RichTextImportExtension} from '@lexical/rich-text';
-import {TableImportExtension} from '@lexical/table';
+import {LinkExtension} from '@lexical/link';
 import {
   $isElementNode,
   $isTextNode,
@@ -111,39 +106,24 @@ export const PlaygroundImportRules = [PlaygroundInlineStyleRule];
  *
  *  - {@link CoreImportExtension} (paragraphs, text, line breaks, generic
  *    block/inline handling)
- *  - {@link LinkImportExtension} (`LinkExtension` is always in the playground)
+ *  - {@link LinkExtension} (always in the playground; registers its own
+ *    `<a>` import rule)
  *  - {@link ClipboardDOMImportExtension} so pastes flow through the pipeline
  *  - the playground-specific {@link PlaygroundImportRules} overlay
  *
- * The rich-text-only importers (rich-text, list, table, code, horizontal-rule)
- * live in {@link PlaygroundRichTextImportExtension} instead: they pull node
- * extensions that must not exist in plain-text mode — notably
- * `RichTextExtension`, which *conflicts* with `PlainTextExtension`. Keeping the
- * importer set aligned with the node set per mode avoids that conflict.
+ * The rich-text-only import rules (rich-text, list, table, code,
+ * horizontal-rule) come along with the corresponding node extensions in
+ * `PlaygroundRichTextExtension` — each node package registers its own
+ * rules — so the importer set automatically matches the node set per
+ * mode, and plain-text mode never pulls in `RichTextExtension` (which
+ * *conflicts* with `PlainTextExtension`).
  */
 export const PlaygroundImportExtension = defineExtension({
   dependencies: [
     CoreImportExtension,
-    LinkImportExtension,
+    LinkExtension,
     ClipboardDOMImportExtension,
     configExtension(DOMImportExtension, {rules: PlaygroundImportRules}),
   ],
   name: '@lexical/playground/Import',
-});
-
-/**
- * The rich-text-only per-package importers, mirroring the rich-text node set.
- * Added to `PlaygroundRichTextExtension` (not the always-on
- * {@link PlaygroundImportExtension}) so plain-text editors never pull in
- * `RichText`/`List`/`Table`/`Code`/`HorizontalRule`.
- */
-export const PlaygroundRichTextImportExtension = defineExtension({
-  dependencies: [
-    RichTextImportExtension,
-    ListImportExtension,
-    TableImportExtension,
-    CodeImportExtension,
-    HorizontalRuleImportExtension,
-  ],
-  name: '@lexical/playground/RichTextImport',
 });

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -85,10 +85,10 @@ function parseOptions(json: unknown): Options {
   return options;
 }
 
-const questionState = createState('question', {
+const questionState = /* @__PURE__ */ createState('question', {
   parse: v => (typeof v === 'string' ? v : ''),
 });
-const optionsState = createState('options', {
+const optionsState = /* @__PURE__ */ createState('options', {
   isEqual: (a, b) =>
     a.length === b.length && JSON.stringify(a) === JSON.stringify(b),
   parse: parseOptions,

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -53,13 +53,13 @@ export type SerializedStickyNode = Spread<
   SerializedLexicalNode
 >;
 
-const StickyEditorExtension = defineExtension({
+const StickyEditorExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
     SharedHistoryExtension,
     PlainTextExtension,
     ReactProviderExtension,
     NestedEditorExtension,
-    configExtension(ReactExtension, {
+    /* @__PURE__ */ configExtension(ReactExtension, {
       contentEditable: (
         <ContentEditable
           placeholder="What's up?"

--- a/packages/lexical-playground/src/plugins/AutoLinkExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/AutoLinkExtension/index.ts
@@ -21,14 +21,17 @@ const URL_REGEX =
 const EMAIL_REGEX =
   /(([^<>()[\]\\.,;:\s@"]{1,64}(\.[^<>()[\]\\.,;:\s@"]{1,64}){0,63})|(".{1,255}"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]{1,63}\.){1,127}[a-zA-Z]{2,63}))/;
 
-export const PlaygroundAutoLinkExtension = configExtension(AutoLinkExtension, {
-  excludeParents: [$isCodeNode],
-  matchers: [
-    createLinkMatcherWithRegExp(URL_REGEX, text => {
-      return text.startsWith('http') ? text : `https://${text}`;
-    }),
-    createLinkMatcherWithRegExp(EMAIL_REGEX, text => {
-      return `mailto:${text}`;
-    }),
-  ],
-});
+export const PlaygroundAutoLinkExtension = /* @__PURE__ */ configExtension(
+  AutoLinkExtension,
+  {
+    excludeParents: [$isCodeNode],
+    matchers: [
+      createLinkMatcherWithRegExp(URL_REGEX, text => {
+        return text.startsWith('http') ? text : `https://${text}`;
+      }),
+      createLinkMatcherWithRegExp(EMAIL_REGEX, text => {
+        return `mailto:${text}`;
+      }),
+    ],
+  },
+);

--- a/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
@@ -335,9 +335,9 @@ function mergeAutocompleteConfig(
   return merged;
 }
 
-export const AutocompleteExtension = defineExtension({
+export const AutocompleteExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<AutocompleteConfig>({
+  config: /* @__PURE__ */ safeCast<AutocompleteConfig>({
     compositionIdleDebounceMs: DEFAULT_COMPOSITION_IDLE_DEBOUNCE_MS,
     detectLanguage: defaultDetectLanguage,
     dictionaries: defaultDictionaries,

--- a/packages/lexical-playground/src/plugins/CodeHighlightExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/CodeHighlightExtension/index.ts
@@ -37,19 +37,22 @@ const NULL_LANG_SHIKI_TOKENIZER = {
  * extensions start in `disabled: true` state and this extension flips
  * their `disabled` signals to route highlighting to the selected engine.
  */
-export const CodeHighlightExtension = defineExtension({
+export const CodeHighlightExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<CodeHighlightConfig>({mode: 'off'}),
+  config: /* @__PURE__ */ safeCast<CodeHighlightConfig>({mode: 'off'}),
   dependencies: [
-    configExtension(CodePrismExtension, {
+    /* @__PURE__ */ configExtension(CodePrismExtension, {
       disabled: true,
       tokenizer: NULL_LANG_PRISM_TOKENIZER,
     }),
-    configExtension(CodeShikiExtension, {
+    /* @__PURE__ */ configExtension(CodeShikiExtension, {
       disabled: true,
       tokenizer: NULL_LANG_SHIKI_TOKENIZER,
     }),
-    configExtension(CodeIndentExtension, {escapeWithArrows: true, tabSize: 2}),
+    /* @__PURE__ */ configExtension(CodeIndentExtension, {
+      escapeWithArrows: true,
+      tabSize: 2,
+    }),
   ],
   name: '@lexical/playground/CodeHighlight',
   register: (editor, config, state) => {

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/index.ts
@@ -55,7 +55,7 @@ import {
   CollapsibleTitleNode,
 } from './CollapsibleTitleNode';
 
-const SummaryRule = defineImportRule({
+const SummaryRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => [
     $createCollapsibleTitleNode().splice(0, 0, ctx.$importChildren(el)),
   ],
@@ -63,7 +63,7 @@ const SummaryRule = defineImportRule({
   name: '@lexical/playground/summary',
 });
 
-const CollapsibleContentRule = defineImportRule({
+const CollapsibleContentRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => [
     $createCollapsibleContentNode().splice(
       0,
@@ -75,7 +75,7 @@ const CollapsibleContentRule = defineImportRule({
   name: '@lexical/playground/collapsible-content',
 });
 
-const DetailsRule = defineImportRule({
+const DetailsRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     let titleNode: CollapsibleTitleNode | null = null;
     // BlockSchema wraps inline runs in paragraphs, and `$onChild` siphons
@@ -126,7 +126,7 @@ const DetailsRule = defineImportRule({
   name: '@lexical/playground/details',
 });
 
-export const INSERT_COLLAPSIBLE_COMMAND = createCommand<void>(
+export const INSERT_COLLAPSIBLE_COMMAND = /* @__PURE__ */ createCommand<void>(
   'INSERT_COLLAPSIBLE_COMMAND',
 );
 
@@ -217,9 +217,9 @@ const $wrapInlineContentChildren = (node: CollapsibleContentNode) => {
   }
 };
 
-export const CollapsibleExtension = defineExtension({
+export const CollapsibleExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
       rules: [DetailsRule, SummaryRule, CollapsibleContentRule],
     }),
   ],

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -78,9 +78,8 @@ import CommentEditorTheme from '../../themes/CommentEditorTheme';
 import Button from '../../ui/Button';
 import ContentEditable from '../../ui/ContentEditable';
 
-export const INSERT_INLINE_COMMAND: LexicalCommand<void> = createCommand(
-  'INSERT_INLINE_COMMAND',
-);
+export const INSERT_INLINE_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('INSERT_INLINE_COMMAND');
 
 function AddCommentBox({
   anchorKey,

--- a/packages/lexical-playground/src/plugins/DateTimeExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/DateTimeExtension/index.tsx
@@ -37,9 +37,9 @@ type CommandPayload = {
 };
 
 export const INSERT_DATETIME_COMMAND: LexicalCommand<CommandPayload> =
-  createCommand('INSERT_DATETIME_COMMAND');
+  /* @__PURE__ */ createCommand('INSERT_DATETIME_COMMAND');
 
-const DateTimeRule = defineImportRule({
+const DateTimeRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const dateTimeValue = el.getAttribute('data-lexical-datetime')!;
     const node = $createDateTimeNode(new Date(Date.parse(dateTimeValue)));
@@ -53,7 +53,7 @@ const DateTimeRule = defineImportRule({
   name: '@lexical/playground/datetime',
 });
 
-const GoogleDocsDateRule = defineImportRule({
+const GoogleDocsDateRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, el, $next) => {
     let parsed: {dat_df?: {dfie_ts?: {tv?: {tv_s?: number}}; dfie_dt?: string}};
     try {
@@ -78,7 +78,7 @@ const GoogleDocsDateRule = defineImportRule({
   name: '@lexical/playground/datetime-google-docs',
 });
 
-export const DateTimeExtension = defineExtension({
+export const DateTimeExtension = /* @__PURE__ */ defineExtension({
   // Depend on CoreImportExtension so this extension's rules are merged after
   // the core rules (later-merged rules win dispatch). Without this the core
   // inline-format `<span>` rule could out-prioritize the `<span
@@ -86,7 +86,7 @@ export const DateTimeExtension = defineExtension({
   // extension relative to the import baseline.
   dependencies: [
     CoreImportExtension,
-    configExtension(DOMImportExtension, {
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
       rules: [DateTimeRule, GoogleDocsDateRule],
     }),
   ],

--- a/packages/lexical-playground/src/plugins/DragDropPasteExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/DragDropPasteExtension/index.ts
@@ -20,7 +20,7 @@ const ACCEPTABLE_IMAGE_TYPES = [
   'image/webp',
 ];
 
-export const DragDropPasteExtension = defineExtension({
+export const DragDropPasteExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/DragDropPaste',
   register: editor =>
     editor.registerCommand(

--- a/packages/lexical-playground/src/plugins/EmojisExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/EmojisExtension/index.ts
@@ -54,7 +54,7 @@ function $textNodeTransform(node: TextNode): void {
   }
 }
 
-export const EmojisExtension = defineExtension({
+export const EmojisExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/Emojis',
   register: editor =>
     editor.registerNodeTransform(TextNode, $textNodeTransform),

--- a/packages/lexical-playground/src/plugins/EquationsExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/EquationsExtension/index.tsx
@@ -37,7 +37,7 @@ type CommandPayload = {
 };
 
 export const INSERT_EQUATION_COMMAND: LexicalCommand<CommandPayload> =
-  createCommand('INSERT_EQUATION_COMMAND');
+  /* @__PURE__ */ createCommand('INSERT_EQUATION_COMMAND');
 
 function $convertEquationElement(el: HTMLElement) {
   const encoded = el.getAttribute('data-lexical-equation');
@@ -52,7 +52,7 @@ function $convertEquationElement(el: HTMLElement) {
   return $createEquationNode(equation, inline);
 }
 
-const EquationImportRule = defineImportRule({
+const EquationImportRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, el, $next) => {
     const node = $convertEquationElement(el);
     return node ? [node] : $next();
@@ -61,9 +61,11 @@ const EquationImportRule = defineImportRule({
   name: '@lexical/playground/equation',
 });
 
-export const EquationsExtension = defineExtension({
+export const EquationsExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {rules: [EquationImportRule]}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: [EquationImportRule],
+    }),
   ],
   name: '@lexical/playground/Equations',
   nodes: [EquationNode],

--- a/packages/lexical-playground/src/plugins/ExcalidrawExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/ExcalidrawExtension/index.tsx
@@ -32,11 +32,10 @@ import {
 } from '../../nodes/ExcalidrawNode';
 import ExcalidrawModal from '../../ui/ExcalidrawModal';
 
-export const INSERT_EXCALIDRAW_COMMAND: LexicalCommand<void> = createCommand(
-  'INSERT_EXCALIDRAW_COMMAND',
-);
+export const INSERT_EXCALIDRAW_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('INSERT_EXCALIDRAW_COMMAND');
 
-const ExcalidrawImportRule = defineImportRule({
+const ExcalidrawImportRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const data = el.getAttribute('data-lexical-excalidraw-json')!;
     const styles = window.getComputedStyle(el);
@@ -54,9 +53,11 @@ const ExcalidrawImportRule = defineImportRule({
   name: '@lexical/playground/excalidraw',
 });
 
-export const ExcalidrawExtension = defineExtension({
+export const ExcalidrawExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {rules: [ExcalidrawImportRule]}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: [ExcalidrawImportRule],
+    }),
   ],
   name: '@lexical/playground/Excalidraw',
   nodes: [ExcalidrawNode],

--- a/packages/lexical-playground/src/plugins/FigmaExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/FigmaExtension/index.ts
@@ -16,11 +16,10 @@ import {
 
 import {$createFigmaNode, FigmaNode} from '../../nodes/FigmaNode';
 
-export const INSERT_FIGMA_COMMAND: LexicalCommand<string> = createCommand(
-  'INSERT_FIGMA_COMMAND',
-);
+export const INSERT_FIGMA_COMMAND: LexicalCommand<string> =
+  /* @__PURE__ */ createCommand('INSERT_FIGMA_COMMAND');
 
-export const FigmaExtension = defineExtension({
+export const FigmaExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/Figma',
   nodes: [FigmaNode],
   register: editor =>

--- a/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
@@ -79,7 +79,7 @@ function isGoogleDocCheckboxImg(img: HTMLImageElement): boolean {
   );
 }
 
-const ImgRule = defineImportRule({
+const ImgRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, el, $next) => {
     const src = el.getAttribute('src');
     if (!src || src.startsWith('file:///') || isGoogleDocCheckboxImg(el)) {
@@ -103,13 +103,13 @@ const ImgRule = defineImportRule({
  * content is imported into the ImageNode's nested caption editor), so a
  * top-level handler drops it entirely.
  */
-const FigcaptionRule = defineImportRule({
+const FigcaptionRule = /* @__PURE__ */ defineImportRule({
   $import: () => [],
   match: sel.tag('figcaption'),
   name: '@lexical/playground/figcaption',
 });
 
-const FigureRule = defineImportRule({
+const FigureRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const imported = ctx.$importChildren(el);
     const figcaption = el.querySelector('figcaption');
@@ -141,7 +141,7 @@ const FigureRule = defineImportRule({
 export type InsertImagePayload = Readonly<ImagePayload>;
 
 export const INSERT_IMAGE_COMMAND: LexicalCommand<InsertImagePayload> =
-  createCommand('INSERT_IMAGE_COMMAND');
+  /* @__PURE__ */ createCommand('INSERT_IMAGE_COMMAND');
 
 export function InsertImageUriDialogBody({
   onClick,
@@ -297,9 +297,9 @@ export function InsertImageDialog({
   );
 }
 
-export const ImagesExtension = defineExtension({
+export const ImagesExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
       rules: [FigcaptionRule, FigureRule, ImgRule],
     }),
   ],

--- a/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
@@ -46,7 +46,7 @@ export const INSERT_LAYOUT_COMMAND: LexicalCommand<string> =
 export const UPDATE_LAYOUT_COMMAND: LexicalCommand<{
   template: string;
   nodeKey: NodeKey;
-}> = createCommand<{template: string; nodeKey: NodeKey}>();
+}> = /* @__PURE__ */ createCommand<{template: string; nodeKey: NodeKey}>();
 
 function getItemsCountFromTemplate(template: string): number {
   return template.trim().split(/\s+/).length;

--- a/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
@@ -41,7 +41,7 @@ import {
 } from '../../nodes/LayoutItemNode';
 
 export const INSERT_LAYOUT_COMMAND: LexicalCommand<string> =
-  createCommand<string>();
+  /* @__PURE__ */ createCommand<string>();
 
 export const UPDATE_LAYOUT_COMMAND: LexicalCommand<{
   template: string;
@@ -52,7 +52,7 @@ function getItemsCountFromTemplate(template: string): number {
   return template.trim().split(/\s+/).length;
 }
 
-const LayoutContainerImportRule = defineImportRule({
+const LayoutContainerImportRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => [
     $createLayoutContainerNode(el.style.gridTemplateColumns).splice(
       0,
@@ -64,7 +64,7 @@ const LayoutContainerImportRule = defineImportRule({
   name: '@lexical/playground/layout-container',
 });
 
-const LayoutItemImportRule = defineImportRule({
+const LayoutItemImportRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => [
     $createLayoutItemNode().splice(0, 0, ctx.$importChildren(el)),
   ],
@@ -91,9 +91,9 @@ const $removeIsolatedLayoutItem = (node: LayoutItemNode): boolean => {
   return false;
 };
 
-export const LayoutExtension = defineExtension({
+export const LayoutExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
       rules: [LayoutContainerImportRule, LayoutItemImportRule],
     }),
   ],

--- a/packages/lexical-playground/src/plugins/MarkdownShortcutsExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownShortcutsExtension/index.ts
@@ -13,8 +13,9 @@ import {PLAYGROUND_TRANSFORMERS} from '../MarkdownTransformers';
 
 // This is not a published extension because markdown transformers
 // should get a refactor to require less manual configuration
-export const PlaygroundMarkdownShortcutsExtension = defineExtension({
-  name: '@lexical/playground/MarkdownShortcuts',
-  register: editor =>
-    registerMarkdownShortcuts(editor, PLAYGROUND_TRANSFORMERS),
-});
+export const PlaygroundMarkdownShortcutsExtension =
+  /* @__PURE__ */ defineExtension({
+    name: '@lexical/playground/MarkdownShortcuts',
+    register: editor =>
+      registerMarkdownShortcuts(editor, PLAYGROUND_TRANSFORMERS),
+  });

--- a/packages/lexical-playground/src/plugins/MaxLengthPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MaxLengthPlugin/index.tsx
@@ -23,9 +23,12 @@ export interface MaxLengthConfig {
   maxLength: number;
 }
 
-export const MaxLengthExtension = defineExtension({
+export const MaxLengthExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<MaxLengthConfig>({disabled: true, maxLength: 30}),
+  config: /* @__PURE__ */ safeCast<MaxLengthConfig>({
+    disabled: true,
+    maxLength: 30,
+  }),
   name: '@lexical/playground/MaxLength',
   register: (editor, config, state) =>
     effect(() => {

--- a/packages/lexical-playground/src/plugins/MentionsExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsExtension/index.tsx
@@ -26,7 +26,7 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {$createMentionNode, MentionNode} from '../../nodes/MentionNode';
 
-const MentionImportRule = defineImportRule({
+const MentionImportRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, el) => {
     const textContent = el.textContent ?? '';
     const mentionName =
@@ -37,14 +37,16 @@ const MentionImportRule = defineImportRule({
   name: '@lexical/playground/mention',
 });
 
-export const MentionsExtension = defineExtension({
+export const MentionsExtension = /* @__PURE__ */ defineExtension({
   // Depend on CoreImportExtension so the `<span data-lexical-mention>` rule is
   // merged after — and therefore out-prioritizes — the core inline-format
   // `<span>` rule, regardless of where the app lists this extension relative
   // to the import baseline.
   dependencies: [
     CoreImportExtension,
-    configExtension(DOMImportExtension, {rules: [MentionImportRule]}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: [MentionImportRule],
+    }),
   ],
   name: '@lexical/playground/Mentions',
   nodes: [MentionNode],

--- a/packages/lexical-playground/src/plugins/PageBreakExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/PageBreakExtension/index.ts
@@ -20,17 +20,20 @@ import {
 
 import {$createPageBreakNode, PageBreakNode} from '../../nodes/PageBreakNode';
 
-export const INSERT_PAGE_BREAK: LexicalCommand<undefined> = createCommand();
+export const INSERT_PAGE_BREAK: LexicalCommand<undefined> =
+  /* @__PURE__ */ createCommand();
 
-const PageBreakImportRule = defineImportRule({
+const PageBreakImportRule = /* @__PURE__ */ defineImportRule({
   $import: () => [$createPageBreakNode()],
   match: sel.tag('figure').attr('type', PageBreakNode.getType()),
   name: '@lexical/playground/page-break',
 });
 
-export const PageBreakExtension = defineExtension({
+export const PageBreakExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {rules: [PageBreakImportRule]}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: [PageBreakImportRule],
+    }),
   ],
   name: '@lexical/playground/PageBreak',
   nodes: [PageBreakNode],

--- a/packages/lexical-playground/src/plugins/PageBreakExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/PageBreakExtension/index.tsx
@@ -19,9 +19,10 @@ import {
 
 import {$createPageBreakNode, PageBreakNode} from '../../nodes/PageBreakNode';
 
-export const INSERT_PAGE_BREAK: LexicalCommand<undefined> = createCommand();
+export const INSERT_PAGE_BREAK: LexicalCommand<undefined> =
+  /* @__PURE__ */ createCommand();
 
-export const PageBreakExtension = defineExtension({
+export const PageBreakExtension = /* @__PURE__ */ defineExtension({
   dependencies: [ReactExtension],
   name: '@lexical/playground/PageBreak',
   nodes: () => [PageBreakNode],

--- a/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
@@ -47,7 +47,7 @@ export interface PagesConfig {
   pageClass: string;
 }
 
-export const PagesExtension = defineExtension({
+export const PagesExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => {
     const getPageSetup = () => editor.getEditorState().read($getPageSetup);
 
@@ -60,7 +60,7 @@ export const PagesExtension = defineExtension({
       ),
     };
   },
-  config: safeCast<PagesConfig>({
+  config: /* @__PURE__ */ safeCast<PagesConfig>({
     disabled: false,
     pageClass: 'PlaygroundEditorTheme__page',
     pageContentClass: 'PlaygroundEditorTheme__pageContent',

--- a/packages/lexical-playground/src/plugins/PagesExtension/pageSetup.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/pageSetup.ts
@@ -53,7 +53,7 @@ function parseMargins(v: unknown): PageSetup['margins'] {
   return DEFAULT_PAGE_SETUP.margins;
 }
 
-export const pageSetupState = createState('pageSetup', {
+export const pageSetupState = /* @__PURE__ */ createState('pageSetup', {
   isEqual: (a: null | PageSetup, b: null | PageSetup) =>
     a === b ||
     (a != null &&

--- a/packages/lexical-playground/src/plugins/PagesReactExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/PagesReactExtension/index.ts
@@ -16,7 +16,7 @@ export {
   type PageSetupDropdownProps,
 } from './PageSetupDropdown';
 
-export const PagesReactExtension = defineExtension({
+export const PagesReactExtension = /* @__PURE__ */ defineExtension({
   build: () => ({Component: PageSetupDropdownComponent}),
   dependencies: [ReactExtension, PagesExtension],
   name: '@lexical/playground/PagesReact',

--- a/packages/lexical-playground/src/plugins/PollExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/PollExtension/index.tsx
@@ -32,9 +32,8 @@ import Button from '../../ui/Button';
 import {DialogActions} from '../../ui/Dialog';
 import TextInput from '../../ui/TextInput';
 
-export const INSERT_POLL_COMMAND: LexicalCommand<string> = createCommand(
-  'INSERT_POLL_COMMAND',
-);
+export const INSERT_POLL_COMMAND: LexicalCommand<string> =
+  /* @__PURE__ */ createCommand('INSERT_POLL_COMMAND');
 
 function $convertPollElement(el: HTMLElement) {
   const question = el.getAttribute('data-lexical-poll-question');
@@ -45,7 +44,7 @@ function $convertPollElement(el: HTMLElement) {
   return $createPollNode(question, JSON.parse(options));
 }
 
-const PollImportRule = defineImportRule({
+const PollImportRule = /* @__PURE__ */ defineImportRule({
   $import: (_ctx, el, $next) => {
     const node = $convertPollElement(el);
     return node ? [node] : $next();
@@ -54,9 +53,11 @@ const PollImportRule = defineImportRule({
   name: '@lexical/playground/poll',
 });
 
-export const PollExtension = defineExtension({
+export const PollExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {rules: [PollImportRule]}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: [PollImportRule],
+    }),
   ],
   name: '@lexical/playground/Poll',
   nodes: [PollNode],

--- a/packages/lexical-playground/src/plugins/SpecialTextExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/SpecialTextExtension/index.ts
@@ -55,9 +55,9 @@ export interface SpecialTextConfig {
   disabled: boolean;
 }
 
-export const SpecialTextExtension = defineExtension({
+export const SpecialTextExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<SpecialTextConfig>({disabled: true}),
+  config: /* @__PURE__ */ safeCast<SpecialTextConfig>({disabled: true}),
   name: '@lexical/playground/SpecialText',
   nodes: [SpecialTextNode],
   register: (editor, config, state) =>

--- a/packages/lexical-playground/src/plugins/SpeechToTextPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/SpeechToTextPlugin/index.ts
@@ -21,9 +21,8 @@ import {useEffect, useRef, useState} from 'react';
 
 import useReport from '../../hooks/useReport';
 
-export const SPEECH_TO_TEXT_COMMAND: LexicalCommand<boolean> = createCommand(
-  'SPEECH_TO_TEXT_COMMAND',
-);
+export const SPEECH_TO_TEXT_COMMAND: LexicalCommand<boolean> =
+  /* @__PURE__ */ createCommand('SPEECH_TO_TEXT_COMMAND');
 
 const VOICE_COMMANDS: Readonly<
   Record<

--- a/packages/lexical-playground/src/plugins/TabFocusExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/TabFocusExtension/index.ts
@@ -33,7 +33,7 @@ function registerKeyTimeStampTracker() {
   );
 }
 
-export const TabFocusExtension = defineExtension({
+export const TabFocusExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/TabFocus',
   register: editor => {
     if (!hasRegisteredKeyDownListener) {

--- a/packages/lexical-playground/src/plugins/TerseExportExtension.ts
+++ b/packages/lexical-playground/src/plugins/TerseExportExtension.ts
@@ -19,7 +19,10 @@ import {
   ParagraphNode,
 } from 'lexical';
 
-export const RenderContextTerse = createRenderState('isTerse', Boolean);
+export const RenderContextTerse = /* @__PURE__ */ createRenderState(
+  'isTerse',
+  Boolean,
+);
 
 /**
  * Install these overrides only for export sessions where terse output was
@@ -30,11 +33,11 @@ const terseOnly: DOMOverrideOptions = {
   disabledForSession: ctx => !ctx.get(RenderContextTerse),
 };
 
-export const TerseExportExtension = defineExtension({
+export const TerseExportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMRenderExtension, {
+    /* @__PURE__ */ configExtension(DOMRenderExtension, {
       overrides: [
-        domOverride(
+        /* @__PURE__ */ domOverride(
           '*',
           {
             $exportDOM: (node, $next) => {
@@ -69,7 +72,7 @@ export const TerseExportExtension = defineExtension({
           },
           terseOnly,
         ),
-        domOverride(
+        /* @__PURE__ */ domOverride(
           [ParagraphNode],
           {
             $exportDOM: (node, $next) => {

--- a/packages/lexical-playground/src/plugins/TwitterExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/TwitterExtension/index.ts
@@ -18,19 +18,20 @@ import {
 
 import {$createTweetNode, TweetNode} from '../../nodes/TweetNode';
 
-export const INSERT_TWEET_COMMAND: LexicalCommand<string> = createCommand(
-  'INSERT_TWEET_COMMAND',
-);
+export const INSERT_TWEET_COMMAND: LexicalCommand<string> =
+  /* @__PURE__ */ createCommand('INSERT_TWEET_COMMAND');
 
-const TweetImportRule = defineImportRule({
+const TweetImportRule = /* @__PURE__ */ defineImportRule({
   $import: ctx => [$createTweetNode(ctx.captures.id[0])],
   match: sel.tag('div').attr('data-lexical-tweet-id', /^.+$/, {capture: 'id'}),
   name: '@lexical/playground/tweet',
 });
 
-export const TwitterExtension = defineExtension({
+export const TwitterExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {rules: [TweetImportRule]}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: [TweetImportRule],
+    }),
   ],
   name: '@lexical/playground/Twitter',
   nodes: [TweetNode],

--- a/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
@@ -52,9 +52,8 @@ const COLORS = [
 
 type User = string; // username
 
-export const SHOW_VERSIONS_COMMAND: LexicalCommand<void> = createCommand(
-  'SHOW_VERSIONS_COMMAND',
-);
+export const SHOW_VERSIONS_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('SHOW_VERSIONS_COMMAND');
 
 export function VersionsPlugin({id}: {id: string}) {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-playground/src/plugins/VisibleNonPrintingExtension.ts
+++ b/packages/lexical-playground/src/plugins/VisibleNonPrintingExtension.ts
@@ -93,7 +93,7 @@ export interface VisibleNonPrintingConfig {
 /**
  * Editor render context state mirroring the extension's `disabled` signal.
  */
-export const VisibleNonPrintingDisabled = createRenderState(
+export const VisibleNonPrintingDisabled = /* @__PURE__ */ createRenderState(
   'visibleNonPrintingDisabled',
   () => false,
 );
@@ -117,13 +117,13 @@ const disabledForEditor = {
   disabledForEditor: ctx => ctx.get(VisibleNonPrintingDisabled),
 } satisfies DOMOverrideOptions;
 
-export const VisibleNonPrintingExtension = defineExtension({
+export const VisibleNonPrintingExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => namedSignals(config),
-  config: safeCast<VisibleNonPrintingConfig>({disabled: false}),
+  config: /* @__PURE__ */ safeCast<VisibleNonPrintingConfig>({disabled: false}),
   dependencies: [
-    configExtension(DOMRenderExtension, {
+    /* @__PURE__ */ configExtension(DOMRenderExtension, {
       overrides: [
-        domOverride(
+        /* @__PURE__ */ domOverride(
           [LineBreakNode],
           {
             $createDOM: (node, $next) => {
@@ -150,7 +150,7 @@ export const VisibleNonPrintingExtension = defineExtension({
           },
           disabledForEditor,
         ),
-        domOverride<ElementNode>(
+        /* @__PURE__ */ domOverride<ElementNode>(
           [ParagraphNode, HeadingNode, ListItemNode, QuoteNode],
           {
             $decorateDOM: (node, _prevNode, dom) => {
@@ -166,7 +166,7 @@ export const VisibleNonPrintingExtension = defineExtension({
           },
           disabledForEditor,
         ),
-        domOverride(
+        /* @__PURE__ */ domOverride(
           [TextNode, TabNode],
           {
             $decorateDOM: (node, _prev, dom) => {

--- a/packages/lexical-playground/src/plugins/YouTubeExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/YouTubeExtension/index.ts
@@ -18,11 +18,10 @@ import {
 
 import {$createYouTubeNode, YouTubeNode} from '../../nodes/YouTubeNode';
 
-export const INSERT_YOUTUBE_COMMAND: LexicalCommand<string> = createCommand(
-  'INSERT_YOUTUBE_COMMAND',
-);
+export const INSERT_YOUTUBE_COMMAND: LexicalCommand<string> =
+  /* @__PURE__ */ createCommand('INSERT_YOUTUBE_COMMAND');
 
-const YouTubeImportRule = defineImportRule({
+const YouTubeImportRule = /* @__PURE__ */ defineImportRule({
   $import: ctx => [$createYouTubeNode(ctx.captures.id[0])],
   match: sel
     .tag('iframe')
@@ -30,9 +29,11 @@ const YouTubeImportRule = defineImportRule({
   name: '@lexical/playground/youtube',
 });
 
-export const YouTubeExtension = defineExtension({
+export const YouTubeExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
-    configExtension(DOMImportExtension, {rules: [YouTubeImportRule]}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: [YouTubeImportRule],
+    }),
   ],
   name: '@lexical/playground/YouTube',
   nodes: [YouTubeNode],

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -58,7 +58,7 @@ export const URL_MATCHER =
   /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
 
 export const INSERT_EMBED_COMMAND: LexicalCommand<EmbedConfig['type']> =
-  createCommand('INSERT_EMBED_COMMAND');
+  /* @__PURE__ */ createCommand('INSERT_EMBED_COMMAND');
 
 export class AutoEmbedOption extends MenuOption {
   title: string;

--- a/packages/lexical-react/src/LexicalExtensionComposer.tsx
+++ b/packages/lexical-react/src/LexicalExtensionComposer.tsx
@@ -89,7 +89,7 @@ export function LexicalExtensionComposer({
   const editor = useMemo(() => {
     const builder = LexicalBuilder.fromExtensions([
       ReactProviderExtension,
-      configExtension(
+      /* @__PURE__ */ configExtension(
         ReactExtension,
         contentEditable === undefined ? {} : {contentEditable},
       ),

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -142,7 +142,7 @@ export {useDynamicPositioning} from './shared/LexicalMenu';
 export const SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND: LexicalCommand<{
   index: number;
   option: MenuOption;
-}> = createCommand('SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND');
+}> = /* @__PURE__ */ createCommand('SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND');
 
 export function useBasicTypeaheadTriggerMatch(
   trigger: string,

--- a/packages/lexical-react/src/ReactExtension.tsx
+++ b/packages/lexical-react/src/ReactExtension.tsx
@@ -72,7 +72,7 @@ const initialConfig: ReactConfig = {
  * location-dependent (e.g. floating UI that does not need to be mounted in
  * some specific location, or effects that return null).
  */
-export const ReactExtension = defineExtension({
+export const ReactExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     const providerPeer = state.getPeer<typeof ReactProviderExtension>(
       ReactProviderExtension.name,
@@ -106,7 +106,7 @@ export const ReactExtension = defineExtension({
   peerDependencies: [
     // We are not trying to avoid the import, just the direct dependency,
     // so using the extension directly is fine.
-    declarePeerDependency<typeof ReactProviderExtension>(
+    /* @__PURE__ */ declarePeerDependency<typeof ReactProviderExtension>(
       ReactProviderExtension.name,
     ),
   ],

--- a/packages/lexical-react/src/ReactPluginHostExtension.tsx
+++ b/packages/lexical-react/src/ReactPluginHostExtension.tsx
@@ -109,9 +109,11 @@ export function mountReactPluginHost(
 }
 
 export const REACT_PLUGIN_HOST_MOUNT_ROOT_COMMAND =
-  createCommand<HostMountCommandArg>('REACT_PLUGIN_HOST_MOUNT_ROOT_COMMAND');
+  /* @__PURE__ */ createCommand<HostMountCommandArg>(
+    'REACT_PLUGIN_HOST_MOUNT_ROOT_COMMAND',
+  );
 export const REACT_PLUGIN_HOST_MOUNT_PLUGIN_COMMAND =
-  createCommand<MountPluginCommandArg>(
+  /* @__PURE__ */ createCommand<MountPluginCommandArg>(
     'REACT_PLUGIN_HOST_MOUNT_PLUGIN_COMMAND',
   );
 
@@ -161,7 +163,7 @@ function PluginHostDecorator({
  * {@link mountReactPluginElement} can be used to render
  * legacy React plug-ins (or any React content).
  */
-export const ReactPluginHostExtension = defineExtension({
+export const ReactPluginHostExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     const mountedPluginsStore = signal({
       plugins: new Map<MountPluginCommandArg['key'], MountPluginCommandArg>(),
@@ -181,7 +183,9 @@ export const ReactPluginHostExtension = defineExtension({
   },
   dependencies: [
     ReactProviderExtension,
-    configExtension(ReactExtension, {decorators: [PluginHostDecorator]}),
+    /* @__PURE__ */ configExtension(ReactExtension, {
+      decorators: [PluginHostDecorator],
+    }),
   ],
   name: '@lexical/react/ReactPluginHost',
   register(editor, _config, state) {

--- a/packages/lexical-react/src/ReactProviderExtension.tsx
+++ b/packages/lexical-react/src/ReactProviderExtension.tsx
@@ -15,6 +15,6 @@ import {defineExtension} from 'lexical';
  *
  * It is a separate extension so it can be used as a peer dependency.
  */
-export const ReactProviderExtension = defineExtension({
+export const ReactProviderExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/react/ReactProvider',
 });

--- a/packages/lexical-react/src/TreeViewExtension.tsx
+++ b/packages/lexical-react/src/TreeViewExtension.tsx
@@ -40,7 +40,7 @@ const config: TreeViewConfig = {
  * Provides a configured TreeView debugging tool (React dependent)
  * as an output component with configurable class names.
  */
-export const TreeViewExtension = defineExtension({
+export const TreeViewExtension = /* @__PURE__ */ defineExtension({
   build: () => ({Component: TreeViewExtensionComponent}),
   config,
   dependencies: [ReactExtension],

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -260,7 +260,7 @@ export function useDynamicPositioning(
 export const SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND: LexicalCommand<{
   index: number;
   option: MenuOption;
-}> = createCommand('SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND');
+}> = /* @__PURE__ */ createCommand('SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND');
 
 function MenuItem({
   index,

--- a/packages/lexical-rich-text/src/LexicalRichTextExtension.ts
+++ b/packages/lexical-rich-text/src/LexicalRichTextExtension.ts
@@ -104,9 +104,9 @@ function mergeRichTextConfig(
   return merged;
 }
 
-export const RichTextExtension = defineExtension({
+export const RichTextExtension = /* @__PURE__ */ defineExtension({
   build: (_editor, config) => namedSignals(config),
-  config: safeCast<RichTextConfig>(DEFAULT_RICH_TEXT_CONFIG),
+  config: /* @__PURE__ */ safeCast<RichTextConfig>(DEFAULT_RICH_TEXT_CONFIG),
   conflictsWith: ['@lexical/plain-text'],
   dependencies: [
     DragonExtension,
@@ -116,7 +116,9 @@ export const RichTextExtension = defineExtension({
     // unless the editor routes HTML through the pipeline (e.g. via
     // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
     CoreImportExtension,
-    configExtension(DOMImportExtension, {rules: RichTextImportRules}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: RichTextImportRules,
+    }),
   ],
   mergeConfig: mergeRichTextConfig,
   name: '@lexical/rich-text',
@@ -136,7 +138,7 @@ export const RichTextExtension = defineExtension({
  * {@link RichTextImportRules} (and `CoreImportExtension`) itself —
  * depend on it directly instead.
  */
-export const RichTextImportExtension = defineExtension({
+export const RichTextImportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [RichTextExtension],
   name: '@lexical/rich-text/Import',
 });

--- a/packages/lexical-rich-text/src/LexicalRichTextExtension.ts
+++ b/packages/lexical-rich-text/src/LexicalRichTextExtension.ts
@@ -15,7 +15,13 @@ import {
   NormalizeInlineElementsExtension,
   NormalizeTripleClickSelectionExtension,
 } from '@lexical/extension';
-import {defineExtension, safeCast, shallowMergeConfig} from 'lexical';
+import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
+import {
+  configExtension,
+  defineExtension,
+  safeCast,
+  shallowMergeConfig,
+} from 'lexical';
 
 import {
   type EscapeFormatTriggerConfig,
@@ -24,6 +30,7 @@ import {
   registerRichText,
   type TriggerConfig,
 } from './index';
+import {RichTextImportRules} from './RichTextImportExtension';
 
 /**
  * Configuration for {@link RichTextExtension}.
@@ -105,6 +112,11 @@ export const RichTextExtension = defineExtension({
     DragonExtension,
     NormalizeInlineElementsExtension,
     NormalizeTripleClickSelectionExtension,
+    // DOMImportExtension support for the nodes registered here. Inert
+    // unless the editor routes HTML through the pipeline (e.g. via
+    // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
+    CoreImportExtension,
+    configExtension(DOMImportExtension, {rules: RichTextImportRules}),
   ],
   mergeConfig: mergeRichTextConfig,
   name: '@lexical/rich-text',
@@ -113,4 +125,18 @@ export const RichTextExtension = defineExtension({
     effect(() =>
       registerRichText(editor, state.getOutput().escapeFormatTriggers),
     ),
+});
+
+/**
+ * Bundles {@link RichTextImportRules} together with the runtime
+ * {@link RichTextExtension}.
+ *
+ * @experimental
+ * @deprecated {@link RichTextExtension} now registers
+ * {@link RichTextImportRules} (and `CoreImportExtension`) itself —
+ * depend on it directly instead.
+ */
+export const RichTextImportExtension = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '@lexical/rich-text/Import',
 });

--- a/packages/lexical-rich-text/src/RichTextImportExtension.ts
+++ b/packages/lexical-rich-text/src/RichTextImportExtension.ts
@@ -6,12 +6,10 @@
  *
  */
 
-import {defineImportRule, DOMImportExtension, sel} from '@lexical/html';
+import {defineImportRule, sel} from '@lexical/html';
 import {
   $setDirectionFromDOM,
   $setFormatFromDOM,
-  configExtension,
-  defineExtension,
   isHTMLElement,
   setNodeIndentFromDOM,
 } from 'lexical';
@@ -21,7 +19,6 @@ import {
   $createQuoteNode,
   type HeadingTagType,
 } from './index';
-import {RichTextExtension} from './LexicalRichTextExtension';
 
 /**
  * Heuristic copied (in spirit) from the legacy `isGoogleDocsTitle`:
@@ -97,6 +94,11 @@ const GoogleDocsTitleSpanRule = defineImportRule({
  * so they precede the generic `<p>` and `<span>` rules from
  * {@link CoreImportRules}.
  *
+ * Registered by {@link RichTextExtension} itself (together with
+ * `CoreImportExtension`), so any editor that uses the rich-text
+ * extension can import these tags through the `DOMImportExtension`
+ * pipeline without further configuration.
+ *
  * @experimental
  */
 export const RichTextImportRules = [
@@ -105,20 +107,3 @@ export const RichTextImportRules = [
   GoogleDocsTitleParagraphRule,
   GoogleDocsTitleSpanRule,
 ];
-
-/**
- * Bundles {@link RichTextImportRules} together with the runtime
- * {@link RichTextExtension}. The application is expected to already
- * have `CoreImportExtension` (or some equivalent) in its dependency
- * graph — the core/text/paragraph/inline-format rules are a shared
- * baseline, not something this leaf importer should re-declare.
- *
- * @experimental
- */
-export const RichTextImportExtension = defineExtension({
-  dependencies: [
-    RichTextExtension,
-    configExtension(DOMImportExtension, {rules: RichTextImportRules}),
-  ],
-  name: '@lexical/rich-text/Import',
-});

--- a/packages/lexical-rich-text/src/RichTextImportExtension.ts
+++ b/packages/lexical-rich-text/src/RichTextImportExtension.ts
@@ -34,7 +34,7 @@ function isGoogleDocsTitleSpan(node: Node): boolean {
   );
 }
 
-const HeadingRule = defineImportRule({
+const HeadingRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const tag = el.nodeName.toLowerCase() as HeadingTagType;
     const node = $createHeadingNode(tag);
@@ -47,7 +47,7 @@ const HeadingRule = defineImportRule({
   name: '@lexical/rich-text/heading',
 });
 
-const QuoteRule = defineImportRule({
+const QuoteRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const node = $createQuoteNode();
     $setFormatFromDOM(node, el);
@@ -66,7 +66,7 @@ const QuoteRule = defineImportRule({
  * descendant rules — including {@link GoogleDocsTitleSpanRule} — fire and
  * produce the heading at this level.
  */
-const GoogleDocsTitleParagraphRule = defineImportRule({
+const GoogleDocsTitleParagraphRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el, $next) => {
     const first = el.firstChild;
     if (first && isGoogleDocsTitleSpan(first)) {
@@ -78,7 +78,7 @@ const GoogleDocsTitleParagraphRule = defineImportRule({
   name: '@lexical/rich-text/google-docs-title-p',
 });
 
-const GoogleDocsTitleSpanRule = defineImportRule({
+const GoogleDocsTitleSpanRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el, $next) =>
     el.style.fontSize !== '26pt'
       ? $next()

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextImportExtension.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextImportExtension.test.ts
@@ -10,12 +10,11 @@ import {
   buildEditorFromExtensions,
   getExtensionDependencyFromEditor,
 } from '@lexical/extension';
-import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
+import {DOMImportExtension} from '@lexical/html';
 import {
   $isHeadingNode,
   $isQuoteNode,
-  HeadingNode,
-  QuoteNode,
+  RichTextExtension,
   RichTextImportExtension,
 } from '@lexical/rich-text';
 import {JSDOM} from 'jsdom';
@@ -31,11 +30,11 @@ import {assert, describe, expect, test} from 'vitest';
 function buildEditor() {
   return buildEditorFromExtensions(
     defineExtension({
-      // Leaf importer extensions no longer pull `CoreImportExtension`
-      // in by themselves — the application is expected to add it once.
-      dependencies: [CoreImportExtension, RichTextImportExtension],
+      // RichTextExtension registers its own import rules (and the
+      // shared CoreImportExtension baseline) — no dedicated import
+      // extension required.
+      dependencies: [RichTextExtension],
       name: 'rich-text-host',
-      nodes: [HeadingNode, QuoteNode],
     }),
   );
 }
@@ -95,6 +94,21 @@ describe('RichTextImportExtension', () => {
       assert($isHeadingNode(node), 'expected HeadingNode');
       expect(node.getTag()).toBe('h1');
       expect(node.getTextContent()).toBe('Title');
+    });
+  });
+
+  test('deprecated RichTextImportExtension alias still imports headings', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [RichTextImportExtension],
+        name: 'rich-text-alias-host',
+      }),
+    );
+    importInto(editor, '<h2>x</h2>');
+    editor.read(() => {
+      const node = $getRoot().getFirstChild();
+      assert($isHeadingNode(node), 'expected HeadingNode');
+      expect(node.getTag()).toBe('h2');
     });
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -127,9 +127,8 @@ export type SerializedHeadingNode = Spread<
   SerializedElementNode
 >;
 
-export const DRAG_DROP_PASTE: LexicalCommand<Array<File>> = createCommand(
-  'DRAG_DROP_PASTE_FILE',
-);
+export const DRAG_DROP_PASTE: LexicalCommand<Array<File>> =
+  /* @__PURE__ */ createCommand('DRAG_DROP_PASTE_FILE');
 
 export type SerializedQuoteNode = SerializedElementNode;
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1455,8 +1455,6 @@ export function registerRichText(
 export {
   type RichTextConfig,
   RichTextExtension,
-} from './LexicalRichTextExtension';
-export {
   RichTextImportExtension,
-  RichTextImportRules,
-} from './RichTextImportExtension';
+} from './LexicalRichTextExtension';
+export {RichTextImportRules} from './RichTextImportExtension';

--- a/packages/lexical-table/src/LexicalTableCommands.ts
+++ b/packages/lexical-table/src/LexicalTableCommands.ts
@@ -24,4 +24,4 @@ export type InsertTableCommandPayload = Readonly<{
 }>;
 
 export const INSERT_TABLE_COMMAND: LexicalCommand<InsertTableCommandPayload> =
-  createCommand('INSERT_TABLE_COMMAND');
+  /* @__PURE__ */ createCommand('INSERT_TABLE_COMMAND');

--- a/packages/lexical-table/src/LexicalTableExtension.ts
+++ b/packages/lexical-table/src/LexicalTableExtension.ts
@@ -7,8 +7,14 @@
  */
 
 import {effect, namedSignals} from '@lexical/extension';
+import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
 import {mergeRegister} from '@lexical/utils';
-import {$fullReconcile, defineExtension, safeCast} from 'lexical';
+import {
+  $fullReconcile,
+  configExtension,
+  defineExtension,
+  safeCast,
+} from 'lexical';
 
 import {TableCellNode} from './LexicalTableCellNode';
 import {
@@ -22,6 +28,7 @@ import {
   registerTableSelectionObserver,
 } from './LexicalTablePluginHelpers';
 import {TableRowNode} from './LexicalTableRowNode';
+import {TableImportRules} from './TableImportExtension';
 
 export interface TableConfig {
   /**
@@ -64,6 +71,13 @@ export const TableExtension = defineExtension({
     hasNestedTables: false,
     hasTabHandler: true,
   }),
+  dependencies: [
+    // DOMImportExtension support for the nodes registered here. Inert
+    // unless the editor routes HTML through the pipeline (e.g. via
+    // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
+    CoreImportExtension,
+    configExtension(DOMImportExtension, {rules: TableImportRules}),
+  ],
   name: '@lexical/table/Table',
   nodes: () => [TableNode, TableRowNode, TableCellNode],
   register(editor, config, state) {
@@ -101,4 +115,18 @@ export const TableExtension = defineExtension({
       ),
     );
   },
+});
+
+/**
+ * Bundles {@link TableImportRules} together with the runtime
+ * {@link TableExtension}.
+ *
+ * @experimental
+ * @deprecated {@link TableExtension} now registers
+ * {@link TableImportRules} (and `CoreImportExtension`) itself — depend on
+ * it directly instead.
+ */
+export const TableImportExtension = defineExtension({
+  dependencies: [TableExtension],
+  name: '@lexical/table/Import',
 });

--- a/packages/lexical-table/src/LexicalTableExtension.ts
+++ b/packages/lexical-table/src/LexicalTableExtension.ts
@@ -60,11 +60,11 @@ export interface TableConfig {
  * Configures {@link TableNode}, {@link TableRowNode}, {@link TableCellNode} and
  * registers table behaviors (see {@link TableConfig})
  */
-export const TableExtension = defineExtension({
+export const TableExtension = /* @__PURE__ */ defineExtension({
   build(editor, config, state) {
     return namedSignals(config);
   },
-  config: safeCast<TableConfig>({
+  config: /* @__PURE__ */ safeCast<TableConfig>({
     hasCellBackgroundColor: true,
     hasCellMerge: true,
     hasHorizontalScroll: true,
@@ -76,7 +76,9 @@ export const TableExtension = defineExtension({
     // unless the editor routes HTML through the pipeline (e.g. via
     // ClipboardDOMImportExtension or $generateNodesFromDOMViaExtension).
     CoreImportExtension,
-    configExtension(DOMImportExtension, {rules: TableImportRules}),
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      rules: TableImportRules,
+    }),
   ],
   name: '@lexical/table/Table',
   nodes: () => [TableNode, TableRowNode, TableCellNode],
@@ -126,7 +128,7 @@ export const TableExtension = defineExtension({
  * {@link TableImportRules} (and `CoreImportExtension`) itself — depend on
  * it directly instead.
  */
-export const TableImportExtension = defineExtension({
+export const TableImportExtension = /* @__PURE__ */ defineExtension({
   dependencies: [TableExtension],
   name: '@lexical/table/Import',
 });

--- a/packages/lexical-table/src/TableImportExtension.ts
+++ b/packages/lexical-table/src/TableImportExtension.ts
@@ -12,7 +12,6 @@ import {
   $propagateTextAlignToBlockChildren,
   contextValue,
   defineImportRule,
-  DOMImportExtension,
   ImportTextFormat,
   ImportTextStyle,
   sel,
@@ -23,8 +22,6 @@ import {
   $isInlineElementOrDecoratorNode,
   $isLineBreakNode,
   $isTextNode,
-  configExtension,
-  defineExtension,
   IS_BOLD,
   IS_ITALIC,
   IS_STRIKETHROUGH,
@@ -40,7 +37,6 @@ import {
   $isTableCellNode,
   TableCellHeaderStates,
 } from './LexicalTableCellNode';
-import {TableExtension} from './LexicalTableExtension';
 import {$createTableNode} from './LexicalTableNode';
 import {$createTableRowNode, $isTableRowNode} from './LexicalTableRowNode';
 
@@ -302,23 +298,11 @@ export const TableRowSchema: ChildSchema = {
  * Import rules for {@link TableNode}, {@link TableRowNode}, and
  * {@link TableCellNode}.
  *
- * @experimental
- */
-export const TableImportRules = [TableRule, TableRowRule, TableCellRule];
-
-/**
- * Bundles {@link TableImportRules} together with the runtime
- * {@link TableExtension}. The application is expected to already have
- * `CoreImportExtension` (or some equivalent) in its dependency graph —
- * the core/text/paragraph/inline-format rules are a shared baseline,
- * not something this leaf importer should re-declare.
+ * Registered by {@link TableExtension} itself (together with
+ * `CoreImportExtension`), so any editor that uses the table extension can
+ * import these tags through the `DOMImportExtension` pipeline without
+ * further configuration.
  *
  * @experimental
  */
-export const TableImportExtension = defineExtension({
-  dependencies: [
-    TableExtension,
-    configExtension(DOMImportExtension, {rules: TableImportRules}),
-  ],
-  name: '@lexical/table/Import',
-});
+export const TableImportRules = [TableRule, TableRowRule, TableCellRule];

--- a/packages/lexical-table/src/TableImportExtension.ts
+++ b/packages/lexical-table/src/TableImportExtension.ts
@@ -122,7 +122,7 @@ function $packageCellChildren(children: LexicalNode[]): LexicalNode[] {
   return result;
 }
 
-const TableRule = defineImportRule({
+const TableRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const node = $createTableNode();
     if (el.hasAttribute('data-lexical-row-striping')) {
@@ -166,7 +166,7 @@ const TableRule = defineImportRule({
   name: '@lexical/table/table',
 });
 
-const TableRowRule = defineImportRule({
+const TableRowRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const height = PIXEL_VALUE_REG_EXP.test(el.style.height)
       ? parseFloat(el.style.height)
@@ -183,7 +183,7 @@ const TableRowRule = defineImportRule({
   name: '@lexical/table/tr',
 });
 
-const TableCellRule = defineImportRule({
+const TableCellRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     const isHeader = el.nodeName === 'TH';
     const width = PIXEL_VALUE_REG_EXP.test(el.style.width)

--- a/packages/lexical-table/src/__tests__/unit/TableImportExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/TableImportExtension.test.ts
@@ -10,12 +10,13 @@ import {
   buildEditorFromExtensions,
   getExtensionDependencyFromEditor,
 } from '@lexical/extension';
-import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
+import {DOMImportExtension} from '@lexical/html';
 import {
   $isTableCellNode,
   $isTableNode,
   $isTableRowNode,
   TableCellNode,
+  TableExtension,
   TableImportExtension,
   TableNode,
   TableRowNode,
@@ -33,11 +34,11 @@ import {assert, describe, expect, test} from 'vitest';
 function buildEditor() {
   return buildEditorFromExtensions(
     defineExtension({
-      // Leaf importer extensions no longer pull `CoreImportExtension`
-      // in by themselves — the application is expected to add it once.
-      dependencies: [CoreImportExtension, TableImportExtension],
+      // TableExtension registers its own import rules (and the shared
+      // CoreImportExtension baseline) — no dedicated import extension
+      // required.
+      dependencies: [TableExtension],
       name: 'table-host',
-      nodes: [TableNode, TableRowNode, TableCellNode],
     }),
   );
 }
@@ -118,6 +119,20 @@ describe('TableImportExtension', () => {
 
   test('row picks up cells via $descendantsMatching', () => {
     using editor = buildEditor();
+    importInto(editor, '<table><tr><td>a</td></tr></table>');
+    editor.read(() => {
+      const cell = $cells($rows($rootTable())[0])[0];
+      expect(cell.getTextContent()).toBe('a');
+    });
+  });
+
+  test('deprecated TableImportExtension alias still imports tables', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [TableImportExtension],
+        name: 'table-alias-host',
+      }),
+    );
     importInto(editor, '<table><tr><td>a</td></tr></table>');
     editor.read(() => {
       const cell = $cells($rows($rootTable())[0])[0];

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -18,7 +18,11 @@ export type {
   InsertTableCommandPayloadHeaders,
 } from './LexicalTableCommands';
 export {INSERT_TABLE_COMMAND} from './LexicalTableCommands';
-export {type TableConfig, TableExtension} from './LexicalTableExtension';
+export {
+  type TableConfig,
+  TableExtension,
+  TableImportExtension,
+} from './LexicalTableExtension';
 export type {SerializedTableNode} from './LexicalTableNode';
 export {
   $createTableNode,
@@ -90,7 +94,6 @@ export {
   $unmergeCell,
 } from './LexicalTableUtils';
 export {
-  TableImportExtension,
   TableImportRules,
   TableRowSchema,
   TableSchema,

--- a/packages/lexical-tailwind/src/index.ts
+++ b/packages/lexical-tailwind/src/index.ts
@@ -170,10 +170,10 @@ const theme: EditorThemeClasses = {
 /**
  * Configures the lexical theme ({@link EditorThemeClasses}) with tailwind defaults
  */
-export const TailwindExtension = defineExtension({
+export const TailwindExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/tailwind',
   peerDependencies: [
-    declarePeerDependency('@lexical/react/TreeView', {
+    /* @__PURE__ */ declarePeerDependency('@lexical/react/TreeView', {
       timeTravelButtonClassName:
         'absolute top-[10px] right-[15px] border-0 p-0 text-xs bg-transparent text-white hover:underline cursor-pointer',
       timeTravelPanelButtonClassName:

--- a/packages/lexical-website/docs/serialization/dom-import.md
+++ b/packages/lexical-website/docs/serialization/dom-import.md
@@ -29,10 +29,14 @@ designed for performance, ergonomics, and composability across
 extensions.
 
 The new pipeline ships side-by-side with the legacy one in
-`@lexical/html`; the default `$generateNodesFromDOM` is unchanged. To
-opt in, depend on `DOMImportExtension` (or a higher-level bundle like
-`CoreImportExtension` / `RichTextImportExtension` / etc.) and read the
-imported nodes from the extension's `$generateNodesFromDOM` output.
+`@lexical/html`; the default `$generateNodesFromDOM` is unchanged. The
+node-providing extensions (`RichTextExtension`, `ListExtension`,
+`LinkExtension`, `TableExtension`, `CodeExtension`, …) register their
+own import rules (plus the shared `CoreImportExtension` baseline), so
+an editor built from them already has a fully configured
+`DOMImportExtension` — to opt in, just read the imported nodes from
+the extension's `$generateNodesFromDOM` output (or add
+`ClipboardDOMImportExtension` to route pastes through it).
 
 ## Quick start
 
@@ -71,22 +75,33 @@ editor.update(() => {
 inline format tags (`<b>`, `<strong>`, `<em>`, `<i>`, `<code>`,
 `<mark>`, `<s>`, `<sub>`, `<sup>`, `<u>`), `<br>`, and `#text` —
 everything the core lexical package's legacy `importDOM` machinery
-handled. Higher-level bundles you can drop in alongside:
+handled — plus `<hr>`, gated on `HorizontalRuleNode` being registered
+(the node lives in `@lexical/extension`, which is upstream of
+`@lexical/html` and so cannot register import rules itself).
+
+The per-tag rules ship with the extensions that provide the nodes, so
+listing the node extensions you want is the entire import
+configuration:
 
 | Extension | Provides |
 | --- | --- |
-| `CoreImportExtension` (`@lexical/html`) | `<p>`, `<span>`, inline format tags, `<br>`, `#text` |
-| `HorizontalRuleImportExtension` (`@lexical/html`) | `<hr>` |
-| `RichTextImportExtension` (`@lexical/rich-text`) | `<h1>`–`<h6>`, `<blockquote>`, Google Docs 26pt-title heuristic |
-| `ListImportExtension` (`@lexical/list`) | `<ol>`, `<ul>` (incl. checklist detection), `<li>`, GitHub task list, Joplin checkbox |
-| `LinkImportExtension` (`@lexical/link`) | `<a>` |
-| `TableImportExtension` (`@lexical/table`) | `<table>`, `<tr>`, `<td>`, `<th>` |
-| `CodeImportExtension` (`@lexical/code-core`) | `<pre>`, multi-line `<code>`, monospace `<div>`, GitHub raw-file-view tables |
+| `CoreImportExtension` (`@lexical/html`) | `<p>`, `<span>`, inline format tags, `<br>`, `#text`, `<hr>` (when `HorizontalRuleNode` is registered) |
+| `RichTextExtension` (`@lexical/rich-text`) | `<h1>`–`<h6>`, `<blockquote>`, Google Docs 26pt-title heuristic |
+| `ListExtension` (`@lexical/list`) | `<ol>`, `<ul>` (incl. checklist detection), `<li>`, GitHub task list, Joplin checkbox |
+| `LinkExtension` (`@lexical/link`) | `<a>` |
+| `TableExtension` (`@lexical/table`) | `<table>`, `<tr>`, `<td>`, `<th>` |
+| `CodeExtension` (`@lexical/code-core`) | `<pre>`, multi-line `<code>`, monospace `<div>`, GitHub raw-file-view tables |
 
-Each bundle depends on `CoreImportExtension` (the inline-format rules
-are nearly always wanted) and on the corresponding node-providing
-extension where possible, so you only have to list the import
-extension in your editor's dependency tree.
+Each of these depends on `CoreImportExtension` itself, so the shared
+baseline comes along automatically. The rules are inert unless the
+editor actually routes HTML through the pipeline (the legacy paste
+path is unchanged), and an extension's rules merge above its
+dependencies' rules, so app-registered rules still win dispatch.
+
+The standalone `RichTextImportExtension` / `ListImportExtension` /
+`LinkImportExtension` / `TableImportExtension` / `CodeImportExtension`
+/ `HorizontalRuleImportExtension` bundles from earlier versions still
+exist as deprecated aliases for the corresponding runtime extensions.
 
 :::tip
 
@@ -874,19 +889,20 @@ configExtension(ClipboardImportExtension, {
 The easy on-switch is `ClipboardDOMImportExtension` from
 `@lexical/clipboard` — add it to your dependencies and `text/html`
 pastes and drops route through the new pipeline (forwarding
-`ImportSource='paste'` and `ImportSourceDataTransfer` automatically):
+`ImportSource='paste'` and `ImportSourceDataTransfer` automatically).
+The node extensions already registered their rules, so nothing else
+needs to be configured:
 
 ```ts
 import {defineExtension} from 'lexical';
 import {ClipboardDOMImportExtension} from '@lexical/clipboard';
-import {CoreImportExtension, RichTextImportExtension} from '@lexical/html';
+import {RichTextExtension} from '@lexical/rich-text';
 
 defineExtension({
   name: 'app',
   dependencies: [
-    CoreImportExtension,
-    RichTextImportExtension,
-    // …other per-package import extensions you want active…
+    RichTextExtension,
+    // …other node extensions (list, link, table, code, …)…
     ClipboardDOMImportExtension,
   ],
 });

--- a/packages/lexical-yjs/src/RenderSnapshot.ts
+++ b/packages/lexical-yjs/src/RenderSnapshot.ts
@@ -28,7 +28,10 @@ export type YChange<UserT = any> = {
   user: UserT | null;
 };
 
-const ychangeState = createState<typeof STATE_KEY, YChange | null>(STATE_KEY, {
+const ychangeState = /* @__PURE__ */ createState<
+  typeof STATE_KEY,
+  YChange | null
+>(STATE_KEY, {
   isEqual: (a, b) => a === b,
   parse: value => (value as YChange) ?? null,
 });

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -41,7 +41,7 @@ export const DIFF_VERSIONS_COMMAND__EXPERIMENTAL: LexicalCommand<{
   prevSnapshot?: Snapshot;
   // Ending snapshot if defined, otherwise compare against current state of the Yjs document.
   snapshot?: Snapshot;
-}> = createCommand('DIFF_VERSIONS_COMMAND');
+}> = /* @__PURE__ */ createCommand('DIFF_VERSIONS_COMMAND');
 export const CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('CLEAR_DIFF_VERSIONS_COMMAND');
 export {$getYChangeState, renderSnapshot__EXPERIMENTAL} from './RenderSnapshot';

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -32,10 +32,9 @@ export type UserState = {
   [key: string]: unknown;
 };
 export const CONNECTED_COMMAND: LexicalCommand<boolean> =
-  createCommand('CONNECTED_COMMAND');
-export const TOGGLE_CONNECT_COMMAND: LexicalCommand<boolean> = createCommand(
-  'TOGGLE_CONNECT_COMMAND',
-);
+  /* @__PURE__ */ createCommand('CONNECTED_COMMAND');
+export const TOGGLE_CONNECT_COMMAND: LexicalCommand<boolean> =
+  /* @__PURE__ */ createCommand('TOGGLE_CONNECT_COMMAND');
 
 export const DIFF_VERSIONS_COMMAND__EXPERIMENTAL: LexicalCommand<{
   // Starting snapshot if defined, otherwise compare since start of time.
@@ -44,7 +43,7 @@ export const DIFF_VERSIONS_COMMAND__EXPERIMENTAL: LexicalCommand<{
   snapshot?: Snapshot;
 }> = createCommand('DIFF_VERSIONS_COMMAND');
 export const CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL: LexicalCommand<void> =
-  createCommand('CLEAR_DIFF_VERSIONS_COMMAND');
+  /* @__PURE__ */ createCommand('CLEAR_DIFF_VERSIONS_COMMAND');
 export {$getYChangeState, renderSnapshot__EXPERIMENTAL} from './RenderSnapshot';
 
 export type ProviderAwareness = {

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -33,7 +33,7 @@ export const SELECTION_CHANGE_COMMAND: LexicalCommand<void> =
 export const SELECTION_INSERT_CLIPBOARD_NODES_COMMAND: LexicalCommand<{
   nodes: Array<LexicalNode>;
   selection: BaseSelection;
-}> = createCommand('SELECTION_INSERT_CLIPBOARD_NODES_COMMAND');
+}> = /* @__PURE__ */ createCommand('SELECTION_INSERT_CLIPBOARD_NODES_COMMAND');
 export const CLICK_COMMAND: LexicalCommand<MouseEvent> =
   /* @__PURE__ */ createCommand('CLICK_COMMAND');
 export const BEFORE_INPUT_COMMAND: LexicalCommand<InputEvent> =
@@ -62,7 +62,7 @@ export const INSERT_PARAGRAPH_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('INSERT_PARAGRAPH_COMMAND');
 export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<
   InputEvent | string
-> = createCommand('CONTROLLED_TEXT_INSERTION_COMMAND');
+> = /* @__PURE__ */ createCommand('CONTROLLED_TEXT_INSERTION_COMMAND');
 export const PASTE_COMMAND: LexicalCommand<PasteCommandType> =
   /* @__PURE__ */ createCommand('PASTE_COMMAND');
 export const REMOVE_TEXT_COMMAND: LexicalCommand<InputEvent | null> =
@@ -195,14 +195,14 @@ export const DRAGEND_COMMAND: LexicalCommand<DragEvent> =
  */
 export const COPY_COMMAND: LexicalCommand<
   ClipboardEvent | KeyboardEvent | null
-> = createCommand('COPY_COMMAND');
+> = /* @__PURE__ */ createCommand('COPY_COMMAND');
 /**
  * Dispatched on a cut event, either via the clipboard or a KeyboardEvent
  * (Cmd+X on macOS, Ctrl+X elsewhere).
  */
 export const CUT_COMMAND: LexicalCommand<
   ClipboardEvent | KeyboardEvent | null
-> = createCommand('CUT_COMMAND');
+> = /* @__PURE__ */ createCommand('CUT_COMMAND');
 /**
  * Dispatched on the select all keyboard shortcut
  * (Cmd+A on macOS, Ctrl+A elsehwere).

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -28,174 +28,167 @@ export function createCommand<T>(type?: string): LexicalCommand<T> {
   return {type};
 }
 
-export const SELECTION_CHANGE_COMMAND: LexicalCommand<void> = createCommand(
-  'SELECTION_CHANGE_COMMAND',
-);
+export const SELECTION_CHANGE_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('SELECTION_CHANGE_COMMAND');
 export const SELECTION_INSERT_CLIPBOARD_NODES_COMMAND: LexicalCommand<{
   nodes: Array<LexicalNode>;
   selection: BaseSelection;
 }> = createCommand('SELECTION_INSERT_CLIPBOARD_NODES_COMMAND');
 export const CLICK_COMMAND: LexicalCommand<MouseEvent> =
-  createCommand('CLICK_COMMAND');
-export const BEFORE_INPUT_COMMAND: LexicalCommand<InputEvent> = createCommand(
-  'BEFORE_INPUT_COMMAND',
-);
+  /* @__PURE__ */ createCommand('CLICK_COMMAND');
+export const BEFORE_INPUT_COMMAND: LexicalCommand<InputEvent> =
+  /* @__PURE__ */ createCommand('BEFORE_INPUT_COMMAND');
 export const INPUT_COMMAND: LexicalCommand<InputEvent> =
-  createCommand('INPUT_COMMAND');
+  /* @__PURE__ */ createCommand('INPUT_COMMAND');
 export const COMPOSITION_START_COMMAND: LexicalCommand<CompositionEvent> =
-  createCommand('COMPOSITION_START_COMMAND');
+  /* @__PURE__ */ createCommand('COMPOSITION_START_COMMAND');
 export const COMPOSITION_END_COMMAND: LexicalCommand<CompositionEvent> =
-  createCommand('COMPOSITION_END_COMMAND');
+  /* @__PURE__ */ createCommand('COMPOSITION_END_COMMAND');
 /**
  * Dispatched to delete a character, the payload will be `true` if the deletion
  * is backwards (backspace or delete on macOS) and `false` if forwards
  * (delete or Fn+Delete on macOS).
  */
-export const DELETE_CHARACTER_COMMAND: LexicalCommand<boolean> = createCommand(
-  'DELETE_CHARACTER_COMMAND',
-);
+export const DELETE_CHARACTER_COMMAND: LexicalCommand<boolean> =
+  /* @__PURE__ */ createCommand('DELETE_CHARACTER_COMMAND');
 /**
  * Dispatched to insert a line break. With a false payload the
  * cursor moves to the new line (Shift+Enter), with a true payload the cursor
  * does not move (Ctrl+O on macOS).
  */
-export const INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean> = createCommand(
-  'INSERT_LINE_BREAK_COMMAND',
-);
-export const INSERT_PARAGRAPH_COMMAND: LexicalCommand<void> = createCommand(
-  'INSERT_PARAGRAPH_COMMAND',
-);
+export const INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean> =
+  /* @__PURE__ */ createCommand('INSERT_LINE_BREAK_COMMAND');
+export const INSERT_PARAGRAPH_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('INSERT_PARAGRAPH_COMMAND');
 export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<
   InputEvent | string
 > = createCommand('CONTROLLED_TEXT_INSERTION_COMMAND');
 export const PASTE_COMMAND: LexicalCommand<PasteCommandType> =
-  createCommand('PASTE_COMMAND');
+  /* @__PURE__ */ createCommand('PASTE_COMMAND');
 export const REMOVE_TEXT_COMMAND: LexicalCommand<InputEvent | null> =
-  createCommand('REMOVE_TEXT_COMMAND');
+  /* @__PURE__ */ createCommand('REMOVE_TEXT_COMMAND');
 /**
  * Dispatched to delete a word, the payload will be `true` if the deletion is
  * backwards (Ctrl+Backspace or Opt+Delete on macOS), and `false` if
  * forwards (Ctrl+Delete or Fn+Opt+Delete on macOS).
  */
-export const DELETE_WORD_COMMAND: LexicalCommand<boolean> = createCommand(
-  'DELETE_WORD_COMMAND',
-);
+export const DELETE_WORD_COMMAND: LexicalCommand<boolean> =
+  /* @__PURE__ */ createCommand('DELETE_WORD_COMMAND');
 /**
  * Dispatched to delete a line, the payload will be `true` if the deletion is
  * backwards (Cmd+Delete on macOS), and `false` if forwards
  * (Fn+Cmd+Delete on macOS).
  */
-export const DELETE_LINE_COMMAND: LexicalCommand<boolean> = createCommand(
-  'DELETE_LINE_COMMAND',
-);
+export const DELETE_LINE_COMMAND: LexicalCommand<boolean> =
+  /* @__PURE__ */ createCommand('DELETE_LINE_COMMAND');
 /**
  * Dispatched to format the selected text.
  */
 export const FORMAT_TEXT_COMMAND: LexicalCommand<TextFormatType> =
-  createCommand('FORMAT_TEXT_COMMAND');
+  /* @__PURE__ */ createCommand('FORMAT_TEXT_COMMAND');
 /**
  * Dispatched on undo (Cmd+Z on macOS, Ctrl+Z elsewhere).
  */
-export const UNDO_COMMAND: LexicalCommand<void> = createCommand('UNDO_COMMAND');
+export const UNDO_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('UNDO_COMMAND');
 /**
  * Dispatched on redo (Shift+Cmd+Z on macOS, Shift+Ctrl+Z or Ctrl+Y elsewhere).
  */
-export const REDO_COMMAND: LexicalCommand<void> = createCommand('REDO_COMMAND');
+export const REDO_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('REDO_COMMAND');
 /**
  * Dispatched when any key is pressed.
  */
 export const KEY_DOWN_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEYDOWN_COMMAND');
+  /* @__PURE__ */ createCommand('KEYDOWN_COMMAND');
 /**
  * Dispatched when the `'ArrowRight'` key is pressed.
  * The shift modifier key may also be down.
  */
 export const KEY_ARROW_RIGHT_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_ARROW_RIGHT_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_ARROW_RIGHT_COMMAND');
 /**
  * Dispatched when the move to end keyboard shortcut is pressed,
  * (Cmd+Right on macOS; Ctrl+Right elsewhere).
  */
 export const MOVE_TO_END: LexicalCommand<KeyboardEvent> =
-  createCommand('MOVE_TO_END');
+  /* @__PURE__ */ createCommand('MOVE_TO_END');
 /**
  * Dispatched when the `'ArrowLeft'` key is pressed.
  * The shift modifier key may also be down.
  */
 export const KEY_ARROW_LEFT_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_ARROW_LEFT_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_ARROW_LEFT_COMMAND');
 /**
  * Dispatched when the move to start keyboard shortcut is pressed,
  * (Cmd+Left on macOS; Ctrl+Left elsewhere).
  */
 export const MOVE_TO_START: LexicalCommand<KeyboardEvent> =
-  createCommand('MOVE_TO_START');
+  /* @__PURE__ */ createCommand('MOVE_TO_START');
 /**
  * Dispatched when the `'ArrowUp'` key is pressed.
  * The shift and/or alt (option) modifier keys may also be down.
  */
 export const KEY_ARROW_UP_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_ARROW_UP_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_ARROW_UP_COMMAND');
 /**
  * Dispatched when the `'ArrowDown'` key is pressed.
  * The shift and/or alt (option) modifier keys may also be down.
  */
 export const KEY_ARROW_DOWN_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_ARROW_DOWN_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_ARROW_DOWN_COMMAND');
 /**
  * Dispatched when the enter key is pressed, may also be called with a null
  * payload when the intent is to insert a newline. The shift modifier key
  * must be down, any other modifier keys may also be down.
  */
 export const KEY_ENTER_COMMAND: LexicalCommand<KeyboardEvent | null> =
-  createCommand('KEY_ENTER_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_ENTER_COMMAND');
 /**
  * Dispatched whenever the space (`' '`) key is pressed, any modifier
  * keys may be down.
  */
 export const KEY_SPACE_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_SPACE_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_SPACE_COMMAND');
 /**
  * Dispatched whenever the `'Backspace'` key is pressed, the shift
  * modifier key may be down.
  */
 export const KEY_BACKSPACE_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_BACKSPACE_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_BACKSPACE_COMMAND');
 /**
  * Dispatched whenever the `'Escape'` key is pressed, any modifier
  * keys may be down.
  */
 export const KEY_ESCAPE_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_ESCAPE_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_ESCAPE_COMMAND');
 /**
  * Dispatched whenever the `'Delete'` key is pressed (Fn+Delete on macOS).
  */
 export const KEY_DELETE_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_DELETE_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_DELETE_COMMAND');
 /**
  * Dispatched whenever the `'Tab'` key is pressed. The shift modifier key
  * may be down.
  */
 export const KEY_TAB_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_TAB_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_TAB_COMMAND');
 export const INSERT_TAB_COMMAND: LexicalCommand<void> =
-  createCommand('INSERT_TAB_COMMAND');
-export const INDENT_CONTENT_COMMAND: LexicalCommand<void> = createCommand(
-  'INDENT_CONTENT_COMMAND',
-);
-export const OUTDENT_CONTENT_COMMAND: LexicalCommand<void> = createCommand(
-  'OUTDENT_CONTENT_COMMAND',
-);
+  /* @__PURE__ */ createCommand('INSERT_TAB_COMMAND');
+export const INDENT_CONTENT_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('INDENT_CONTENT_COMMAND');
+export const OUTDENT_CONTENT_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('OUTDENT_CONTENT_COMMAND');
 export const DROP_COMMAND: LexicalCommand<DragEvent> =
-  createCommand('DROP_COMMAND');
+  /* @__PURE__ */ createCommand('DROP_COMMAND');
 export const FORMAT_ELEMENT_COMMAND: LexicalCommand<ElementFormatType> =
-  createCommand('FORMAT_ELEMENT_COMMAND');
+  /* @__PURE__ */ createCommand('FORMAT_ELEMENT_COMMAND');
 export const DRAGSTART_COMMAND: LexicalCommand<DragEvent> =
-  createCommand('DRAGSTART_COMMAND');
+  /* @__PURE__ */ createCommand('DRAGSTART_COMMAND');
 export const DRAGOVER_COMMAND: LexicalCommand<DragEvent> =
-  createCommand('DRAGOVER_COMMAND');
+  /* @__PURE__ */ createCommand('DRAGOVER_COMMAND');
 export const DRAGEND_COMMAND: LexicalCommand<DragEvent> =
-  createCommand('DRAGEND_COMMAND');
+  /* @__PURE__ */ createCommand('DRAGEND_COMMAND');
 /**
  * Dispatched on a copy event, either via the clipboard or a KeyboardEvent
  * (Cmd+C on macOS, Ctrl+C elsewhere).
@@ -215,21 +208,19 @@ export const CUT_COMMAND: LexicalCommand<
  * (Cmd+A on macOS, Ctrl+A elsehwere).
  */
 export const SELECT_ALL_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('SELECT_ALL_COMMAND');
-export const CLEAR_EDITOR_COMMAND: LexicalCommand<void> = createCommand(
-  'CLEAR_EDITOR_COMMAND',
-);
-export const CLEAR_HISTORY_COMMAND: LexicalCommand<void> = createCommand(
-  'CLEAR_HISTORY_COMMAND',
-);
+  /* @__PURE__ */ createCommand('SELECT_ALL_COMMAND');
+export const CLEAR_EDITOR_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('CLEAR_EDITOR_COMMAND');
+export const CLEAR_HISTORY_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('CLEAR_HISTORY_COMMAND');
 export const CAN_REDO_COMMAND: LexicalCommand<boolean> =
-  createCommand('CAN_REDO_COMMAND');
+  /* @__PURE__ */ createCommand('CAN_REDO_COMMAND');
 export const CAN_UNDO_COMMAND: LexicalCommand<boolean> =
-  createCommand('CAN_UNDO_COMMAND');
+  /* @__PURE__ */ createCommand('CAN_UNDO_COMMAND');
 export const FOCUS_COMMAND: LexicalCommand<FocusEvent> =
-  createCommand('FOCUS_COMMAND');
+  /* @__PURE__ */ createCommand('FOCUS_COMMAND');
 export const BLUR_COMMAND: LexicalCommand<FocusEvent> =
-  createCommand('BLUR_COMMAND');
+  /* @__PURE__ */ createCommand('BLUR_COMMAND');
 /**
  * @deprecated in v0.31.0, use KEY_DOWN_COMMAND and check for modifiers
  * directly.
@@ -237,4 +228,4 @@ export const BLUR_COMMAND: LexicalCommand<FocusEvent> =
  * Dispatched after any KeyboardEvent when modifiers are pressed
  */
 export const KEY_MODIFIER_COMMAND: LexicalCommand<KeyboardEvent> =
-  createCommand('KEY_MODIFIER_COMMAND');
+  /* @__PURE__ */ createCommand('KEY_MODIFIER_COMMAND');

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -343,7 +343,10 @@ async function build(
       isProd &&
         terser({
           ecma: 2019,
-          format: {ascii_only: true},
+          // Keep /* @__PURE__ */ and @__NO_SIDE_EFFECTS__ annotations in the
+          // prod output so downstream bundlers can tree-shake unused
+          // extension/command/rule definitions out of application bundles.
+          format: {ascii_only: true, preserve_annotations: true},
           module: format === 'esm',
         }),
       {


### PR DESCRIPTION
## Breaking Change

If you have started using the extensions that provide DOMImportExtension rules from v0.45.0, these are all now deprecated and unified with their main extension. For example, the import rules previously defined by `CodeImportExtension` are now defined by `CodeExtension`, so `CodeImportExtension` is now simply an alias. As an `@experimental` API, these compatibility aliases may be removed as soon as v0.47.0. If you had not started using these yet, there are no breaking changes. The motivation for this change is to reduce the amount of configuration required to start using the new DOM import pipeline (e.g. `ClipboardDOMImportExtension` to handle paste or an explicit call to `$generateNodesFromDOMViaExtension`).

## Description

The `DOMImportExtension` pipeline previously required listing a per-package
import extension for every node package, plus the shared core baseline. This
PR makes the import rules implicit — each node-providing extension registers
its own rules — and then makes the repo's tree-shaking annotations actually
work so the implicit rules (and everything else built on the pure factories)
can be dropped from bundles that don't use them.

**1. Import rules ship with the node extensions** (`RichTextExtension`,
`ListExtension`, `LinkExtension`, `TableExtension`, `CodeExtension` each
depend on `CoreImportExtension` + `configExtension(DOMImportExtension,
{rules})`):

- Rules are inert unless the editor routes HTML through the pipeline
  (`ClipboardDOMImportExtension` or `$generateNodesFromDOMViaExtension`);
  the legacy paste path is unchanged.
- The `<hr>` rule moves into `CoreImportRules`, gated on
  `HorizontalRuleNode` registration (mirroring the legacy `importDOM`
  contract), because `@lexical/extension` is upstream of `@lexical/html`
  and cannot register import rules itself.
- `ClipboardDOMImportExtension` now depends on `CoreImportExtension`, so
  the paste on-switch is self-sufficient.
- `RichTextImportExtension` / `ListImportExtension` / `LinkImportExtension`
  / `TableImportExtension` / `CodeImportExtension` /
  `HorizontalRuleImportExtension` remain as deprecated aliases.
- Rule precedence is preserved: configs merge in dependency order, so each
  package's rules sit above the core baseline, and apps control
  cross-package priority by extension order (covered by a new test for
  GitHub code-table vs. `TableExtension`).

**2. Make `@__NO_SIDE_EFFECTS__` effective.** esbuild only honors the
definition annotation for same-file calls (webpack/terser not at all), so
unused extension/command/rule definitions were never tree-shaken. All
module-scope calls to the pure factories now carry call-site
`/* @__PURE__ */` annotations (including argument-position
`configExtension`/`safeCast` calls, which otherwise pin the enclosing
definition), and terser is configured with `format.preserve_annotations`
so the annotations survive into prod dist output.

**3. Keep it that way automatically.** New
`@lexical/internal/require-pure-annotation` ESLint rule (with autofixer)
requires the annotation on module-scope calls to the pure factories;
pre-commit `eslint --fix` inserts them, CI lint backstops. Documented in
`AGENTS.md`.

The dev example, playground, and `serialization/dom-import.md` docs are
updated for the implicit configuration.

## Test plan

### Before

Editor setup required explicit importer wiring:

```ts
dependencies: [
  RichTextExtension, ListExtension, /* … */
  CoreImportExtension,
  RichTextImportExtension,
  ListImportExtension,
  LinkImportExtension,
  TableImportExtension,
  HorizontalRuleImportExtension,
  CodeImportExtension,
  ClipboardDOMImportExtension,
],
```

Unused `defineExtension(...)`/`createCommand(...)` results were retained by
esbuild/webpack consumers; e.g. importing only `$createListNode` from
`@lexical/list` retained `ListExtension`, and ~14 KB minified of unused
clipboard/DOM-import definitions shipped in every rich-text bundle.

### After

```ts
dependencies: [
  RichTextExtension, ListExtension, /* … */
  ClipboardDOMImportExtension,
],
```

- `pnpm run test-unit` — 159 files / 3,774 tests pass (new coverage:
  implicit-rule editors per package, `<hr>` gating, deprecated aliases,
  cross-package rule precedence, ESLint rule fixture tests).
- `pnpm run ci-check` (tsc, Flow, Prettier, ESLint incl. the new rule)
  passes.
- Bundle measurements (esbuild against workspace sources,
  `NODE_ENV=production`, minified/gzip):
  - Importing only `$createListNode`: unchanged (unused extensions now
    fully tree-shaken).
  - Editor already using the pipeline: −0.3 KB minified.
  - Rich-text editor not using the pipeline: net +0.2 KB gzip vs. `main`
    (implicit rules cost ~5 KB gzip, offset by ~4.7 KB recovered from the
    tree-shaking fix); typical multi-feature editor: net +1.3 KB gzip.