### PR TITLE
[ci] Bug Fix: Fix intermittent EACCES in Windows CI browser tests by pinning Vitest browser port

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -109,6 +109,14 @@ export default defineConfig({
         plugins: [react()],
         test: {
           browser: {
+            // Vitest's default browser server port (63315) is in the
+            // ephemeral range, and Windows reserves randomized blocks of
+            // that range (Hyper-V excluded port ranges), so on Windows CI
+            // runners listen() occasionally fails with EACCES
+            // (vitest-dev/vitest#9035). Pin a port below the ephemeral
+            // range instead; if it happens to be busy, Vite falls back to
+            // the next free port rather than failing.
+            api: {port: 8315},
             enabled: true,
             // Headless everywhere by default so the suite runs the same way in
             // CI and in headless dev containers. Pass `--browser.headless=false`


### PR DESCRIPTION
## Description

Vitest's browser mode defaults its Vite server to port 63315, which is inside the ephemeral port range. Windows reserves randomized blocks of that range (Hyper-V/WinNAT excluded port ranges), so on windows-2022 runners the bind occasionally fails with 'listen EACCES: permission denied ::1:63315' (vitest-dev/vitest#9035). Vite only retries EADDRINUSE, not EACCES, so the run dies with an unhandled error.

Pin browser.api.port to 8315, below the ephemeral range, where Windows does not place exclusions. If the port is taken, Vite still falls back to the next free port.

## Test plan

This change is isolated to test configuration