### PR TITLE
[lexical-playground] Bug Fix: clear block alignment and indent with a collapsed selection but not a partial one

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
@@ -8,6 +8,7 @@
 
 import {
   centerAlign,
+  clearFormatting,
   indent,
   moveToPrevWord,
   outdent,
@@ -267,6 +268,25 @@ test.describe('Clear All Formatting', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
           <span data-lexical-text="true">Hello World Test</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can clear alignment and indent with a collapsed selection`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Hello World');
+    await rightAlign(page);
+    await indent(page);
+    await clearFormatting(page);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+          <span data-lexical-text="true">Hello World</span>
         </p>
       `,
     );

--- a/packages/lexical-playground/__tests__/unit/ToolbarPluginClearFormatting.test.ts
+++ b/packages/lexical-playground/__tests__/unit/ToolbarPluginClearFormatting.test.ts
@@ -7,7 +7,7 @@
  */
 
 import {buildEditorFromExtensions} from '@lexical/extension';
-import {RichTextExtension} from '@lexical/rich-text';
+import {$createHeadingNode, RichTextExtension} from '@lexical/rich-text';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -167,6 +167,61 @@ describe('clearFormatting (Toolbar)', () => {
       assert($isParagraphNode(firstParagraph), 'Expected a ParagraphNode');
       assert($isParagraphNode(secondParagraph), 'Expected a ParagraphNode');
       expect(firstParagraph.getFormatType()).toBe('');
+      expect(secondParagraph.getFormatType()).toBe('right');
+    });
+  });
+
+  test('clears block formatting only for fully selected blocks with a backward selection', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const firstText = $createTextNode('first');
+        const secondText = $createTextNode('second');
+        const firstParagraph = $createParagraphNode().append(firstText);
+        firstParagraph.setFormat('center');
+        const secondParagraph = $createParagraphNode().append(secondText);
+        secondParagraph.setFormat('right');
+        $getRoot().clear().append(firstParagraph, secondParagraph);
+        firstText
+          .select(0, 0)
+          .setTextNodeRange(secondText, 'sec'.length, firstText, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => clearFormatting(editor), {discrete: true});
+
+    editor.read(() => {
+      const [firstParagraph, secondParagraph] = $getRoot().getChildren();
+      assert($isParagraphNode(firstParagraph), 'Expected a ParagraphNode');
+      assert($isParagraphNode(secondParagraph), 'Expected a ParagraphNode');
+      expect(firstParagraph.getFormatType()).toBe('');
+      expect(secondParagraph.getFormatType()).toBe('right');
+    });
+  });
+
+  test('handles a selection that starts at an empty heading (#8666)', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const heading = $createHeadingNode('h1');
+        const text = $createTextNode('second');
+        const paragraph = $createParagraphNode().append(text);
+        paragraph.setFormat('right');
+        $getRoot().clear().append(heading, paragraph);
+        // The anchor is an element point on the heading, which is
+        // replaced with a paragraph during clearFormatting
+        heading.select(0, 0).focus.set(text.getKey(), 'sec'.length, 'text');
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => clearFormatting(editor), {discrete: true});
+
+    editor.read(() => {
+      const [firstParagraph, secondParagraph] = $getRoot().getChildren();
+      assert($isParagraphNode(firstParagraph), 'Expected a ParagraphNode');
+      assert($isParagraphNode(secondParagraph), 'Expected a ParagraphNode');
       expect(secondParagraph.getFormatType()).toBe('right');
     });
   });

