### PR TITLE
[lexical-rich-text][lexical-plain-text] Spec hardening: call event.preventDefault() in dragover for HTML5 DnD compliance

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -415,6 +415,8 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     editor.registerCommand<DragEvent>(
       DRAGOVER_COMMAND,
       event => {
+        // Files check is inlined (rather than using eventFiles() from
+        // @lexical/rich-text) because plain-text cannot import from rich-text.
         const dataTransfer = event.dataTransfer;
         if (dataTransfer !== null && dataTransfer.types.includes('Files')) {
           return false;

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -23,7 +23,7 @@ import {
   $moveCharacter,
   $shouldOverrideDefaultCharacterSelection,
 } from '@lexical/selection';
-import {mergeRegister, objectKlassEquals} from '@lexical/utils';
+import {eventFiles, mergeRegister, objectKlassEquals} from '@lexical/utils';
 import {
   $getSelection,
   $isRangeSelection,
@@ -415,10 +415,8 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     editor.registerCommand<DragEvent>(
       DRAGOVER_COMMAND,
       event => {
-        // Files check is inlined (rather than using eventFiles() from
-        // @lexical/rich-text) because plain-text cannot import from rich-text.
-        const dataTransfer = event.dataTransfer;
-        if (dataTransfer !== null && dataTransfer.types.includes('Files')) {
+        const [isFileTransfer] = eventFiles(event);
+        if (isFileTransfer) {
           return false;
         }
         // contenteditable is not a native drop target; preventDefault() is

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -38,6 +38,7 @@ import {
   DELETE_CHARACTER_COMMAND,
   DELETE_LINE_COMMAND,
   DELETE_WORD_COMMAND,
+  DRAGOVER_COMMAND,
   DRAGSTART_COMMAND,
   DROP_COMMAND,
   INSERT_LINE_BREAK_COMMAND,
@@ -409,6 +410,20 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     editor.registerCommand<DragEvent>(
       DROP_COMMAND,
       event => $handlePlainTextDrop(event, editor),
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand<DragEvent>(
+      DRAGOVER_COMMAND,
+      event => {
+        const dataTransfer = event.dataTransfer;
+        if (dataTransfer !== null && dataTransfer.types.includes('Files')) {
+          return false;
+        }
+        // contenteditable is not a native drop target; preventDefault() is
+        // required on dragover to allow the drop event to fire in Firefox.
+        event.preventDefault();
+        return true;
+      },
       COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand<DragEvent>(

--- a/packages/lexical-playground/__tests__/e2e/TextDragDrop.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextDragDrop.spec.mjs
@@ -14,6 +14,7 @@ import {
 import {
   assertHTML,
   evaluate,
+  expect,
   focusEditor,
   html,
   initialize,
@@ -151,6 +152,30 @@ test.describe('Text drag and drop', () => {
         </p>
       `,
     );
+  });
+
+  test('dragover calls event.preventDefault() for text drags', async ({
+    page,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    await focusEditor(page);
+    await page.keyboard.type('hello world');
+
+    const defaultPrevented = await evaluate(page, () => {
+      const editable = document.querySelector('[contenteditable="true"]');
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/plain', 'hello');
+      const event = new DragEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      });
+      editable.dispatchEvent(event);
+      return event.defaultPrevented;
+    });
+
+    expect(defaultPrevented).toBe(true);
   });
 
   test('moves a selected word forward within the same block (plain text)', async ({

--- a/packages/lexical-playground/__tests__/e2e/TextDragDrop.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextDragDrop.spec.mjs
@@ -14,7 +14,6 @@ import {
 import {
   assertHTML,
   evaluate,
-  expect,
   focusEditor,
   html,
   initialize,
@@ -54,6 +53,19 @@ async function dragSelectionToOffset(page, sourceText, clientTextOffset) {
           dataTransfer,
         }),
       );
+      const dragoverEvent = new DragEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        clientX,
+        clientY,
+        dataTransfer,
+      });
+      editable.dispatchEvent(dragoverEvent);
+      if (!dragoverEvent.defaultPrevented) {
+        throw new Error(
+          'dragover was not prevented; drop will not fire in Firefox',
+        );
+      }
       editable.dispatchEvent(
         new DragEvent('drop', {
           bubbles: true,
@@ -152,30 +164,6 @@ test.describe('Text drag and drop', () => {
         </p>
       `,
     );
-  });
-
-  test('dragover calls event.preventDefault() for text drags', async ({
-    page,
-    isCollab,
-  }) => {
-    test.skip(isCollab);
-    await focusEditor(page);
-    await page.keyboard.type('hello world');
-
-    const defaultPrevented = await evaluate(page, () => {
-      const editable = document.querySelector('[contenteditable="true"]');
-      const dataTransfer = new DataTransfer();
-      dataTransfer.setData('text/plain', 'hello');
-      const event = new DragEvent('dragover', {
-        bubbles: true,
-        cancelable: true,
-        dataTransfer,
-      });
-      editable.dispatchEvent(event);
-      return event.defaultPrevented;
-    });
-
-    expect(defaultPrevented).toBe(true);
   });
 
   test('moves a selected word forward within the same block (plain text)', async ({

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1248,17 +1248,6 @@ export function registerRichText(
         // contenteditable is not a native drop target; preventDefault() is
         // required on dragover to allow the drop event to fire in Firefox.
         event.preventDefault();
-        const x = event.clientX;
-        const y = event.clientY;
-        const eventRange = caretFromPoint(x, y);
-        if (eventRange !== null) {
-          const node = $getNearestNodeFromDOMNode(eventRange.node);
-          if ($isDecoratorNode(node)) {
-            // Show browser caret as the user is dragging the media across the screen. Won't work
-            // for DecoratorNode nor it's relevant.
-            event.preventDefault();
-          }
-        }
         return true;
       },
       COMMAND_PRIORITY_EDITOR,

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1245,6 +1245,9 @@ export function registerRichText(
         if (isFileTransfer && !$isRangeSelection(selection)) {
           return false;
         }
+        // contenteditable is not a native drop target; preventDefault() is
+        // required on dragover to allow the drop event to fire in Firefox.
+        event.preventDefault();
         const x = event.clientX;
         const y = event.clientY;
         const eventRange = caretFromPoint(x, y);

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -20,7 +20,6 @@ import type {
   NodeKey,
   NodeSelection,
   ParagraphNode,
-  PasteCommandType,
   RangeSelection,
   SerializedElementNode,
   Spread,
@@ -47,6 +46,7 @@ import {
   $getNearestBlockElementAncestorOrThrow,
   $handleIndentAndOutdent,
   addClassNamesToElement,
+  eventFiles,
   isHTMLElement,
   mergeRegister,
   objectKlassEquals,
@@ -513,29 +513,7 @@ async function onCutForRichText(
   );
 }
 
-// Clipboard may contain files that we aren't allowed to read. While the event is arguably useless,
-// in certain occasions, we want to know whether it was a file transfer, as opposed to text. We
-// control this with the first boolean flag.
-export function eventFiles(
-  event: DragEvent | PasteCommandType,
-): [boolean, File[], boolean] {
-  let dataTransfer: null | DataTransfer = null;
-  if (objectKlassEquals(event, DragEvent)) {
-    dataTransfer = event.dataTransfer;
-  } else if (objectKlassEquals(event, ClipboardEvent)) {
-    dataTransfer = event.clipboardData;
-  }
-
-  if (dataTransfer === null) {
-    return [false, [], false];
-  }
-
-  const types = dataTransfer.types;
-  const hasFiles = types.includes('Files');
-  const hasContent =
-    types.includes('text/html') || types.includes('text/plain');
-  return [hasFiles, Array.from(dataTransfer.files), hasContent];
-}
+export {eventFiles} from '@lexical/utils';
 
 function $isTargetWithinDecorator(target: HTMLElement): boolean {
   const node = $getNearestNodeFromDOMNode(target);

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -63,6 +63,7 @@ import {
   makeStepwiseIterator,
   type NodeCaret,
   type NodeKey,
+  type PasteCommandType,
   PointCaret,
   type RangeSelection,
   type SiblingCaret,
@@ -689,6 +690,30 @@ export function objectKlassEquals<T>(
   return object !== null
     ? Object.getPrototypeOf(object).constructor.name === objectClass.name
     : false;
+}
+
+// Clipboard may contain files that we aren't allowed to read. While the event is arguably useless,
+// in certain occasions, we want to know whether it was a file transfer, as opposed to text. We
+// control this with the first boolean flag.
+export function eventFiles(
+  event: DragEvent | PasteCommandType,
+): [boolean, File[], boolean] {
+  let dataTransfer: null | DataTransfer = null;
+  if (objectKlassEquals(event, DragEvent)) {
+    dataTransfer = event.dataTransfer;
+  } else if (objectKlassEquals(event, ClipboardEvent)) {
+    dataTransfer = event.clipboardData;
+  }
+
+  if (dataTransfer === null) {
+    return [false, [], false];
+  }
+
+  const types = dataTransfer.types;
+  const hasFiles = types.includes('Files');
+  const hasContent =
+    types.includes('text/html') || types.includes('text/plain');
+  return [hasFiles, Array.from(dataTransfer.files), hasContent];
 }
 
 /**


### PR DESCRIPTION
## Description

Per the HTML5 DnD spec, an element must call `event.preventDefault()` in its`dragover` handler to signal that it accepts drops. The native auto-accept exception applies only to `<textarea>` and `<input type="text">`, not to
`contenteditable` divs.

The user-visible drag-and-drop failure (#8014) was already fixed by #8373, which rewired the `DROP_COMMAND` handler to actually process the drop. Before #8373 the handler returned `true` without doing anything, so text never moved regardless of browser.

This PR hardens the dragover layer to match the spec:

- `registerRichText`: add unconditional `event.preventDefault()` after the existing file-transfer guard in `DRAGOVER_COMMAND`. The decorator-specific call that was already there is now removed as redundant.
- `registerPlainText`: add a new `DRAGOVER_COMMAND` handler with a file-transfer guard followed by `event.preventDefault()`.

The change is safe and correct on all current browsers. It also guards against a future Firefox version enforcing the spec strictly, which would silently break drag-and-drop again.

Related: #8014