### PR TITLE
[lexical-table] Bug Fix: don't throw on stale table node keys in $handleTableSelectionChangeCommand

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -156,6 +156,62 @@ export class TableObservers {
     }
     return null;
   }
+
+  /**
+   * @internal
+   * Remove the observer for tableKey from the registry and unregister all
+   * of its listeners, e.g. because the table was removed from the document
+   * or its DOM was recreated.
+   *
+   * @returns true if an observer was registered for tableKey
+   */
+  removeObserver(tableKey: NodeKey): boolean {
+    const observerAndElement = this.observers.get(tableKey);
+    if (observerAndElement === undefined) {
+      return false;
+    }
+    observerAndElement[0].removeListeners();
+    this.observers.delete(tableKey);
+    return true;
+  }
+
+  /**
+   * @internal
+   * Remove all observers from the registry and unregister their listeners,
+   * e.g. because the table selection observer is being unregistered.
+   */
+  removeAllObservers(): void {
+    for (const tableKey of Array.from(this.observers.keys())) {
+      this.removeObserver(tableKey);
+    }
+  }
+
+  /**
+   * @internal
+   * Get a snapshot of the registry as [TableNode, TableObserver] pairs for
+   * the current editor state. A table's destroyed mutation can be missed
+   * entirely (e.g. when it is removed during an update while the editor's
+   * root element is detached), so any entry whose table no longer exists
+   * is removed from the registry instead of being returned, otherwise such
+   * an entry would poison the registry and break every subsequent
+   * selection change.
+   *
+   * Must be called within an editor read or update.
+   */
+  $getTableNodesAndObservers(): [TableNode, TableObserver][] {
+    const tableNodesAndObservers: [TableNode, TableObserver][] = [];
+    for (const [tableKey, [tableObserver]] of Array.from(
+      this.observers.entries(),
+    )) {
+      const tableNode = $getNodeByKey(tableKey);
+      if ($isTableNode(tableNode)) {
+        tableNodesAndObservers.push([tableNode, tableObserver]);
+      } else {
+        this.removeObserver(tableKey);
+      }
+    }
+    return tableNodesAndObservers;
+  }
 }
 
 export class TableObserver {

--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -364,15 +364,11 @@ export function registerTableSelectionObserver(
                   initializeTableNode(tableNode, nodeKey, tableElement);
                 } else if (tableElement !== tableSelection[1]) {
                   // The update created a new DOM node, destroy the existing TableObserver
-                  tableSelection[0].removeListeners();
-                  tableObservers.observers.delete(nodeKey);
+                  tableObservers.removeObserver(nodeKey);
                   initializeTableNode(tableNode, nodeKey, tableElement);
                 }
               } else if (mutation === 'destroyed') {
-                if (tableSelection !== undefined) {
-                  tableSelection[0].removeListeners();
-                  tableObservers.observers.delete(nodeKey);
-                }
+                tableObservers.removeObserver(nodeKey);
               }
             }
           },