--- a/packages/lexical-playground/__tests__/unit/ToolbarPluginClearFormatting.test.ts
+++ b/packages/lexical-playground/__tests__/unit/ToolbarPluginClearFormatting.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  $isTextNode,
+  defineExtension,
+  ParagraphNode,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+import {clearFormatting} from '../../src/plugins/ToolbarPlugin/utils';
+
+function createEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [RichTextExtension],
+      name: 'test',
+    }),
+  );
+}
+
+const $getFirstParagraph = (): ParagraphNode => {
+  const paragraph = $getRoot().getFirstChild();
+  assert($isParagraphNode(paragraph), 'Expected a ParagraphNode');
+  return paragraph;
+};
+
+describe('clearFormatting (Toolbar)', () => {
+  test('clears text and block formatting when all content is selected', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const text = $createTextNode('Hello World');
+        text.toggleFormat('bold');
+        const paragraph = $createParagraphNode().append(text);
+        paragraph.setFormat('center');
+        paragraph.setIndent(1);
+        $getRoot().clear().append(paragraph);
+        text.select(0, 'Hello World'.length);
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => clearFormatting(editor), {discrete: true});
+
+    editor.read(() => {
+      const paragraph = $getFirstParagraph();
+      expect(paragraph.getFormatType()).toBe('');
+      expect(paragraph.getIndent()).toBe(0);
+      const text = paragraph.getFirstChild();
+      assert($isTextNode(text), 'Expected a TextNode');
+      expect(text.hasFormat('bold')).toBe(false);
+    });
+  });
+
+  test('keeps block formatting when the selection is partial', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const text = $createTextNode('Hello World');
+        text.toggleFormat('bold');
+        const paragraph = $createParagraphNode().append(text);
+        paragraph.setFormat('center');
+        paragraph.setIndent(1);
+        $getRoot().clear().append(paragraph);
+        text.select(0, 'Hello'.length);
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => clearFormatting(editor), {discrete: true});
+
+    editor.read(() => {
+      const paragraph = $getFirstParagraph();
+      expect(paragraph.getFormatType()).toBe('center');
+      expect(paragraph.getIndent()).toBe(1);
+      const [selected, rest] = paragraph.getChildren();
+      assert($isTextNode(selected), 'Expected a TextNode');
+      assert($isTextNode(rest), 'Expected a TextNode');
+      expect(selected.hasFormat('bold')).toBe(false);
+      expect(rest.hasFormat('bold')).toBe(true);
+    });
+  });
+
+  test('clears block formatting of an empty block with a collapsed selection', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.setFormat('center');
+        paragraph.setIndent(1);
+        $getRoot().clear().append(paragraph);
+        paragraph.select();
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => clearFormatting(editor), {discrete: true});
+
+    editor.read(() => {
+      const paragraph = $getFirstParagraph();
+      expect(paragraph.getFormatType()).toBe('');
+      expect(paragraph.getIndent()).toBe(0);
+    });
+  });
+
+  test('clears block but not text formatting with a collapsed selection in text (#7383)', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const text = $createTextNode('Hello World');
+        text.toggleFormat('bold');
+        const paragraph = $createParagraphNode().append(text);
+        paragraph.setFormat('right');
+        paragraph.setIndent(1);
+        $getRoot().clear().append(paragraph);
+        text.select('Hello World'.length, 'Hello World'.length);
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => clearFormatting(editor), {discrete: true});
+
+    editor.read(() => {
+      const paragraph = $getFirstParagraph();
+      expect(paragraph.getFormatType()).toBe('');
+      expect(paragraph.getIndent()).toBe(0);
+      const text = paragraph.getFirstChild();
+      assert($isTextNode(text), 'Expected a TextNode');
+      expect(text.hasFormat('bold')).toBe(true);
+    });
+  });
+
+  test('clears block formatting only for fully selected blocks across paragraphs', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const firstText = $createTextNode('first');
+        const secondText = $createTextNode('second');
+        const firstParagraph = $createParagraphNode().append(firstText);
+        firstParagraph.setFormat('center');
+        const secondParagraph = $createParagraphNode().append(secondText);
+        secondParagraph.setFormat('right');
+        $getRoot().clear().append(firstParagraph, secondParagraph);
+        firstText
+          .select(0, 0)
+          .setTextNodeRange(firstText, 0, secondText, 'sec'.length);
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => clearFormatting(editor), {discrete: true});
+
+    editor.read(() => {
+      const [firstParagraph, secondParagraph] = $getRoot().getChildren();
+      assert($isParagraphNode(firstParagraph), 'Expected a ParagraphNode');
+      assert($isParagraphNode(secondParagraph), 'Expected a ParagraphNode');
+      expect(firstParagraph.getFormatType()).toBe('');
+      expect(secondParagraph.getFormatType()).toBe('right');
+    });
+  });
+});

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -24,27 +24,23 @@ import {$isTableSelection} from '@lexical/table';
 import {
   $findMatchingParent,
   $getNearestBlockElementAncestorOrThrow,
+  $isBlockFullySelected,
 } from '@lexical/utils';
 import {
   $addUpdateTag,
-  $caretRangeFromSelection,
-  $comparePointCaretNext,
   $createParagraphNode,
   $createRangeSelection,
-  $getCaretInDirection,
-  $getChildCaret,
   $getSelection,
   $isBlockElementNode,
   $isLineBreakNode,
   $isRangeSelection,
   $isTextNode,
-  $normalizeCaret,
   $setSelection,
   $splitNode,
-  CaretRange,
   ElementNode,
   LexicalEditor,
   LexicalNode,
+  NodeKey,
   RangeSelection,
   SKIP_DOM_SELECTION_TAG,
   SKIP_SELECTION_FOCUS_TAG,
@@ -350,28 +346,6 @@ function $clearBlockFormat(block: ElementNode): void {
   }
 }
 
