### PR TITLE
[lexical-dragon] Bug Fix: Handle makeChanges messages and the listener registration race

### DIFF
--- a/packages/lexical-dragon/README.md
+++ b/packages/lexical-dragon/README.md
@@ -2,6 +2,42 @@
 
 [![See API Documentation](https://lexical.dev/img/see-api-documentation.svg)](https://lexical.dev/docs/api/modules/lexical_dragon)
 
-This package contains compatibility with Dragon NaturallySpeaking accessibility tools.
+This package adds compatibility with Dragon NaturallySpeaking, a speech
+recognition tool whose web extension drives editable fields through window
+messages. The handler applies those edits through Lexical APIs and stops the
+messages from reaching the extension's own handler, which would otherwise
+edit the DOM directly behind Lexical's back.
 
-More documentation coming soon.
+Editors register automatically through `DragonExtension` (a dependency of
+`@lexical/rich-text` and `@lexical/plain-text` extensions) or by calling
+`registerDragonSupport(editor)`.
+
+## Registering early
+
+Browsers invoke a window's message listeners in registration order, and the
+Dragon extension's content script registers its listener at `document_end`
+of the initial page load. Editors that mount later (after a navigation in a
+single page app, in a dialog, in any lazily rendered view) register their
+handler after the extension's, too late to block it, and edits end up
+applied twice.
+
+To win that race, call `installDragonSupport()` synchronously from every
+entrypoint that may render an editor lazily, so the shared listener is
+registered before the extension's:
+
+```js
+import {installDragonSupport} from '@lexical/dragon';
+
+installDragonSupport();
+```
+
+It returns a teardown function; the listener is removed once every teardown
+(including the ones from `registerDragonSupport`) has been called.
+
+For editors mounted inside iframes, pass the iframe's window so the
+listener is installed against the right one. State is kept per window,
+so multiple frames can coexist:
+
+```js
+installDragonSupport(iframe.contentWindow);
+```

--- a/packages/lexical-dragon/flow/LexicalDragon.js.flow
+++ b/packages/lexical-dragon/flow/LexicalDragon.js.flow
@@ -9,6 +9,7 @@
 import type {LexicalEditor, LexicalExtension} from 'lexical';
 import type {NamedSignalsOutput} from '@lexical/extension';
 import {$getSelection, $isRangeSelection, $isTextNode} from 'lexical';
+declare export function installDragonSupport(): () => void;
 declare export function registerDragonSupport(
   editor: LexicalEditor,
 ): () => void;

--- a/packages/lexical-dragon/flow/LexicalDragon.js.flow
+++ b/packages/lexical-dragon/flow/LexicalDragon.js.flow
@@ -9,7 +9,7 @@
 import type {LexicalEditor, LexicalExtension} from 'lexical';
 import type {NamedSignalsOutput} from '@lexical/extension';
 import {$getSelection, $isRangeSelection, $isTextNode} from 'lexical';
-declare export function installDragonSupport(): () => void;
+declare export function installDragonSupport(targetWindow?: typeof globalThis.window): () => void;
 declare export function registerDragonSupport(
   editor: LexicalEditor,
 ): () => void;

--- a/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
+++ b/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {DragonExtension, installDragonSupport} from '@lexical/dragon';
 import {buildEditorFromExtensions} from '@lexical/extension';
 import {
   $createParagraphNode,
@@ -18,8 +19,6 @@ import {
   defineExtension,
 } from 'lexical';
 import {assert, describe, expect, test} from 'vitest';
-
-import {DragonExtension, installDragonSupport} from '../../index';
 
 function setUpEditor() {
   return buildEditorFromExtensions(

--- a/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
+++ b/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isParagraphNode,
+  $isRangeSelection,
+  $isTextNode,
+  defineExtension,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+import {DragonExtension} from '../../index';
+
+function setUpEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: () => {
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('Hello world')),
+        );
+      },
+      dependencies: [DragonExtension],
+      name: 'dragon-test',
+      register: editor => {
+        const rootElement = document.createElement('div');
+        rootElement.setAttribute('contenteditable', 'true');
+        rootElement.tabIndex = 0;
+        document.body.appendChild(rootElement);
+        editor.setRootElement(rootElement);
+        rootElement.focus();
+        return () => rootElement.remove();
+      },
+    }),
+  );
+}
+
+function $selectStartOfFirstTextNode() {
+  const paragraph = $getRoot().getFirstChild();
+  assert($isParagraphNode(paragraph));
+  const textNode = paragraph.getFirstChild();
+  assert($isTextNode(textNode));
+  textNode.select(0, 0);
+}
+
+// The Dragon NaturallySpeaking web extension sends makeChanges messages with
+// args [elementStart, elementLength, text, selStart, selLength]. A text of -1
+// (a number, not a string) means "change the selection without touching the
+// text", which is how Select-and-Say corrections and cursor moves by voice
+// arrive.
+function dispatchMakeChanges(args: unknown): void {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: JSON.stringify({
+        payload: {args, functionId: 'makeChanges'},
+        protocol: 'nuanria_messaging',
+        type: 'request',
+      }),
+      origin: window.location.origin,
+    }),
+  );
+}
+
+describe('DragonExtension', () => {
+  test('replaces the addressed range on makeChanges', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, 'Howdy', 5, 0]);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Howdy world');
+    });
+  });
+
+  test('moves the selection without touching the text when text is -1', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, -1, 6, 5]);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Hello world');
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.anchor.offset).toBe(6);
+      expect(selection.focus.offset).toBe(11);
+    });
+  });
+
+  test('applies a correction after a selection-only makeChanges', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, -1, 0, 5]);
+    dispatchMakeChanges([0, 5, 'Howdy', 5, 0]);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Howdy world');
+    });
+  });
+
+  test('collapses a final selection whose end precedes its start', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, -1, 8, -3]);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Hello world');
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.anchor.offset).toBe(8);
+      expect(selection.focus.offset).toBe(8);
+    });
+  });
+
+  test('collapses a final selection with negative offsets', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, -1, -5, 100]);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Hello world');
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.anchor.offset).toBe(0);
+      expect(selection.focus.offset).toBe(0);
+    });
+  });
+
+  test('ignores malformed makeChanges payloads', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges('garbage');
+    dispatchMakeChanges({blockStart: 4});
+    dispatchMakeChanges(['4', '9', 'Hi', 0, 0]);
+    dispatchMakeChanges([0, 5, 5, 0, 0]);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Hello world');
+    });
+  });
+});