@@ -384,9 +380,7 @@ export function registerTableSelectionObserver(
     () => {
       // Hook might be called multiple times so cleaning up tables listeners as well,
       // as it'll be reinitialized during recurring call
-      for (const [, [tableSelection]] of tableObservers.observers) {
-        tableSelection.removeListeners();
-      }
+      tableObservers.removeAllObservers();
     },
   );
 }

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -52,6 +52,7 @@ import {
   $getAdjacentChildCaret,
   $getChildCaret,
   $getNearestNodeFromDOMNode,
+  $getNodeByKey,
   $getNodeByKeyOrThrow,
   $getPreviousSelection,
   $getSelection,
@@ -900,24 +901,28 @@ export function $handleTableSelectionChangeCommand(
     $isRangeSelection(selection) &&
     selection.isCollapsed()
   ) {
-    const tableNode = $getTableNodeByKeyOrThrow(shouldCheckSelectionForTable);
-    const anchor = selection.anchor.getNode();
-    const firstRow = tableNode.getFirstChild();
-    const anchorCell = $findCellNode(anchor);
-    if (anchorCell !== null && $isTableRowNode(firstRow)) {
-      const firstCell = firstRow.getFirstChild();
-      if (
-        $isTableCellNode(firstCell) &&
-        tableNode.is(
-          $findMatchingParent(
-            anchorCell,
-            node => node.is(tableNode) || node.is(firstCell),
-          ),
-        )
-      ) {
-        // The selection moved to the table, but not in the first cell
-        firstCell.selectStart();
-        return true;
+    // The table may have been removed before this selection change
+    // was dispatched, in which case there is nothing to check
+    const tableNode = $getNodeByKey(shouldCheckSelectionForTable);
+    if ($isTableNode(tableNode)) {
+      const anchor = selection.anchor.getNode();
+      const firstRow = tableNode.getFirstChild();
+      const anchorCell = $findCellNode(anchor);
+      if (anchorCell !== null && $isTableRowNode(firstRow)) {
+        const firstCell = firstRow.getFirstChild();
+        if (
+          $isTableCellNode(firstCell) &&
+          tableNode.is(
+            $findMatchingParent(
+              anchorCell,
+              node => node.is(tableNode) || node.is(firstCell),
+            ),
+          )
+        ) {
+          // The selection moved to the table, but not in the first cell
+          firstCell.selectStart();
+          return true;
+        }
       }
     }
   }
@@ -933,13 +938,10 @@ export function $handleTableSelectionChangeCommand(
   // Generic selection logic that runs across every table observer when the selection changes.
   // Note: the selection might have changed in the code above, which re-dispatches the selection change command
   // and gets handled here on the second pass. This should be refactored.
-  const tableNodesAndObservers = Array.from(
-    tableObservers.observers.entries(),
-  ).map(([tableKey, [tableObserver]]) => ({
-    tableNode: $getTableNodeByKeyOrThrow(tableKey),
+  for (const [
+    tableNode,
     tableObserver,
-  }));
-  for (const {tableNode, tableObserver} of tableNodesAndObservers) {
+  ] of tableObservers.$getTableNodesAndObservers()) {
     $syncTableSelectionState(editor, tableNode, tableObserver);
   }
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createTableNodeWithDimensions, TableExtension} from '@lexical/table';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  defineExtension,
+  KEY_ARROW_DOWN_COMMAND,
+  LexicalEditorWithDispose,
+  SELECTION_CHANGE_COMMAND,
+} from 'lexical';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+
+describe('LexicalTableSelectionHelpers', () => {
+  describe('regression #8670', () => {
+    let editor: LexicalEditorWithDispose;
+    let container: HTMLDivElement;
+
+    function $createTableBelowParagraph() {
+      const paragraph = $createParagraphNode().append($createTextNode('above'));
+      $getRoot()
+        .clear()
+        .append(paragraph, $createTableNodeWithDimensions(2, 2, false));
+      paragraph.selectEnd();
+    }
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      editor = buildEditorFromExtensions(
+        defineExtension({
+          dependencies: [TableExtension],
+          name: 'regression-8670-test',
+        }),
+      );
+      editor.setRootElement(container);
+    });
+
+    afterEach(() => {
+      editor.dispose();
+      document.body.removeChild(container);
+    });
+
+    test('selection change ignores the table recorded on ArrowDown when it was removed', () => {
+      editor.update($createTableBelowParagraph, {discrete: true});
+
+      // Pressing ArrowDown above the table records the table key to check
+      // on the next selection change (the Firefox workaround for scrollable
+      // tables, which TableExtension enables by default via
+      // hasHorizontalScroll)
+      editor.dispatchCommand(
+        KEY_ARROW_DOWN_COMMAND,
+        new KeyboardEvent('keydown', {key: 'ArrowDown'}),
+      );
+
+      // The table is removed before the next selection change occurs
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.getLastChildOrThrow().remove();
+          root.selectEnd();
+        },
+        {discrete: true},
+      );
+
+      expect(() =>
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined),
+      ).not.toThrow();
+    });
+
+    test('selection change self-heals observers for tables removed while the root element was detached', () => {
+      editor.update($createTableBelowParagraph, {discrete: true});
+
+      // Removing the table while the root element is detached skips
+      // reconciliation, so the TableNode destroyed mutation never fires
+      // and the observers registry keeps a stale entry
+      editor.setRootElement(null);
+      editor.update(
+        () => {
+          $getRoot().getLastChildOrThrow().remove();
+        },
+        {discrete: true},
+      );
+      editor.setRootElement(container);
+
+      // Without self-healing every subsequent selection change throws
+      expect(() => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      }).not.toThrow();
+
+      // New tables still work after the registry healed itself
+      editor.update(
+        () => {
+          $getRoot().append($createTableNodeWithDimensions(2, 2, false));
+        },
+        {discrete: true},
+      );
+      expect(() =>
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined),
+      ).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Description

The `SELECTION_CHANGE_COMMAND` handler dereferenced table node keys with `$getNodeByKeyOrThrow` in two places where the key can be stale, throwing invariant `#63` ("Expected node with key %s to exist but it's not in the nodeMap"):

- The `shouldCheckSelectionForTable` key recorded on ArrowDown (the Firefox workaround for scrollable tables) when the table is removed before the next selection change.
- The `tableObservers` registry sweep, when a `TableNode`'s destroyed mutation was missed (e.g. an update performed while the editor's root element was detached skips reconciliation), leaving a permanently poisoned registry that threw on every subsequent selection change.

The `shouldCheckSelectionForTable` lookup now uses `$getNodeByKey` and skips missing nodes, and the registry maintenance is centralized in the `TableObservers` class so it self-heals instead of erroring for the rest of the session:

- `TableObservers.removeObserver(tableKey)` is the canonical teardown (removeListeners + registry delete) used by the mutation listener (destroyed and DOM-recreated branches)
- `TableObservers.removeAllObservers()` handles plugin unregistration
- `TableObservers.$getTableNodesAndObservers()` returns a snapshot of the registry for the current editor state, pruning entries whose table no longer exists so a missed destroyed mutation can't poison the registry

`TableObservers` is not exported from the package, so the public API is unchanged.

Closes #8670

## Test plan

New unit tests