-function $isBlockFullySelected(block: ElementNode, range: CaretRange): boolean {
-  const [startCaret, endCaret] =
-    range.direction === 'next'
-      ? [
-          $getCaretInDirection(range.anchor, 'next'),
-          $getCaretInDirection(range.focus, 'next'),
-        ]
-      : [
-          $getCaretInDirection(range.focus, 'next'),
-          $getCaretInDirection(range.anchor, 'next'),
-        ];
-  const blockStart = $normalizeCaret($getChildCaret(block, 'next'));
-  const blockEnd = $getCaretInDirection(
-    $normalizeCaret($getChildCaret(block, 'previous')),
-    'next',
-  );
-  return (
-    $comparePointCaretNext(startCaret, blockStart) <= 0 &&
-    $comparePointCaretNext(endCaret, blockEnd) >= 0
-  );
-}
-
 export const clearFormatting = (
   editor: LexicalEditor,
   skipRefocus: boolean = false,
@@ -393,10 +367,26 @@ export const clearFormatting = (
         return;
       }
 
+      // Determine which blocks are fully selected before making any
+      // changes, since the mutations below (such as replacing a
+      // HeadingNode with a ParagraphNode) would detach nodes that the
+      // selection's carets may refer to
       const postExtractSelection = $getSelection();
-      const caretRange = $isRangeSelection(postExtractSelection)
-        ? $caretRangeFromSelection(postExtractSelection)
-        : null;
+      let fullySelectedBlocks: null | Set<NodeKey> = null;
+      if ($isRangeSelection(postExtractSelection)) {
+        fullySelectedBlocks = new Set();
+        for (const node of extractedNodes) {
+          if ($isTextNode(node)) {
+            const block = $getNearestBlockElementAncestorOrThrow(node);
+            if (
+              !fullySelectedBlocks.has(block.getKey()) &&
+              $isBlockFullySelected(block, postExtractSelection)
+            ) {
+              fullySelectedBlocks.add(block.getKey());
+            }
+          }
+        }
+      }
 
       extractedNodes.forEach(node => {
         if ($isTextNode(node)) {
@@ -409,8 +399,8 @@ export const clearFormatting = (
           const nearestBlockElement =
             $getNearestBlockElementAncestorOrThrow(node);
           if (
-            caretRange === null ||
-            $isBlockFullySelected(nearestBlockElement, caretRange)
+            fullySelectedBlocks === null ||
+            fullySelectedBlocks.has(nearestBlockElement.getKey())
           ) {
             $clearBlockFormat(nearestBlockElement);
           }

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -27,15 +27,21 @@ import {
 } from '@lexical/utils';
 import {
   $addUpdateTag,
+  $caretRangeFromSelection,
+  $comparePointCaretNext,
   $createParagraphNode,
   $createRangeSelection,
+  $getCaretInDirection,
+  $getChildCaret,
   $getSelection,
   $isBlockElementNode,
   $isLineBreakNode,
   $isRangeSelection,
   $isTextNode,
+  $normalizeCaret,
   $setSelection,
   $splitNode,
+  CaretRange,
   ElementNode,
   LexicalEditor,
   LexicalNode,
@@ -335,6 +341,37 @@ export const formatCode = (editor: LexicalEditor, blockType: string) => {
   }
 };
 
+function $clearBlockFormat(block: ElementNode): void {
+  if (block.getFormat() !== 0) {
+    block.setFormat('');
+  }
+  if (block.getIndent() !== 0) {
+    block.setIndent(0);
+  }
+}
+
+function $isBlockFullySelected(block: ElementNode, range: CaretRange): boolean {
+  const [startCaret, endCaret] =
+    range.direction === 'next'
+      ? [
+          $getCaretInDirection(range.anchor, 'next'),
+          $getCaretInDirection(range.focus, 'next'),
+        ]
+      : [
+          $getCaretInDirection(range.focus, 'next'),
+          $getCaretInDirection(range.anchor, 'next'),
+        ];
+  const blockStart = $normalizeCaret($getChildCaret(block, 'next'));
+  const blockEnd = $getCaretInDirection(
+    $normalizeCaret($getChildCaret(block, 'previous')),
+    'next',
+  );
+  return (
+    $comparePointCaretNext(startCaret, blockStart) <= 0 &&
+    $comparePointCaretNext(endCaret, blockEnd) >= 0
+  );
+}
+
 export const clearFormatting = (
   editor: LexicalEditor,
   skipRefocus: boolean = false,
@@ -350,8 +387,16 @@ export const clearFormatting = (
       const extractedNodes = selection.extract();
 
       if (anchor.key === focus.key && anchor.offset === focus.offset) {
+        $clearBlockFormat(
+          $getNearestBlockElementAncestorOrThrow(anchor.getNode()),
+        );
         return;
       }
+
+      const postExtractSelection = $getSelection();
+      const caretRange = $isRangeSelection(postExtractSelection)
+        ? $caretRangeFromSelection(postExtractSelection)
+        : null;
 
       extractedNodes.forEach(node => {
         if ($isTextNode(node)) {
@@ -363,11 +408,11 @@ export const clearFormatting = (
           }
           const nearestBlockElement =
             $getNearestBlockElementAncestorOrThrow(node);
-          if (nearestBlockElement.getFormat() !== 0) {
-            nearestBlockElement.setFormat('');
-          }
-          if (nearestBlockElement.getIndent() !== 0) {
-            nearestBlockElement.setIndent(0);
+          if (
+            caretRange === null ||
+            $isBlockFullySelected(nearestBlockElement, caretRange)
+          ) {
+            $clearBlockFormat(nearestBlockElement);
           }
         } else if ($isHeadingNode(node) || $isQuoteNode(node)) {
           node.replace($createParagraphNode(), true);


### PR DESCRIPTION
## Description

Clear formatting did nothing on a collapsed selection, so alignment set without selecting text could never be cleared (#7383). It also wiped a paragraph's alignment when you only selected one word in it.

Now a collapsed selection resets the caret block's alignment/indent, and a ranged selection only resets them when the whole block is selected. This follows the review feedback on #8237: the fully-selected check uses `$isBlockFullySelected` from `@lexical/utils` (#8532) against the selection after `selection.extract()`, and the empty aligned paragraph case works too.

The set of fully selected blocks is computed before any nodes are mutated, because the mutations in the loop (such as replacing a `HeadingNode` with a `ParagraphNode`) detach nodes that the selection's carets may refer to, which made `$comparePointCaretNext` throw an invariant violation (e.g. with a selection that starts at an empty heading).

Closes #7383

## Test plan

Unit tests for the cases asked for in the #8237 review (full, partial, collapsed, empty block, cross-paragraph), plus backward selections and a regression test for the empty heading invariant violation, and an e2e test. Existing ClearFormatting e2e tests pass.

### Before


https://github.com/user-attachments/assets/7a376e6a-b2f7-4598-845c-d79dd4e60b2b



### After


https://github.com/user-attachments/assets/4d39ff9c-d86d-46e4-9e47-233a5b7984ea