--- a/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
+++ b/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
@@ -53,10 +53,11 @@ function $selectStartOfFirstTextNode() {
 }
 
 // The Dragon NaturallySpeaking web extension sends makeChanges messages with
-// args [elementStart, elementLength, text, selStart, selLength]. A text of -1
-// (a number, not a string) means "change the selection without touching the
-// text", which is how Select-and-Say corrections and cursor moves by voice
-// arrive.
+// args [elementStart, elementLength, text, selStart, selLength, formatCommand].
+// A text of -1 (a number, not a string) means "change the selection without
+// touching the text", which is how Select-and-Say corrections and cursor moves
+// by voice arrive. The optional sixth argument carries an execCommand name
+// (bold, italic, underline, ...) for voice commands such as "bold that".
 function dispatchMakeChanges(args: unknown): void {
   window.dispatchEvent(
     new MessageEvent('message', {
@@ -150,6 +151,54 @@ describe('DragonExtension', () => {
 
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('Hello world');
+    });
+  });
+
+  test('formats the final selection when formatCommand is present', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, -1, 0, 5, 'bold']);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Hello world');
+      const paragraph = $getRoot().getFirstChild();
+      assert($isParagraphNode(paragraph));
+      const textNode = paragraph.getFirstChild();
+      assert($isTextNode(textNode));
+      expect(textNode.getTextContent()).toBe('Hello');
+      expect(textNode.hasFormat('bold')).toBe(true);
+    });
+  });
+
+  test('does not toggle format when the final selection is collapsed', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, -1, 20, 5, 'bold']);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Hello world');
+      const selection = $getSelection();
+      assert($isRangeSelection(selection));
+      expect(selection.format).toBe(0);
+    });
+  });
+
+  test('ignores unknown formatCommand values', () => {
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, -1, 0, 5, 'fontName']);
+    dispatchMakeChanges([0, 5, -1, 0, 5, 'toString']);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Hello world');
+      const paragraph = $getRoot().getFirstChild();
+      assert($isParagraphNode(paragraph));
+      const textNode = paragraph.getFirstChild();
+      assert($isTextNode(textNode));
+      expect(textNode.getFormat()).toBe(0);
     });
   });
 });

--- a/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
+++ b/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
@@ -19,7 +19,7 @@ import {
 } from 'lexical';
 import {assert, describe, expect, test} from 'vitest';
 
