### PR TITLE
[lexical][*] Chore: stop using deprecated traversal type parameters in tests

### DIFF
--- a/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
@@ -15,10 +15,11 @@ import {
   $isElementNode,
   KEY_ENTER_COMMAND,
 } from 'lexical';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
 import {describe, expect, it} from 'vitest';
 
 import {$createCodeHighlightNode} from '../../CodeHighlightNode';
-import {$isCodeNode, CodeNode} from '../../CodeNode';
+import {$isCodeNode} from '../../CodeNode';
 
 describe('CodeExtension', () => {
   it('should not escape code block when content has consecutive blank lines (paste scenario)', () => {
@@ -67,7 +68,10 @@ describe('CodeExtension', () => {
     using editor = buildEditorFromExtensions(ext);
     editor.update(
       () => {
-        const codeNode = $getRoot().getFirstChildOrThrow<CodeNode>();
+        const codeNode = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isCodeNode,
+        );
         codeNode.select(codeNode.getChildrenSize(), codeNode.getChildrenSize());
       },
       {discrete: true},
@@ -108,7 +112,10 @@ describe('CodeExtension', () => {
     using editor = buildEditorFromExtensions(ext);
     editor.update(
       () => {
-        const codeNode = $getRoot().getFirstChildOrThrow<CodeNode>();
+        const codeNode = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isCodeNode,
+        );
         codeNode.select(codeNode.getChildrenSize(), codeNode.getChildrenSize());
       },
       {discrete: true},
@@ -148,7 +155,10 @@ describe('CodeExtension', () => {
     using editor = buildEditorFromExtensions(ext);
     editor.update(
       () => {
-        const codeNode = $getRoot().getFirstChildOrThrow<CodeNode>();
+        const codeNode = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isCodeNode,
+        );
         codeNode.select(1, 1);
       },
       {discrete: true},

--- a/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
@@ -17,6 +17,7 @@ import {
 import {waitForReact} from '@lexical/react/src/__tests__/utils';
 import {$createTextNode, $getRoot, ParagraphNode, TextNode} from 'lexical';
 import {
+  $assertNodeType,
   expectHtmlToBeEqual,
   html,
   initializeUnitTest,
@@ -244,9 +245,12 @@ describe('LexicalListNode tests', () => {
 
         expect(listNode.append(...nodesToAppend)).toBe(listNode);
         expect($isListItemNode(listNode.getFirstChild())).toBe(true);
-        expect(listNode.getFirstChild<ListItemNode>()!.getFirstChild()).toBe(
-          nestedListNode,
-        );
+        expect(
+          $assertNodeType(
+            listNode.getFirstChild(),
+            $isListItemNode,
+          ).getFirstChild(),
+        ).toBe(nestedListNode);
       });
     });
 
@@ -354,7 +358,10 @@ describe('LexicalListNode tests', () => {
 
       await waitForReact(() => {
         editor.update(() => {
-          const listNode = $getRoot().getFirstChildOrThrow<ListNode>();
+          const listNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isListNode,
+          );
           listNode.setListType('bullet');
         });
       });
@@ -395,8 +402,14 @@ describe('LexicalListNode tests', () => {
 
       await waitForReact(() => {
         editor.update(() => {
-          const listNode = $getRoot().getFirstChildOrThrow<ListNode>();
-          const listItemNode = listNode.getChildAtIndex<ListItemNode>(1)!;
+          const listNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isListNode,
+          );
+          const listItemNode = $assertNodeType(
+            listNode.getChildAtIndex(1),
+            $isListItemNode,
+          );
           listItemNode.append(
             $createListNode('bullet').append($createListItemNode()),
           );

--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -21,9 +21,9 @@ import {
   $createTableCellNode,
   $createTableNode,
   $createTableRowNode,
-  TableCellNode,
-  TableNode,
-  TableRowNode,
+  $isTableCellNode,
+  $isTableNode,
+  $isTableRowNode,
 } from '@lexical/table';
 import {
   $createLineBreakNode,
@@ -40,6 +40,7 @@ import {
   LexicalNode,
 } from 'lexical';
 import {
+  $assertNodeType,
   $createTestDecoratorNode,
   initializeUnitTest,
 } from 'lexical/src/__tests__/utils';
@@ -144,10 +145,9 @@ describe('insertList', () => {
       });
 
       editor.read(() => {
-        const cell = $getRoot()
-          .getFirstChildOrThrow<TableNode>()
-          .getFirstChildOrThrow<TableRowNode>()
-          .getFirstChildOrThrow<TableCellNode>();
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
+        const row = $assertNodeType(table.getFirstChild(), $isTableRowNode);
+        const cell = $assertNodeType(row.getFirstChild(), $isTableCellNode);
 
         expect(cell.getChildrenSize()).toBe(1);
 

--- a/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
+++ b/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
@@ -6,20 +6,20 @@
  *
  */
 import {$generateNodesFromDOM} from '@lexical/html';
-import {$isMarkNode, $wrapSelectionInMarkNode, MarkNode} from '@lexical/mark';
+import {$isMarkNode, $wrapSelectionInMarkNode} from '@lexical/mark';
 import {$insertNodeIntoLeaf} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
   $getRoot,
+  $isElementNode,
   $isParagraphNode,
   $isTextNode,
   $setSelection,
-  ParagraphNode,
-  TextNode,
 } from 'lexical';
 import {
+  $assertNodeType,
   $createTestDecoratorNode,
   $createTestElementNode,
   $createTestInlineElementNode,
@@ -44,8 +44,10 @@ describe('LexicalMarkNode tests', () => {
 
         editor.update(() => {
           const textNode = $createTextNode('marked');
-          const paragraphNode =
-            $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraphNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraphNode.append(textNode);
           const selection = $createRangeSelection();
           selection.anchor.set(textNode.getKey(), 0, 'text');
@@ -57,7 +59,10 @@ describe('LexicalMarkNode tests', () => {
           $wrapSelectionInMarkNode(selection, false, 'my-id');
 
           expect(paragraphNode.getChildren()).toHaveLength(1);
-          const markNode = paragraphNode.getFirstChildOrThrow<MarkNode>();
+          const markNode = $assertNodeType(
+            paragraphNode.getFirstChild(),
+            $isMarkNode,
+          );
           expect(markNode.getType()).toEqual('mark');
           expect(markNode.getIDs()).toEqual(['my-id']);
           expect(markNode.getChildren()).toHaveLength(1);
@@ -75,8 +80,10 @@ describe('LexicalMarkNode tests', () => {
 
         editor.update(() => {
           const textNode = $createTextNode('unmarked marked unmarked');
-          const paragraphNode =
-            $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraphNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraphNode.append(textNode);
           const selection = $createRangeSelection();
           selection.anchor.set(textNode.getKey(), 'unmarked '.length, 'text');
@@ -107,8 +114,10 @@ describe('LexicalMarkNode tests', () => {
         editor.update(() => {
           const decoratorNode = $createTestDecoratorNode();
           const textNode = $createTextNode('more text');
-          const paragraphNode =
-            $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraphNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraphNode.append(decoratorNode, textNode);
           const selection = $createRangeSelection();
           selection.anchor.set(paragraphNode.getKey(), 0, 'element');
@@ -120,7 +129,10 @@ describe('LexicalMarkNode tests', () => {
           $wrapSelectionInMarkNode(selection, false, 'my-id');
 
           expect(paragraphNode.getChildren()).toHaveLength(1);
-          const markNode = paragraphNode.getFirstChildOrThrow<MarkNode>();
+          const markNode = $assertNodeType(
+            paragraphNode.getFirstChild(),
+            $isMarkNode,
+          );
           expect(markNode.getType()).toEqual('mark');
           expect(markNode.getChildren().map(c => c.getKey())).toEqual([
             decoratorNode.getKey(),
@@ -173,8 +185,10 @@ describe('LexicalMarkNode tests', () => {
         editor.update(() => {
           const elementNode = $createTestInlineElementNode();
           const textNode = $createTextNode('more text');
-          const paragraphNode =
-            $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraphNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraphNode.append(elementNode, textNode);
           const selection = $createRangeSelection();
           selection.anchor.set(paragraphNode.getKey(), 0, 'element');
@@ -186,7 +200,10 @@ describe('LexicalMarkNode tests', () => {
           $wrapSelectionInMarkNode(selection, false, 'my-id');
 
           expect(paragraphNode.getChildren()).toHaveLength(1);
-          const markNode = paragraphNode.getFirstChildOrThrow<MarkNode>();
+          const markNode = $assertNodeType(
+            paragraphNode.getFirstChild(),
+            $isMarkNode,
+          );
           expect(markNode.getType()).toEqual('mark');
           expect(markNode.getChildren().map(c => c.getKey())).toEqual([
             elementNode.getKey(),
@@ -201,8 +218,10 @@ describe('LexicalMarkNode tests', () => {
         editor.update(() => {
           const elementNode = $createTestElementNode();
           const textNode = $createTextNode('more text');
-          const paragraphNode =
-            $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraphNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraphNode.append(elementNode, textNode);
           const selection = $createRangeSelection();
           selection.anchor.set(paragraphNode.getKey(), 0, 'element');
@@ -219,7 +238,10 @@ describe('LexicalMarkNode tests', () => {
           );
 
           // the text part of the selection should still be marked
-          const markNode = paragraphNode.getChildAtIndex(1) as MarkNode;
+          const markNode = $assertNodeType(
+            paragraphNode.getChildAtIndex(1),
+            $isMarkNode,
+          );
           expect(markNode.getType()).toEqual('mark');
           expect(markNode.getChildren()).toHaveLength(1);
           expect(markNode.getTextContent()).toEqual('more text');
@@ -247,11 +269,22 @@ describe('LexicalMarkNode tests', () => {
           const nodes = $generateNodesFromDOM(editor, dom);
 
           expect(nodes).toHaveLength(1);
-          const paragraphNode = nodes[0] as ParagraphNode;
+          const paragraphNode = $assertNodeType(nodes[0], $isElementNode);
           expect(paragraphNode.getChildren()).toHaveLength(3);
-          const textNode1 = paragraphNode.getChildAtIndex(0) as TextNode;
-          const markNode = paragraphNode.getChildAtIndex(1) as MarkNode;
-          const textNode2 = paragraphNode.getChildAtIndex(2) as TextNode;
+          // The <mark> element is imported as plain text in this test, so all
+          // three children are TextNodes.
+          const textNode1 = $assertNodeType(
+            paragraphNode.getChildAtIndex(0),
+            $isTextNode,
+          );
+          const markNode = $assertNodeType(
+            paragraphNode.getChildAtIndex(1),
+            $isTextNode,
+          );
+          const textNode2 = $assertNodeType(
+            paragraphNode.getChildAtIndex(2),
+            $isTextNode,
+          );
 
           expect(textNode1.getTextContent()).toEqual('Foo ');
           expect(markNode.getTextContent()).toEqual('Bar');

--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -11,13 +11,13 @@ import {
   $createTextNode,
   $getRoot,
   $getState,
+  $isParagraphNode,
   $isTextNode,
   $setState,
   createState,
-  ParagraphNode,
-  TextNode,
   UNDO_COMMAND,
 } from 'lexical';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
 import {act} from 'react';
 import {afterEach, assert, beforeEach, describe, expect, it} from 'vitest';
 import * as Y from 'yjs';
@@ -78,11 +78,14 @@ describe('Collaboration', () => {
           client1.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>();
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
 
             const text = $createTextNode('Hello world');
 
-            paragraph!.append(text);
+            paragraph.append(text);
           });
         });
 
@@ -97,8 +100,14 @@ describe('Collaboration', () => {
           client2.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>()!;
-            const text = paragraph.getFirstChild<TextNode>()!;
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
+            const text = $assertNodeType(
+              paragraph.getFirstChild(),
+              $isTextNode,
+            );
 
             text.spliceText(6, 5, 'metaverse');
           });
@@ -132,7 +141,10 @@ describe('Collaboration', () => {
           client1.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>()!;
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
             const text = $createTextNode('Hello world');
 
             paragraph.append(text);
@@ -148,7 +160,10 @@ describe('Collaboration', () => {
           client2.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>()!;
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
             const text = $createTextNode('Hello world');
 
             paragraph.append(text);
@@ -177,8 +192,14 @@ describe('Collaboration', () => {
           client1.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>()!;
-            const text = paragraph.getFirstChild<TextNode>()!;
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
+            const text = $assertNodeType(
+              paragraph.getFirstChild(),
+              $isTextNode,
+            );
 
             text.spliceText(11, 11, '');
           });
@@ -195,8 +216,14 @@ describe('Collaboration', () => {
           client2.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>()!;
-            const text = paragraph.getFirstChild<TextNode>()!;
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
+            const text = $assertNodeType(
+              paragraph.getFirstChild(),
+              $isTextNode,
+            );
 
             text.spliceText(11, 11, '!');
           });
@@ -230,7 +257,10 @@ describe('Collaboration', () => {
           client1.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>()!;
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
             const text = $createTextNode('Hello world');
             paragraph.append(text);
           });
@@ -249,7 +279,10 @@ describe('Collaboration', () => {
           client1.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>()!;
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
             paragraph.getFirstChild()!.remove();
           });
         });
@@ -264,11 +297,16 @@ describe('Collaboration', () => {
           client2.update(() => {
             const root = $getRoot();
 
-            const paragraph = root.getFirstChild<ParagraphNode>()!;
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isParagraphNode,
+            );
 
-            paragraph
-              .getFirstChild<TextNode>()!
-              .spliceText(11, 0, 'Hello world');
+            $assertNodeType(paragraph.getFirstChild(), $isTextNode).spliceText(
+              11,
+              0,
+              'Hello world',
+            );
           });
         });
 
@@ -327,7 +365,10 @@ describe('Collaboration', () => {
         // Override direction
         await waitForReact(() => {
           client1.update(() => {
-            const paragraph = $getRoot().getFirstChild<ParagraphNode>()!;
+            const paragraph = $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            );
             paragraph.setDirection('rtl');
           });
         });
@@ -484,7 +525,10 @@ describe('Collaboration', () => {
 
         await waitForReact(() => {
           client1.update(() => {
-            const paragraph = $getRoot().getFirstChild<ParagraphNode>()!;
+            const paragraph = $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            );
             paragraph.append($createTextNode('Hello'));
           });
         });
@@ -644,7 +688,10 @@ describe('Collaboration', () => {
       client1.getEditor().update(() => {
         const root = $getRoot();
 
-        const paragraph = root.getFirstChild<ParagraphNode>()!;
+        const paragraph = $assertNodeType(
+          root.getFirstChild(),
+          $isParagraphNode,
+        );
         paragraph.append($createTextNode('1'));
       });
     });
@@ -720,7 +767,10 @@ describe('Collaboration', () => {
 
       editor.update(
         () => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           $setState(paragraph, state, 'bar');
           // Include another update otherwise equalYTypePNode would return true
           paragraph.append($createTextNode('!'));
@@ -749,20 +799,29 @@ describe('Collaboration', () => {
       });
 
       let editor2State = client2.getEditorState().read(() => {
-        const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+        const paragraph = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isParagraphNode,
+        );
         return $getState(paragraph, state);
       });
       expect(editor2State).toEqual('bar');
 
       await waitForReact(() => {
         client1.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           $setState(paragraph, state, undefined);
         });
       });
 
       editor2State = client2.getEditorState().read(() => {
-        const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+        const paragraph = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isParagraphNode,
+        );
         return $getState(paragraph, state);
       });
       expect(editor2State).toBeUndefined();

--- a/packages/lexical-react/src/__tests__/unit/CollaborationSnapshot.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationSnapshot.test.ts
@@ -16,12 +16,18 @@ import {
   $createTextNode,
   $getNodeByKeyOrThrow,
   $getRoot,
+  $isParagraphNode,
+  $isTextNode,
   LexicalEditor,
   MutationListener,
   ParagraphNode,
   TextNode,
 } from 'lexical';
-import {expectHtmlToBeEqual, html} from 'lexical/src/__tests__/utils';
+import {
+  $assertNodeType,
+  expectHtmlToBeEqual,
+  html,
+} from 'lexical/src/__tests__/utils';
 import {afterEach, beforeEach, describe, it} from 'vitest';
 import * as Y from 'yjs';
 
@@ -56,7 +62,7 @@ describe('CollaborationSnapshot', () => {
             continue;
           }
           element.classList.remove('removed', 'added');
-          const node = $getNodeByKeyOrThrow<TextNode>(nodeKey);
+          const node = $getNodeByKeyOrThrow(nodeKey);
           const ychange = $getYChangeState<void>(node);
           if (!ychange) {
             continue;
@@ -111,7 +117,10 @@ describe('CollaborationSnapshot', () => {
       await waitForReact(() =>
         editor1.update(
           () => {
-            $getRoot().getChildAtIndex<ParagraphNode>(2)!.remove();
+            $assertNodeType(
+              $getRoot().getChildAtIndex(2),
+              $isParagraphNode,
+            ).remove();
           },
           {discrete: true},
         ),
@@ -122,9 +131,18 @@ describe('CollaborationSnapshot', () => {
       await waitForReact(() =>
         editor1.update(
           () => {
-            const paragraph = $getRoot().getChildAtIndex<ParagraphNode>(0)!;
-            paragraph.getChildAtIndex<TextNode>(0)!.spliceText(2, 1, '123');
-            $getRoot().getChildAtIndex<ParagraphNode>(1)!.remove();
+            const paragraph = $assertNodeType(
+              $getRoot().getChildAtIndex(0),
+              $isParagraphNode,
+            );
+            $assertNodeType(
+              paragraph.getChildAtIndex(0),
+              $isTextNode,
+            ).spliceText(2, 1, '123');
+            $assertNodeType(
+              $getRoot().getChildAtIndex(1),
+              $isParagraphNode,
+            ).remove();
           },
           {discrete: true},
         ),
@@ -135,7 +153,10 @@ describe('CollaborationSnapshot', () => {
       await waitForReact(() =>
         editor1.update(
           () => {
-            const paragraph = $getRoot().getChildAtIndex<ParagraphNode>(0)!;
+            const paragraph = $assertNodeType(
+              $getRoot().getChildAtIndex(0),
+              $isParagraphNode,
+            );
             paragraph.append($createTextNode('!'));
           },
           {discrete: true},
@@ -179,7 +200,10 @@ describe('CollaborationSnapshot', () => {
       await waitForReact(() =>
         editor1.update(
           () => {
-            const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+            const paragraph = $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            );
             paragraph.append($createTextNode('Hello'));
           },
           {discrete: true},
@@ -191,7 +215,10 @@ describe('CollaborationSnapshot', () => {
       await waitForReact(() =>
         editor1.update(
           () => {
-            const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+            const paragraph = $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            );
             paragraph.append($createTextNode(' world'));
           },
           {discrete: true},
@@ -227,7 +254,10 @@ describe('CollaborationSnapshot', () => {
       await waitForReact(() =>
         editor1.update(
           () => {
-            const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+            const paragraph = $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            );
             paragraph.append($createTextNode('Hello'));
           },
           {discrete: true},
@@ -238,7 +268,10 @@ describe('CollaborationSnapshot', () => {
       await waitForReact(() =>
         editor1.update(
           () => {
-            const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+            const paragraph = $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            );
             paragraph.append($createTextNode(' world'));
           },
           {discrete: true},
@@ -275,9 +308,10 @@ describe('CollaborationSnapshot', () => {
       await waitForReact(() =>
         editor1.update(
           () => {
-            $getRoot()
-              .getFirstChildOrThrow<ParagraphNode>()
-              .append($createTextNode('First paragraph'));
+            $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            ).append($createTextNode('First paragraph'));
           },
           {discrete: true},
         ),
@@ -328,7 +362,10 @@ describe('CollaborationSnapshot', () => {
     it('should ignore changes from other clients while in diff mode', async () => {
       await waitForReact(() => {
         editor1.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraph.append($createTextNode('ABC'));
         });
       });
@@ -343,7 +380,10 @@ describe('CollaborationSnapshot', () => {
 
       await waitForReact(() => {
         editor2.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraph.append($createTextNode('XYZ'));
         });
       });
@@ -370,7 +410,10 @@ describe('CollaborationSnapshot', () => {
     it('should not sync changes to yjs while in diff mode', async () => {
       await waitForReact(() => {
         editor1.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraph.append($createTextNode('ABC'));
         });
       });
@@ -385,7 +428,10 @@ describe('CollaborationSnapshot', () => {
 
       await waitForReact(() => {
         editor1.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraph.append($createTextNode('!'));
         });
       });
@@ -415,7 +461,10 @@ describe('CollaborationSnapshot', () => {
     it('recover editor state after clear diff versions command', async () => {
       await waitForReact(() => {
         editor1.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraph.append($createTextNode('ABC'));
         });
       });
@@ -430,7 +479,10 @@ describe('CollaborationSnapshot', () => {
 
       await waitForReact(() => {
         editor2.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraph.append($createTextNode('XYZ'));
         });
       });
@@ -457,14 +509,20 @@ describe('CollaborationSnapshot', () => {
       // Ensure that updates after synced again.
       await waitForReact(() => {
         editor1.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraph.append($createTextNode('!'));
         });
       });
 
       await waitForReact(() => {
         editor2.update(() => {
-          const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const paragraph = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isParagraphNode,
+          );
           paragraph.append($createTextNode('?'));
         });
       });

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
@@ -18,12 +18,12 @@ import {
   $getRoot,
   $getSelection,
   $isNodeSelection,
+  $isParagraphNode,
   $isRangeSelection,
   LexicalEditor,
   NodeKey,
-  ParagraphNode,
 } from 'lexical';
-import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {$assertNodeType, initializeUnitTest} from 'lexical/src/__tests__/utils';
 import {describe, expect, it} from 'vitest';
 
 import {$mergePrevious} from '../../shared/useCharacterLimit';
@@ -61,9 +61,14 @@ describe('LexicalNodeHelpers tests', () => {
             [overflowLeftKey, overflowRightKey] =
               $initializeEditorWithLeftRightOverflowNodes();
 
-            const overflowLeft = $getNodeByKey<OverflowNode>(overflowLeftKey)!;
-            const overflowRight =
-              $getNodeByKey<OverflowNode>(overflowRightKey)!;
+            const overflowLeft = $assertNodeType(
+              $getNodeByKey(overflowLeftKey),
+              $isOverflowNode,
+            );
+            const overflowRight = $assertNodeType(
+              $getNodeByKey(overflowRightKey),
+              $isOverflowNode,
+            );
 
             const text1 = $createTextNode('1');
             const text2 = $createTextNode('2');
@@ -85,10 +90,15 @@ describe('LexicalNodeHelpers tests', () => {
           });
 
           await editor.update(() => {
-            const paragraph = $getRoot().getFirstChild<ParagraphNode>()!;
+            const paragraph = $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            );
 
-            const overflowRight =
-              $getNodeByKey<OverflowNode>(overflowRightKey)!;
+            const overflowRight = $assertNodeType(
+              $getNodeByKey(overflowRightKey),
+              $isOverflowNode,
+            );
 
             $mergePrevious(overflowRight);
 
@@ -123,9 +133,14 @@ describe('LexicalNodeHelpers tests', () => {
           await editor.update(() => {
             [overflowLeftKey, overflowRightKey] =
               $initializeEditorWithLeftRightOverflowNodes();
-            const overflowLeft = $getNodeByKey<OverflowNode>(overflowLeftKey)!;
-            const overflowRight =
-              $getNodeByKey<OverflowNode>(overflowRightKey)!;
+            const overflowLeft = $assertNodeType(
+              $getNodeByKey(overflowLeftKey),
+              $isOverflowNode,
+            );
+            const overflowRight = $assertNodeType(
+              $getNodeByKey(overflowRightKey),
+              $isOverflowNode,
+            );
 
             const text1 = $createTextNode('1');
             const text2 = $createTextNode('2');
@@ -158,9 +173,14 @@ describe('LexicalNodeHelpers tests', () => {
           });
 
           await editor.update(() => {
-            const paragraph = $getRoot().getFirstChild<ParagraphNode>()!;
-            const overflowRight =
-              $getNodeByKey<OverflowNode>(overflowRightKey)!;
+            const paragraph = $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isParagraphNode,
+            );
+            const overflowRight = $assertNodeType(
+              $getNodeByKey(overflowRightKey),
+              $isOverflowNode,
+            );
 
             $mergePrevious(overflowRight);
 

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
@@ -24,12 +24,14 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
-  ElementNode,
+  $isElementNode,
+  $isTextNode,
   ParagraphNode,
   RangeSelection,
   TextNode,
 } from 'lexical';
 import {
+  $assertNodeType,
   $createTestElementNode,
   initializeUnitTest,
   invariant,
@@ -200,7 +202,10 @@ describe('LexicalHeadingNode tests', () => {
       );
       await editor.update(
         () => {
-          const heading = $getRoot().getFirstChildOrThrow<HeadingNode>();
+          const heading = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isHeadingNode,
+          );
           expect(heading.getTag()).toBe('h1');
           heading.setTag('h2');
           expect(heading.getTag()).toBe('h2');
@@ -405,7 +410,7 @@ describe('Backspace at start of heading (#4359)', () => {
           );
           $getRoot().clear().append(heading);
           originalKey = heading.getKey();
-          heading.getFirstChildOrThrow<TextNode>().select(0, 0);
+          $assertNodeType(heading.getFirstChild(), $isTextNode).select(0, 0);
           heading.collapseAtStart();
         },
         {discrete: true},
@@ -438,7 +443,10 @@ describe('Backspace at start of heading (#4359)', () => {
         {discrete: true},
       );
       editor.read(() => {
-        const wrap = $getRoot().getFirstChildOrThrow<ElementNode>();
+        const wrap = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isElementNode,
+        );
         expect(wrap.getType()).toBe('test_block');
         const inner = wrap.getFirstChild();
         invariant($isHeadingNode(inner));

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -57,6 +57,7 @@ import {
   TextNode,
 } from 'lexical';
 import {
+  $assertNodeType,
   $assertRangeSelection,
   $createTestDecoratorNode,
   $createTestElementNode,
@@ -1316,7 +1317,10 @@ describe('LexicalSelection tests', () => {
       await editor!.update(() => {
         const root = $getRoot();
 
-        const paragraph = root.getFirstChild<ParagraphNode>()!;
+        const paragraph = $assertNodeType(
+          root.getFirstChild(),
+          $isParagraphNode,
+        );
 
         const elementNode = $createTestElementNode();
         const text = $createTextNode('foo');
@@ -1340,7 +1344,10 @@ describe('LexicalSelection tests', () => {
       await editor!.update(() => {
         const root = $getRoot();
 
-        const paragraph = root.getFirstChild<ParagraphNode>()!;
+        const paragraph = $assertNodeType(
+          root.getFirstChild(),
+          $isParagraphNode,
+        );
 
         const elementNode = $createTestElementNode();
         const text = $createTextNode();
@@ -1914,7 +1921,10 @@ describe('LexicalSelection tests', () => {
               await editor!.update(() => {
                 const root = $getRoot();
 
-                const paragraph = root.getFirstChild<ParagraphNode>()!;
+                const paragraph = $assertNodeType(
+                  root.getFirstChild(),
+                  $isParagraphNode,
+                );
                 const textNode = $createTextNode('foo');
                 // Note: line break can't be selected by the DOM
                 const linebreak = $createLineBreakNode();
@@ -2082,7 +2092,10 @@ describe('LexicalSelection tests', () => {
       await editor!.update(() => {
         const root = $getRoot();
 
-        const paragraph = root.getFirstChild<ParagraphNode>()!;
+        const paragraph = $assertNodeType(
+          root.getFirstChild(),
+          $isParagraphNode,
+        );
         const paragraphKey = paragraph.getKey();
         const textNode = $createTextNode('foo');
         const textNodeKey = textNode.getKey();
@@ -2207,7 +2220,10 @@ describe('LexicalSelection tests', () => {
             await editor!.update(() => {
               const root = $getRoot();
 
-              const paragraph = root.getFirstChild<ParagraphNode>()!;
+              const paragraph = $assertNodeType(
+                root.getFirstChild(),
+                $isParagraphNode,
+              );
               const textNode1 = $createTextNode('1');
               const textNode2 = $createTextNode('2');
               const decorator = $createTestDecoratorNode();

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -23,7 +23,6 @@ import {
   $mergeCells,
   INSERT_TABLE_COMMAND,
   TableExtension,
-  type TableNode,
 } from '@lexical/table';
 import {
   $createParagraphNode,
@@ -38,6 +37,7 @@ import {
   NodeKey,
   SELECT_ALL_COMMAND,
 } from 'lexical';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
 import {
   afterEach,
   assert,
@@ -83,7 +83,7 @@ describe('TableExtension', () => {
         'table',
         'paragraph',
       ]);
-      const table = children[1] as TableNode;
+      const table = $assertNodeType(children[1], $isTableNode);
       expect($isTableNode(table)).toBe(true);
       const rows = table.getChildren();
       expect(rows.length).toBe(2);
@@ -409,7 +409,7 @@ describe('TableExtension', () => {
             columns: '2',
             rows: '2',
           });
-          const table = root.getFirstChildOrThrow<TableNode>();
+          const table = $assertNodeType(root.getFirstChild(), $isTableNode);
           table.setColWidths([]);
         },
         {discrete: true},
@@ -417,7 +417,7 @@ describe('TableExtension', () => {
 
       editor.getEditorState().read(() => {
         const root = $getRoot();
-        const table = root.getFirstChildOrThrow<TableNode>();
+        const table = $assertNodeType(root.getFirstChild(), $isTableNode);
         expect(table.getColWidths()).toBe(undefined);
       });
     });
@@ -431,7 +431,7 @@ describe('TableExtension', () => {
             columns: '3',
             rows: '2',
           });
-          const table = root.getFirstChildOrThrow<TableNode>();
+          const table = $assertNodeType(root.getFirstChild(), $isTableNode);
           table.setColWidths([10, 20]);
         },
         {discrete: true},
@@ -439,7 +439,7 @@ describe('TableExtension', () => {
 
       editor.getEditorState().read(() => {
         const root = $getRoot();
-        const table = root.getFirstChildOrThrow<TableNode>();
+        const table = $assertNodeType(root.getFirstChild(), $isTableNode);
         expect(table.getColWidths()).toEqual([10, 20, 20]);
       });
     });
@@ -453,7 +453,7 @@ describe('TableExtension', () => {
             columns: '2',
             rows: '2',
           });
-          const table = root.getFirstChildOrThrow<TableNode>();
+          const table = $assertNodeType(root.getFirstChild(), $isTableNode);
           table.setColWidths([10, 20, 30]);
         },
         {discrete: true},
@@ -461,7 +461,7 @@ describe('TableExtension', () => {
 
       editor.getEditorState().read(() => {
         const root = $getRoot();
-        const table = root.getFirstChildOrThrow<TableNode>();
+        const table = $assertNodeType(root.getFirstChild(), $isTableNode);
         expect(table.getColWidths()).toEqual([10, 20]);
       });
     });

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -20,7 +20,6 @@ import {
   $isScrollableTablesActive,
   $isTableCellNode,
   $isTableNode,
-  TableNode,
 } from '@lexical/table';
 import {$dfs} from '@lexical/utils';
 import {
@@ -28,13 +27,14 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $isParagraphNode,
   $isRangeSelection,
   $selectAll,
   $setSelection,
   CUT_COMMAND,
-  ParagraphNode,
 } from 'lexical';
 import {
+  $assertNodeType,
   expectHtmlToBeEqual,
   html,
   initializeUnitTest,
@@ -805,14 +805,17 @@ describe('LexicalTableNode tests', () => {
 
             await editor.update(() => {
               const root = $getRoot();
-              const paragraph = root.getFirstChild<ParagraphNode>();
+              const paragraph = $assertNodeType(
+                root.getFirstChild(),
+                $isParagraphNode,
+              );
               const beforeText = $createTextNode('text before the table');
               const table = $createTableNodeWithDimensions(4, 4, true);
               const afterText = $createTextNode('text after the table');
 
-              paragraph?.append(beforeText);
-              paragraph?.append(table);
-              paragraph?.append(afterText);
+              paragraph.append(beforeText);
+              paragraph.append(table);
+              paragraph.append(afterText);
             });
             await editor.update(() => {
               editor.focus();
@@ -835,12 +838,15 @@ describe('LexicalTableNode tests', () => {
 
             await editor.update(() => {
               const root = $getRoot();
-              const paragraph = root.getFirstChild<ParagraphNode>();
+              const paragraph = $assertNodeType(
+                root.getFirstChild(),
+                $isParagraphNode,
+              );
               const beforeText = $createTextNode('text before the table');
               const table = $createTableNodeWithDimensions(4, 4, true);
 
-              paragraph?.append(beforeText);
-              paragraph?.append(table);
+              paragraph.append(beforeText);
+              paragraph.append(table);
             });
             await editor.update(() => {
               editor.focus();
@@ -863,12 +869,15 @@ describe('LexicalTableNode tests', () => {
 
             await editor.update(() => {
               const root = $getRoot();
-              const paragraph = root.getFirstChild<ParagraphNode>();
+              const paragraph = $assertNodeType(
+                root.getFirstChild(),
+                $isParagraphNode,
+              );
               const table = $createTableNodeWithDimensions(4, 4, true);
               const afterText = $createTextNode('text after the table');
 
-              paragraph?.append(table);
-              paragraph?.append(afterText);
+              paragraph.append(table);
+              paragraph.append(afterText);
             });
             await editor.update(() => {
               editor.focus();
@@ -896,19 +905,19 @@ describe('LexicalTableNode tests', () => {
             });
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
+              const table = root.getLastChild();
+              if ($isTableNode(table)) {
                 const DOMTable = $getElementForTableNode(editor, table);
                 if (DOMTable) {
-                  table
-                    ?.getCellNodeFromCords(0, 0, DOMTable)
-                    ?.getLastChild<ParagraphNode>()
-                    ?.append($createTextNode('some text'));
+                  $assertNodeType(
+                    table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
+                    $isParagraphNode,
+                  ).append($createTextNode('some text'));
                   const selection = $createTableSelection();
                   selection.set(
                     table.__key,
-                    table?.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                    table?.getCellNodeFromCords(3, 3, DOMTable)?.__key || '',
+                    table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                    table.getCellNodeFromCords(3, 3, DOMTable)?.__key || '',
                   );
                   $setSelection(selection);
                   editor.dispatchCommand(
@@ -937,19 +946,19 @@ describe('LexicalTableNode tests', () => {
             });
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
+              const table = root.getLastChild();
+              if ($isTableNode(table)) {
                 const DOMTable = $getElementForTableNode(editor, table);
                 if (DOMTable) {
-                  table
-                    ?.getCellNodeFromCords(0, 0, DOMTable)
-                    ?.getLastChild<ParagraphNode>()
-                    ?.append($createTextNode('some text'));
+                  $assertNodeType(
+                    table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
+                    $isParagraphNode,
+                  ).append($createTextNode('some text'));
                   const selection = $createTableSelection();
                   selection.set(
                     table.__key,
-                    table?.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                    table?.getCellNodeFromCords(2, 2, DOMTable)?.__key || '',
+                    table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                    table.getCellNodeFromCords(2, 2, DOMTable)?.__key || '',
                   );
                   $setSelection(selection);
                   editor.dispatchCommand(
@@ -1042,42 +1051,40 @@ describe('LexicalTableNode tests', () => {
             });
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
-                const DOMTable = $getElementForTableNode(editor, table);
-                if (DOMTable) {
-                  table
-                    ?.getCellNodeFromCords(0, 0, DOMTable)
-                    ?.getLastChild<ParagraphNode>()
-                    ?.append($createTextNode('1'));
-                  table
-                    ?.getCellNodeFromCords(1, 0, DOMTable)
-                    ?.getLastChild<ParagraphNode>()
-                    ?.append($createTextNode(''));
-                  table
-                    ?.getCellNodeFromCords(2, 0, DOMTable)
-                    ?.getLastChild<ParagraphNode>()
-                    ?.append($createTextNode('2'));
-                  table
-                    ?.getCellNodeFromCords(0, 1, DOMTable)
-                    ?.getLastChild<ParagraphNode>()
-                    ?.append($createTextNode('3'));
-                  table
-                    ?.getCellNodeFromCords(1, 1, DOMTable)
-                    ?.getLastChild<ParagraphNode>()
-                    ?.append($createTextNode('4'));
-                  table
-                    ?.getCellNodeFromCords(2, 1, DOMTable)
-                    ?.getLastChild<ParagraphNode>()
-                    ?.append($createTextNode(''));
-                  const selection = $createTableSelection();
-                  selection.set(
-                    table.__key,
-                    table?.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                    table?.getCellNodeFromCords(2, 1, DOMTable)?.__key || '',
-                  );
-                  expect(selection.getTextContent()).toBe(`1\t\t2\n3\t4\t\n`);
-                }
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
+              const DOMTable = $getElementForTableNode(editor, table);
+              if (DOMTable) {
+                $assertNodeType(
+                  table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
+                  $isParagraphNode,
+                ).append($createTextNode('1'));
+                $assertNodeType(
+                  table.getCellNodeFromCords(1, 0, DOMTable)?.getLastChild(),
+                  $isParagraphNode,
+                ).append($createTextNode(''));
+                $assertNodeType(
+                  table.getCellNodeFromCords(2, 0, DOMTable)?.getLastChild(),
+                  $isParagraphNode,
+                ).append($createTextNode('2'));
+                $assertNodeType(
+                  table.getCellNodeFromCords(0, 1, DOMTable)?.getLastChild(),
+                  $isParagraphNode,
+                ).append($createTextNode('3'));
+                $assertNodeType(
+                  table.getCellNodeFromCords(1, 1, DOMTable)?.getLastChild(),
+                  $isParagraphNode,
+                ).append($createTextNode('4'));
+                $assertNodeType(
+                  table.getCellNodeFromCords(2, 1, DOMTable)?.getLastChild(),
+                  $isParagraphNode,
+                ).append($createTextNode(''));
+                const selection = $createTableSelection();
+                selection.set(
+                  table.__key,
+                  table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                  table.getCellNodeFromCords(2, 1, DOMTable)?.__key || '',
+                );
+                expect(selection.getTextContent()).toBe(`1\t\t2\n3\t4\t\n`);
               }
             });
           });
@@ -1092,17 +1099,15 @@ describe('LexicalTableNode tests', () => {
             });
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
-                table.setRowStriping(true);
-              }
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
+              table.setRowStriping(true);
             });
 
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
-                table!.createDOM(editorConfig).outerHTML,
+                table.createDOM(editorConfig).outerHTML,
                 html`
                   <table
                     class="${editorConfig.theme.table} ${editorConfig.theme
@@ -1121,17 +1126,15 @@ describe('LexicalTableNode tests', () => {
 
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
-                table.setRowStriping(false);
-              }
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
+              table.setRowStriping(false);
             });
 
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
-                table!.createDOM(editorConfig).outerHTML,
+                table.createDOM(editorConfig).outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
                     <colgroup>
@@ -1157,17 +1160,21 @@ describe('LexicalTableNode tests', () => {
               });
               await editor.update(() => {
                 const root = $getRoot();
-                const table = root.getLastChild<TableNode>();
-                if (table) {
-                  table.setFrozenColumns(1);
-                }
+                const table = $assertNodeType(
+                  root.getLastChild(),
+                  $isTableNode,
+                );
+                table.setFrozenColumns(1);
               });
 
               await editor.update(() => {
                 const root = $getRoot();
-                const table = root.getLastChild<TableNode>();
+                const table = $assertNodeType(
+                  root.getLastChild(),
+                  $isTableNode,
+                );
                 expectHtmlToBeEqual(
-                  table!.createDOM(editorConfig).outerHTML,
+                  table.createDOM(editorConfig).outerHTML,
                   html`
                     <div
                       class="${editorConfig.theme
@@ -1633,17 +1640,21 @@ describe('LexicalTableNode tests', () => {
 
               await editor.update(() => {
                 const root = $getRoot();
-                const table = root.getLastChild<TableNode>();
-                if (table) {
-                  table.setFrozenColumns(0);
-                }
+                const table = $assertNodeType(
+                  root.getLastChild(),
+                  $isTableNode,
+                );
+                table.setFrozenColumns(0);
               });
 
               await editor.update(() => {
                 const root = $getRoot();
-                const table = root.getLastChild<TableNode>();
+                const table = $assertNodeType(
+                  root.getLastChild(),
+                  $isTableNode,
+                );
                 expectHtmlToBeEqual(
-                  table!.createDOM(editorConfig).outerHTML,
+                  table.createDOM(editorConfig).outerHTML,
                   html`
                     <div class="${editorConfig.theme.tableScrollableWrapper}">
                       <table class="${editorConfig.theme.table}">
@@ -1671,17 +1682,15 @@ describe('LexicalTableNode tests', () => {
             });
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
-                table.setFormat('center');
-              }
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
+              table.setFormat('center');
             });
 
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
-                table!.createDOM(editorConfig).outerHTML,
+                table.createDOM(editorConfig).outerHTML,
                 html`
                   <table
                     class="${editorConfig.theme.table} ${editorConfig.theme
@@ -1699,17 +1708,15 @@ describe('LexicalTableNode tests', () => {
 
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
-                table.setFormat('left');
-              }
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
+              table.setFormat('left');
             });
 
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
-                table!.createDOM(editorConfig).outerHTML,
+                table.createDOM(editorConfig).outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
                     <colgroup>
@@ -1736,15 +1743,15 @@ describe('LexicalTableNode tests', () => {
             // Set widths
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              table!.setColWidths([50, 50]);
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
+              table.setColWidths([50, 50]);
             });
 
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
-                table!.createDOM(editorConfig).outerHTML,
+                table.createDOM(editorConfig).outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
                     <colgroup>
@@ -1754,37 +1761,37 @@ describe('LexicalTableNode tests', () => {
                   </table>
                 `,
               );
-              const colWidths = table!.getColWidths();
+              const colWidths = table.getColWidths();
 
               // colwidths should be immutable in DEV
               expect(() => {
                 (colWidths as number[]).push(100);
               }).toThrow();
-              expect(table!.getColWidths()).toStrictEqual([50, 50]);
-              expect(table!.getColumnCount()).toBe(2);
+              expect(table.getColWidths()).toStrictEqual([50, 50]);
+              expect(table.getColumnCount()).toBe(2);
             });
 
             // Add a column
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              const DOMTable = $getElementForTableNode(editor, table!);
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
+              const DOMTable = $getElementForTableNode(editor, table);
               const selection = $createTableSelection();
               selection.set(
-                table!.__key,
-                table!.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                table!.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                table.__key,
+                table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
               );
               $setSelection(selection);
               $insertTableColumnAtSelection();
-              table!.setColWidths([50, 50, 100]);
+              table.setColWidths([50, 50, 100]);
             });
 
             await editor.update(() => {
               const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
+              const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
-                table!.createDOM(editorConfig).outerHTML,
+                table.createDOM(editorConfig).outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
                     <colgroup>
@@ -1795,8 +1802,8 @@ describe('LexicalTableNode tests', () => {
                   </table>
                 `,
               );
-              expect(table!.getColWidths()).toStrictEqual([50, 50, 100]);
-              expect(table!.getColumnCount()).toBe(3);
+              expect(table.getColWidths()).toStrictEqual([50, 50, 100]);
+              expect(table.getColumnCount()).toBe(3);
             });
           });
         },

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -81,7 +81,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -91,7 +91,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -113,7 +113,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -123,7 +123,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -145,7 +145,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -155,7 +155,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -177,7 +177,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -187,7 +187,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -209,7 +209,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -219,7 +219,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -241,7 +241,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -251,7 +251,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -273,7 +273,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -283,7 +283,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -305,7 +305,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -315,7 +315,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -339,7 +339,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -349,7 +349,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -393,7 +393,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -403,7 +403,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -433,7 +433,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -443,7 +443,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }
@@ -466,7 +466,7 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild<TableNode>();
+        const table = $getRoot().getFirstChild();
         if (!$isTableNode(table)) {
           throw new Error('Expected table node');
         }
@@ -476,7 +476,7 @@ describe('$moveTableColumn', () => {
     );
 
     editor.getEditorState().read(() => {
-      const table = $getRoot().getFirstChild<TableNode>();
+      const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
       }

--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -19,6 +19,7 @@ import {
   NodeKey,
 } from 'lexical';
 import {
+  $assertNodeType,
   $createTestElementNode,
   initializeUnitTest,
   invariant,
@@ -202,7 +203,10 @@ describe('LexicalNodeHelpers tests', () => {
                 ),
               );
 
-            const paragraph = root.getFirstChildOrThrow<ElementNode>();
+            const paragraph = $assertNodeType(
+              root.getFirstChild(),
+              $isElementNode,
+            );
             const children = paragraph.getChildren();
             expect($dfs(children[1])).toEqual([{depth: 2, node: children[1]}]);
           },

--- a/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
@@ -15,6 +15,7 @@ import {
   $applyNodeReplacement,
   $createTextNode,
   $getRoot,
+  $isElementNode,
   ElementNode,
   LexicalEditor,
   TextNode,
@@ -22,7 +23,11 @@ import {
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 
 import {ElementDOMSlot} from '../../LexicalDOMSlot';
-import {$createTestDecoratorNode, TestDecoratorNode} from '../utils';
+import {
+  $assertNodeType,
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from '../utils';
 
 describe('ElementDOMSlot class', () => {
   function makeElement(): HTMLElement {
@@ -751,7 +756,10 @@ describe('ElementDOMSlot block cursor handling', () => {
     // selection — the scenario from the issue.
     editor.update(
       () => {
-        const wrap = $getRoot().getFirstChildOrThrow<ElementNode>();
+        const wrap = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isElementNode,
+        );
         wrap.getFirstChildOrThrow().insertBefore($createTextNode('inserted'));
       },
       {discrete: true},

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -88,6 +88,7 @@ import {afterEach, assert, beforeEach, describe, expect, it, vi} from 'vitest';
 import {emptyFunction} from '../../LexicalUtils';
 import {SerializedParagraphNode} from '../../nodes/LexicalParagraphNode';
 import {
+  $assertNodeType,
   $createTestDecoratorNode,
   $createTestElementNode,
   $createTestInlineElementNode,
@@ -1392,11 +1393,13 @@ describe('LexicalEditor tests', () => {
 
     editor.update(() => {
       const root = $getRoot();
-      root
-        .getFirstChild<ElementNode>()!
-        .getFirstChild<ElementNode>()!
-        .getFirstChild<TextNode>()!
-        .setTextContent('Foo');
+      $assertNodeType(
+        $assertNodeType(
+          $assertNodeType(root.getFirstChild(), $isElementNode).getFirstChild(),
+          $isElementNode,
+        ).getFirstChild(),
+        $isTextNode,
+      ).setTextContent('Foo');
     });
 
     expect(errorListener).toHaveBeenCalledTimes(1);
@@ -1730,7 +1733,12 @@ describe('LexicalEditor tests', () => {
       );
       parsedEditorStateFromObject.read(() => {
         const root = $getRoot();
-        expect(root.getFirstChild<ParagraphNode>()!.getDirection()).toBe('rtl');
+        expect(
+          $assertNodeType(
+            root.getFirstChild(),
+            $isParagraphNode,
+          ).getDirection(),
+        ).toBe('rtl');
         expect(root.getTextContent()).toMatch(/Hello world/);
       });
     });

--- a/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
@@ -30,7 +30,7 @@ import {
 import {beforeEach, describe, expect, expectTypeOf, test} from 'vitest';
 
 import {nodeStatesAreEquivalent} from '../../LexicalNodeState';
-import {initializeUnitTest, invariant} from '../utils';
+import {$assertNodeType, initializeUnitTest, invariant} from '../utils';
 import {TestNode} from './LexicalNode.test';
 
 // https://www.totaltypescript.com/how-to-test-your-types
@@ -499,8 +499,10 @@ describe('LexicalNode state', () => {
           // Revert to default value for number state.
           editor.update(
             () => {
-              const paragraph =
-                $getRoot().getFirstChildOrThrow<ParagraphNode>();
+              const paragraph = $assertNodeType(
+                $getRoot().getFirstChild(),
+                $isParagraphNode,
+              );
               const [firstTextNode] = paragraph.getChildren();
               $setState(firstTextNode, numberState, 0);
             },

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -17,6 +17,7 @@ import {
   $createTextNode,
   $getNodeByKey,
   $getRoot,
+  $isDecoratorNode,
   $isElementNode,
   $isParagraphNode,
   $isTextNode,
@@ -31,6 +32,7 @@ import {afterEach, describe, expect, test, vi} from 'vitest';
 
 import {$getReconciledDirection} from '../../LexicalReconciler';
 import {
+  $assertNodeType,
   $createTestDecoratorNode,
   $createTestElementNode,
   initializeUnitTest,
@@ -54,8 +56,10 @@ describe('LexicalReconciler', () => {
 
       const directions = editor.read(() => {
         return $getRoot()
-          .getChildren<ParagraphNode>()
-          .map(child => $getReconciledDirection(child));
+          .getChildren()
+          .map(child =>
+            $getReconciledDirection($assertNodeType(child, $isElementNode)),
+          );
       });
       expect(directions).toEqual(['auto', 'auto', 'auto']);
     });
@@ -75,8 +79,10 @@ describe('LexicalReconciler', () => {
 
       const directions = editor.read(() => {
         return $getRoot()
-          .getChildren<ParagraphNode>()
-          .map(child => $getReconciledDirection(child));
+          .getChildren()
+          .map(child =>
+            $getReconciledDirection($assertNodeType(child, $isElementNode)),
+          );
       });
       expect(directions).toEqual([null, null, null]);
     });
@@ -107,8 +113,10 @@ describe('LexicalReconciler', () => {
 
       const directions = editor.read(() => {
         return $getRoot()
-          .getChildren<ParagraphNode>()
-          .map(child => $getReconciledDirection(child));
+          .getChildren()
+          .map(child =>
+            $getReconciledDirection($assertNodeType(child, $isElementNode)),
+          );
       });
       expect(directions).toEqual(['rtl', 'ltr', 'ltr', 'rtl', 'auto']);
     });
@@ -130,8 +138,10 @@ describe('LexicalReconciler', () => {
 
       const directions = editor.read(() => {
         return $getRoot()
-          .getChildren<ParagraphNode>()
-          .map(child => $getReconciledDirection(child));
+          .getChildren()
+          .map(child =>
+            $getReconciledDirection($assertNodeType(child, $isElementNode)),
+          );
       });
       expect(directions).toEqual(['ltr', null, null]);
     });
@@ -151,8 +161,10 @@ describe('LexicalReconciler', () => {
 
       let directions = editor.read(() => {
         return $getRoot()
-          .getChildren<ParagraphNode>()
-          .map(child => $getReconciledDirection(child));
+          .getChildren()
+          .map(child =>
+            $getReconciledDirection($assertNodeType(child, $isElementNode)),
+          );
       });
       expect(directions).toEqual(['auto', 'ltr']);
 
@@ -163,8 +175,10 @@ describe('LexicalReconciler', () => {
 
       directions = editor.read(() => {
         return $getRoot()
-          .getChildren<ParagraphNode>()
-          .map(child => $getReconciledDirection(child));
+          .getChildren()
+          .map(child =>
+            $getReconciledDirection($assertNodeType(child, $isElementNode)),
+          );
       });
       expect(directions).toEqual([null, 'ltr']);
 
@@ -175,8 +189,10 @@ describe('LexicalReconciler', () => {
 
       directions = editor.read(() => {
         return $getRoot()
-          .getChildren<ParagraphNode>()
-          .map(child => $getReconciledDirection(child));
+          .getChildren()
+          .map(child =>
+            $getReconciledDirection($assertNodeType(child, $isElementNode)),
+          );
       });
       expect(directions).toEqual(['auto', 'ltr']);
     });
@@ -210,9 +226,13 @@ describe('LexicalReconciler', () => {
         );
 
         await editor.update(() => {
-          const decorator = $getRoot()
-            .getFirstChildOrThrow<ParagraphNode>()
-            .getFirstChildOrThrow<TestDecoratorNode>();
+          const decorator = $assertNodeType(
+            $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isElementNode,
+            ).getFirstChild(),
+            $isDecoratorNode,
+          );
           const wrapper = $createTestElementNode();
           decorator.insertBefore(wrapper);
           wrapper.append(decorator);
@@ -243,9 +263,13 @@ describe('LexicalReconciler', () => {
           const root = $getRoot();
           const newParagraph = $createParagraphNode();
           root.append(newParagraph);
-          const element = root
-            .getFirstChildOrThrow<ParagraphNode>()
-            .getFirstChildOrThrow<TestElementNode>();
+          const element = $assertNodeType(
+            $assertNodeType(
+              root.getFirstChild(),
+              $isElementNode,
+            ).getFirstChild(),
+            $isElementNode,
+          );
           newParagraph.append(element);
         });
 
@@ -278,9 +302,13 @@ describe('LexicalReconciler', () => {
           const root = $getRoot();
           const newParagraph = $createParagraphNode();
           root.append(newParagraph);
-          const outer = root
-            .getFirstChildOrThrow<ParagraphNode>()
-            .getFirstChildOrThrow<TestElementNode>();
+          const outer = $assertNodeType(
+            $assertNodeType(
+              root.getFirstChild(),
+              $isElementNode,
+            ).getFirstChild(),
+            $isElementNode,
+          );
           newParagraph.append(outer);
         });
 
@@ -317,9 +345,13 @@ describe('LexicalReconciler', () => {
         );
 
         await editor.update(() => {
-          const decorator = $getRoot()
-            .getFirstChildOrThrow<ParagraphNode>()
-            .getFirstChildOrThrow<TestDecoratorNode>();
+          const decorator = $assertNodeType(
+            $assertNodeType(
+              $getRoot().getFirstChild(),
+              $isElementNode,
+            ).getFirstChild(),
+            $isDecoratorNode,
+          );
           const wrapper = $createTestElementNode();
           decorator.insertBefore(wrapper);
           wrapper.append(decorator);
@@ -356,9 +388,15 @@ describe('LexicalReconciler', () => {
         // Should not throw — slot=null call sites fall back to the regular
         // create path when reuse would be unsafe.
         await editor.update(() => {
-          const [pX, pY] = $getRoot().getChildren<ParagraphNode>();
-          const a = pX.getFirstChildOrThrow<TestDecoratorNode>();
-          const b = pY.getFirstChildOrThrow<TestDecoratorNode>();
+          const children = $getRoot().getChildren();
+          const pX = $assertNodeType(children[0], $isElementNode);
+          const pY = $assertNodeType(children[1], $isElementNode);
+          const a = $assertNodeType(
+            pX.getFirstChild(),
+            (node): node is TestDecoratorNode =>
+              node instanceof TestDecoratorNode,
+          );
+          const b = $assertNodeType(pY.getFirstChild(), $isDecoratorNode);
           a.setIsInline(false); // forces updateDOM=true on a
           pY.append(a);
           pX.append(b);
@@ -394,9 +432,9 @@ describe('LexicalReconciler', () => {
         await editor.update(() => {
           const root = $getRoot();
           // Reorder [a, b, c] → [c, a, b] within the same parent.
-          const c = root.getLastChildOrThrow<ParagraphNode>();
+          const c = $assertNodeType(root.getLastChild(), $isElementNode);
           c.remove();
-          root.getFirstChildOrThrow<ParagraphNode>().insertBefore(c);
+          $assertNodeType(root.getFirstChild(), $isElementNode).insertBefore(c);
         });
 
         expect(editor.getElementByKey(keyA)).toBe(domA);
@@ -424,7 +462,10 @@ describe('LexicalReconciler', () => {
       editor.setRootElement(document.createElement('div'));
 
       editor.read(() => {
-        const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+        const para = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isElementNode,
+        );
         const dom = editor.getElementByKey(para.getKey());
         // The resolved CSS variable would only cascade after the element is
         // attached and styled. Emitting `var(...)` defers resolution to the
@@ -455,14 +496,20 @@ describe('LexicalReconciler', () => {
 
       editor.update(
         () => {
-          const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+          const para = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isElementNode,
+          );
           para.setIndent(0);
         },
         {discrete: true},
       );
 
       editor.read(() => {
-        const para = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+        const para = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isElementNode,
+        );
         const dom = editor.getElementByKey(para.getKey());
         expect(dom!.style.paddingInlineStart).toBe('');
       });

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -524,6 +524,23 @@ export function $assertRangeSelection(selection: unknown): RangeSelection {
   return selection;
 }
 
+/**
+ * Assert that a node matches the given type guard, returning it narrowed to
+ * the guard's type. Useful for safely narrowing the result of traversal
+ * methods such as getFirstChild() or getChildAtIndex() without an unchecked
+ * type cast.
+ */
+export function $assertNodeType<T extends LexicalNode>(
+  node: LexicalNode | null | undefined,
+  guard: (value: LexicalNode | null) => value is T,
+): T {
+  const resolved = node ?? null;
+  if (!guard(resolved)) {
+    throw new Error(`Expected node to match type guard, got ${node}`);
+  }
+  return resolved;
+}
+
 export function invariant(cond?: boolean, message?: string): asserts cond {
   if (cond) {
     return;

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -34,6 +34,7 @@ import {
 } from 'vitest';
 
 import {
+  $assertNodeType,
   $createTestElementNode,
   createTestEditor,
 } from '../../../__tests__/utils';
@@ -198,7 +199,10 @@ describe('LexicalElementNode tests', () => {
 
     test('some children', async () => {
       await update(() => {
-        const children = $getRoot().getFirstChild<ElementNode>()!.getChildren();
+        const children = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isElementNode,
+        ).getChildren();
         expect(children).toHaveLength(3);
       });
     });
@@ -207,9 +211,10 @@ describe('LexicalElementNode tests', () => {
   describe('getAllTextNodes()', () => {
     test('basic', async () => {
       await update(() => {
-        const textNodes = $getRoot()
-          .getFirstChild<ElementNode>()!
-          .getAllTextNodes();
+        const textNodes = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isElementNode,
+        ).getAllTextNodes();
         expect(textNodes).toHaveLength(3);
       });
     });
@@ -249,8 +254,7 @@ describe('LexicalElementNode tests', () => {
     test('basic', async () => {
       await update(() => {
         expect(
-          $getRoot()
-            .getFirstChild<ElementNode>()!
+          $assertNodeType($getRoot().getFirstChild(), $isElementNode)
             .getFirstChild()!
             .getTextContent(),
         ).toBe('Foo');
@@ -269,8 +273,7 @@ describe('LexicalElementNode tests', () => {
     test('basic', async () => {
       await update(() => {
         expect(
-          $getRoot()
-            .getFirstChild<ElementNode>()!
+          $assertNodeType($getRoot().getFirstChild(), $isElementNode)
             .getLastChild()!
             .getTextContent(),
         ).toBe('Baz');
@@ -695,7 +698,10 @@ describe('LexicalElementNode tests', () => {
 
       await update(() => {
         block.splice(1, 0, [
-          $getRoot().getLastChild<ElementNode>()!.getChildAtIndex(1)!,
+          $assertNodeType(
+            $getRoot().getLastChild(),
+            $isElementNode,
+          ).getChildAtIndex(1)!,
         ]);
       });
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
@@ -11,15 +11,17 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
   $isRootNode,
+  $isTextNode,
   ElementNode,
   RootNode,
-  TextNode,
 } from 'lexical';
 import {beforeEach, describe, expect, test} from 'vitest';
 
 import {
+  $assertNodeType,
   $createTestDecoratorNode,
   $createTestElementNode,
   $createTestInlineElementNode,
@@ -246,7 +248,10 @@ describe('LexicalRootNode tests', () => {
       expectRootTextContentToBe('');
 
       await editor.update(() => {
-        const firstParagraph = $getRoot().getFirstChild<ElementNode>()!;
+        const firstParagraph = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isElementNode,
+        );
 
         firstParagraph.append($createTextNode('first line'));
       });
@@ -260,7 +265,10 @@ describe('LexicalRootNode tests', () => {
       expectRootTextContentToBe('first line\n\n');
 
       await editor.update(() => {
-        const secondParagraph = $getRoot().getLastChild<ElementNode>()!;
+        const secondParagraph = $assertNodeType(
+          $getRoot().getLastChild(),
+          $isElementNode,
+        );
 
         secondParagraph.append($createTextNode('second line'));
       });
@@ -274,15 +282,24 @@ describe('LexicalRootNode tests', () => {
       expectRootTextContentToBe('first line\n\nsecond line\n\n');
 
       await editor.update(() => {
-        const thirdParagraph = $getRoot().getLastChild<ElementNode>()!;
+        const thirdParagraph = $assertNodeType(
+          $getRoot().getLastChild(),
+          $isElementNode,
+        );
         thirdParagraph.append($createTextNode('third line'));
       });
 
       expectRootTextContentToBe('first line\n\nsecond line\n\nthird line');
 
       await editor.update(() => {
-        const secondParagraph = $getRoot().getChildAtIndex<ElementNode>(1)!;
-        const secondParagraphText = secondParagraph.getFirstChild<TextNode>()!;
+        const secondParagraph = $assertNodeType(
+          $getRoot().getChildAtIndex(1),
+          $isElementNode,
+        );
+        const secondParagraphText = $assertNodeType(
+          secondParagraph.getFirstChild(),
+          $isTextNode,
+        );
         secondParagraphText.setTextContent('second line!');
       });
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -13,13 +13,14 @@ import {
   $getRoot,
   $getSelection,
   $getState,
+  $isElementNode,
   $isNodeSelection,
+  $isParagraphNode,
   $isRangeSelection,
+  $isTextNode,
   $setState,
   createState,
-  ElementNode,
   LexicalEditor,
-  ParagraphNode,
   TextFormatType,
   TextModeType,
   TextNode,
@@ -30,6 +31,7 @@ import {createRoot} from 'react-dom/client';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 
 import {
+  $assertNodeType,
   $createTestSegmentedNode,
   createTestEditor,
 } from '../../../__tests__/utils';
@@ -163,7 +165,9 @@ describe('LexicalTextNode tests', () => {
         expect(textNode.getTextContent()).toBe('Text');
         expect(textNode.__text).toBe('Text');
 
-        $getRoot().getFirstChild<ElementNode>()!.append(textNode);
+        $assertNodeType($getRoot().getFirstChild(), $isElementNode).append(
+          textNode,
+        );
       });
 
       expect(
@@ -184,14 +188,17 @@ describe('LexicalTextNode tests', () => {
     test('prepend node', async () => {
       await update(() => {
         const textNode = $createTextNode('World').toggleUnmergeable();
-        $getRoot().getFirstChild<ElementNode>()!.append(textNode);
+        $assertNodeType($getRoot().getFirstChild(), $isElementNode).append(
+          textNode,
+        );
       });
 
       await update(() => {
         const textNode = $createTextNode('Hello ').toggleUnmergeable();
-        const previousTextNode = $getRoot()
-          .getFirstChild<ElementNode>()!
-          .getFirstChild()!;
+        const previousTextNode = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isElementNode,
+        ).getFirstChild()!;
         previousTextNode.insertBefore(textNode);
       });
 
@@ -231,8 +238,14 @@ describe('LexicalTextNode tests', () => {
     test(`getFormatFlags(${formatFlag})`, async () => {
       await update(() => {
         const root = $getRoot();
-        const paragraphNode = root.getFirstChild<ParagraphNode>()!;
-        const textNode = paragraphNode.getFirstChild<TextNode>()!;
+        const paragraphNode = $assertNodeType(
+          root.getFirstChild(),
+          $isParagraphNode,
+        );
+        const textNode = $assertNodeType(
+          paragraphNode.getFirstChild(),
+          $isTextNode,
+        );
         const newFormat = textNode.getFormatFlags(formatFlag, null);
 
         expect(newFormat).toBe(stateFormat);
@@ -247,8 +260,14 @@ describe('LexicalTextNode tests', () => {
     test(`predicate for ${formatFlag}`, async () => {
       await update(() => {
         const root = $getRoot();
-        const paragraphNode = root.getFirstChild<ParagraphNode>()!;
-        const textNode = paragraphNode.getFirstChild<TextNode>()!;
+        const paragraphNode = $assertNodeType(
+          root.getFirstChild(),
+          $isParagraphNode,
+        );
+        const textNode = $assertNodeType(
+          paragraphNode.getFirstChild(),
+          $isTextNode,
+        );
 
         textNode.setFormat(stateFormat);
 
@@ -264,8 +283,14 @@ describe('LexicalTextNode tests', () => {
 
       await update(() => {
         const root = $getRoot();
-        const paragraphNode = root.getFirstChild<ParagraphNode>()!;
-        const textNode = paragraphNode.getFirstChild<TextNode>()!;
+        const paragraphNode = $assertNodeType(
+          root.getFirstChild(),
+          $isParagraphNode,
+        );
+        const textNode = $assertNodeType(
+          paragraphNode.getFirstChild(),
+          $isTextNode,
+        );
 
         expect(flagPredicate(textNode)).toBe(false);
 
@@ -996,7 +1021,10 @@ describe('LexicalTextNode tests', () => {
 
   test('mergeWithSibling', async () => {
     await update(() => {
-      const paragraph = $getRoot().getFirstChild<ElementNode>()!;
+      const paragraph = $assertNodeType(
+        $getRoot().getFirstChild(),
+        $isElementNode,
+      );
       const textNode1 = $createTextNode('1');
       const textNode2 = $createTextNode('2');
       const textNode3 = $createTextNode('3');


### PR DESCRIPTION
## Description

Migrate the remaining call sites (all in tests) off the deprecated unsafe type parameters that #8661 added to the node traversal methods (getFirstChild<T>(), getParent<T>(), getChildAtIndex<T>(), $getNodeByKey<T>(), etc.). The deprecated overloads themselves are retained for backwards compatibility with consumers.

Add a $assertNodeType test helper that narrows a node via a type guard instead of an unchecked cast, and use it (alongside the existing $is* guards) in place of the deprecated type parameters and a few remaining unsafe `as` casts in the affected tests.

Follow-up to #8661

## Test plan

Only unit test syntax is affected, behavior should be identical and no runtime code has changed.