### PR TITLE
[lexical][lexical-table] Bug Fix: Delete empty paragraph before table

### DIFF
--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -25,7 +25,6 @@ import {
   $getRoot,
   $getSelection,
   $isParagraphNode,
-  $isRangeSelection,
   $isTextNode,
   $setSelection,
 } from 'lexical';
@@ -175,15 +174,13 @@ describe('table selection', () => {
             const root = $getRoot();
             const paragraph = $createParagraphNode();
             root.clear().append(paragraph, tableNode);
-            paragraph.select();
-
-            const selection = $getSelection();
-            if (!$isRangeSelection(selection)) {
-              throw new Error('Expected range selection');
-            }
+            const selection = paragraph.select();
             selection.deleteCharacter(false);
 
             expect(root.getChildren()).toEqual([tableNode]);
+            expect(selection.anchor.key).toBe(
+              tableNode.getAllTextNodes()[0].getKey(),
+            );
           },
           {discrete: true},
         );

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -25,6 +25,7 @@ import {
   $getRoot,
   $getSelection,
   $isParagraphNode,
+  $isRangeSelection,
   $isTextNode,
   $setSelection,
 } from 'lexical';
@@ -164,6 +165,28 @@ describe('table selection', () => {
             expect(nodes).toEqual([]);
           }
         });
+      });
+    });
+
+    describe('regression #8075', () => {
+      test('forward delete removes an empty paragraph before a table', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            const paragraph = $createParagraphNode();
+            root.clear().append(paragraph, tableNode);
+            paragraph.select();
+
+            const selection = $getSelection();
+            if (!$isRangeSelection(selection)) {
+              throw new Error('Expected range selection');
+            }
+            selection.deleteCharacter(false);
+
+            expect(root.getChildren()).toEqual([tableNode]);
+          },
+          {discrete: true},
+        );
       });
     });
   });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1747,19 +1747,15 @@ export class RangeSelection implements BaseSelection {
         anchorNode.getNextSibling() ||
         (parent === null ? null : parent.getNextSibling());
 
-      if ($isElementNode(nextSibling) && nextSibling.isShadowRoot()) {
-        if (
+      if (
+        $isElementNode(nextSibling) &&
+        nextSibling.isShadowRoot() &&
+        !(
           anchor.type === 'element' &&
           $isElementNode(anchorNode) &&
           anchorNode.isEmpty()
-        ) {
-          const caret = $normalizeCaret($getChildCaret(nextSibling, 'next'));
-          $updateRangeSelectionFromCaretRange(
-            this,
-            $getCaretRange(caret, caret),
-          );
-          anchorNode.remove();
-        }
+        )
+      ) {
         return true;
       }
     }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1748,6 +1748,18 @@ export class RangeSelection implements BaseSelection {
         (parent === null ? null : parent.getNextSibling());
 
       if ($isElementNode(nextSibling) && nextSibling.isShadowRoot()) {
+        if (
+          anchor.type === 'element' &&
+          $isElementNode(anchorNode) &&
+          anchorNode.isEmpty()
+        ) {
+          const caret = $normalizeCaret($getChildCaret(nextSibling, 'next'));
+          $updateRangeSelectionFromCaretRange(
+            this,
+            $getCaretRange(caret, caret),
+          );
+          anchorNode.remove();
+        }
         return true;
       }
     }

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -44,6 +44,7 @@ import {
   $assertRangeSelection,
   $createTestDecoratorNode,
   $createTestInlineElementNode,
+  $createTestShadowRootNode,
   initializeUnitTest,
   invariant,
 } from '../utils';
@@ -54,6 +55,26 @@ function mapLatest<T extends LexicalNode>(nodes: T[]): T[] {
 
 describe('LexicalSelection tests', () => {
   initializeUnitTest(testEnv => {
+    describe('deleteCharacter', () => {
+      test('forward delete removes an empty paragraph before a shadow root', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            const paragraph = $createParagraphNode();
+            const shadowRoot = $createTestShadowRootNode();
+            root.clear().append(paragraph, shadowRoot);
+
+            const selection = paragraph.select();
+            selection.deleteCharacter(false);
+
+            expect(root.getChildren()).toEqual([shadowRoot]);
+            expect(selection.anchor.key).toBe(shadowRoot.getKey());
+          },
+          {discrete: true},
+        );
+      });
+    });
+
     describe('Inserting text either side of inline elements', () => {
       const setup = async (
         mode: 'start-of-paragraph' | 'mid-paragraph' | 'end-of-paragraph',


### PR DESCRIPTION
## Description

Forward delete from an empty paragraph immediately before a table was swallowed by the shadow-root protection in `RangeSelection.forwardDeletion`. That guard correctly prevents deleting the table itself, but it also returned before the empty paragraph could be removed.

This change preserves the protected table behavior while removing the empty anchor paragraph and moving the selection to the table boundary.

Closes #8075

## Test plan

### Before

Forward delete from an empty paragraph directly before a table left the empty paragraph in place, so the Delete key appeared to do nothing.

### After

Forward delete removes the empty paragraph and keeps the table protected. Added regression coverage for the paragraph-before-table case and for the shared shadow-root path.

Automated tests:

- `node node_modules/vitest/vitest.mjs --project unit packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx --run`
- `node node_modules/vitest/vitest.mjs --project unit packages/lexical/src/__tests__/unit/LexicalSelection.test.ts --run`
- `node node_modules/prettier/bin/prettier.cjs --check packages/lexical/src/LexicalSelection.ts packages/lexical/src/__tests__/unit/LexicalSelection.test.ts packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx`
- `node node_modules/eslint/bin/eslint.js packages/lexical/src/LexicalSelection.ts packages/lexical/src/__tests__/unit/LexicalSelection.test.ts packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx`