-import {DragonExtension} from '../../index';
+import {DragonExtension, installDragonSupport} from '../../index';
 
 function setUpEditor() {
   return buildEditorFromExtensions(
@@ -72,6 +72,61 @@ function dispatchMakeChanges(args: unknown): void {
 }
 
 describe('DragonExtension', () => {
+  test('installDragonSupport at the entrypoint wins the registration race', () => {
+    const uninstall = installDragonSupport();
+    const extensionEdits: Array<unknown> = [];
+    const extensionListener = (event: MessageEvent) => {
+      extensionEdits.push(event.data);
+    };
+    window.addEventListener('message', extensionListener);
+    try {
+      using editor = setUpEditor();
+      editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+      dispatchMakeChanges([0, 5, 'Howdy', 5, 0]);
+
+      editor.read(() => {
+        expect($getRoot().getTextContent()).toBe('Howdy world');
+      });
+      // stopImmediatePropagation kept the message from the extension's
+      // listener even though the editor mounted after it
+      expect(extensionEdits).toEqual([]);
+    } finally {
+      window.removeEventListener('message', extensionListener);
+      uninstall();
+    }
+  });
+
+  test('dispatches to the focused editor', () => {
+    using first = setUpEditor();
+    using second = setUpEditor();
+    second.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, 'Howdy', 5, 0]);
+
+    first.read(() => {
+      expect($getRoot().getTextContent()).toBe('Hello world');
+    });
+    second.read(() => {
+      expect($getRoot().getTextContent()).toBe('Howdy world');
+    });
+  });
+
+  test('keeps working for editors created after others are disposed', () => {
+    {
+      using disposed = setUpEditor();
+      void disposed;
+    }
+    using editor = setUpEditor();
+    editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+    dispatchMakeChanges([0, 5, 'Howdy', 5, 0]);
+
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('Howdy world');
+    });
+  });
+
   test('replaces the addressed range on makeChanges', () => {
     using editor = setUpEditor();
     editor.update($selectStartOfFirstTextNode, {discrete: true});
@@ -200,5 +255,72 @@ describe('DragonExtension', () => {
       assert($isTextNode(textNode));
       expect(textNode.getFormat()).toBe(0);
     });
+  });
+
+  test('handles editors mounted inside an iframe', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    const iframeWindow = iframe.contentWindow;
+    assert(iframeWindow !== null);
+    const iframeDocument = iframeWindow.document;
+    iframeDocument.open();
+    iframeDocument.write('<!doctype html><html><body></body></html>');
+    iframeDocument.close();
+
+    const uninstall = installDragonSupport(iframeWindow);
+    const topEdits: Array<unknown> = [];
+    const topListener = (event: MessageEvent) => topEdits.push(event.data);
+    window.addEventListener('message', topListener);
+    try {
+      const editor = buildEditorFromExtensions(
+        defineExtension({
+          $initialEditorState: () => {
+            $getRoot().append(
+              $createParagraphNode().append($createTextNode('Hello world')),
+            );
+          },
+          dependencies: [DragonExtension],
+          name: 'dragon-iframe-test',
+          register: theEditor => {
+            const rootElement = iframeDocument.createElement('div');
+            rootElement.setAttribute('contenteditable', 'true');
+            rootElement.tabIndex = 0;
+            iframeDocument.body.appendChild(rootElement);
+            theEditor.setRootElement(rootElement);
+            rootElement.focus();
+            return () => rootElement.remove();
+          },
+        }),
+      );
+      try {
+        editor.update($selectStartOfFirstTextNode, {discrete: true});
+
+        iframeWindow.dispatchEvent(
+          new MessageEvent('message', {
+            data: JSON.stringify({
+              payload: {
+                args: [0, 5, 'Howdy', 5, 0],
+                functionId: 'makeChanges',
+              },
+              protocol: 'nuanria_messaging',
+              type: 'request',
+            }),
+            origin: iframeWindow.location.origin,
+          }),
+        );
+
+        editor.read(() => {
+          expect($getRoot().getTextContent()).toBe('Howdy world');
+        });
+        // The top window's listener never saw the iframe's message
+        expect(topEdits).toEqual([]);
+      } finally {
+        editor.dispose();
+      }
+    } finally {
+      window.removeEventListener('message', topListener);
+      uninstall();
+      iframe.remove();
+    }
   });
 });

--- a/packages/lexical-dragon/src/index.ts
+++ b/packages/lexical-dragon/src/index.ts
@@ -49,7 +49,7 @@ export function registerDragonSupport(editor: LexicalEditor): () => void {
         if (payload && payload.functionId === 'makeChanges') {
           const args = payload.args;
 
-          if (args) {
+          if (Array.isArray(args)) {
             const [
               elementStart,
               elementLength,
@@ -60,6 +60,14 @@ export function registerDragonSupport(editor: LexicalEditor): () => void {
             ] = args;
             // TODO: we should probably handle formatCommand somehow?
             // formatCommand;
+            if (
+              ![elementStart, elementLength, selStart, selLength].every(
+                Number.isFinite,
+              ) ||
+              (typeof text !== 'string' && text !== -1)
+            ) {
+              return;
+            }
             editor.update(() => {
               const selection = $getSelection();
 
@@ -84,25 +92,31 @@ export function registerDragonSupport(editor: LexicalEditor): () => void {
                   }
                 }
 
-                if (setSelStart !== setSelEnd || text !== '') {
+                // Dragon sends -1 (a number, not a string) as text for
+                // selection-only changes, such as Select-and-Say
+                // corrections and cursor moves by voice
+                if (
+                  typeof text === 'string' &&
+                  (setSelStart !== setSelEnd || text !== '')
+                ) {
                   selection.insertRawText(text);
                   anchorNode = anchor.getNode();
                 }
 
                 if ($isTextNode(anchorNode)) {
                   // set final selection
-                  setSelStart = selStart;
-                  setSelEnd = selStart + selLength;
                   const anchorNodeTextLength = anchorNode.getTextContentSize();
-                  // If the offset is more than the end, make it the end
-                  setSelStart =
-                    setSelStart > anchorNodeTextLength
-                      ? anchorNodeTextLength
-                      : setSelStart;
+                  // Clamp to the text size. Negative offsets have no meaning
+                  // in the protocol, so they collapse the selection instead
+                  // of leaving a range the next input would replace
+                  setSelStart = Math.min(
+                    Math.max(selStart, 0),
+                    anchorNodeTextLength,
+                  );
                   setSelEnd =
-                    setSelEnd > anchorNodeTextLength
-                      ? anchorNodeTextLength
-                      : setSelEnd;
+                    selStart < 0 || selLength < 0
+                      ? setSelStart
+                      : Math.min(selStart + selLength, anchorNodeTextLength);
                   selection.setTextNodeRange(
                     anchorNode,
                     setSelStart,

--- a/packages/lexical-dragon/src/index.ts
+++ b/packages/lexical-dragon/src/index.ts
@@ -14,7 +14,17 @@ import {
   defineExtension,
   LexicalEditor,
   safeCast,
+  TextFormatType,
 } from 'lexical';
+
+const TEXT_FORMAT_BY_EXEC_COMMAND = new Map<string, TextFormatType>([
+  ['bold', 'bold'],
+  ['italic', 'italic'],
+  ['strikeThrough', 'strikethrough'],
+  ['subscript', 'subscript'],
+  ['superscript', 'superscript'],
+  ['underline', 'underline'],
+]);
 
 export function registerDragonSupport(editor: LexicalEditor): () => void {
   const origin = window.location.origin;
@@ -56,10 +66,8 @@ export function registerDragonSupport(editor: LexicalEditor): () => void {
               text,
               selStart,
               selLength,
-              _formatCommand,
+              formatCommand,
             ] = args;
-            // TODO: we should probably handle formatCommand somehow?
-            // formatCommand;
             if (
               ![elementStart, elementLength, selStart, selLength].every(
                 Number.isFinite,
@@ -123,6 +131,20 @@ export function registerDragonSupport(editor: LexicalEditor): () => void {
                     anchorNode,
                     setSelEnd,
                   );
+                }
+
+                // format the selection, e.g. for the "bold that" voice
+                // command. Dragon's extension applies this through
+                // document.execCommand, so the values are execCommand names.
+                if (
+                  typeof formatCommand === 'string' &&
+                  selLength > 0 &&
+                  !selection.isCollapsed()
+                ) {
+                  const format = TEXT_FORMAT_BY_EXEC_COMMAND.get(formatCommand);
+                  if (format !== undefined) {
+                    selection.formatText(format);
+                  }
                 }
 
                 // block the chrome extension from handling this event

--- a/packages/lexical-dragon/src/index.ts
+++ b/packages/lexical-dragon/src/index.ts
@@ -6,39 +6,48 @@
  *
  */
 
-import {effect, namedSignals} from '@lexical/extension';
+import {effect, namedSignals, watchedSignal} from '@lexical/extension';
 import {
   $getSelection,
   $isRangeSelection,
   $isTextNode,
   defineExtension,
+  getEditorPropertyFromDOMNode,
+  isLexicalEditor,
   LexicalEditor,
   safeCast,
   TextFormatType,
 } from 'lexical';
 
-const TEXT_FORMAT_BY_EXEC_COMMAND = new Map<string, TextFormatType>([
-  ['bold', 'bold'],
-  ['italic', 'italic'],
-  ['strikeThrough', 'strikethrough'],
-  ['subscript', 'subscript'],
-  ['superscript', 'superscript'],
-  ['underline', 'underline'],
-]);
-
-interface WindowState {
-  editors: Set<LexicalEditor>;
-  installCount: number;
-  removeListener: (() => void) | null;
+interface WithWindowState {
+  [WINDOW_STATE_KEY]?: WindowState | undefined;
 }
 
-const windowStates = new Map<Window, WindowState>();
+const TEXT_FORMAT_BY_EXEC_COMMAND: {readonly [K in string]?: TextFormatType} = {
+  bold: 'bold',
+  italic: 'italic',
+  strikeThrough: 'strikethrough',
+  subscript: 'subscript',
+  superscript: 'superscript',
+  underline: 'underline',
+};
 
-function getOrCreateWindowState(targetWindow: Window): WindowState {
-  let state = windowStates.get(targetWindow);
+const WINDOW_STATE_KEY = Symbol.for('@lexical/dragon/WindowState');
+type InstallKey = symbol;
+
+interface WindowState {
+  editors: Map<LexicalEditor, Set<InstallKey>>;
+  installs: Set<InstallKey>;
+  dispose: () => void;
+}
+
+function getOrCreateWindowState(
+  targetWindow: Window & WithWindowState,
+): WindowState {
+  let state = targetWindow[WINDOW_STATE_KEY];
   if (state === undefined) {
-    state = {editors: new Set(), installCount: 0, removeListener: null};
-    windowStates.set(targetWindow, state);
+    state = {dispose: () => {}, editors: new Map(), installs: new Set()};
+    targetWindow[WINDOW_STATE_KEY] = state;
   }
   return state;
 }
@@ -71,87 +80,99 @@ function defaultWindow(): Window | undefined {
  * teardown for it (including the ones returned by
  * {@link registerDragonSupport}) has been called.
  */
-export function installDragonSupport(targetWindow?: Window): () => void {
-  const win = targetWindow ?? defaultWindow();
-  if (win === undefined) {
-    return () => {};
+export function installDragonSupport(
+  targetWindow: undefined | Window = defaultWindow(),
+): () => void {
+  return targetWindow
+    ? addInstall(
+        targetWindow,
+        Symbol('@lexical/dragon/globalInstall'),
+        undefined,
+      )
+    : () => {};
+}
+
+function addInstall(
+  targetWindow: Window,
+  installKey: InstallKey,
+  editor: undefined | LexicalEditor,
+): () => void {
+  const state = getOrCreateWindowState(targetWindow);
+  if (state.installs.size === 0) {
+    const boundHandleMessage = handleMessage.bind(targetWindow);
+    targetWindow.addEventListener('message', boundHandleMessage, true);
+    state.dispose = () => {
+      targetWindow.removeEventListener('message', boundHandleMessage, true);
+    };
   }
-  const state = getOrCreateWindowState(win);
-  state.installCount++;
-  if (state.removeListener === null) {
-    const handler = (event: MessageEvent) => handleMessage(event, win);
-    win.addEventListener('message', handler, true);
-    state.removeListener = () =>
-      win.removeEventListener('message', handler, true);
+  state.installs.add(installKey);
+  if (editor) {
+    const installSet = state.editors.get(editor) || new Set();
+    installSet.add(installKey);
+    state.editors.set(editor, installSet);
   }
-  let removed = false;
-  return () => {
-    if (removed) {
-      return;
+  return removeInstall.bind(null, targetWindow, state, installKey, editor);
+}
+
+function removeInstall(
+  targetWindow: Window & WithWindowState,
+  state: WindowState,
+  installKey: InstallKey,
+  editor?: LexicalEditor,
+): void {
+  if (editor) {
+    const installSet = state.editors.get(editor);
+    if (installSet && installSet.delete(installKey) && installSet.size === 0) {
+      state.editors.delete(editor);
     }
-    removed = true;
-    state.installCount--;
-    if (state.installCount === 0 && state.removeListener !== null) {
-      state.removeListener();
-      state.removeListener = null;
-      windowStates.delete(win);
-    }
-  };
+  }
+  if (state.installs.delete(installKey) && state.installs.size === 0) {
+    state.dispose();
+    delete targetWindow[WINDOW_STATE_KEY];
+  }
+}
+
+function getDefaultView(el: HTMLElement | null): Window | null {
+  return el && el.ownerDocument.defaultView;
 }
 
 export function registerDragonSupport(editor: LexicalEditor): () => void {
-  let registeredWindow: Window | null = null;
-  let uninstall: (() => void) | null = null;
-
-  const detach = () => {
-    if (registeredWindow !== null) {
-      const state = windowStates.get(registeredWindow);
-      if (state !== undefined) {
-        state.editors.delete(editor);
-      }
-      registeredWindow = null;
+  const windowSignal = watchedSignal(
+    () => getDefaultView(editor.getRootElement()),
+    self =>
+      editor.registerRootListener(rootElement => {
+        self.value = getDefaultView(rootElement);
+      }),
+  );
+  return effect(() => {
+    const targetWindow = windowSignal.value;
+    if (targetWindow) {
+      return addInstall(
+        targetWindow,
+        Symbol('@lexical/dragon/editorInstall'),
+        editor,
+      );
     }
-    if (uninstall !== null) {
-      uninstall();
-      uninstall = null;
-    }
-  };
-
-  const unregisterRoot = editor.registerRootListener(rootElement => {
-    detach();
-    if (rootElement === null) {
-      return;
-    }
-    const targetWindow = rootElement.ownerDocument.defaultView;
-    if (targetWindow === null) {
-      return;
-    }
-    registeredWindow = targetWindow;
-    getOrCreateWindowState(targetWindow).editors.add(editor);
-    uninstall = installDragonSupport(targetWindow);
   });
-
-  return () => {
-    detach();
-    unregisterRoot();
-  };
 }
 
-function getFocusedEditor(targetWindow: Window): LexicalEditor | null {
-  const state = windowStates.get(targetWindow);
+function getFocusedEditor(
+  targetWindow: Window & WithWindowState,
+): LexicalEditor | null {
+  const state = targetWindow[WINDOW_STATE_KEY];
   if (state === undefined) {
     return null;
   }
-  const activeElement = targetWindow.document.activeElement;
-  for (const editor of state.editors) {
-    if (editor.getRootElement() === activeElement) {
-      return editor;
-    }
-  }
-  return null;
+  const activeEditor = getEditorPropertyFromDOMNode(
+    targetWindow.document.activeElement,
+  );
+  return isLexicalEditor(activeEditor) && state.editors.has(activeEditor)
+    ? activeEditor
+    : null;
 }
 
-function handleMessage(event: MessageEvent, targetWindow: Window): void {
+function handleMessage(this: Window, event: MessageEvent): void {
+  const targetWindow = this;
   if (event.origin !== targetWindow.location.origin) {
     return;
   }
@@ -264,7 +285,7 @@ function handleMessage(event: MessageEvent, targetWindow: Window): void {
                 selLength > 0 &&
                 !selection.isCollapsed()
               ) {
-                const format = TEXT_FORMAT_BY_EXEC_COMMAND.get(formatCommand);
+                const format = TEXT_FORMAT_BY_EXEC_COMMAND[formatCommand];
                 if (format !== undefined) {
                   selection.formatText(format);
                 }

--- a/packages/lexical-dragon/src/index.ts
+++ b/packages/lexical-dragon/src/index.ts
@@ -26,105 +26,194 @@ const TEXT_FORMAT_BY_EXEC_COMMAND = new Map<string, TextFormatType>([
   ['underline', 'underline'],
 ]);
 
+interface WindowState {
+  editors: Set<LexicalEditor>;
+  installCount: number;
+  removeListener: (() => void) | null;
+}
+
+const windowStates = new Map<Window, WindowState>();
+
+function getOrCreateWindowState(targetWindow: Window): WindowState {
+  let state = windowStates.get(targetWindow);
+  if (state === undefined) {
+    state = {editors: new Set(), installCount: 0, removeListener: null};
+    windowStates.set(targetWindow, state);
+  }
+  return state;
+}
+
+function defaultWindow(): Window | undefined {
+  return typeof window !== 'undefined' ? window : undefined;
+}
+
+/**
+ * Install the shared window listener that handles Dragon NaturallySpeaking's
+ * web extension messages for every registered editor in the given window.
+ *
+ * Browsers invoke a window's message listeners in registration order, and
+ * the extension's content script registers its own listener at document_end
+ * of the initial page load. {@link registerDragonSupport} installs this
+ * listener lazily, when an editor's root element is mounted, which loses
+ * that race whenever editors mount after the initial load (a navigation in
+ * a single page app, a dialog, any lazily rendered field). The extension
+ * then edits the DOM directly before Lexical can stopImmediatePropagation,
+ * and the edit is applied twice.
+ *
+ * Call this synchronously from every entrypoint that may render an editor
+ * lazily, before document_end, so the listener is ahead of the extension's
+ * and editors win the race no matter when they mount.
+ *
+ * Pass `targetWindow` to install the listener on a window other than the
+ * global one (for example, an editor mounted inside an iframe). When
+ * omitted, defaults to the current `window` when available. Returns a
+ * teardown function; the listener for a window is removed once every
+ * teardown for it (including the ones returned by
+ * {@link registerDragonSupport}) has been called.
+ */
+export function installDragonSupport(targetWindow?: Window): () => void {
+  const win = targetWindow ?? defaultWindow();
+  if (win === undefined) {
+    return () => {};
+  }
+  const state = getOrCreateWindowState(win);
+  state.installCount++;
+  if (state.removeListener === null) {
+    const handler = (event: MessageEvent) => handleMessage(event, win);
+    win.addEventListener('message', handler, true);
+    state.removeListener = () =>
+      win.removeEventListener('message', handler, true);
+  }
+  let removed = false;
+  return () => {
+    if (removed) {
+      return;
+    }
+    removed = true;
+    state.installCount--;
+    if (state.installCount === 0 && state.removeListener !== null) {
+      state.removeListener();
+      state.removeListener = null;
+      windowStates.delete(win);
+    }
+  };
+}
+
 export function registerDragonSupport(editor: LexicalEditor): () => void {
-  const origin = window.location.origin;
-  const handler = (event: MessageEvent) => {
-    if (event.origin !== origin) {
-      return;
-    }
-    const rootElement = editor.getRootElement();
+  let registeredWindow: Window | null = null;
+  let uninstall: (() => void) | null = null;
 
-    if (document.activeElement !== rootElement) {
-      return;
-    }
-
-    const data = event.data;
-
-    if (typeof data === 'string') {
-      let parsedData;
-
-      try {
-        parsedData = JSON.parse(data);
-      } catch (_e) {
-        return;
+  const detach = () => {
+    if (registeredWindow !== null) {
+      const state = windowStates.get(registeredWindow);
+      if (state !== undefined) {
+        state.editors.delete(editor);
       }
+      registeredWindow = null;
+    }
+    if (uninstall !== null) {
+      uninstall();
+      uninstall = null;
+    }
+  };
 
-      if (
-        parsedData &&
-        parsedData.protocol === 'nuanria_messaging' &&
-        parsedData.type === 'request'
-      ) {
-        const payload = parsedData.payload;
+  const unregisterRoot = editor.registerRootListener(rootElement => {
+    detach();
+    if (rootElement === null) {
+      return;
+    }
+    const targetWindow = rootElement.ownerDocument.defaultView;
+    if (targetWindow === null) {
+      return;
+    }
+    registeredWindow = targetWindow;
+    getOrCreateWindowState(targetWindow).editors.add(editor);
+    uninstall = installDragonSupport(targetWindow);
+  });
 
-        if (payload && payload.functionId === 'makeChanges') {
-          const args = payload.args;
+  return () => {
+    detach();
+    unregisterRoot();
+  };
+}
 
-          if (Array.isArray(args)) {
-            const [
-              elementStart,
-              elementLength,
-              text,
-              selStart,
-              selLength,
-              formatCommand,
-            ] = args;
-            if (
-              ![elementStart, elementLength, selStart, selLength].every(
-                Number.isFinite,
-              ) ||
-              (typeof text !== 'string' && text !== -1)
-            ) {
-              return;
-            }
-            editor.update(() => {
-              const selection = $getSelection();
+function getFocusedEditor(targetWindow: Window): LexicalEditor | null {
+  const state = windowStates.get(targetWindow);
+  if (state === undefined) {
+    return null;
+  }
+  const activeElement = targetWindow.document.activeElement;
+  for (const editor of state.editors) {
+    if (editor.getRootElement() === activeElement) {
+      return editor;
+    }
+  }
+  return null;
+}
 
-              if ($isRangeSelection(selection)) {
-                const anchor = selection.anchor;
-                let anchorNode = anchor.getNode();
-                let setSelStart = 0;
-                let setSelEnd = 0;
+function handleMessage(event: MessageEvent, targetWindow: Window): void {
+  if (event.origin !== targetWindow.location.origin) {
+    return;
+  }
+  const editor = getFocusedEditor(targetWindow);
 
-                if ($isTextNode(anchorNode)) {
-                  // set initial selection
-                  if (elementStart >= 0 && elementLength >= 0) {
-                    setSelStart = elementStart;
-                    setSelEnd = elementStart + elementLength;
-                    // If the offset is more than the end, make it the end
-                    selection.setTextNodeRange(
-                      anchorNode,
-                      setSelStart,
-                      anchorNode,
-                      setSelEnd,
-                    );
-                  }
-                }
+  if (editor === null) {
+    return;
+  }
 
-                // Dragon sends -1 (a number, not a string) as text for
-                // selection-only changes, such as Select-and-Say
-                // corrections and cursor moves by voice
-                if (
-                  typeof text === 'string' &&
-                  (setSelStart !== setSelEnd || text !== '')
-                ) {
-                  selection.insertRawText(text);
-                  anchorNode = anchor.getNode();
-                }
+  const data = event.data;
 
-                if ($isTextNode(anchorNode)) {
-                  // set final selection
-                  const anchorNodeTextLength = anchorNode.getTextContentSize();
-                  // Clamp to the text size. Negative offsets have no meaning
-                  // in the protocol, so they collapse the selection instead
-                  // of leaving a range the next input would replace
-                  setSelStart = Math.min(
-                    Math.max(selStart, 0),
-                    anchorNodeTextLength,
-                  );
-                  setSelEnd =
-                    selStart < 0 || selLength < 0
-                      ? setSelStart
-                      : Math.min(selStart + selLength, anchorNodeTextLength);
+  if (typeof data === 'string') {
+    let parsedData;
+
+    try {
+      parsedData = JSON.parse(data);
+    } catch (_e) {
+      return;
+    }
+
+    if (
+      parsedData &&
+      parsedData.protocol === 'nuanria_messaging' &&
+      parsedData.type === 'request'
+    ) {
+      const payload = parsedData.payload;
+
+      if (payload && payload.functionId === 'makeChanges') {
+        const args = payload.args;
+
+        if (Array.isArray(args)) {
+          const [
+            elementStart,
+            elementLength,
+            text,
+            selStart,
+            selLength,
+            formatCommand,
+          ] = args;
+          if (
+            ![elementStart, elementLength, selStart, selLength].every(
+              Number.isFinite,
+            ) ||
+            (typeof text !== 'string' && text !== -1)
+          ) {
+            return;
+          }
+          editor.update(() => {
+            const selection = $getSelection();
+
+            if ($isRangeSelection(selection)) {
+              const anchor = selection.anchor;
+              let anchorNode = anchor.getNode();
+              let setSelStart = 0;
+              let setSelEnd = 0;
+
+              if ($isTextNode(anchorNode)) {
+                // set initial selection
+                if (elementStart >= 0 && elementLength >= 0) {
+                  setSelStart = elementStart;
+                  setSelEnd = elementStart + elementLength;
+                  // If the offset is more than the end, make it the end
                   selection.setTextNodeRange(
                     anchorNode,
                     setSelStart,
@@ -132,35 +221,63 @@ export function registerDragonSupport(editor: LexicalEditor): () => void {
                     setSelEnd,
                   );
                 }
-
-                // format the selection, e.g. for the "bold that" voice
-                // command. Dragon's extension applies this through
-                // document.execCommand, so the values are execCommand names.
-                if (
-                  typeof formatCommand === 'string' &&
-                  selLength > 0 &&
-                  !selection.isCollapsed()
-                ) {
-                  const format = TEXT_FORMAT_BY_EXEC_COMMAND.get(formatCommand);
-                  if (format !== undefined) {
-                    selection.formatText(format);
-                  }
-                }
-
-                // block the chrome extension from handling this event
-                event.stopImmediatePropagation();
               }
-            });
-          }
+
+              // Dragon sends -1 (a number, not a string) as text for
+              // selection-only changes, such as Select-and-Say
+              // corrections and cursor moves by voice
+              if (
+                typeof text === 'string' &&
+                (setSelStart !== setSelEnd || text !== '')
+              ) {
+                selection.insertRawText(text);
+                anchorNode = anchor.getNode();
+              }
+
+              if ($isTextNode(anchorNode)) {
+                // set final selection
+                const anchorNodeTextLength = anchorNode.getTextContentSize();
+                // Clamp to the text size. Negative offsets have no meaning
+                // in the protocol, so they collapse the selection instead
+                // of leaving a range the next input would replace
+                setSelStart = Math.min(
+                  Math.max(selStart, 0),
+                  anchorNodeTextLength,
+                );
+                setSelEnd =
+                  selStart < 0 || selLength < 0
+                    ? setSelStart
+                    : Math.min(selStart + selLength, anchorNodeTextLength);
+                selection.setTextNodeRange(
+                  anchorNode,
+                  setSelStart,
+                  anchorNode,
+                  setSelEnd,
+                );
+              }
+
+              // format the selection, e.g. for the "bold that" voice
+              // command. Dragon's extension applies this through
+              // document.execCommand, so the values are execCommand names.
+              if (
+                typeof formatCommand === 'string' &&
+                selLength > 0 &&
+                !selection.isCollapsed()
+              ) {
+                const format = TEXT_FORMAT_BY_EXEC_COMMAND.get(formatCommand);
+                if (format !== undefined) {
+                  selection.formatText(format);
+                }
+              }
+
+              // block the chrome extension from handling this event
+              event.stopImmediatePropagation();
+            }
+          });
         }
       }
     }
-  };
-
-  window.addEventListener('message', handler, true);
-  return () => {
-    window.removeEventListener('message', handler, true);
-  };
+  }
 }
 
 export interface DragonConfig {


### PR DESCRIPTION
## Description

The Dragon NaturallySpeaking web extension drives editable fields through window messages (protocol `nuanria_messaging`, function `makeChanges`, args `[elementStart, elementLength, text, selStart, selLength, formatCommand]`).

Dragon sends the number -1 as the `text` argument to mean "change the selection without touching the text". This is how Select-and-Say corrections and cursor moves by voice arrive, and the extension's own contenteditable handler special-cases `text === -1` the same way. `registerDragonSupport` passes the value straight to `insertRawText`, which throws `text.split is not a function` inside `editor.update` on the first voice correction. The editor is left permanently broken, and the raw DOM edits the extension applies afterwards diverge from the editor state, so content after the correction point is lost when Lexical reconciles.

There is a second problem: browsers invoke a window's message listeners in registration order, and the extension's content script registers its listener at `document_end` of the initial page load. Per-editor handlers register when the editor mounts, which on most real pages (navigations in single page apps, dialogs, lazily rendered fields) is later, so their `stopImmediatePropagation` can never keep the extension from applying the edit through raw DOM mutations first, and edits end up applied twice.

So this PR, one commit per change:

- Treats a non-string `text` as selection-only, and validates the payload up front so nothing can throw inside `editor.update`: `args` must be an array (destructuring a string inserts stray characters and destructuring a non-iterable throws), the offsets must be finite numbers (string offsets pass `>= 0` checks through coercion and then concatenate), and negative final offsets collapse the selection instead of leaving a range the next input would replace.
- Applies the `formatCommand` argument (execCommand names like `bold`, sent by voice commands like "bold that") by mapping the supported names to Lexical text formats, resolving the existing TODO.
- Following the direction suggested in #8664, moves the package to a per-window shared listener that dispatches to the focused editor among the ones registered in its window, installed lazily by `registerDragonSupport` through `editor.registerRootListener` so editors mounted inside an iframe register against the iframe's window, and exports `installDragonSupport(targetWindow?)` so apps can call it synchronously at their entrypoints to register the listener before the extension's content script. The race and the entrypoint pattern are documented in the package README.

These are the first unit tests for the package.

Closes #8664. Related but not addressed here: #3384 (offsets beyond the first text node).

## Test plan

### Before

Dictating into a Lexical editor with Dragon and saying "correct \<word\>" throws `TypeError: text.split is not a function` and the editor stops accepting updates. There is no way to register the message handling before an editor mounts, so on pages where editors mount lazily the extension's listener always runs first (verified against the unpacked extension content scripts in a real browser).

### After

`pnpm exec vitest run --project unit packages/lexical-dragon` passes all 13 tests, covering the protocol (replacement, selection-only, the correction flow, malformed and out-of-range payloads, format commands) and the shared listener (`installDragonSupport` before any editor mounts blocks foreign listeners, dispatching to the focused editor among several, editors created after others are disposed, editors mounted inside an iframe).