### PR TITLE
[*] Chore: always use T[] syntax instead of Array<T> in TypeScript and Flow

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -354,6 +354,7 @@ export default [
           isSafeDollarFunction: '$createRootNode',
         }),
       ],
+      '@typescript-eslint/array-type': [ERROR, {default: 'array'}],
       '@typescript-eslint/ban-ts-comment': OFF,
       '@typescript-eslint/no-this-alias': OFF,
       '@typescript-eslint/no-unused-vars': [

--- a/examples/agent-example/src/ai/mergeEntities.ts
+++ b/examples/agent-example/src/ai/mergeEntities.ts
@@ -37,8 +37,8 @@ export interface MergedEntity {
 export function computeTokenOffsets(
   tokens: NERToken[],
   text: string,
-): Array<NERToken & {end: number; start: number}> {
-  const result: Array<NERToken & {end: number; start: number}> = [];
+): (NERToken & {end: number; start: number})[] {
+  const result: (NERToken & {end: number; start: number})[] = [];
   let cursor = 0;
   const lowerText = text.toLowerCase();
 
@@ -97,12 +97,12 @@ export function mergeEntities(
 ): MergedEntity[] {
   const withOffsets = computeTokenOffsets(tokens, text);
 
-  const merged: Array<{
+  const merged: {
     end: number;
     entity: string;
     minScore: number;
     start: number;
-  }> = [];
+  }[] = [];
 
   for (const token of withOffsets) {
     const prefix = token.entity.slice(0, 2); // "B-" or "I-"

--- a/libdefs/environment.js
+++ b/libdefs/environment.js
@@ -25,7 +25,7 @@ declare class StaticRange {
 declare class InputEvent extends UIEvent {
   +data: string | null;
   +dataTransfer?: DataTransfer;
-  +getTargetRanges?: () => Array<StaticRange>;
+  +getTargetRanges?: () => StaticRange[];
   +inputType: string;
   +isComposing: boolean;
 }

--- a/libdefs/prismjs.js
+++ b/libdefs/prismjs.js
@@ -8,10 +8,10 @@
 
 'use strict';
 
-type TokenStream = Array<string | Token>;
+type TokenStream = (string | Token)[];
 
 type Token = {
-  alias: string | Array<string>,
+  alias: string | string[],
   content: string | TokenStream,
   type: string,
 };

--- a/libdefs/yjs.js
+++ b/libdefs/yjs.js
@@ -32,7 +32,7 @@ declare module 'yjs' {
     on(type: string, () => void): void;
     parent: null | XmlText | XmlElement;
     setAttribute(string: string, value: string | number | YDoc): void;
-    toDelta(): Array<TextOperation>;
+    toDelta(): TextOperation[];
     toJSON(): Object;
     unobserve(fn: Function): void;
     unobserveDeep(fn: Function): void;
@@ -72,13 +72,13 @@ declare module 'yjs' {
     insert: string | {...},
   };
 
-  declare type Delta = Array<Operation>;
+  declare type Delta = Operation[];
 
   declare export interface YMapEvent extends YEvent {
     changes: {
       keys: YMapEventKeyChanges,
     };
-    delta: Array<TextOperation>;
+    delta: TextOperation[];
     keysChanged: Set<string>;
   }
 
@@ -90,7 +90,7 @@ declare module 'yjs' {
 
   declare export interface YTextEvent extends YEvent {
     childListChanged: boolean;
-    delta: Array<TextOperation>;
+    delta: TextOperation[];
     keysChanged: Set<string>;
     target: XmlText;
   }
@@ -98,7 +98,7 @@ declare module 'yjs' {
   declare export interface YXmlEvent extends YEvent {
     attributesChanged: Set<string>;
     childListChanged: boolean;
-    delta: Array<TextOperation>;
+    delta: TextOperation[];
     keysChanged: Set<string>;
     target: XmlText;
   }
@@ -306,7 +306,7 @@ declare module 'yjs' {
     /**
      * An alternative constructor to create a Y.Array based on existing content.
      */
-    static from(Array<T>): YArray<T>;
+    static from(T[]): YArray<T>;
 
     /**
      * Retrieve the n-th element.
@@ -318,7 +318,7 @@ declare module 'yjs' {
      * content is always an array of elements. I.e. yarray.insert(0, [1]) inserts
      * 1 at position 0.
      */
-    insert(index: number, content: Array<T>): void;
+    insert(index: number, content: T[]): void;
 
     /**
      * The number of elements that this Y.Array holds.
@@ -329,7 +329,7 @@ declare module 'yjs' {
      * Creates a new Array filled with the results of calling the provided
      * function on each element in the Y.Array.
      */
-    map<M>(f: (item: T, index: number, array: YArray<T>) => M): Array<M>;
+    map<M>(f: (item: T, index: number, array: YArray<T>) => M): M[];
 
     /**
      * Registers a change observer that will be called synchronously every time
@@ -347,7 +347,7 @@ declare module 'yjs' {
      * Events created by itself or any of its children.
      */
     observeDeep(
-      observer: (events: Array<YEvent>, transaction?: Transaction) => void,
+      observer: (events: YEvent[], transaction?: Transaction) => void,
     ): void;
 
     /**
@@ -360,7 +360,7 @@ declare module 'yjs' {
      * Append content at the end of the Y.Array. Same as
      * yarray.insert(yarray.length, content).
      */
-    push(content: Array<T>): void;
+    push(content: T[]): void;
 
     /**
      * Retrieve a range of content starting from index start (inclusive) to index
@@ -369,9 +369,9 @@ declare module 'yjs' {
      * yarray.slice(0, -1) returns all but the last element. Works similarly to
      * the Array.slice method.
      */
-    slice(start?: number, end?: number): Array<T>;
+    slice(start?: number, end?: number): T[];
 
-    toArray(): Array<T>;
+    toArray(): T[];
 
     /**
      * Retrieve the JSON representation of this type. The result is a fresh Array
@@ -393,14 +393,14 @@ declare module 'yjs' {
      * yarray.observeDeep.
      */
     unobserveDeep(
-      observer: (events: Array<YEvent>, transaction?: Transaction) => void,
+      observer: (events: YEvent[], transaction?: Transaction) => void,
     ): void;
 
     /**
      * Prepend content to the beginning of the Y.Array. Same as yarray.insert(0,
      * content).
      */
-    unshift(content: Array<T>): void;
+    unshift(content: T[]): void;
   }
 
   /**
@@ -476,7 +476,7 @@ declare module 'yjs' {
      * Events created by itself or any of its children.
      */
     observeDeep(
-      observer: (events: Array<YEvent>, transaction?: Transaction) => void,
+      observer: (events: YEvent[], transaction?: Transaction) => void,
     ): void;
 
     /**
@@ -514,7 +514,7 @@ declare module 'yjs' {
      * ymap.observeDeep.
      */
     unobserveDeep(
-      observer: (events: Array<YEvent>, transaction?: Transaction) => void,
+      observer: (events: YEvent[], transaction?: Transaction) => void,
     ): void;
 
     /**
@@ -593,7 +593,7 @@ declare module 'yjs' {
      * Events created by itself or any of its children.
      */
     observeDeep(
-      observer: (events: Array<YEvent>, transaction?: Transaction) => void,
+      observer: (events: YEvent[], transaction?: Transaction) => void,
     ): void;
 
     /**
@@ -630,7 +630,7 @@ declare module 'yjs' {
      * ytext.observeDeep.
      */
     unobserveDeep(
-      observer: (events: Array<YEvent>, transaction?: Transaction) => void,
+      observer: (events: YEvent[], transaction?: Transaction) => void,
     ): void;
   }
 

--- a/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
+++ b/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
@@ -35,7 +35,7 @@ declare export function $getLexicalContent(
 
 declare export function $insertGeneratedNodes(
   editor: LexicalEditor,
-  nodes: Array<LexicalNode>,
+  nodes: LexicalNode[],
   selection: BaseSelection,
 ): void;
 /*
@@ -68,7 +68,7 @@ declare export function $writeDragSourceToDataTransfer(
 ): void;
 
 interface BaseSerializedNode {
-  children?: Array<BaseSerializedNode>;
+  children?: BaseSerializedNode[];
   type: string;
   version: number;
 }
@@ -80,12 +80,12 @@ declare export function $generateJSONFromSelectedNodes<
   selection: BaseSelection | null,
 ): {
   namespace: string,
-  nodes: Array<SerializedNode>,
+  nodes: SerializedNode[],
 };
 
 declare export function $generateNodesFromSerializedNodes(
-  serializedNodes: Array<BaseSerializedNode>,
-): Array<LexicalNode>;
+  serializedNodes: BaseSerializedNode[],
+): LexicalNode[];
 
 declare export function copyToClipboard(
   editor: LexicalEditor,

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -394,7 +394,7 @@ export function $handlePlainTextDrop(
  */
 export function $insertGeneratedNodes(
   editor: LexicalEditor,
-  nodes: Array<LexicalNode>,
+  nodes: LexicalNode[],
   selection: BaseSelection,
 ): void {
   if (
@@ -448,7 +448,7 @@ function $updateSelectionOnInsert(selection: BaseSelection): void {
 }
 
 export interface BaseSerializedNode {
-  children?: Array<BaseSerializedNode>;
+  children?: BaseSerializedNode[];
   type: string;
   version: number;
 }
@@ -484,7 +484,7 @@ function $appendNodesToJSON(
   editor: LexicalEditor,
   selection: BaseSelection | null,
   currentNode: LexicalNode,
-  targetArray: Array<BaseSerializedNode> = [],
+  targetArray: BaseSerializedNode[] = [],
 ): boolean {
   let shouldInclude =
     selection !== null ? currentNode.isSelected(selection) : true;
@@ -551,9 +551,9 @@ export function $generateJSONFromSelectedNodes<
   selection: BaseSelection | null,
 ): {
   namespace: string;
-  nodes: Array<SerializedNode>;
+  nodes: SerializedNode[];
 } {
-  const nodes: Array<SerializedNode> = [];
+  const nodes: SerializedNode[] = [];
   const root = $getRoot();
   const topLevelChildren = root.getChildren();
   for (let i = 0; i < topLevelChildren.length; i++) {
@@ -575,8 +575,8 @@ export function $generateJSONFromSelectedNodes<
  * @returns an Array of Lexical Node objects.
  */
 export function $generateNodesFromSerializedNodes(
-  serializedNodes: Array<BaseSerializedNode>,
-): Array<LexicalNode> {
+  serializedNodes: BaseSerializedNode[],
+): LexicalNode[] {
   const nodes = [];
   for (const serializedNode of serializedNodes) {
     nodes.push($parseSerializedNode(serializedNode));

--- a/packages/lexical-code-prism/flow/LexicalCodePrism.js.flow
+++ b/packages/lexical-code-prism/flow/LexicalCodePrism.js.flow
@@ -38,7 +38,7 @@ declare export var CodePrismExtension: LexicalExtension<CodePrismConfig, "@lexic
 
 declare export function normalizeCodeLanguage(lang: string): string;
 
-declare export var getCodeLanguages: () => Array<string>;
+declare export var getCodeLanguages: () => string[];
 declare export function getLanguageFriendlyName(lang: string): string;
 
 declare export var CODE_LANGUAGE_FRIENDLY_NAME_MAP: {[string]: string};

--- a/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
@@ -264,11 +264,11 @@ function $updateAndRetainSelection(
 // Finds minimal diff range between two nodes lists. It returns from/to range boundaries of prevNodes
 // that needs to be replaced with `nodes` (subset of nextNodes) to make prevNodes equal to nextNodes.
 function getDiffRange(
-  prevNodes: Array<LexicalNode>,
-  nextNodes: Array<LexicalNode>,
+  prevNodes: LexicalNode[],
+  nextNodes: LexicalNode[],
 ): {
   from: number;
-  nodesForReplacement: Array<LexicalNode>;
+  nodesForReplacement: LexicalNode[];
   to: number;
 } {
   let leadingMatch = 0;

--- a/packages/lexical-code-prism/src/FacadePrism.ts
+++ b/packages/lexical-code-prism/src/FacadePrism.ts
@@ -83,7 +83,7 @@ export function getLanguageFriendlyName(lang: string) {
   return CODE_LANGUAGE_FRIENDLY_NAME_MAP[_lang] || _lang;
 }
 
-export const getCodeLanguages = (): Array<string> =>
+export const getCodeLanguages = (): string[] =>
   Object.keys(Prism.languages)
     .filter(
       // Prism has several language helpers mixed into languages object
@@ -152,7 +152,7 @@ function getTextContent(token: TokenStream): string {
 export function tokenizeDiffHighlight(
   tokens: (string | Token)[],
   language: string,
-): Array<string | Token> {
+): (string | Token)[] {
   const diffLanguage = language;
   const diffGrammar = Prism.languages[diffLanguage];
   const env = {tokens};
@@ -257,7 +257,7 @@ export function $getHighlightNodes(
 
   const code = codeNode.getTextContent();
 
-  let tokens: Array<string | Token> = Prism.tokenize(
+  let tokens: (string | Token)[] = Prism.tokenize(
     code,
     Prism.languages[diffLanguageMatch ? 'diff' : language],
   );
@@ -268,7 +268,7 @@ export function $getHighlightNodes(
 }
 
 function $mapTokensToLexicalStructure(
-  tokens: Array<string | Token>,
+  tokens: (string | Token)[],
   type?: string,
 ): LexicalNode[] {
   const nodes: LexicalNode[] = [];

--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -289,11 +289,11 @@ function $updateAndRetainSelection(
 // Finds minimal diff range between two nodes lists. It returns from/to range boundaries of prevNodes
 // that needs to be replaced with `nodes` (subset of nextNodes) to make prevNodes equal to nextNodes.
 function getDiffRange(
-  prevNodes: Array<LexicalNode>,
-  nextNodes: Array<LexicalNode>,
+  prevNodes: LexicalNode[],
+  nextNodes: LexicalNode[],
 ): {
   from: number;
-  nodesForReplacement: Array<LexicalNode>;
+  nodesForReplacement: LexicalNode[];
   to: number;
 } {
   let leadingMatch = 0;

--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -141,7 +141,7 @@ declare export function registerCodeHighlighting(
 declare export function normalizeCodeLang(lang: string): string;
 declare export function normalizeCodeLanguage(lang: string): string;
 
-declare export var getCodeLanguages: () => Array<string>;
+declare export var getCodeLanguages: () => string[];
 declare export function getLanguageFriendlyName(lang: string): string;
 
 declare export var CODE_LANGUAGE_FRIENDLY_NAME_MAP: {[string]: string};

--- a/packages/lexical-devtools-core/src/TreeView.tsx
+++ b/packages/lexical-devtools-core/src/TreeView.tsx
@@ -47,7 +47,7 @@ export const TreeView = forwardRef<
   ref,
 ): JSX.Element {
   const [timeStampedEditorStates, setTimeStampedEditorStates] = useState<
-    Array<[number, EditorState]>
+    [number, EditorState][]
   >([]);
   const [content, setContent] = useState<string>('');
   const [timeTravelEnabled, setTimeTravelEnabled] = useState(false);

--- a/packages/lexical-devtools-core/src/generateContent.ts
+++ b/packages/lexical-devtools-core/src/generateContent.ts
@@ -122,7 +122,7 @@ export function generateContent(
     () => {
       const selection = $getSelection();
 
-      visitTree($getRoot(), (node: LexicalNode, indent: Array<string>) => {
+      visitTree($getRoot(), (node: LexicalNode, indent: string[]) => {
         const nodeKey = node.getKey();
         const nodeKeyDisplay = `(${nodeKey})`;
         const typeDisplay = node.getType() || '';
@@ -218,8 +218,8 @@ function printTableSelection(selection: TableSelection): string {
 
 function visitTree(
   currentNode: ElementNode,
-  visitor: (node: LexicalNode, indentArr: Array<string>) => void,
-  indent: Array<string> = [],
+  visitor: (node: LexicalNode, indentArr: string[]) => void,
+  indent: string[] = [],
 ) {
   const childNodes = currentNode.getChildren();
   const childNodesLength = childNodes.length;
@@ -431,7 +431,7 @@ function $printSelectedCharsLine({
   selection,
   typeDisplay,
 }: {
-  indent: Array<string>;
+  indent: string[];
   isSelected: boolean;
   node: LexicalNode;
   nodeKeyDisplay: string;

--- a/packages/lexical-devtools-core/src/useLexicalCommandsLog.ts
+++ b/packages/lexical-devtools-core/src/useLexicalCommandsLog.ts
@@ -15,7 +15,7 @@ export type LexicalCommandEntry = {index: number} & LexicalCommand<unknown> & {
     payload: unknown;
   };
 
-export type LexicalCommandLog = ReadonlyArray<LexicalCommandEntry>;
+export type LexicalCommandLog = readonly LexicalCommandEntry[];
 
 export function registerLexicalCommandLogger(
   editor: LexicalEditor,

--- a/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
+++ b/packages/lexical-dragon/src/__tests__/unit/LexicalDragon.test.ts
@@ -73,7 +73,7 @@ function dispatchMakeChanges(args: unknown): void {
 describe('DragonExtension', () => {
   test('installDragonSupport at the entrypoint wins the registration race', () => {
     const uninstall = installDragonSupport();
-    const extensionEdits: Array<unknown> = [];
+    const extensionEdits: unknown[] = [];
     const extensionListener = (event: MessageEvent) => {
       extensionEdits.push(event.data);
     };
@@ -267,7 +267,7 @@ describe('DragonExtension', () => {
     iframeDocument.close();
 
     const uninstall = installDragonSupport(iframeWindow);
-    const topEdits: Array<unknown> = [];
+    const topEdits: unknown[] = [];
     const topListener = (event: MessageEvent) => topEdits.push(event.data);
     window.addEventListener('message', topListener);
     try {

--- a/packages/lexical-history/flow/LexicalHistory.js.flow
+++ b/packages/lexical-history/flow/LexicalHistory.js.flow
@@ -16,8 +16,8 @@ export type HistoryStateEntry = {
 };
 export type HistoryState = {
   current: null | HistoryStateEntry,
-  redoStack: Array<HistoryStateEntry>,
-  undoStack: Array<HistoryStateEntry>,
+  redoStack: HistoryStateEntry[],
+  undoStack: HistoryStateEntry[],
 };
 declare export function registerHistory(
   editor: LexicalEditor,

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -59,8 +59,8 @@ export type HistoryStateEntry = {
 };
 export type HistoryState = {
   current: null | HistoryStateEntry;
-  redoStack: Array<HistoryStateEntry>;
-  undoStack: Array<HistoryStateEntry>;
+  redoStack: HistoryStateEntry[];
+  undoStack: HistoryStateEntry[];
 };
 
 type IntentionallyMarkedAsDirtyElement = boolean;
@@ -69,7 +69,7 @@ function getDirtyNodes(
   editorState: EditorState,
   dirtyLeaves: Set<NodeKey>,
   dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,
-): Array<LexicalNode> {
+): LexicalNode[] {
   const nodeMap = editorState._nodeMap;
   const nodes = [];
 

--- a/packages/lexical-html/flow/LexicalHtml.js.flow
+++ b/packages/lexical-html/flow/LexicalHtml.js.flow
@@ -178,7 +178,7 @@ declare export function $withRenderContext(
 declare export function $generateNodesFromDOM(
   editor: LexicalEditor,
   dom: Document,
-): Array<LexicalNode>;
+): LexicalNode[];
 
 declare export function $generateDOMFromNodes<
   T extends HTMLElement | DocumentFragment,

--- a/packages/lexical-html/src/__tests__/unit/DOMRenderExtension.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/DOMRenderExtension.test.ts
@@ -346,7 +346,7 @@ describe('DOMRenderExtension', () => {
     );
   });
   test('$decorateDOM runs after children are reconciled', () => {
-    const childCounts: Array<{type: string; count: number}> = [];
+    const childCounts: {type: string; count: number}[] = [];
     using editor = buildEditorFromExtensions(
       defineExtension({
         $initialEditorState: () => {

--- a/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
@@ -33,11 +33,11 @@ import {
 import {assert, describe, expect, test} from 'vitest';
 
 describe('HTML', () => {
-  type Input = Array<{
+  type Input = {
     name: string;
     html: string;
     initializeEditorState: () => void;
-  }>;
+  }[];
 
   const HTML_SERIALIZE: Input = [
     {

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -146,14 +146,14 @@ const IGNORE_TAGS = new Set(['STYLE', 'SCRIPT']);
 export function $generateNodesFromDOM(
   editor: LexicalEditor,
   dom: Document | ParentNode,
-): Array<LexicalNode> {
+): LexicalNode[] {
   $inlineStylesFromStyleSheetsDOM(dom);
 
   const elements = isDOMDocumentNode(dom)
     ? dom.body.childNodes
     : dom.childNodes;
-  const lexicalNodes: Array<LexicalNode> = [];
-  const allArtificialNodes: Array<ArtificialNode__DO_NOT_USE> = [];
+  const lexicalNodes: LexicalNode[] = [];
+  const allArtificialNodes: ArtificialNode__DO_NOT_USE[] = [];
   for (const element of elements) {
     if (!IGNORE_TAGS.has(element.nodeName)) {
       const lexicalNode = $createNodesFromDOM(
@@ -376,12 +376,12 @@ function getConversionFunction(
 function $createNodesFromDOM(
   node: Node,
   editor: LexicalEditor,
-  allArtificialNodes: Array<ArtificialNode__DO_NOT_USE>,
+  allArtificialNodes: ArtificialNode__DO_NOT_USE[],
   hasBlockAncestorLexicalNode: boolean,
   forChildMap: Map<string, DOMChildConversion> = new Map(),
   parentLexicalNode?: LexicalNode | null | undefined,
-): Array<LexicalNode> {
-  const lexicalNodes: Array<LexicalNode> = [];
+): LexicalNode[] {
+  const lexicalNodes: LexicalNode[] = [];
 
   if (IGNORE_TAGS.has(node.nodeName)) {
     return lexicalNodes;
@@ -498,13 +498,13 @@ function $createNodesFromDOM(
 
 function wrapContinuousInlines(
   domNode: Node,
-  nodes: Array<LexicalNode>,
+  nodes: LexicalNode[],
   createWrapperFn: () => ElementNode,
-): Array<LexicalNode> {
+): LexicalNode[] {
   const textAlign = (domNode as HTMLElement).style
     .textAlign as ElementFormatType;
-  const out: Array<LexicalNode> = [];
-  let continuousInlines: Array<LexicalNode> = [];
+  const out: LexicalNode[] = [];
+  let continuousInlines: LexicalNode[] = [];
   // wrap contiguous inline child nodes in para
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
@@ -531,7 +531,7 @@ function wrapContinuousInlines(
 }
 
 function $unwrapArtificialNodes(
-  allArtificialNodes: Array<ArtificialNode__DO_NOT_USE>,
+  allArtificialNodes: ArtificialNode__DO_NOT_USE[],
 ) {
   // Replace artificial node with its children, inserting a linebreak
   // between adjacent artificial nodes

--- a/packages/lexical-internal/flow/LexicalInternalDevInvariant.js.flow
+++ b/packages/lexical-internal/flow/LexicalInternalDevInvariant.js.flow
@@ -10,5 +10,5 @@
 declare export default function devInvariant(
   cond?: boolean,
   message?: string,
-  ...args: Array<string>
+  ...args: string[]
 ): void;

--- a/packages/lexical-internal/flow/LexicalInternalFormatProdErrorMessage.js.flow
+++ b/packages/lexical-internal/flow/LexicalInternalFormatProdErrorMessage.js.flow
@@ -9,5 +9,5 @@
 
 declare export default function formatProdErrorMessage(
   code: string,
-  ...args: Array<string>
+  ...args: string[]
 ): empty;

--- a/packages/lexical-internal/flow/LexicalInternalFormatProdWarningMessage.js.flow
+++ b/packages/lexical-internal/flow/LexicalInternalFormatProdWarningMessage.js.flow
@@ -9,5 +9,5 @@
 
 declare export default function formatProdWarningMessage(
   code: string,
-  ...args: Array<string>
+  ...args: string[]
 ): void;

--- a/packages/lexical-internal/flow/LexicalInternalInvariant.js.flow
+++ b/packages/lexical-internal/flow/LexicalInternalInvariant.js.flow
@@ -10,5 +10,5 @@
 declare export default function invariant(
   cond?: boolean,
   message?: string,
-  ...args: Array<string>
+  ...args: string[]
 ): void;

--- a/packages/lexical-link/src/LexicalAutoLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalAutoLinkExtension.ts
@@ -68,7 +68,7 @@ export function createLinkMatcherWithRegExp(
 
 function findFirstMatch(
   text: string,
-  matchers: Array<LinkMatcher>,
+  matchers: LinkMatcher[],
 ): LinkMatcherResult | null {
   for (let i = 0; i < matchers.length; i++) {
     const match = matchers[i](text);
@@ -292,7 +292,7 @@ function $createAutoLinkNode_(
 
 function $handleLinkCreation(
   nodes: TextNode[],
-  matchers: Array<LinkMatcher>,
+  matchers: LinkMatcher[],
   onChange: ChangeHandler,
   separatorRegex: RegExp,
 ): void {
@@ -368,7 +368,7 @@ function $handleLinkCreation(
 
 function handleLinkEdit(
   linkNode: AutoLinkNode,
-  matchers: Array<LinkMatcher>,
+  matchers: LinkMatcher[],
   onChange: ChangeHandler,
   separatorRegex: RegExp,
 ): void {
@@ -428,7 +428,7 @@ function handleLinkEdit(
 // Given the creation preconditions, these can only be simple text nodes.
 function handleBadNeighbors(
   textNode: TextNode,
-  matchers: Array<LinkMatcher>,
+  matchers: LinkMatcher[],
   onChange: ChangeHandler,
   separatorRegex: RegExp,
 ): void {
@@ -492,7 +492,7 @@ function handleBadNeighbors(
   }
 }
 
-function replaceWithChildren(node: ElementNode): Array<LexicalNode> {
+function replaceWithChildren(node: ElementNode): LexicalNode[] {
   const children = node.getChildren();
   const childrenLength = children.length;
 

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -45,7 +45,7 @@ import {
 
 function $isSelectingEmptyListItem(
   anchorNode: ListItemNode | LexicalNode,
-  nodes: Array<LexicalNode>,
+  nodes: LexicalNode[],
 ): boolean {
   return (
     $isListItemNode(anchorNode) &&
@@ -153,7 +153,7 @@ export function $insertList(listType: ListType): void {
   }
 }
 
-function append(node: ElementNode, nodesToAppend: Array<LexicalNode>) {
+function append(node: ElementNode, nodesToAppend: LexicalNode[]) {
   node.splice(node.getChildrenSize(), 0, nodesToAppend);
 }
 

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -100,9 +100,9 @@ export function $isLastItemInList(listItem: ListItemNode): boolean {
  * @returns An array containing all nodes of type ListItemNode found.
  */
 // This should probably be $getAllChildrenOfType
-export function $getAllListItems(node: ListNode): Array<ListItemNode> {
-  let listItemNodes: Array<ListItemNode> = [];
-  const listChildren: Array<ListItemNode> = node
+export function $getAllListItems(node: ListNode): ListItemNode[] {
+  let listItemNodes: ListItemNode[] = [];
+  const listChildren: ListItemNode[] = node
     .getChildren()
     .filter($isListItemNode);
 

--- a/packages/lexical-mark/flow/LexicalMark.js.flow
+++ b/packages/lexical-mark/flow/LexicalMark.js.flow
@@ -18,18 +18,18 @@ import type {
 import {ElementNode, LexicalNode} from 'lexical';
 
 export type SerializedMarkNode = SerializedElementNode & {
-  ids: Array<string>,
+  ids: string[],
 };
 
 declare export class MarkNode extends ElementNode {
-  __ids: Array<string>;
+  __ids: string[];
 
   // $FlowFixMe[incompatible-variance]
   static clone(node: this): MarkNode;
-  constructor(ids: Array<string>, key?: NodeKey): void;
+  constructor(ids: string[], key?: NodeKey): void;
 
   hasID(id: string): boolean;
-  getIDs(): Array<string>;
+  getIDs(): string[];
   addID(id: string): void;
   deleteID(id: string): void;
   canInsertTextBefore(): false;
@@ -41,18 +41,18 @@ declare export function $isMarkNode(
   node: ?LexicalNode,
 ): node is MarkNode;
 
-declare export function $createMarkNode(ids: Array<string>): MarkNode;
+declare export function $createMarkNode(ids: string[]): MarkNode;
 
 declare export function $getMarkIDs(
   node: TextNode,
   offset: number,
-): null | Array<string>;
+): null | string[];
 
 declare export function $wrapSelectionInMarkNode(
   selection: RangeSelection,
   isBackward: boolean,
   id: string,
-  createNode?: (ids: Array<string>) => MarkNode,
+  createNode?: (ids: string[]) => MarkNode,
 ): void;
 
 declare export function $unwrapMarkNode(node: MarkNode): void;

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -25,7 +25,7 @@ import {$applyNodeReplacement, $isRangeSelection, ElementNode} from 'lexical';
 
 export type SerializedMarkNode = Spread<
   {
-    ids: Array<string>;
+    ids: string[];
   },
   SerializedElementNode
 >;
@@ -110,7 +110,7 @@ export class MarkNode extends ElementNode {
     return this.getIDs().includes(id);
   }
 
-  getIDs(): Array<string> {
+  getIDs(): string[] {
     return Array.from(this.getLatest().__ids);
   }
 

--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -38,7 +38,7 @@ export function $wrapSelectionInMarkNode(
   selection: RangeSelection,
   isBackward: boolean,
   id: string,
-  createNode?: (ids: Array<string>) => MarkNode,
+  createNode?: (ids: string[]) => MarkNode,
 ): void {
   // Force a forwards selection since append is used, ignore the argument.
   // A new selection is used to avoid side-effects of flipping the given
@@ -135,10 +135,7 @@ export function $wrapSelectionInMarkNode(
   }
 }
 
-export function $getMarkIDs(
-  node: TextNode,
-  offset: number,
-): null | Array<string> {
+export function $getMarkIDs(node: TextNode, offset: number): null | string[] {
   let currentNode: LexicalNode | null = node;
   while (currentNode !== null) {
     if ($isMarkNode(currentNode)) {

--- a/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
+++ b/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
@@ -23,7 +23,7 @@ export type Transformer =
   | TextMatchTransformer;
 
 export type ElementTransformer = {
-  dependencies: Array<Class<LexicalNode>>,
+  dependencies: Class<LexicalNode>[],
   export: (
     node: LexicalNode,
     traverseChildren: (node: ElementNode) => string,
@@ -31,8 +31,8 @@ export type ElementTransformer = {
   regExp: RegExp,
   replace: (
     parentNode: ElementNode,
-    children: Array<LexicalNode>,
-    match: Array<string>,
+    children: LexicalNode[],
+    match: string[],
     isImport: boolean,
   ) => boolean | void,
   type: 'element',
@@ -40,13 +40,13 @@ export type ElementTransformer = {
 };
 
 export type MultilineElementTransformer = {
-  dependencies: Array<Class<LexicalNode>>;
+  dependencies: Class<LexicalNode>[];
   export?: (
     node: LexicalNode,
     traverseChildren: (node: ElementNode) => string,
   ) => string | null;
   handleImportAfterStartMatch?: (args: {
-    lines: Array<string>;
+    lines: string[];
     rootNode: ElementNode;
     startLineIndex: number;
     startMatch: RegExp$matchResult;
@@ -61,10 +61,10 @@ export type MultilineElementTransformer = {
       };
   replace: (
     rootNode: ElementNode,
-    children: Array<LexicalNode> | null,
-    startMatch: Array<string>,
-    endMatch: Array<string> | null,
-    linesInBetween: Array<string> | null,
+    children: LexicalNode[] | null,
+    startMatch: string[],
+    endMatch: string[] | null,
+    linesInBetween: string[] | null,
     isImport: boolean,
   ) => boolean | void;
   type: 'multiline-element';
@@ -78,7 +78,7 @@ export type TextFormatTransformer = Readonly<{
 }>;
 
 export type TextMatchTransformer = Readonly<{
-  dependencies: Array<Class<LexicalNode>>,
+  dependencies: Class<LexicalNode>[],
   export?: (
     node: LexicalNode,
     exportChildren: (node: ElementNode) => string,
@@ -94,12 +94,12 @@ export type TextMatchTransformer = Readonly<{
 
 declare export function registerMarkdownShortcuts(
   editor: LexicalEditor,
-  transformers?: Array<Transformer>,
+  transformers?: Transformer[],
 ): () => void;
 
 declare export function $convertFromMarkdownString(
   markdown: string,
-  transformers?: Array<Transformer>,
+  transformers?: Transformer[],
   node?: ElementNode,
   shouldPreserveNewLines?: boolean,
   shouldMergeAdjacentLines?: boolean,
@@ -112,7 +112,7 @@ declare export function $convertSelectionToMarkdownString(
 ): string;
 
 declare export function $convertToMarkdownString(
-  transformers?: Array<Transformer>,
+  transformers?: Transformer[],
   node?: ElementNode,
   shouldPreserveNewLines?: boolean,
 ): string;
@@ -136,8 +136,8 @@ declare export var ORDERED_LIST: ElementTransformer;
 
 declare export var LINK: TextMatchTransformer;
 
-declare export var TRANSFORMERS: Array<Transformer>;
-declare export var ELEMENT_TRANSFORMERS: Array<ElementTransformer>;
-declare export var MULTILINE_ELEMENT_TRANSFORMERS: Array<MultilineElementTransformer>;
-declare export var TEXT_FORMAT_TRANSFORMERS: Array<TextFormatTransformer>;
-declare export var TEXT_MATCH_TRANSFORMERS: Array<TextFormatTransformer>;
+declare export var TRANSFORMERS: Transformer[];
+declare export var ELEMENT_TRANSFORMERS: ElementTransformer[];
+declare export var MULTILINE_ELEMENT_TRANSFORMERS: MultilineElementTransformer[];
+declare export var TEXT_FORMAT_TRANSFORMERS: TextFormatTransformer[];
+declare export var TEXT_MATCH_TRANSFORMERS: TextFormatTransformer[];

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -39,7 +39,7 @@ import {isEmptyParagraph, transformersByType} from './utils';
  * Renders string from markdown. The selection is moved to the start after the operation.
  */
 export function createMarkdownExport(
-  transformers: Array<Transformer>,
+  transformers: Transformer[],
   shouldPreserveNewLines: boolean = false,
 ): (node?: ElementNode) => string {
   const byType = transformersByType(transformers);
@@ -343,9 +343,9 @@ function $exportChildrenForSelection(
 
 function $exportTopLevelElements(
   node: LexicalNode,
-  elementTransformers: Array<ElementTransformer | MultilineElementTransformer>,
-  textTransformersIndex: Array<TextFormatTransformer>,
-  textMatchTransformers: Array<TextMatchTransformer>,
+  elementTransformers: (ElementTransformer | MultilineElementTransformer)[],
+  textTransformersIndex: TextFormatTransformer[],
+  textMatchTransformers: TextMatchTransformer[],
   shouldPreserveNewLines: boolean,
 ): string | null {
   for (const transformer of elementTransformers) {
@@ -386,10 +386,10 @@ function $exportTopLevelElements(
 
 function $exportChildren(
   node: ElementNode,
-  textTransformersIndex: Array<TextFormatTransformer>,
-  textMatchTransformers: Array<TextMatchTransformer>,
-  unclosedTags?: Array<{format: TextFormatType; tag: string}>,
-  unclosableTags?: Array<{format: TextFormatType; tag: string}>,
+  textTransformersIndex: TextFormatTransformer[],
+  textMatchTransformers: TextMatchTransformer[],
+  unclosedTags?: {format: TextFormatType; tag: string}[],
+  unclosableTags?: {format: TextFormatType; tag: string}[],
   shouldPreserveNewLines: boolean = false,
 ): string {
   const output = [];
@@ -481,10 +481,10 @@ function $exportLineBreak(node: LineBreakNode): string {
 function exportTextFormat(
   node: TextNode,
   textContent: string,
-  textTransformers: Array<TextFormatTransformer>,
+  textTransformers: TextFormatTransformer[],
   // unclosed tags include the markdown tags that haven't been closed yet, and their associated formats
-  unclosedTags: Array<{format: TextFormatType; tag: string}>,
-  unclosableTags?: Array<{format: TextFormatType; tag: string}>,
+  unclosedTags: {format: TextFormatType; tag: string}[],
+  unclosableTags?: {format: TextFormatType; tag: string}[],
   shouldPreserveNewLines: boolean = false,
 ): string {
   // This function handles the case of a string looking like this: "   foo   "

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -43,7 +43,7 @@ export type TextFormatTransformersIndex = Readonly<{
  * Renders markdown from a string. The selection is moved to the start after the operation.
  */
 export function createMarkdownImport(
-  transformers: Array<Transformer>,
+  transformers: Transformer[],
   shouldPreserveNewLines = false,
 ): (markdownString: string, node?: ElementNode) => void {
   const byType = transformersByType(transformers);
@@ -118,9 +118,9 @@ export function createMarkdownImport(
  * @returns first element of the returned tuple is a boolean indicating if a multiline element was imported. The second element is the index of the last line that was processed.
  */
 function $importMultiline(
-  lines: Array<string>,
+  lines: string[],
   startLineIndex: number,
-  multilineElementTransformers: Array<MultilineElementTransformer>,
+  multilineElementTransformers: MultilineElementTransformer[],
   rootNode: ElementNode,
 ): [boolean, number] {
   for (const transformer of multilineElementTransformers) {
@@ -232,9 +232,9 @@ function $importMultiline(
 function $importBlocks(
   lineText: string,
   rootNode: ElementNode,
-  elementTransformers: Array<ElementTransformer>,
+  elementTransformers: ElementTransformer[],
   textFormatTransformersIndex: TextFormatTransformersIndex,
-  textMatchTransformers: Array<TextMatchTransformer>,
+  textMatchTransformers: TextMatchTransformer[],
   shouldPreserveNewLines: boolean,
 ) {
   const textNode = $createTextNode(lineText);
@@ -315,7 +315,7 @@ function $normalizeMarkdownTextNode(textNode: TextNode): void {
 }
 
 function createTextFormatTransformersIndex(
-  textTransformers: Array<TextFormatTransformer>,
+  textTransformers: TextFormatTransformer[],
 ): TextFormatTransformersIndex {
   const transformersByTag: Record<string, TextFormatTransformer> = {};
   const fullMatchRegExpByTag: Record<string, RegExp> = {};

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -43,7 +43,7 @@ function runElementTransformers(
   parentNode: ElementNode,
   anchorNode: TextNode,
   anchorOffset: number,
-  elementTransformers: ReadonlyArray<ElementTransformer>,
+  elementTransformers: readonly ElementTransformer[],
   triggerOnEnter?: boolean,
 ): boolean {
   const grandParentNode = parentNode.getParent();
@@ -97,7 +97,7 @@ function runMultilineElementTransformers(
   parentNode: ElementNode,
   anchorNode: TextNode,
   anchorOffset: number,
-  elementTransformers: ReadonlyArray<MultilineElementTransformer>,
+  elementTransformers: readonly MultilineElementTransformer[],
   triggerOnEnter?: boolean,
 ): boolean {
   const grandParentNode = parentNode.getParent();
@@ -162,7 +162,7 @@ function runMultilineElementTransformers(
 function runTextMatchTransformers(
   anchorNode: TextNode,
   anchorOffset: number,
-  transformersByTrigger: Readonly<Record<string, Array<TextMatchTransformer>>>,
+  transformersByTrigger: Readonly<Record<string, TextMatchTransformer[]>>,
 ): boolean {
   let textContent = anchorNode.getTextContent();
   const lastChar = textContent[anchorOffset - 1];
@@ -210,7 +210,7 @@ function $runTextFormatTransformers(
   anchorNode: TextNode,
   anchorOffset: number,
   textFormatTransformers: Readonly<
-    Record<string, ReadonlyArray<TextFormatTransformer>>
+    Record<string, readonly TextFormatTransformer[]>
   >,
 ): boolean {
   const textContent = anchorNode.getTextContent();
@@ -435,7 +435,7 @@ function isEqualSubString(
 
 export function registerMarkdownShortcuts(
   editor: LexicalEditor,
-  transformers: Array<Transformer> = TRANSFORMERS,
+  transformers: Transformer[] = TRANSFORMERS,
 ): () => void {
   const byType = transformersByType(transformers);
   const elementTransformersForEnter = byType.element.filter(

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -59,7 +59,7 @@ export type Transformer =
   | TextMatchTransformer;
 
 export type ElementTransformer = {
-  dependencies: Array<Klass<LexicalNode>>;
+  dependencies: Klass<LexicalNode>[];
   /**
    * `export` is called when the `$convertToMarkdownString` is called to convert the editor state into markdown.
    *
@@ -80,8 +80,8 @@ export type ElementTransformer = {
    */
   replace: (
     parentNode: ElementNode,
-    children: Array<LexicalNode>,
-    match: Array<string>,
+    children: LexicalNode[],
+    match: string[],
     /**
      * Whether the match is from an import operation (e.g. through `$convertFromMarkdownString`) or not (e.g. through typing in the editor).
      */
@@ -104,13 +104,13 @@ export type MultilineElementTransformer = {
    * @returns a tuple or null. The first element of the returned tuple is a boolean indicating if a multiline element was imported. The second element is the index of the last line that was processed. If null is returned, the next multilineElementTransformer will be tried. If undefined is returned, the default behavior will be used.
    */
   handleImportAfterStartMatch?: (args: {
-    lines: Array<string>;
+    lines: string[];
     rootNode: ElementNode;
     startLineIndex: number;
     startMatch: RegExpMatchArray;
     transformer: MultilineElementTransformer;
   }) => [boolean, number] | null | undefined;
-  dependencies: Array<Klass<LexicalNode>>;
+  dependencies: Klass<LexicalNode>[];
   /**
    * `export` is called when the `$convertToMarkdownString` is called to convert the editor state into markdown.
    *
@@ -151,14 +151,14 @@ export type MultilineElementTransformer = {
      * During markdown shortcut transforms, children nodes may be provided to the transformer. If this is the case, no `linesInBetween` will be provided and
      * the children nodes should be used instead of the `linesInBetween` to create the new node.
      */
-    children: Array<LexicalNode> | null,
-    startMatch: Array<string>,
-    endMatch: Array<string> | null,
+    children: LexicalNode[] | null,
+    startMatch: string[],
+    endMatch: string[] | null,
     /**
      * linesInBetween includes the text between the start & end matches, split up by lines, not including the matches themselves.
      * This is null when the transformer is triggered through markdown shortcuts (by typing in the editor)
      */
-    linesInBetween: Array<string> | null,
+    linesInBetween: string[] | null,
     /**
      * Whether the match is from an import operation (e.g. through `$convertFromMarkdownString`) or not (e.g. through typing in the editor).
      */
@@ -168,14 +168,14 @@ export type MultilineElementTransformer = {
 };
 
 export type TextFormatTransformer = Readonly<{
-  format: ReadonlyArray<TextFormatType>;
+  format: readonly TextFormatType[];
   tag: string;
   intraword?: boolean;
   type: 'text-format';
 }>;
 
 export type TextMatchTransformer = Readonly<{
-  dependencies: Array<Klass<LexicalNode>>;
+  dependencies: Klass<LexicalNode>[];
   /**
    * Determines how a node should be exported to markdown
    */
@@ -324,7 +324,7 @@ export function parseMarkdownHardLineBreak(
 }
 
 function hasNonWhitespaceContentOnLine(
-  children: Array<LexicalNode>,
+  children: LexicalNode[],
   endIndex: number,
 ): boolean {
   for (let i = endIndex - 1; i >= 0; i--) {
@@ -383,7 +383,7 @@ export function $createMarkdownLineBreakNode(
 }
 
 const createBlockNode = (
-  createNode: (match: Array<string>) => ElementNode,
+  createNode: (match: string[]) => ElementNode,
 ): ElementTransformer['replace'] => {
   return (parentNode, children, match, isImport) => {
     const node = createNode(match);
@@ -901,21 +901,22 @@ export const LINK: TextMatchTransformer = {
   type: 'text-match',
 };
 
-export const ELEMENT_TRANSFORMERS: Array<ElementTransformer> = [
+export const ELEMENT_TRANSFORMERS: ElementTransformer[] = [
   HEADING,
   QUOTE,
   UNORDERED_LIST,
   ORDERED_LIST,
 ];
 
-export const MULTILINE_ELEMENT_TRANSFORMERS: Array<MultilineElementTransformer> =
-  [CODE];
+export const MULTILINE_ELEMENT_TRANSFORMERS: MultilineElementTransformer[] = [
+  CODE,
+];
 
 // Order of text format transformers matters:
 //
 // - code should go first as it prevents any transformations inside
 // - then longer tags match (e.g. ** or __ should go before * or _)
-export const TEXT_FORMAT_TRANSFORMERS: Array<TextFormatTransformer> = [
+export const TEXT_FORMAT_TRANSFORMERS: TextFormatTransformer[] = [
   INLINE_CODE,
   BOLD_ITALIC_STAR,
   BOLD_ITALIC_UNDERSCORE,
@@ -927,9 +928,9 @@ export const TEXT_FORMAT_TRANSFORMERS: Array<TextFormatTransformer> = [
   STRIKETHROUGH,
 ];
 
-export const TEXT_MATCH_TRANSFORMERS: Array<TextMatchTransformer> = [LINK];
+export const TEXT_MATCH_TRANSFORMERS: TextMatchTransformer[] = [LINK];
 
-export const TRANSFORMERS: Array<Transformer> = [
+export const TRANSFORMERS: Transformer[] = [
   ...ELEMENT_TRANSFORMERS,
   ...MULTILINE_ELEMENT_TRANSFORMERS,
   ...TEXT_FORMAT_TRANSFORMERS,

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -272,7 +272,7 @@ export const CANCELED_HEADING_REPLACE_EXAMPLE: ElementTransformer = {
 };
 
 describe('Markdown', () => {
-  type Input = Array<{
+  type Input = {
     html: string;
     md: string;
     skipExport?: true;
@@ -281,7 +281,7 @@ describe('Markdown', () => {
     shouldMergeAdjacentLines?: true | false;
     customTransformers?: Transformer[];
     mdAfterExport?: string;
-  }>;
+  }[];
 
   const URL = 'https://lexical.dev';
 

--- a/packages/lexical-markdown/src/importTextFormatTransformer.ts
+++ b/packages/lexical-markdown/src/importTextFormatTransformer.ts
@@ -39,7 +39,7 @@ export function findOutermostTextFormatTransformer(
   const codeRegex = textFormatTransformersIndex.fullMatchRegExpByTag['`'];
   const codeTransformer = textFormatTransformersIndex.transformersByTag['`'];
 
-  const excludeRanges: Array<{start: number; end: number}> = [];
+  const excludeRanges: {start: number; end: number}[] = [];
   let codeMatch = null;
   if (codeRegex && codeTransformer) {
     const globalRegex = new RegExp(codeRegex.source, 'g');
@@ -125,7 +125,7 @@ export function findOutermostTextFormatTransformer(
 function scanDelimiters(
   text: string,
   transformersIndex: TextFormatTransformersIndex,
-  excludeRanges: Array<{start: number; end: number}> = [],
+  excludeRanges: {start: number; end: number}[] = [],
 ): Delimiter[] {
   const delimiters: Delimiter[] = [];
   const delimiterChars = new Set(

--- a/packages/lexical-markdown/src/importTextMatchTransformer.ts
+++ b/packages/lexical-markdown/src/importTextMatchTransformer.ts
@@ -11,7 +11,7 @@ import {type TextNode} from 'lexical';
 
 export function findOutermostTextMatchTransformer(
   textNode_: TextNode,
-  textMatchTransformers: Array<TextMatchTransformer>,
+  textMatchTransformers: TextMatchTransformer[],
 ): {
   startIndex: number;
   endIndex: number;

--- a/packages/lexical-markdown/src/importTextTransformers.ts
+++ b/packages/lexical-markdown/src/importTextTransformers.ts
@@ -41,7 +41,7 @@ export function canContainTransformableMarkdown(
 export function importTextTransformers(
   textNode: TextNode,
   textFormatTransformersIndex: TextFormatTransformersIndex,
-  textMatchTransformers: Array<TextMatchTransformer>,
+  textMatchTransformers: TextMatchTransformer[],
 ) {
   let foundTextFormat = findOutermostTextFormatTransformer(
     textNode,

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -57,7 +57,7 @@ import {
  */
 function $convertFromMarkdownString(
   markdown: string,
-  transformers: Array<Transformer> = TRANSFORMERS,
+  transformers: Transformer[] = TRANSFORMERS,
   node?: ElementNode,
   shouldPreserveNewLines = false,
   shouldMergeAdjacentLines = false,
@@ -76,7 +76,7 @@ function $convertFromMarkdownString(
  * Renders string from markdown. The selection is moved to the start after the operation.
  */
 function $convertToMarkdownString(
-  transformers: Array<Transformer> = TRANSFORMERS,
+  transformers: Transformer[] = TRANSFORMERS,
   node?: ElementNode,
   shouldPreserveNewLines: boolean = false,
 ): string {

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -65,7 +65,7 @@ type MarkdownCriteria = Readonly<{
   requiresParagraphStart: boolean | null | undefined;
 }>;
 
-type MarkdownCriteriaArray = Array<MarkdownCriteria>;
+type MarkdownCriteriaArray = MarkdownCriteria[];
 
 const autoFormatBase: MarkdownCriteria = {
   markdownFormatKind: null,
@@ -404,10 +404,10 @@ function codeBlockExport(node: LexicalNode) {
 }
 
 export function indexBy<T>(
-  list: Array<T>,
+  list: T[],
   callback: (arg0: T) => string | undefined,
-): Readonly<Record<string, Array<T>>> {
-  const index: Record<string, Array<T>> = {};
+): Readonly<Record<string, T[]>> {
+  const index: Record<string, T[]> = {};
 
   for (const item of list) {
     const key = callback(item);
@@ -426,20 +426,20 @@ export function indexBy<T>(
   return index;
 }
 
-export function transformersByType(transformers: Array<Transformer>): Readonly<{
-  element: Array<ElementTransformer>;
-  multilineElement: Array<MultilineElementTransformer>;
-  textFormat: Array<TextFormatTransformer>;
-  textMatch: Array<TextMatchTransformer>;
+export function transformersByType(transformers: Transformer[]): Readonly<{
+  element: ElementTransformer[];
+  multilineElement: MultilineElementTransformer[];
+  textFormat: TextFormatTransformer[];
+  textMatch: TextMatchTransformer[];
 }> {
   const byType = indexBy(transformers, t => t.type);
 
   return {
-    element: (byType.element || []) as Array<ElementTransformer>,
+    element: (byType.element || []) as ElementTransformer[],
     multilineElement: (byType['multiline-element'] ||
-      []) as Array<MultilineElementTransformer>,
-    textFormat: (byType['text-format'] || []) as Array<TextFormatTransformer>,
-    textMatch: (byType['text-match'] || []) as Array<TextMatchTransformer>,
+      []) as MultilineElementTransformer[],
+    textFormat: (byType['text-format'] || []) as TextFormatTransformer[],
+    textMatch: (byType['text-match'] || []) as TextMatchTransformer[],
   };
 }
 

--- a/packages/lexical-offset/src/index.ts
+++ b/packages/lexical-offset/src/index.ts
@@ -502,7 +502,7 @@ function $createOffsetChild(
     offset: number;
     prevIsBlock: boolean;
   },
-  children: Array<NodeKey>,
+  children: NodeKey[],
   parent: null | OffsetElementNode,
   nodeMap: NodeMap,
   offsetMap: OffsetMap,

--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -29,13 +29,13 @@ export type Comment = {
 };
 
 export type Thread = {
-  comments: Array<Comment>;
+  comments: Comment[];
   id: string;
   quote: string;
   type: 'thread';
 };
 
-export type Comments = Array<Thread | Comment>;
+export type Comments = (Thread | Comment)[];
 
 function createUID(): string {
   return Math.random()
@@ -66,7 +66,7 @@ export function createComment(
 
 export function createThread(
   quote: string,
-  comments: Array<Comment>,
+  comments: Comment[],
   id?: string,
 ): Thread {
   return {
@@ -326,7 +326,7 @@ export class CommentStore {
     const onSharedCommentChanges = (
       // The YJS types explicitly use `any` as well.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      events: Array<YEvent<any>>,
+      events: YEvent<any>[],
       transaction: Transaction,
     ) => {
       if (transaction.origin !== this) {

--- a/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
@@ -38,7 +38,7 @@ import {StickyNode} from './StickyNode';
 import {TweetNode} from './TweetNode';
 import {YouTubeNode} from './YouTubeNode';
 
-const PlaygroundNodes: Array<Klass<LexicalNode>> = [
+const PlaygroundNodes: Klass<LexicalNode>[] = [
   HeadingNode,
   ListNode,
   ListItemNode,

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -22,12 +22,12 @@ import {
 } from 'lexical';
 import * as React from 'react';
 
-export type Options = ReadonlyArray<Option>;
+export type Options = readonly Option[];
 
 export type Option = Readonly<{
   text: string;
   uid: string;
-  votes: Array<string>;
+  votes: string[];
 }>;
 
 const PollComponent = React.lazy(() => import('./PollComponent'));
@@ -47,11 +47,7 @@ export function createPollOption(text = ''): Option {
   };
 }
 
-function cloneOption(
-  option: Option,
-  text: string,
-  votes?: Array<string>,
-): Option {
+function cloneOption(option: Option, text: string, votes?: string[]): Option {
   return {
     text,
     uid: option.uid,

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -37,7 +37,7 @@ interface PlaygroundEmbedConfig extends EmbedConfig {
   exampleUrl: string;
 
   // For extra searching.
-  keywords: Array<string>;
+  keywords: string[];
 
   // Embed a Figma Project.
   description?: string;

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -266,7 +266,7 @@ function CommentInputBox({
           }px`;
           const selectionRectsLength = selectionRects.length;
           const {container} = selectionState;
-          const elements: Array<HTMLSpanElement> = selectionState.elements;
+          const elements: HTMLSpanElement[] = selectionState.elements;
           const elementsLength = elements.length;
 
           for (let i = 0; i < selectionRectsLength; i++) {
@@ -531,7 +531,7 @@ function CommentsPanelList({
   submitAddComment,
   markNodeMap,
 }: {
-  activeIDs: Array<string>;
+  activeIDs: string[];
   comments: Comments;
   deleteCommentOrThread: (
     commentOrThread: Comment | Thread,
@@ -673,7 +673,7 @@ function CommentsPanel({
   submitAddComment,
   markNodeMap,
 }: {
-  activeIDs: Array<string>;
+  activeIDs: string[];
   comments: Comments;
   deleteCommentOrThread: (
     commentOrThread: Comment | Thread,
@@ -727,7 +727,7 @@ export default function CommentPlugin({
     return new Map();
   }, []);
   const [activeAnchorKey, setActiveAnchorKey] = useState<NodeKey | null>();
-  const [activeIDs, setActiveIDs] = useState<Array<string>>([]);
+  const [activeIDs, setActiveIDs] = useState<string[]>([]);
   const [showCommentInput, setShowCommentInput] = useState(false);
   const [showComments, setShowComments] = useState(false);
   const {yjsDocMap} = collabContext;
@@ -813,7 +813,7 @@ export default function CommentPlugin({
   );
 
   useEffect(() => {
-    const changedElems: Array<HTMLElement> = [];
+    const changedElems: HTMLElement[] = [];
     for (let i = 0; i < activeIDs.length; i++) {
       const id = activeIDs[i];
       const keys = markNodeMap.get(id);
@@ -838,7 +838,7 @@ export default function CommentPlugin({
   }, [activeIDs, editor, markNodeMap]);
 
   useEffect(() => {
-    const markNodeKeysToIDs: Map<NodeKey, Array<string>> = new Map();
+    const markNodeKeysToIDs: Map<NodeKey, string[]> = new Map();
 
     return mergeRegister(
       registerNestedElementResolver<MarkNode>(

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -54,7 +54,7 @@ export class ComponentPickerOption extends MenuOption {
   // Icon for display
   icon?: JSX.Element;
   // For extra searching.
-  keywords: Array<string>;
+  keywords: string[];
   // TBD
   keyboardShortcut?: string;
   // What happens when you select this option?
@@ -64,7 +64,7 @@ export class ComponentPickerOption extends MenuOption {
     title: string,
     options: {
       icon?: JSX.Element;
-      keywords?: Array<string>;
+      keywords?: string[];
       keyboardShortcut?: string;
       onSelect: (queryString: string) => void;
     },
@@ -113,7 +113,7 @@ export function ComponentPickerMenuItem({
 }
 
 export function getDynamicOptions(editor: LexicalEditor, queryString: string) {
-  const options: Array<ComponentPickerOption> = [];
+  const options: ComponentPickerOption[] = [];
 
   if (queryString == null) {
     return options;

--- a/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
@@ -23,13 +23,13 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 class EmojiOption extends MenuOption {
   title: string;
   emoji: string;
-  keywords: Array<string>;
+  keywords: string[];
 
   constructor(
     title: string,
     emoji: string,
     options: {
-      keywords?: Array<string>;
+      keywords?: string[];
     },
   ) {
     super(title);
@@ -43,8 +43,8 @@ type Emoji = {
   emoji: string;
   description: string;
   category: string;
-  aliases: Array<string>;
-  tags: Array<string>;
+  aliases: string[];
+  tags: string[];
   unicode_version: string;
   ios_version: string;
   skin_tones?: boolean;
@@ -55,7 +55,7 @@ const MAX_EMOJI_SUGGESTION_COUNT = 10;
 export default function EmojiPickerPlugin() {
   const [editor] = useLexicalComposerContext();
   const [queryString, setQueryString] = useState<string | null>(null);
-  const [emojis, setEmojis] = useState<Array<Emoji>>([]);
+  const [emojis, setEmojis] = useState<Emoji[]>([]);
 
   useEffect(() => {
     import('../../utils/emoji-list').then(file => setEmojis(file.default));
@@ -81,7 +81,7 @@ export default function EmojiPickerPlugin() {
     punctuation: '\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\[\\]\\\\/!%\'"~=<>:;', // allow _ and -
   });
 
-  const options: Array<EmojiOption> = useMemo(() => {
+  const options: EmojiOption[] = useMemo(() => {
     return emojiOptions
       .filter((option: EmojiOption) => {
         return queryString != null

--- a/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
@@ -301,7 +301,7 @@ const $createTableCell = (textContent: string): TableCellNode => {
   return cell;
 };
 
-const mapToTableCells = (textContent: string): Array<TableCellNode> | null => {
+const mapToTableCells = (textContent: string): TableCellNode[] | null => {
   const match = textContent.match(TABLE_ROW_REG_EXP);
   if (!match || !match[1]) {
     return null;
@@ -309,7 +309,7 @@ const mapToTableCells = (textContent: string): Array<TableCellNode> | null => {
   return match[1].split('|').map(text => $createTableCell(text));
 };
 
-export const PLAYGROUND_TRANSFORMERS: Array<Transformer> = [
+export const PLAYGROUND_TRANSFORMERS: Transformer[] = [
   TABLE,
   HR,
   IMAGE,

--- a/packages/lexical-playground/src/plugins/MentionsExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsExtension/index.tsx
@@ -524,7 +524,7 @@ const dummyMentionsData = [
 ];
 
 const dummyLookupService = {
-  search(string: string, callback: (results: Array<string>) => void): void {
+  search(string: string, callback: (results: string[]) => void): void {
     setTimeout(() => {
       const results = dummyMentionsData.filter(mention =>
         mention.toLowerCase().includes(string.toLowerCase()),
@@ -535,7 +535,7 @@ const dummyLookupService = {
 };
 
 function useMentionLookupService(mentionString: string | null) {
-  const [results, setResults] = useState<Array<string>>([]);
+  const [results, setResults] = useState<string[]>([]);
 
   useEffect(() => {
     const cachedResults = mentionsCache.get(mentionString);

--- a/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
@@ -354,7 +354,7 @@ export const PagesExtension = /* @__PURE__ */ defineExtension({
           () => {
             const root = $getRoot();
             const children = root.getChildren();
-            const pages = [] as Array<PageNode | PageBreakNode>;
+            const pages = [] as (PageNode | PageBreakNode)[];
             for (const child of children) {
               if ($isPageNode(child) || $isPageBreakNode(child)) {
                 if ($isPageNode(child)) {

--- a/packages/lexical-playground/src/plugins/PagesReactExtension/PageSetupDropdown.tsx
+++ b/packages/lexical-playground/src/plugins/PagesReactExtension/PageSetupDropdown.tsx
@@ -21,10 +21,10 @@ function dropDownActiveClass(active: boolean): string {
   return active ? 'active dropdown-item-active' : '';
 }
 
-const MARGIN_PRESETS: ReadonlyArray<{
+const MARGIN_PRESETS: readonly {
   label: string;
   margins: PageSetup['margins'];
-}> = [
+}[] = [
   {
     label: 'Narrow (0.25")',
     margins: {bottom: 0.25, left: 0.25, right: 0.25, top: 0.25},

--- a/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
@@ -52,7 +52,7 @@ function getTotalTableWidth(colWidths: readonly number[]): number {
 
 function $calculateResizeRootTables(
   tables: ReadonlySet<TableNode>,
-): ReadonlyArray<TableNode> {
+): readonly TableNode[] {
   const inputTables: ReadonlySet<LexicalNode> = tables;
   const roots: TableNode[] = [];
   for (const table of tables) {

--- a/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
@@ -203,7 +203,7 @@ function TableHoverActionsV2({
   const dragHandleRef = useRef<HTMLButtonElement | null>(null);
   const hoveredLeftCellRef = useRef<HTMLTableCellElement | null>(null);
   const hoveredTopCellRef = useRef<HTMLTableCellElement | null>(null);
-  const dropIndicatorCleanupRef = useRef<Array<() => void>>([]);
+  const dropIndicatorCleanupRef = useRef<(() => void)[]>([]);
   const [hoveredTable, setHoveredTable] = useState<HTMLTableElement | null>(
     null,
   );

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -47,7 +47,7 @@ function isHeadingBelowTheTopOfThePage(element: HTMLElement): boolean {
 function TableOfContentsList({
   tableOfContents,
 }: {
-  tableOfContents: Array<TableOfContentsEntry>;
+  tableOfContents: TableOfContentsEntry[];
 }): JSX.Element {
   const [selectedKey, setSelectedKey] = useState('');
   const selectedIndex = useRef(0);

--- a/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
@@ -37,7 +37,7 @@ export default function TypingPerfPlugin(): JSX.Element | null {
     let start = 0;
     let timerId: ReturnType<typeof setTimeout> | null;
     let keyPressTimerId: ReturnType<typeof setTimeout> | null;
-    let log: Array<DOMHighResTimeStamp> = [];
+    let log: DOMHighResTimeStamp[] = [];
     let invalidatingEvent = false;
 
     const measureEventEnd = function logKeyPress() {

--- a/packages/lexical-playground/src/utils/joinClasses.ts
+++ b/packages/lexical-playground/src/utils/joinClasses.ts
@@ -7,7 +7,7 @@
  */
 
 export default function joinClasses(
-  ...args: Array<string | boolean | null | undefined>
+  ...args: (string | boolean | null | undefined)[]
 ) {
   return args.filter(Boolean).join(' ');
 }

--- a/packages/lexical-react/flow/LexicalAutoEmbedPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoEmbedPlugin.js.flow
@@ -36,13 +36,13 @@ export const INSERT_EMBED_COMMAND: LexicalCommand<EmbedConfig['type']> =
   createCommand('INSERT_EMBED_COMMAND');
 
 type LexicalAutoEmbedPluginProps<TEmbedConfig> = {
-  embedConfigs: Array<TEmbedConfig>,
+  embedConfigs: TEmbedConfig[],
   onOpenEmbedModalForConfig: (embedConfig: TEmbedConfig) => void,
   getMenuOptions: (
     activeEmbedConfig: TEmbedConfig,
     embedFn: () => void,
     dismissFn: () => void,
-  ) => Array<AutoEmbedOption>,
+  ) => AutoEmbedOption[],
   menuRenderFn?: MenuRenderFn<AutoEmbedOption>,
 };
 

--- a/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
@@ -17,8 +17,8 @@ export type HistoryStateEntry = {
 
 export type HistoryState = {
   current: null | HistoryStateEntry,
-  redoStack: Array<HistoryStateEntry>,
-  undoStack: Array<HistoryStateEntry>,
+  redoStack: HistoryStateEntry[],
+  undoStack: HistoryStateEntry[],
 };
 
 declare export function HistoryPlugin({

--- a/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
@@ -9,8 +9,8 @@
 
 import type {Transformer} from '@lexical/markdown';
 
-declare export var DEFAULT_TRANSFORMERS: Array<Transformer>;
+declare export var DEFAULT_TRANSFORMERS: Transformer[];
 
 declare export function MarkdownShortcutPlugin({
-  transformers?: Array<Transformer>,
+  transformers?: Transformer[],
 }): React.Node;

--- a/packages/lexical-react/flow/LexicalNodeMenuPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalNodeMenuPlugin.js.flow
@@ -35,7 +35,7 @@ export type MenuRenderFn<TOption> = (
     selectedIndex: number | null,
     selectOptionAndCleanUp: (option: TOption) => void,
     setHighlightedIndex: (index: number) => void,
-    options: Array<TOption>,
+    options: TOption[],
   },
   matchingString: string,
 ) => React$Portal | React.MixedElement | null;
@@ -52,7 +52,7 @@ type NodeMenuPluginProps<TOption> = {
     closeMenu: () => void,
     matchingString: string,
   ) => void,
-  options: Array<TOption>,
+  options: TOption[],
   nodeKey: NodeKey | null,
   menuRenderFn?: MenuRenderFn<TOption>,
   onClose?: () => void,

--- a/packages/lexical-react/flow/LexicalSelectionAlwaysOnDisplay.js.flow
+++ b/packages/lexical-react/flow/LexicalSelectionAlwaysOnDisplay.js.flow
@@ -11,5 +11,5 @@
  * LexicalSelectionAlwaysOnDisplay
  */
 declare export function SelectionAlwaysOnDisplay({
-  onReposition?: (node: Array<HTMLElement>) => void,
+  onReposition?: (node: HTMLElement[]) => void,
 }): null;

--- a/packages/lexical-react/flow/LexicalTableOfContentsPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalTableOfContentsPlugin.js.flow
@@ -12,7 +12,7 @@ import type {LexicalEditor, NodeKey} from 'lexical';
 
 declare export function TableOfContentsPlugin({
   children: (
-    tableOfContents: Array<[NodeKey, string, HeadingTagType]>,
+    tableOfContents: [NodeKey, string, HeadingTagType][],
     editor: LexicalEditor,
   ) => React.Node,
 }): React.Node;

--- a/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
@@ -38,7 +38,7 @@ export type MenuRenderFn<TOption> = (
     selectedIndex: number | null,
     selectOptionAndCleanUp: (option: TOption) => void,
     setHighlightedIndex: (index: number) => void,
-    options: Array<TOption>,
+    options: TOption[],
   },
   matchingString: string,
 ) => React$Portal | React.MixedElement | null;
@@ -66,7 +66,7 @@ export type TypeaheadMenuPluginProps<TOption> = {
     closeMenu: () => void,
     matchingString: string,
   ) => void,
-  options: Array<TOption>,
+  options: TOption[],
   triggerFn: TriggerFn,
   menuRenderFn?: MenuRenderFn<TOption>,
   onOpen?: (resolution: MenuResolution) => void,

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -23,9 +23,9 @@ export {
 
 function useAutoLink(
   editor: LexicalEditor,
-  matchers: Array<LinkMatcher>,
+  matchers: LinkMatcher[],
   onChange?: ChangeHandler,
-  excludeParents?: Array<(parent: ElementNode) => boolean>,
+  excludeParents?: ((parent: ElementNode) => boolean)[],
 ): void {
   useEffect(() => {
     if (!editor.hasNodes([AutoLinkNode])) {
@@ -49,9 +49,9 @@ export function AutoLinkPlugin({
   onChange,
   excludeParents,
 }: {
-  matchers: Array<LinkMatcher>;
+  matchers: LinkMatcher[];
   onChange?: ChangeHandler;
-  excludeParents?: Array<(parent: ElementNode) => boolean>;
+  excludeParents?: ((parent: ElementNode) => boolean)[];
 }): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
 

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -66,7 +66,7 @@ export type InitialEditorStateType =
 
 export type InitialConfigType = Readonly<{
   namespace: string;
-  nodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
+  nodes?: readonly (Klass<LexicalNode> | LexicalNodeReplacement)[];
   onError: (error: Error, editor: LexicalEditor) => void;
   /**
    * Optional handler for recoverable, warn-level conditions (e.g. the

--- a/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
+++ b/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
@@ -44,7 +44,7 @@ export const DEFAULT_TRANSFORMERS = [HR, ...TRANSFORMERS];
 export function MarkdownShortcutPlugin({
   transformers = DEFAULT_TRANSFORMERS,
 }: Readonly<{
-  transformers?: Array<Transformer>;
+  transformers?: Transformer[];
 }>): null {
   const [editor] = useLexicalComposerContext();
 

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -60,7 +60,7 @@ export interface LexicalNestedComposerProps {
    * editor = createEditor({nodes: [], parentEditor: $getEditor()});
    * ```
    */
-  initialNodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
+  initialNodes?: readonly (Klass<LexicalNode> | LexicalNodeReplacement)[];
   /**
    * If this is not explicitly set to true, and the collab plugin is active,
    * rendering the children of this component will not happen until collab is ready.

--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -145,8 +145,8 @@ const NodeContextMenuPlugin = forwardRef<
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const [isOpen, setIsOpen] = useState(false);
 
-  const listItemsRef = useRef<Array<HTMLButtonElement | null>>([]);
-  const listContentRef = useRef<Array<string | null>>([]);
+  const listItemsRef = useRef<(HTMLButtonElement | null)[]>([]);
+  const listContentRef = useRef<(string | null)[]>([]);
 
   const {refs, floatingStyles, context} = useFloating({
     middleware: [

--- a/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
@@ -30,7 +30,7 @@ export type NodeMenuPluginProps<TOption extends MenuOption> = {
     closeMenu: () => void,
     matchingString: string,
   ) => void;
-  options: Array<TOption>;
+  options: TOption[];
   nodeKey: NodeKey | null;
   menuRenderFn?: MenuRenderFn<TOption>;
   onClose?: () => void;

--- a/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
@@ -36,13 +36,13 @@ function toEntry(heading: HeadingNode): TableOfContentsEntry {
 function $insertHeadingIntoTableOfContents(
   prevHeading: HeadingNode | null,
   newHeading: HeadingNode | null,
-  currentTableOfContents: Array<TableOfContentsEntry>,
-): Array<TableOfContentsEntry> {
+  currentTableOfContents: TableOfContentsEntry[],
+): TableOfContentsEntry[] {
   if (newHeading === null) {
     return currentTableOfContents;
   }
   const newEntry: TableOfContentsEntry = toEntry(newHeading);
-  let newTableOfContents: Array<TableOfContentsEntry> = [];
+  let newTableOfContents: TableOfContentsEntry[] = [];
   if (prevHeading === null) {
     // check if key already exists
     if (
@@ -73,8 +73,8 @@ function $insertHeadingIntoTableOfContents(
 
 function $deleteHeadingFromTableOfContents(
   key: NodeKey,
-  currentTableOfContents: Array<TableOfContentsEntry>,
-): Array<TableOfContentsEntry> {
+  currentTableOfContents: TableOfContentsEntry[],
+): TableOfContentsEntry[] {
   const newTableOfContents = [];
   for (const heading of currentTableOfContents) {
     if (heading[0] !== key) {
@@ -86,9 +86,9 @@ function $deleteHeadingFromTableOfContents(
 
 function $updateHeadingInTableOfContents(
   heading: HeadingNode,
-  currentTableOfContents: Array<TableOfContentsEntry>,
-): Array<TableOfContentsEntry> {
-  const newTableOfContents: Array<TableOfContentsEntry> = [];
+  currentTableOfContents: TableOfContentsEntry[],
+): TableOfContentsEntry[] {
+  const newTableOfContents: TableOfContentsEntry[] = [];
   for (const oldHeading of currentTableOfContents) {
     if (oldHeading[0] === heading.getKey()) {
       newTableOfContents.push(toEntry(heading));
@@ -106,9 +106,9 @@ function $updateHeadingInTableOfContents(
 function $updateHeadingPosition(
   prevHeading: HeadingNode | null,
   heading: HeadingNode,
-  currentTableOfContents: Array<TableOfContentsEntry>,
-): Array<TableOfContentsEntry> {
-  const newTableOfContents: Array<TableOfContentsEntry> = [];
+  currentTableOfContents: TableOfContentsEntry[],
+): TableOfContentsEntry[] {
+  const newTableOfContents: TableOfContentsEntry[] = [];
   const newEntry: TableOfContentsEntry = toEntry(heading);
 
   if (!prevHeading) {
@@ -137,19 +137,19 @@ function $getPreviousHeading(node: HeadingNode): HeadingNode | null {
 
 type Props = {
   children: (
-    values: Array<TableOfContentsEntry>,
+    values: TableOfContentsEntry[],
     editor: LexicalEditor,
   ) => JSX.Element;
 };
 
 export function TableOfContentsPlugin({children}: Props): JSX.Element {
   const [tableOfContents, setTableOfContents] = useState<
-    Array<TableOfContentsEntry>
+    TableOfContentsEntry[]
   >([]);
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
     // Set table of contents initial state
-    let currentTableOfContents: Array<TableOfContentsEntry> = [];
+    let currentTableOfContents: TableOfContentsEntry[] = [];
     editor.getEditorState().read(() => {
       const updateCurrentTableOfContents = (node: ElementNode) => {
         for (const child of node.getChildren()) {

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -200,7 +200,7 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
     closeMenu: () => void,
     matchingString: string,
   ) => void;
-  options: Array<TOption>;
+  options: TOption[];
   triggerFn: TriggerFn;
   menuRenderFn?: MenuRenderFn<TOption>;
   onOpen?: (resolution: MenuResolution) => void;

--- a/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
@@ -29,7 +29,7 @@ import {
   waitForReact,
 } from '../utils';
 
-const $insertParagraph = (...children: Array<string | LexicalNode>) => {
+const $insertParagraph = (...children: (string | LexicalNode)[]) => {
   const root = $getRoot();
   const paragraph = $createParagraphNode();
   const nodes = children.map(child => {
@@ -46,9 +46,9 @@ const $createSelectionByPath = ({
   focusOffset,
 }: {
   anchorOffset: number;
-  anchorPath: Array<number>;
+  anchorPath: number[];
   focusOffset: number;
-  focusPath: Array<number>;
+  focusPath: number[];
 }): BaseSelection => {
   const selection = $createRangeSelection();
   const root = $getRoot();
@@ -86,9 +86,9 @@ const $replaceTextByPath = ({
   text = '',
 }: {
   anchorOffset: number;
-  anchorPath: Array<number>;
+  anchorPath: number[];
   focusOffset: number;
-  focusPath: Array<number>;
+  focusPath: number[];
   text: string | null | undefined;
 }) => {
   const selection = $createSelectionByPath({
@@ -113,12 +113,12 @@ describe('CollaborationWithCollisions', () => {
     container = null;
   });
 
-  const SIMPLE_TEXT_COLLISION_TESTS: Array<{
-    clients: Array<() => void>;
+  const SIMPLE_TEXT_COLLISION_TESTS: {
+    clients: (() => void)[];
     expectedHTML: string | null | undefined;
     init: () => void;
     name: string;
-  }> = [
+  }[] = [
     {
       clients: [
         () => {

--- a/packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx
@@ -136,7 +136,7 @@ function TypeaheadPluginWithoutMenuRenderFn({
 
 function createApp(
   plugin: React.ReactNode,
-  nodes: Array<typeof ParagraphNode> = [],
+  nodes: (typeof ParagraphNode)[] = [],
 ): React.FC {
   return function App() {
     return (

--- a/packages/lexical-react/src/__tests__/utils/index.tsx
+++ b/packages/lexical-react/src/__tests__/utils/index.tsx
@@ -317,7 +317,7 @@ export function createAndStartClients(
   connector: TestConnection,
   aContainer: HTMLDivElement,
   count: number,
-): Array<Client> {
+): Client[] {
   const result = [];
 
   for (let i = 0; i < count; ++i) {
@@ -330,25 +330,25 @@ export function createAndStartClients(
   return result;
 }
 
-export function disconnectClients(clients: Array<Client>) {
+export function disconnectClients(clients: Client[]) {
   for (let i = 0; i < clients.length; ++i) {
     clients[i].disconnect();
   }
 }
 
-export function connectClients(clients: Array<Client>) {
+export function connectClients(clients: Client[]) {
   for (let i = 0; i < clients.length; ++i) {
     clients[i].connect();
   }
 }
 
-export function stopClients(clients: Array<Client>) {
+export function stopClients(clients: Client[]) {
   for (let i = 0; i < clients.length; ++i) {
     clients[i].stop();
   }
 }
 
-export function testClientsForEquality(clients: Array<Client>) {
+export function testClientsForEquality(clients: Client[]) {
   for (let i = 1; i < clients.length; ++i) {
     expect(clients[0].getHTML()).toEqual(clients[i].getHTML());
     expect(clients[0].getDocJSON()).toEqual(clients[i].getDocJSON());

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -73,7 +73,7 @@ export type MenuRenderFn<TOption extends MenuOption> = (
     selectedIndex: number | null;
     selectOptionAndCleanUp: (option: TOption) => void;
     setHighlightedIndex: (index: number) => void;
-    options: Array<TOption>;
+    options: TOption[];
   },
   matchingString: string,
 ) => ReactPortal | JSX.Element | null;
@@ -312,7 +312,7 @@ export function LexicalMenu<TOption extends MenuOption>({
   editor: LexicalEditor;
   anchorElementRef: RefObject<HTMLElement | null>;
   resolution: MenuResolution;
-  options: Array<TOption>;
+  options: TOption[];
   shouldSplitNodeWithQuery?: boolean;
   menuRenderFn?: MenuRenderFn<TOption>;
   onSelectOption: (

--- a/packages/lexical-react/src/shared/useDecorators.tsx
+++ b/packages/lexical-react/src/shared/useDecorators.tsx
@@ -27,7 +27,7 @@ export type ErrorBoundaryType =
 export function useDecorators(
   editor: LexicalEditor,
   ErrorBoundary: ErrorBoundaryType,
-): Array<JSX.Element> {
+): JSX.Element[] {
   const [decorators, setDecorators] = useState<Record<NodeKey, JSX.Element>>(
     () => editor.getDecorators<JSX.Element>(),
   );

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -72,7 +72,7 @@ const COLLAB_UNDO_MANAGER = Symbol.for('@lexical/yjs/UndoManager');
 type OnYjsTreeChanges = (
   // The below `any` type is taken directly from the vendor types for YJS.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  events: Array<YEvent<any>>,
+  events: YEvent<any>[],
   transaction: Transaction,
 ) => void;
 

--- a/packages/lexical-rich-text/flow/LexicalRichText.js.flow
+++ b/packages/lexical-rich-text/flow/LexicalRichText.js.flow
@@ -23,7 +23,7 @@ import type {
 } from 'lexical';
 import {ElementNode} from 'lexical';
 
-declare export var DRAG_DROP_PASTE: LexicalCommand<Array<File>>;
+declare export var DRAG_DROP_PASTE: LexicalCommand<File[]>;
 declare export class QuoteNode extends ElementNode {
   static getType(): string;
   static clone(node: QuoteNode): QuoteNode;

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -127,7 +127,7 @@ export type SerializedHeadingNode = Spread<
   SerializedElementNode
 >;
 
-export const DRAG_DROP_PASTE: LexicalCommand<Array<File>> =
+export const DRAG_DROP_PASTE: LexicalCommand<File[]> =
   /* @__PURE__ */ createCommand('DRAG_DROP_PASTE_FILE');
 
 export type SerializedQuoteNode = SerializedElementNode;
@@ -518,7 +518,7 @@ async function onCutForRichText(
 // control this with the first boolean flag.
 export function eventFiles(
   event: DragEvent | PasteCommandType,
-): [boolean, Array<File>, boolean] {
+): [boolean, File[], boolean] {
   let dataTransfer: null | DataTransfer = null;
   if (objectKlassEquals(event, DragEvent)) {
     dataTransfer = event.dataTransfer;

--- a/packages/lexical-selection/flow/LexicalSelection.js.flow
+++ b/packages/lexical-selection/flow/LexicalSelection.js.flow
@@ -73,7 +73,7 @@ declare export function createDOMRange(
 declare export function createRectsFromDOMRange(
   editor: LexicalEditor,
   range: Range,
-): Array<ClientRect>;
+): ClientRect[];
 
 declare export function $trimTextContentFromAnchor(
   editor: LexicalEditor,

--- a/packages/lexical-selection/src/__tests__/utils/index.ts
+++ b/packages/lexical-selection/src/__tests__/utils/index.ts
@@ -37,7 +37,7 @@ if (!Selection.prototype.modify) {
     /[\s.,\\/#!$%^&*;:{}=\-`~()\uD800-\uDBFF\uDC00-\uDFFF\u3000-\u303F]/u;
 
   const pushSegment = function (
-    segments: Array<Segment>,
+    segments: Segment[],
     index: number,
     str: string,
     isWordLike: boolean,
@@ -49,7 +49,7 @@ if (!Selection.prototype.modify) {
     });
   };
 
-  const getWordsFromString = function (string: string): Array<Segment> {
+  const getWordsFromString = function (string: string): Segment[] {
     const segments: Segment[] = [];
     let wordString = '';
     let nonWordString = '';

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -127,7 +127,7 @@ export function createDOMRange(
 export function createRectsFromDOMRange(
   editor: LexicalEditor,
   range: Range,
-): Array<ClientRect> {
+): ClientRect[] {
   const rootElement = editor.getRootElement();
 
   if (rootElement === null) {

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -94,7 +94,7 @@ export type TableMapValueType = {
   startRow: number,
   startColumn: number,
 };
-export type TableMapType = Array<Array<TableMapValueType>>;
+export type TableMapType = TableMapValueType[][];
 
 declare export class TableNode extends ElementNode {
   static getType(): string;
@@ -168,7 +168,7 @@ export type TableDOMCell = {
   y: number,
 };
 
-export type TableDOMRows = Array<Array<TableDOMCell>>;
+export type TableDOMRows = TableDOMCell[][];
 
 export type TableDOMTable = {
   cells: TableDOMRows,
@@ -380,18 +380,18 @@ declare export class TableSelection implements BaseSelection {
   set(tableKey: NodeKey, anchorCellKey: NodeKey, focusCellKey: NodeKey): void;
   clone(): TableSelection;
   getCharacterOffsets(): [number, number];
-  extract(): Array<LexicalNode>;
+  extract(): LexicalNode[];
   insertRawText(): void;
   insertText(): void;
   isCollapsed(): false;
   isBackward(): boolean;
   getShape(): TableSelectionShape;
-  getNodes(): Array<LexicalNode>;
+  getNodes(): LexicalNode[];
   getTextContent(): string;
-  insertNodes(nodes: Array<LexicalNode>): void;
+  insertNodes(nodes: LexicalNode[]): void;
   getStartEndPoints(): [PointType, PointType];
-  getCachedNodes(): null | Array<LexicalNode>;
-  setCachedNodes(nodes: null | Array<LexicalNode>): void;
+  getCachedNodes(): null | LexicalNode[];
+  setCachedNodes(nodes: null | LexicalNode[]): void;
 }
 
 declare export function $isTableSelection(

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -54,7 +54,7 @@ export type TableDOMCell = {
   y: number;
 };
 
-export type TableDOMRows = Array<Array<TableDOMCell | undefined> | undefined>;
+export type TableDOMRows = ((TableDOMCell | undefined)[] | undefined)[];
 
 export type TableDOMTable = {
   domRows: TableDOMRows;

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -50,7 +50,7 @@ export type TableMapValueType = {
   startRow: number;
   startColumn: number;
 };
-export type TableMapType = Array<Array<TableMapValueType>>;
+export type TableMapType = TableMapValueType[][];
 
 function $getCellNodes(tableSelection: TableSelection): {
   anchorCell: TableCellNode;
@@ -112,7 +112,7 @@ export class TableSelection implements BaseSelection {
   tableKey: NodeKey;
   anchor: PointType;
   focus: PointType;
-  _cachedNodes: Array<LexicalNode> | null;
+  _cachedNodes: LexicalNode[] | null;
   dirty: boolean;
 
   constructor(tableKey: NodeKey, anchor: PointType, focus: PointType) {
@@ -206,7 +206,7 @@ export class TableSelection implements BaseSelection {
     return false;
   }
 
-  extract(): Array<LexicalNode> {
+  extract(): LexicalNode[] {
     return this.getNodes();
   }
 
@@ -240,7 +240,7 @@ export class TableSelection implements BaseSelection {
     return (format & formatFlag) !== 0;
   }
 
-  insertNodes(nodes: Array<LexicalNode>) {
+  insertNodes(nodes: LexicalNode[]) {
     const focusNode = this.focus.getNode();
     invariant(
       $isElementNode(focusNode),
@@ -292,7 +292,7 @@ export class TableSelection implements BaseSelection {
     };
   }
 
-  getNodes(): Array<LexicalNode> {
+  getNodes(): LexicalNode[] {
     if (!this.isValid()) {
       return [];
     }

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -104,7 +104,7 @@ describe('LexicalTableCellNode tests', () => {
       const {editor} = testEnv;
       const parser = new DOMParser();
 
-      const cases: Array<[string, string]> = [
+      const cases: [string, string][] = [
         [
           html`
             <table>

--- a/packages/lexical-text/flow/LexicalText.js.flow
+++ b/packages/lexical-text/flow/LexicalText.js.flow
@@ -40,4 +40,4 @@ declare export function registerLexicalTextEntity<N extends TextNode>(
   getMatch: (text: string) => null | EntityMatch,
   targetNode: Class<N>,
   createNode: (textNode: TextNode) => N,
-): Array<() => void>;
+): (() => void)[];

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -42,7 +42,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
   getMatch: (text: string) => null | EntityMatch,
   targetNode: Klass<T>,
   createNode: (textNode: TextNode) => T,
-): Array<() => void> {
+): (() => void)[] {
   const isTargetNode = (node: LexicalNode | null | undefined): node is T => {
     return node instanceof targetNode;
   };

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -22,20 +22,20 @@ import type {
 } from 'lexical';
 declare export function addClassNamesToElement(
   element: HTMLElement,
-  ...classNames: Array<typeof undefined | boolean | null | string>
+  ...classNames: (typeof undefined | boolean | null | string)[]
 ): void;
 declare export function removeClassNamesFromElement(
   element: HTMLElement,
-  ...classNames: Array<typeof undefined | boolean | null | string>
+  ...classNames: (typeof undefined | boolean | null | string)[]
 ): void;
 declare export function isMimeType(
   file: File,
-  acceptableMimeTypes: Array<string>,
+  acceptableMimeTypes: string[],
 ): boolean;
 declare export function mediaFileReader(
-  files: Array<File>,
-  acceptableMimeTypes: Array<string>,
-): Promise<Array<Readonly<{file: File, result: string}>>>;
+  files: File[],
+  acceptableMimeTypes: string[],
+): Promise<Readonly<{file: File, result: string}>[]>;
 export type DFSNode = Readonly<{
   depth: number,
   node: LexicalNode,
@@ -43,7 +43,7 @@ export type DFSNode = Readonly<{
 declare export function $dfs(
   startNode?: LexicalNode,
   endNode?: LexicalNode,
-): Array<DFSNode>;
+): DFSNode[];
 type DFSIterator = {
   next: () => IteratorResult<DFSNode, void>;
   @@iterator: () => DFSIterator;
@@ -71,19 +71,19 @@ declare export function $findMatchingParent(
   startingNode: LexicalNode,
   findFn: (LexicalNode) => boolean,
 ): LexicalNode | null;
-declare export function mergeRegister(...func: Array<() => void>): () => void;
+declare export function mergeRegister(...func: (() => void)[]): () => void;
 declare export function markSelection(
   editor: LexicalEditor,
-  onReposition?: (node: Array<HTMLElement>) => void,
+  onReposition?: (node: HTMLElement[]) => void,
 ): () => void;
 declare export function positionNodeOnRange(
   editor: LexicalEditor,
   range: Range,
-  onReposition: (node: Array<HTMLElement>) => void,
+  onReposition: (node: HTMLElement[]) => void,
 ): () => void;
 declare export function selectionAlwaysOnDisplay(
   editor: LexicalEditor,
-  onReposition?: (node: Array<HTMLElement>) => void,
+  onReposition?: (node: HTMLElement[]) => void,
 ): () => void;
 declare export function $getNearestBlockElementAncestorOrThrow(
   startNode: LexicalNode,
@@ -123,9 +123,9 @@ declare export function objectKlassEquals<T>(
 ): boolean;
 
 declare export function $filter<T>(
-  nodes: Array<LexicalNode>,
+  nodes: LexicalNode[],
   filterFn: (node: LexicalNode) => null | T,
-): Array<T>;
+): T[];
 
 declare export function $handleIndentAndOutdent(
   indentOrOutdent: (block: ElementNode) => void,
@@ -160,7 +160,7 @@ declare export function $getAdjacentCaret<D extends CaretDirection>(
 declare export function $reverseDfs(
   startNode?: LexicalNode,
   endNode?: LexicalNode,
-): Array<DFSNode>;
+): DFSNode[];
 
 declare export function $reverseDfsIterator(
   startNode?: LexicalNode,

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
@@ -36,14 +36,14 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
     editor._headless = true;
   });
 
-  const testCases: Array<{
+  const testCases: {
     _: string;
     expectedHtml: string;
     initialHtml: string;
-    selectionPath: Array<number>;
+    selectionPath: number[];
     selectionOffset: number;
     only?: boolean;
-  }> = [
+  }[] = [
     {
       _: 'insert into paragraph in between two text nodes',
       expectedHtml:

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -28,14 +28,14 @@ describe('LexicalUtils#splitNode', () => {
     editor._headless = true;
   });
 
-  const testCases: Array<{
+  const testCases: {
     _: string;
     expectedHtml: string;
     initialHtml: string;
-    splitPath: Array<number>;
+    splitPath: number[];
     splitOffset: number;
     only?: boolean;
-  }> = [
+  }[] = [
     {
       _: 'split paragraph in between two text nodes',
       expectedHtml:

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -106,10 +106,7 @@ export {
  * @param acceptableMimeTypes - An array of strings of types which the file is checked against.
  * @returns true if the file is an acceptable mime type, false otherwise.
  */
-export function isMimeType(
-  file: File,
-  acceptableMimeTypes: Array<string>,
-): boolean {
+export function isMimeType(file: File, acceptableMimeTypes: string[]): boolean {
   for (const acceptableType of acceptableMimeTypes) {
     if (file.type.startsWith(acceptableType)) {
       return true;
@@ -130,12 +127,12 @@ export function isMimeType(
  * \\}));
  */
 export function mediaFileReader(
-  files: Array<File>,
-  acceptableMimeTypes: Array<string>,
-): Promise<Array<{file: File; result: string}>> {
+  files: File[],
+  acceptableMimeTypes: string[],
+): Promise<{file: File; result: string}[]> {
   const filesIterator = files[Symbol.iterator]();
   return new Promise((resolve, reject) => {
-    const processed: Array<{file: File; result: string}> = [];
+    const processed: {file: File; result: string}[] = [];
     const handleNextFile = () => {
       const {done, value: file} = filesIterator.next();
       if (done) {
@@ -180,7 +177,7 @@ export interface DFSNode {
 export function $dfs(
   startNode?: LexicalNode,
   endNode?: LexicalNode,
-): Array<DFSNode> {
+): DFSNode[] {
   return Array.from($dfsIterator(startNode, endNode));
 }
 
@@ -205,7 +202,7 @@ export function $getAdjacentCaret<D extends CaretDirection>(
 export function $reverseDfs(
   startNode?: LexicalNode,
   endNode?: LexicalNode,
-): Array<DFSNode> {
+): DFSNode[] {
   return Array.from($reverseDfsIterator(startNode, endNode));
 }
 
@@ -668,9 +665,9 @@ export function objectKlassEquals<T>(
  */
 
 export function $filter<T>(
-  nodes: Array<LexicalNode>,
+  nodes: LexicalNode[],
   filterFn: (node: LexicalNode) => null | T,
-): Array<T> {
+): T[] {
   const result: T[] = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = filterFn(nodes[i]);

--- a/packages/lexical-utils/src/positionNodeOnRange.ts
+++ b/packages/lexical-utils/src/positionNodeOnRange.ts
@@ -38,12 +38,12 @@ function prependDOMNode(parent: HTMLElement, node: HTMLElement) {
 export default function mlcPositionNodeOnRange(
   editor: LexicalEditor,
   range: Range,
-  onReposition: (node: Array<HTMLElement>) => void,
+  onReposition: (node: HTMLElement[]) => void,
 ): () => void {
   let rootDOMNode: null | HTMLElement = null;
   let parentDOMNode: null | HTMLElement = null;
   let observer: null | MutationObserver = null;
-  let lastNodes: Array<HTMLElement> = [];
+  let lastNodes: HTMLElement[] = [];
   const wrapperNode = document.createElement('div');
   wrapperNode.style.position = 'relative';
 

--- a/packages/lexical-website/src/components/Gallery/Card.tsx
+++ b/packages/lexical-website/src/components/Gallery/Card.tsx
@@ -24,7 +24,7 @@ function getCardImage(item: Example) {
   );
 }
 
-function CardTagChips({tags}: {tags: Array<string>}) {
+function CardTagChips({tags}: {tags: string[]}) {
   return (
     <ul className={clsx('clean-list', styles.cardTags)}>
       {tags.map(tagKey => {

--- a/packages/lexical-website/src/components/Gallery/GalleryCards.tsx
+++ b/packages/lexical-website/src/components/Gallery/GalleryCards.tsx
@@ -19,7 +19,7 @@ import styles from './styles.module.css';
 import {TagList} from './tagList';
 import {useFilteredExamples} from './utils';
 
-function CardList({cards}: {cards: Array<Example>}) {
+function CardList({cards}: {cards: Example[]}) {
   return (
     <div className="container">
       <ul className={clsx('clean-list', styles.cardList)}>

--- a/packages/lexical-website/src/components/Gallery/components/Filters.tsx
+++ b/packages/lexical-website/src/components/Gallery/components/Filters.tsx
@@ -85,7 +85,7 @@ function TagList({
   );
 }
 
-function HeadingText({filteredPlugins}: {filteredPlugins: Array<Example>}) {
+function HeadingText({filteredPlugins}: {filteredPlugins: Example[]}) {
   return (
     <div className={styles.headingText}>
       <Heading as="h2">Filters</Heading>
@@ -98,7 +98,7 @@ function HeadingText({filteredPlugins}: {filteredPlugins: Array<Example>}) {
   );
 }
 
-function HeadingRow({filteredPlugins}: {filteredPlugins: Array<Example>}) {
+function HeadingRow({filteredPlugins}: {filteredPlugins: Example[]}) {
   return (
     <div className={clsx('margin-bottom--sm', styles.headingRow)}>
       <HeadingText filteredPlugins={filteredPlugins} />
@@ -111,8 +111,8 @@ export default function Filters({
   filteredPlugins,
   tagList,
 }: {
-  allPlugins: Array<Example>;
-  filteredPlugins: Array<Example>;
+  allPlugins: Example[];
+  filteredPlugins: Example[];
   tagList: {[type in string]: Tag};
 }): ReactNode {
   const tagCounts = useMemo(() => {

--- a/packages/lexical-website/src/components/Gallery/pluginList.tsx
+++ b/packages/lexical-website/src/components/Gallery/pluginList.tsx
@@ -20,12 +20,10 @@ export type Example = {
   uri?: string;
   preview?: string;
   renderPreview?: () => ReactNode;
-  tags: Array<string>;
+  tags: string[];
 };
 
-export const plugins = (customFields: {
-  [key: string]: unknown;
-}): Array<Example> =>
+export const plugins = (customFields: {[key: string]: unknown}): Example[] =>
   galleryExamples.map(example => ({
     description: example.description,
     preview: getScreenshotPreview(example),

--- a/packages/lexical-website/src/components/Gallery/utils.tsx
+++ b/packages/lexical-website/src/components/Gallery/utils.tsx
@@ -24,9 +24,9 @@ function filterExamples({
   searchName,
   tags,
 }: {
-  examples: Array<Example>;
+  examples: Example[];
   searchName: string;
-  tags: Array<string>;
+  tags: string[];
 }) {
   if (searchName) {
     examples = examples.filter(example =>
@@ -41,7 +41,7 @@ function filterExamples({
   return examples;
 }
 
-export function useFilteredExamples(examples: Array<Example>) {
+export function useFilteredExamples(examples: Example[]) {
   const [searchName] = useSearchName();
   const [tags] = useTags();
   return useMemo(

--- a/packages/lexical-yjs/flow/LexicalYjs.js.flow
+++ b/packages/lexical-yjs/flow/LexicalYjs.js.flow
@@ -72,7 +72,7 @@ export type TextOperation = {
 
 // CSS Custom Highlight API; lib.dom in TS but not in Flow's bundled defs.
 declare class Highlight {
-  constructor(...initialRanges: Array<Range>): void;
+  constructor(...initialRanges: Range[]): void;
   add(range: Range): Highlight;
   clear(): void;
 }
@@ -91,7 +91,7 @@ export type CursorSelection = {
   highlight: Highlight | null,
   highlightName: string,
   name: HTMLSpanElement,
-  selections: Array<HTMLElement>,
+  selections: HTMLElement[],
 };
 
 export type Cursor = {
@@ -255,12 +255,12 @@ type IntentionallyMarkedAsDirtyElement = boolean;
 
 declare export class CollabElementNode {
   _key: NodeKey;
-  _children: Array<
+  _children: (
     | CollabElementNode
     | CollabTextNode
     | CollabDecoratorNode
-    | CollabLineBreakNode,
-  >;
+    | CollabLineBreakNode
+  )[];
   _xmlText: XmlText;
   _type: string;
   _parent: null | CollabElementNode;
@@ -292,7 +292,7 @@ declare export class CollabElementNode {
     keysChanged: null | Set<string>,
   ): void;
 
-  applyChildrenYjsDelta(binding: Binding, deltas: Array<TextOperation>): void;
+  applyChildrenYjsDelta(binding: Binding, deltas: TextOperation[]): void;
 
   syncChildrenFromYjs(binding: Binding): void;
 
@@ -416,7 +416,7 @@ declare export function syncLexicalUpdateToYjs(
 declare export function syncYjsChangesToLexical(
   binding: Binding,
   provider: Provider,
-  events: Array<YjsEvent>,
+  events: YjsEvent[],
 ): void;
 
 declare export var CONNECTED_COMMAND: LexicalCommand<boolean>;

--- a/packages/lexical-yjs/src/CollabElementNode.ts
+++ b/packages/lexical-yjs/src/CollabElementNode.ts
@@ -39,12 +39,12 @@ type IntentionallyMarkedAsDirtyElement = boolean;
 
 export class CollabElementNode {
   _key: NodeKey;
-  _children: Array<
+  _children: (
     | CollabElementNode
     | CollabTextNode
     | CollabDecoratorNode
     | CollabLineBreakNode
-  >;
+  )[];
   _xmlText: XmlText;
   _type: string;
   _parent: null | CollabElementNode;
@@ -119,14 +119,14 @@ export class CollabElementNode {
 
   applyChildrenYjsDelta(
     binding: Binding,
-    deltas: Array<{
+    deltas: {
       insert?: string | object | AbstractType<unknown>;
       delete?: number;
       retain?: number;
       attributes?: {
         [x: string]: unknown;
       };
-    }>,
+    }[],
   ): void {
     const children = this._children;
     let currIndex = 0;
@@ -277,7 +277,7 @@ export class CollabElementNode {
 
     const key = lexicalNode.__key;
     const prevLexicalChildrenKeys = $createChildrenArray(lexicalNode, null);
-    const nextLexicalChildrenKeys: Array<NodeKey> = [];
+    const nextLexicalChildrenKeys: NodeKey[] = [];
     const lexicalChildrenKeysLength = prevLexicalChildrenKeys.length;
     const collabChildren = this._children;
     const collabChildrenLength = collabChildren.length;

--- a/packages/lexical-yjs/src/CollabV2Mapping.ts
+++ b/packages/lexical-yjs/src/CollabV2Mapping.ts
@@ -66,8 +66,8 @@ export class CollabV2Mapping {
 
   get(sharedType: XmlElement): LexicalNode | undefined;
   get(sharedType: XmlText): TextNode[] | undefined;
-  get(sharedType: SharedType): LexicalNode | Array<TextNode> | undefined;
-  get(sharedType: SharedType): LexicalNode | Array<TextNode> | undefined {
+  get(sharedType: SharedType): LexicalNode | TextNode[] | undefined;
+  get(sharedType: SharedType): LexicalNode | TextNode[] | undefined {
     const nodes = this._sharedTypeToNodeKeys.get(sharedType);
     if (nodes === undefined) {
       return undefined;
@@ -75,7 +75,7 @@ export class CollabV2Mapping {
     if (sharedType instanceof XmlText) {
       const arr = Array.from(
         nodes.map(nodeKey => this._nodeMap.get(nodeKey)!),
-      ) as Array<TextNode>;
+      ) as TextNode[];
       return arr.length > 0 ? arr : undefined;
     }
     return this._nodeMap.get(nodes[0])!;

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -66,7 +66,7 @@ export type CursorSelection = {
   highlightName: string;
   name: HTMLSpanElement;
   /** Legacy fallback only: absolutely-positioned rect spans, one per visual rect. */
-  selections: Array<HTMLElement>;
+  selections: HTMLElement[];
 };
 
 const SUPPORTS_CSS_HIGHLIGHTS =
@@ -486,7 +486,7 @@ function updateCursor(
 
   // legacy fallback path: per-rect absolutely-positioned span
   const selections = nextSelection.selections;
-  let selectionRects: Array<DOMRect>;
+  let selectionRects: DOMRect[];
 
   // In the case of a collapsed selection on a linebreak, we need
   // to improvise as the browser will return nothing here as <br>

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -134,7 +134,7 @@ function $syncEvent(binding: Binding, event: any): void {
 export function syncYjsChangesToLexical(
   binding: Binding,
   provider: Provider,
-  events: Array<YEvent<YText>>,
+  events: YEvent<YText>[],
   isFromUndoManger: boolean,
   syncCursorPositionsFn: SyncCursorPositionsFn = syncCursorPositions,
 ): void {
@@ -363,7 +363,7 @@ function $syncEventV2(
 export function syncYjsChangesToLexicalV2__EXPERIMENTAL(
   binding: BindingV2,
   provider: Provider,
-  events: Array<YEvent<XmlElement | XmlText>>,
+  events: YEvent<XmlElement | XmlText>[],
   transaction: YTransaction,
   isFromUndoManger: boolean,
 ): void {

--- a/packages/lexical-yjs/src/SyncV2.ts
+++ b/packages/lexical-yjs/src/SyncV2.ts
@@ -274,7 +274,7 @@ const $createOrUpdateTextNodesFromYText = (
   snapshot?: Snapshot,
   prevSnapshot?: Snapshot,
   computeYChange?: ComputeYChange,
-): Array<TextNode> | null => {
+): TextNode[] | null => {
   const deltas = toDelta(text, snapshot, prevSnapshot, computeYChange);
 
   // Use existing text nodes if the count and types all align, otherwise throw out the existing
@@ -407,7 +407,7 @@ const equalAttrs = (
   return eq;
 };
 
-type NormalizedPNodeContent = Array<Array<TextNode> | LexicalNode>;
+type NormalizedPNodeContent = (TextNode[] | LexicalNode)[];
 
 const normalizeNodeContent = (node: LexicalNode): NormalizedPNodeContent => {
   if (!(node instanceof ElementNode)) {
@@ -629,7 +629,7 @@ const toDelta = (
   snapshot?: Snapshot,
   prevSnapshot?: Snapshot,
   computeYChange?: ComputeYChange,
-): Array<{insert: string; attributes: TextAttributes}> => {
+): {insert: string; attributes: TextAttributes}[] => {
   return ytext
     .toDelta(snapshot, prevSnapshot, computeYChange)
     .map((delta: {insert: string; attributes?: TextAttributes}) => {

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -73,7 +73,7 @@ export type Operation = {
   };
   insert: string | Record<string, unknown>;
 };
-export type Delta = Array<Operation>;
+export type Delta = Operation[];
 export type YjsNode = Record<string, unknown>;
 export type YjsEvent = Record<string, unknown>;
 export type {Provider};

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -62,7 +62,7 @@ declare export var SELECT_ALL_COMMAND: LexicalCommand<KeyboardEvent>;
 declare export var MOVE_TO_END: LexicalCommand<KeyboardEvent>;
 declare export var MOVE_TO_START: LexicalCommand<KeyboardEvent>;
 declare export var SELECTION_INSERT_CLIPBOARD_NODES_COMMAND: LexicalCommand<{
-  nodes: Array<LexicalNode>;
+  nodes: LexicalNode[];
   selection: BaseSelection;
 }>;
 
@@ -158,7 +158,7 @@ export type Transform<T> = (node: T) => void;
 
 type DOMConversionCache = Map<
   string,
-  Array<(node: Node) => DOMConversion | null>,
+  ((node: Node) => DOMConversion | null)[],
 >;
 
 export type DOMSlotForNode<N extends LexicalNode> = N extends ElementNode
@@ -233,8 +233,8 @@ declare export class LexicalEditor {
   _htmlConversions: DOMConversionCache;
   _pendingEditorState: null | EditorState;
   _compositionKey: null | NodeKey;
-  _deferred: Array<() => void>;
-  _updates: Array<[() => void, void | EditorUpdateOptions]>;
+  _deferred: (() => void)[];
+  _updates: [() => void, void | EditorUpdateOptions][];
   _updating: boolean;
   _keyToDOMMap: Map<NodeKey, HTMLElement>;
   _listeners: Listeners;
@@ -282,7 +282,7 @@ declare export class LexicalEditor {
   ): () => void;
   dispatchCommand<P>(command: LexicalCommand<P>, payload: P): boolean;
   hasNode(node: Class<LexicalNode>): boolean;
-  hasNodes(nodes: Array<Class<LexicalNode>>): boolean;
+  hasNodes(nodes: Class<LexicalNode>[]): boolean;
   getKey(): string;
   getDecorators<X>(): {
     [NodeKey]: X,
@@ -309,7 +309,7 @@ type EditorReadOptions = {
 };
 export type EditorUpdateOptions = {
   onUpdate?: () => void,
-  tag?: string | Array<string>,
+  tag?: string | string[],
   skipTransforms?: true,
   discrete?: true,
 };
@@ -343,9 +343,9 @@ export type EditorThemeClasses = {
   image?: EditorThemeClassName,
   list?: {
     ul?: EditorThemeClassName,
-    ulDepth?: Array<EditorThemeClassName>,
+    ulDepth?: EditorThemeClassName[],
     ol?: EditorThemeClassName,
-    olDepth?: Array<EditorThemeClassName>,
+    olDepth?: EditorThemeClassName[],
     checklist?: EditorThemeClassName,
     listitem?: EditorThemeClassName,
     listitemChecked?: EditorThemeClassName,
@@ -463,9 +463,9 @@ export type DOMConversionMap = {
 };
 type NodeName = string;
 export type DOMConversionOutput = {
-  after?: (childLexicalNodes: Array<LexicalNode>) => Array<LexicalNode>,
+  after?: (childLexicalNodes: LexicalNode[]) => LexicalNode[],
   forChild?: DOMChildConversion,
-  node: null | LexicalNode | Array<LexicalNode>,
+  node: null | LexicalNode | LexicalNode[],
 };
 export type DOMExportOutput = {
   after?: (generatedElement: ?HTMLElement) => ?HTMLElement,
@@ -506,14 +506,14 @@ declare export class LexicalNode {
   getParentOrThrow<T extends ElementNode>(): T;
   getTopLevelElement(): DecoratorNode<unknown> | ElementNode | null;
   getTopLevelElementOrThrow(): DecoratorNode<unknown> | ElementNode;
-  getParents(): Array<ElementNode>;
+  getParents(): ElementNode[];
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast and
    * will be removed in a future release. Call this method without a type
    * argument and narrow the result with a type guard instead.
    */
-  getParents<T extends ElementNode>(): Array<T>;
-  getParentKeys(): Array<NodeKey>;
+  getParents<T extends ElementNode>(): T[];
+  getParentKeys(): NodeKey[];
   getPreviousSibling(): LexicalNode | null;
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast and
@@ -521,13 +521,13 @@ declare export class LexicalNode {
    * argument and narrow the result with a type guard instead.
    */
   getPreviousSibling<T extends LexicalNode>(): T | null;
-  getPreviousSiblings(): Array<LexicalNode>;
+  getPreviousSiblings(): LexicalNode[];
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast and
    * will be removed in a future release. Call this method without a type
    * argument and narrow the result with a type guard instead.
    */
-  getPreviousSiblings<T extends LexicalNode>(): Array<T>;
+  getPreviousSiblings<T extends LexicalNode>(): T[];
   getNextSibling(): LexicalNode | null;
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast and
@@ -535,18 +535,18 @@ declare export class LexicalNode {
    * argument and narrow the result with a type guard instead.
    */
   getNextSibling<T extends LexicalNode>(): T | null;
-  getNextSiblings(): Array<LexicalNode>;
+  getNextSiblings(): LexicalNode[];
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast and
    * will be removed in a future release. Call this method without a type
    * argument and narrow the result with a type guard instead.
    */
-  getNextSiblings<T extends LexicalNode>(): Array<T>;
+  getNextSiblings<T extends LexicalNode>(): T[];
   getCommonAncestor<T extends ElementNode>(node: LexicalNode): T | null;
   is(object: ?LexicalNode): boolean;
   isBefore(targetNode: LexicalNode): boolean;
   isParentOf(targetNode: LexicalNode): boolean;
-  getNodesBetween(targetNode: LexicalNode): Array<LexicalNode>;
+  getNodesBetween(targetNode: LexicalNode): LexicalNode[];
   isDirty(): boolean;
   // $FlowFixMe[incompatible-type]
   getLatest<T extends LexicalNode>(this: T): T;
@@ -594,8 +594,8 @@ declare export function $isBlockElementNode(
 export interface BaseSelection {
   dirty: boolean;
   clone(): BaseSelection;
-  extract(): Array<LexicalNode>;
-  getNodes(): Array<LexicalNode>;
+  extract(): LexicalNode[];
+  getNodes(): LexicalNode[];
   getStartEndPoints(): null | [PointType, PointType];
   getTextContent(): string;
   insertRawText(text: string): void;
@@ -603,9 +603,9 @@ export interface BaseSelection {
   isBackward(): boolean;
   isCollapsed(): boolean;
   insertText(text: string): void;
-  insertNodes(nodes: Array<LexicalNode>): void;
-  getCachedNodes(): null | Array<LexicalNode>;
-  setCachedNodes(nodes: null | Array<LexicalNode>): void;
+  insertNodes(nodes: LexicalNode[]): void;
+  getCachedNodes(): null | LexicalNode[];
+  setCachedNodes(nodes: null | LexicalNode[]): void;
 }
 
 declare export class NodeSelection implements BaseSelection {
@@ -620,15 +620,15 @@ declare export class NodeSelection implements BaseSelection {
   clear(): void;
   has(key: NodeKey): boolean;
   clone(): NodeSelection;
-  extract(): Array<LexicalNode>;
+  extract(): LexicalNode[];
   insertRawText(): void;
   insertText(): void;
-  getNodes(): Array<LexicalNode>;
+  getNodes(): LexicalNode[];
   getStartEndPoints(): null;
   getTextContent(): string;
-  insertNodes(nodes: Array<LexicalNode>): void;
-  getCachedNodes(): null | Array<LexicalNode>;
-  setCachedNodes(nodes: null | Array<LexicalNode>): void;
+  insertNodes(nodes: LexicalNode[]): void;
+  getCachedNodes(): null | LexicalNode[];
+  setCachedNodes(nodes: null | LexicalNode[]): void;
 }
 
 declare export function $isNodeSelection(
@@ -645,7 +645,7 @@ declare export class RangeSelection implements BaseSelection {
   is(selection: null | BaseSelection): boolean;
   isBackward(): boolean;
   isCollapsed(): boolean;
-  getNodes(): Array<LexicalNode>;
+  getNodes(): LexicalNode[];
   setTextNodeRange(
     anchorNode: TextNode,
     anchorOffset: number,
@@ -663,10 +663,10 @@ declare export class RangeSelection implements BaseSelection {
   insertRawText(text: string): void;
   removeText(): void;
   formatText(formatType: TextFormatType): void;
-  insertNodes(nodes: Array<LexicalNode>): void;
+  insertNodes(nodes: LexicalNode[]): void;
   insertParagraph(): void;
   insertLineBreak(selectStart?: boolean): void;
-  extract(): Array<LexicalNode>;
+  extract(): LexicalNode[];
   modify(
     alter: 'move' | 'extend',
     isBackward: boolean,
@@ -675,9 +675,9 @@ declare export class RangeSelection implements BaseSelection {
   deleteCharacter(isBackward: boolean): void;
   deleteLine(isBackward: boolean): void;
   deleteWord(isBackward: boolean): void;
-  insertNodes(nodes: Array<LexicalNode>): void;
-  getCachedNodes(): null | Array<LexicalNode>;
-  setCachedNodes(nodes: null | Array<LexicalNode>): void;
+  insertNodes(nodes: LexicalNode[]): void;
+  getCachedNodes(): null | LexicalNode[];
+  setCachedNodes(nodes: null | LexicalNode[]): void;
   forwardDeletion(anchor: PointType, anchorNode: ElementNode | TextNode, isBackward: boolean): boolean;
   getStartEndPoints(): [PointType, PointType];
 }
@@ -722,7 +722,7 @@ declare export function $isRangeSelection(
 ): x is RangeSelection;
 declare export function $getSelection(): null | BaseSelection;
 declare export function $getPreviousSelection(): null | BaseSelection;
-declare export function $insertNodes(nodes: Array<LexicalNode>): void;
+declare export function $insertNodes(nodes: LexicalNode[]): void;
 declare export function $getCharacterOffsets(
   selection: BaseSelection,
 ): [number, number];
@@ -794,7 +794,7 @@ declare export class TextNode extends LexicalNode {
   ): TextNode;
   canInsertTextBefore(): boolean;
   canInsertTextAfter(): boolean;
-  splitText(...splitOffsets: Array<number>): Array<TextNode>;
+  splitText(...splitOffsets: number[]): TextNode[];
   mergeWithSibling(target: TextNode): TextNode;
   isTextEntity(): boolean;
   static importJSON(serializedTextNode: SerializedTextNode): TextNode;
@@ -863,7 +863,7 @@ declare export class RootNode extends ElementNode {
   replace<N extends LexicalNode>(node: N): N;
   insertBefore<T extends LexicalNode>(nodeToInsert: T): T;
   insertAfter<T extends LexicalNode>(nodeToInsert: T): T;
-  append(...nodesToAppend: Array<LexicalNode>): this;
+  append(...nodesToAppend: LexicalNode[]): this;
   canBeEmpty(): false;
 }
 declare export function $isRootNode(
@@ -894,24 +894,24 @@ declare export class ElementNode extends LexicalNode {
   getFormat(): number;
   getFormatType(): ElementFormatType;
   getIndent(): number;
-  getChildren(): Array<LexicalNode>;
+  getChildren(): LexicalNode[];
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast and
    * will be removed in a future release. Call this method without a type
    * argument and narrow the result with a type guard instead.
    */
-  getChildren<T extends LexicalNode>(): Array<T>;
+  getChildren<T extends LexicalNode>(): T[];
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast and
    * will be removed in a future release. Call this method without a type
    * argument and narrow the result with a type guard instead.
    */
-  getChildren<T extends Array<LexicalNode>>(): T;
-  getChildrenKeys(): Array<NodeKey>;
+  getChildren<T extends LexicalNode[]>(): T;
+  getChildrenKeys(): NodeKey[];
   getChildrenSize(): number;
   isEmpty(): boolean;
   isDirty(): boolean;
-  getAllTextNodes(): Array<TextNode>;
+  getAllTextNodes(): TextNode[];
   getFirstDescendant(): null | LexicalNode;
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast and
@@ -975,7 +975,7 @@ declare export class ElementNode extends LexicalNode {
   selectStart(): RangeSelection;
   selectEnd(): RangeSelection;
   clear(): this;
-  append(...nodesToAppend: Array<LexicalNode>): this;
+  append(...nodesToAppend: LexicalNode[]): this;
   setDirection(direction: 'ltr' | 'rtl' | null): this;
   setFormat(type: ElementFormatType): this;
   setIndent(indentLevel: number): this;
@@ -1002,7 +1002,7 @@ declare export class ElementNode extends LexicalNode {
   splice(
     start: number,
     deleteCount: number,
-    nodesToInsert: Array<LexicalNode>,
+    nodesToInsert: LexicalNode[],
   ): this;
   exportJSON(): SerializedElementNode;
   getDOMSlot(element: HTMLElement): ElementDOMSlot<HTMLElement>;
@@ -1139,7 +1139,7 @@ declare export function $setCompositionKey(
   compositionKey: null | NodeKey,
 ): void;
 declare export function $setSelection(selection: null | BaseSelection): void;
-declare export function $nodesOfType<T extends LexicalNode>(klass: Class<T>): Array<T>;
+declare export function $nodesOfType<T extends LexicalNode>(klass: Class<T>): T[];
 declare export function $getAdjacentNode(
   focus: Point,
   isBackward: boolean,
@@ -1193,7 +1193,7 @@ declare export function $normalizeSelection__EXPERIMENTAL(
  * */
 
 type InternalSerializedNode = {
-  children?: Array<InternalSerializedNode>,
+  children?: InternalSerializedNode[],
   type: string,
   version: number,
 };
@@ -1224,7 +1224,7 @@ export type SerializedTextNode = {
 
 export type SerializedElementNode = {
   ...SerializedLexicalNode,
-  children: Array<SerializedLexicalNode>,
+  children: SerializedLexicalNode[],
   direction: 'ltr' | 'rtl' | null,
   format: ElementFormatType,
   indent: number,
@@ -1923,14 +1923,14 @@ declare export function getTransformSetFromKlass(
 
 declare export function addClassNamesToElement(
   element: HTMLElement,
-  ...classNames: Array<typeof undefined | boolean | null | string>
+  ...classNames: (typeof undefined | boolean | null | string)[]
 ): void;
 declare export function removeClassNamesFromElement(
   element: HTMLElement,
-  ...classNames: Array<typeof undefined | boolean | null | string>
+  ...classNames: (typeof undefined | boolean | null | string)[]
 ): void;
-declare export function mergeRegister(...func: Array<() => void>): () => void;
-declare export function normalizeClassNames(...classNames: Array<typeof undefined | boolean | null | string>): Array<string>;
+declare export function mergeRegister(...func: (() => void)[]): () => void;
+declare export function normalizeClassNames(...classNames: (typeof undefined | boolean | null | string)[]): string[];
 declare export function getStyleObjectFromCSS(css: string): {
   [string]: string,
 };

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -31,7 +31,7 @@ export function createCommand<T>(type?: string): LexicalCommand<T> {
 export const SELECTION_CHANGE_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('SELECTION_CHANGE_COMMAND');
 export const SELECTION_INSERT_CLIPBOARD_NODES_COMMAND: LexicalCommand<{
-  nodes: Array<LexicalNode>;
+  nodes: LexicalNode[];
   selection: BaseSelection;
 }> = /* @__PURE__ */ createCommand('SELECTION_INSERT_CLIPBOARD_NODES_COMMAND');
 export const CLICK_COMMAND: LexicalCommand<MouseEvent> =

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -166,9 +166,9 @@ export interface EditorThemeClasses {
   link?: EditorThemeClassName;
   list?: {
     ul?: EditorThemeClassName;
-    ulDepth?: Array<EditorThemeClassName>;
+    ulDepth?: EditorThemeClassName[];
     ol?: EditorThemeClassName;
-    olDepth?: Array<EditorThemeClassName>;
+    olDepth?: EditorThemeClassName[];
     checklist?: EditorThemeClassName;
     listitem?: EditorThemeClassName;
     listitemChecked?: EditorThemeClassName;
@@ -341,7 +341,7 @@ export interface CreateEditorArgs {
   disableEvents?: boolean;
   editorState?: EditorState;
   namespace?: string;
-  nodes?: ReadonlyArray<LexicalNodeConfig>;
+  nodes?: readonly LexicalNodeConfig[];
   onError?: ErrorHandler;
   /**
    * Optional handler for recoverable, warn-level conditions (e.g. the
@@ -626,10 +626,7 @@ export type TransformerType = 'text' | 'decorator' | 'element' | 'root';
 
 type IntentionallyMarkedAsDirtyElement = boolean;
 
-type DOMConversionCache = Map<
-  string,
-  Array<(node: Node) => DOMConversion | null>
->;
+type DOMConversionCache = Map<string, ((node: Node) => DOMConversion | null)[]>;
 
 export type SerializedEditor = {
   editorState: SerializedEditorState;
@@ -985,11 +982,11 @@ export class LexicalEditor {
   /** @internal */
   _compositionKey: null | NodeKey;
   /** @internal */
-  _deferred: Array<() => void>;
+  _deferred: (() => void)[];
   /** @internal */
   _keyToDOMMap: Map<NodeKey, HTMLElement & LexicalPrivateDOM>;
   /** @internal */
-  _updates: Array<[() => void, EditorUpdateOptions | undefined]>;
+  _updates: [() => void, EditorUpdateOptions | undefined][];
   /** @internal */
   _updating: boolean;
   /** @internal */
@@ -1419,7 +1416,7 @@ export class LexicalEditor {
    * depend on have been registered.
    * @returns True if the editor has registered all of the provided node types, false otherwise.
    */
-  hasNodes<T extends Klass<LexicalNode>>(nodes: Array<T>): boolean {
+  hasNodes<T extends Klass<LexicalNode>>(nodes: T[]): boolean {
     return nodes.every(this.hasNode.bind(this));
   }
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -153,13 +153,11 @@ import {
   isUndo,
 } from './LexicalUtils';
 
-type RootElementRemoveHandles = Array<() => void>;
-type RootElementEvents = Array<
-  [
-    string,
-    Record<string, unknown> | ((event: Event, editor: LexicalEditor) => void),
-  ]
->;
+type RootElementRemoveHandles = (() => void)[];
+type RootElementEvents = [
+  string,
+  Record<string, unknown> | ((event: Event, editor: LexicalEditor) => void),
+][];
 const PASS_THROUGH_COMMAND = Object.freeze({});
 const ANDROID_COMPOSITION_LATENCY = 30;
 const rootElementEvents: RootElementEvents = [

--- a/packages/lexical/src/LexicalGC.ts
+++ b/packages/lexical/src/LexicalGC.ts
@@ -42,7 +42,7 @@ function $garbageCollectDetachedDeepChildNodes(
   parentKey: NodeKey,
   prevNodeMap: NodeMap,
   nodeMap: NodeMap,
-  nodeMapDelete: Array<NodeKey>,
+  nodeMapDelete: NodeKey[],
   dirtyNodes: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,
 ): void {
   let child = node.getFirstChild();
@@ -83,7 +83,7 @@ export function $garbageCollectDetachedNodes(
   const nodeMap = editorState._nodeMap;
   // Store dirtyElements in a queue for later deletion; deleting dirty subtrees too early will
   // hinder accessing .__next on child nodes
-  const nodeMapDelete: Array<NodeKey> = [];
+  const nodeMapDelete: NodeKey[] = [];
 
   for (const [nodeKey] of dirtyElements) {
     const node = nodeMap.get(nodeKey);

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -138,7 +138,7 @@ function $getNearestManagedNodePairFromDOMNode(
 
 function flushMutations(
   editor: LexicalEditor,
-  mutations: Array<MutationRecord>,
+  mutations: MutationRecord[],
   observer: MutationObserver,
 ): void {
   isProcessingMutations = true;
@@ -313,7 +313,7 @@ export function flushRootMutations(editor: LexicalEditor): void {
 export function initMutationObserver(editor: LexicalEditor): void {
   initTextEntryListener(editor);
   editor._observer = new MutationObserver(
-    (mutations: Array<MutationRecord>, observer: MutationObserver) => {
+    (mutations: MutationRecord[], observer: MutationObserver) => {
       flushMutations(editor, mutations, observer);
     },
   );

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -552,9 +552,9 @@ export type DOMConversionMap<T extends HTMLElement = HTMLElement> = Record<
 type NodeName = string;
 
 export type DOMConversionOutput = {
-  after?: (childLexicalNodes: Array<LexicalNode>) => Array<LexicalNode>;
+  after?: (childLexicalNodes: LexicalNode[]) => LexicalNode[];
   forChild?: DOMChildConversion;
-  node: null | LexicalNode | Array<LexicalNode>;
+  node: null | LexicalNode | LexicalNode[];
 };
 
 export type DOMExportOutputMap = Map<
@@ -1030,8 +1030,8 @@ export class LexicalNode {
    * all the way up to the RootNode.
    *
    */
-  getParents(): Array<ElementNode> {
-    const parents: Array<ElementNode> = [];
+  getParents(): ElementNode[] {
+    const parents: ElementNode[] = [];
     let node = this.getParent();
     while (node !== null) {
       parents.push(node);
@@ -1045,7 +1045,7 @@ export class LexicalNode {
    * all the way up to the RootNode.
    *
    */
-  getParentKeys(): Array<NodeKey> {
+  getParentKeys(): NodeKey[] {
     const parents = [];
     let node = this.getParent();
     while (node !== null) {
@@ -1077,16 +1077,16 @@ export class LexicalNode {
    * Returns all nodes before this one in the same parent,
    * in document order.
    */
-  getPreviousSiblings(): Array<LexicalNode>;
+  getPreviousSiblings(): LexicalNode[];
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast,
-   * equivalent to `node.getPreviousSiblings() as Array<T>`, and will be
+   * equivalent to `node.getPreviousSiblings() as T[]`, and will be
    * removed in a future release. Call this method without a type argument
    * and narrow the results with a type guard instead.
    */
-  getPreviousSiblings<T extends LexicalNode>(): Array<T>;
-  getPreviousSiblings(): Array<LexicalNode> {
-    const siblings: Array<LexicalNode> = [];
+  getPreviousSiblings<T extends LexicalNode>(): T[];
+  getPreviousSiblings(): LexicalNode[] {
+    const siblings: LexicalNode[] = [];
     const parent = this.getParent();
     if (parent === null) {
       return siblings;
@@ -1124,16 +1124,16 @@ export class LexicalNode {
    * Returns all nodes after this one in the same parent,
    * in document order.
    */
-  getNextSiblings(): Array<LexicalNode>;
+  getNextSiblings(): LexicalNode[];
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast,
-   * equivalent to `node.getNextSiblings() as Array<T>`, and will be
+   * equivalent to `node.getNextSiblings() as T[]`, and will be
    * removed in a future release. Call this method without a type argument
    * and narrow the results with a type guard instead.
    */
-  getNextSiblings<T extends LexicalNode>(): Array<T>;
-  getNextSiblings(): Array<LexicalNode> {
-    const siblings: Array<LexicalNode> = [];
+  getNextSiblings<T extends LexicalNode>(): T[];
+  getNextSiblings(): LexicalNode[] {
+    const siblings: LexicalNode[] = [];
     let node = this.getNextSibling();
     while (node !== null) {
       siblings.push(node);
@@ -1220,7 +1220,7 @@ export class LexicalNode {
    *
    * @param targetNode - the node that marks the other end of the range of nodes to be returned.
    */
-  getNodesBetween(targetNode: LexicalNode): Array<LexicalNode> {
+  getNodesBetween(targetNode: LexicalNode): LexicalNode[] {
     const isBefore = this.isBefore(targetNode);
     const nodes = [];
     const visited = new Set();

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -336,7 +336,7 @@ function $destroyNode(key: NodeKey, parentDOM: null | HTMLElement): void {
 }
 
 function $destroyChildren(
-  children: Array<NodeKey>,
+  children: NodeKey[],
   _startIndex: number,
   endIndex: number,
   dom: null | HTMLElement,
@@ -541,7 +541,7 @@ function $createNode(key: NodeKey, slot: ElementDOMSlot | null): HTMLElement {
 }
 
 function $createChildren(
-  children: Array<NodeKey>,
+  children: NodeKey[],
   element: ElementNode,
   _startIndex: number,
   endIndex: number,
@@ -1585,7 +1585,7 @@ function getNextSibling(element: HTMLElement): Node | null {
   return nextSibling;
 }
 
-function childrenSet(children: Array<NodeKey>, start: number): Set<NodeKey> {
+function childrenSet(children: NodeKey[], start: number): Set<NodeKey> {
   const s = new Set<NodeKey>();
   for (let i = start; i < children.length; i++) {
     s.add(children[i]);
@@ -1595,8 +1595,8 @@ function childrenSet(children: Array<NodeKey>, start: number): Set<NodeKey> {
 
 function $reconcileNodeChildren(
   nextElement: ElementNode,
-  prevChildren: Array<NodeKey>,
-  nextChildren: Array<NodeKey>,
+  prevChildren: NodeKey[],
+  nextChildren: NodeKey[],
   prevChildrenLength: number,
   nextChildrenLength: number,
   slot: ElementDOMSlot,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -309,17 +309,17 @@ function $transferStartingElementPointToTextPoint(
 }
 
 export interface BaseSelection {
-  _cachedNodes: Array<LexicalNode> | null;
+  _cachedNodes: LexicalNode[] | null;
   dirty: boolean;
 
   clone(): BaseSelection;
-  extract(): Array<LexicalNode>;
-  getNodes(): Array<LexicalNode>;
+  extract(): LexicalNode[];
+  getNodes(): LexicalNode[];
   getTextContent(): string;
   insertText(text: string): void;
   insertRawText(text: string): void;
   is(selection: null | BaseSelection): boolean;
-  insertNodes(nodes: Array<LexicalNode>): void;
+  insertNodes(nodes: LexicalNode[]): void;
   getStartEndPoints(): null | [PointType, PointType];
   isCollapsed(): boolean;
   isBackward(): boolean;
@@ -329,7 +329,7 @@ export interface BaseSelection {
 
 export class NodeSelection implements BaseSelection {
   _nodes: Set<NodeKey>;
-  _cachedNodes: Array<LexicalNode> | null;
+  _cachedNodes: LexicalNode[] | null;
   dirty: boolean;
 
   constructor(objects: Set<NodeKey>) {
@@ -393,7 +393,7 @@ export class NodeSelection implements BaseSelection {
     return new NodeSelection(new Set(this._nodes));
   }
 
-  extract(): Array<LexicalNode> {
+  extract(): LexicalNode[] {
     return this.getNodes();
   }
 
@@ -405,7 +405,7 @@ export class NodeSelection implements BaseSelection {
     // Do nothing?
   }
 
-  insertNodes(nodes: Array<LexicalNode>) {
+  insertNodes(nodes: LexicalNode[]) {
     const selectedNodes = this.getNodes();
     const selectedNodesLength = selectedNodes.length;
     const lastSelectedNode = selectedNodes[selectedNodesLength - 1];
@@ -424,7 +424,7 @@ export class NodeSelection implements BaseSelection {
     }
   }
 
-  getNodes(): Array<LexicalNode> {
+  getNodes(): LexicalNode[] {
     const cachedNodes = this._cachedNodes;
     if (cachedNodes !== null) {
       return cachedNodes;
@@ -478,7 +478,7 @@ export class RangeSelection implements BaseSelection {
   style: string;
   anchor: PointType;
   focus: PointType;
-  _cachedNodes: Array<LexicalNode> | null;
+  _cachedNodes: LexicalNode[] | null;
   /** @internal */
   _cachedIsBackward: boolean | null;
   dirty: boolean;
@@ -547,7 +547,7 @@ export class RangeSelection implements BaseSelection {
    *
    * @returns an Array containing all the nodes in the Selection
    */
-  getNodes(): Array<LexicalNode> {
+  getNodes(): LexicalNode[] {
     const cachedNodes = this._cachedNodes;
     if (cachedNodes !== null) {
       return cachedNodes;
@@ -1211,7 +1211,7 @@ export class RangeSelection implements BaseSelection {
     }
 
     const selectedNodes = this.getNodes();
-    const selectedTextNodes: Array<TextNode> = [];
+    const selectedTextNodes: TextNode[] = [];
     for (const selectedNode of selectedNodes) {
       if ($isTextNode(selectedNode)) {
         selectedTextNodes.push(selectedNode);
@@ -1350,7 +1350,7 @@ export class RangeSelection implements BaseSelection {
    *
    * @param nodes - the nodes to insert
    */
-  insertNodes(nodes: Array<LexicalNode>): void {
+  insertNodes(nodes: LexicalNode[]): void {
     if (nodes.length === 0) {
       return;
     }
@@ -1517,7 +1517,7 @@ export class RangeSelection implements BaseSelection {
    *
    * @returns The nodes in the Selection
    */
-  extract(): Array<LexicalNode> {
+  extract(): LexicalNode[] {
     const selectedNodes = [...this.getNodes()];
     const selectedNodesLength = selectedNodes.length;
     let firstNode = selectedNodes[0];
@@ -3289,7 +3289,7 @@ export function $updateDOMSelection(
   markSelectionChangeFromDOMUpdate();
 }
 
-export function $insertNodes(nodes: Array<LexicalNode>) {
+export function $insertNodes(nodes: LexicalNode[]) {
   let selection = $getSelection() || $getPreviousSelection();
 
   if (selection === null) {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -211,7 +211,7 @@ export function internalGetActiveEditorState(): EditorState | null {
 export function $applyTransforms(
   editor: LexicalEditor,
   node: LexicalNode,
-  transformsCache: Map<string, Array<Transform<LexicalNode>>>,
+  transformsCache: Map<string, Transform<LexicalNode>[]>,
 ) {
   const type = node.__type;
   const registeredNode = getRegisteredNodeOrThrow(editor, type);
@@ -388,7 +388,7 @@ function $applyAllTransforms(
 }
 
 type InternalSerializedNode = {
-  children?: Array<InternalSerializedNode>;
+  children?: InternalSerializedNode[];
   type: string;
   version: number;
 };
@@ -1013,7 +1013,7 @@ function $triggerEnqueuedUpdates(editor: LexicalEditor): void {
 
 function triggerDeferredUpdateCallbacks(
   editor: LexicalEditor,
-  deferred: Array<() => void>,
+  deferred: (() => void)[],
 ): void {
   editor._deferred = [];
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -733,9 +733,7 @@ export function doesContainSurrogatePair(str: string): boolean {
   return /[\uD800-\uDBFF][\uDC00-\uDFFF]/g.test(str);
 }
 
-export function getEditorsToPropagate(
-  editor: LexicalEditor,
-): Array<LexicalEditor> {
+export function getEditorsToPropagate(editor: LexicalEditor): LexicalEditor[] {
   const editorsToPropagate: LexicalEditor[] = [];
   for (
     let currentEditor: LexicalEditor | null = editor;
@@ -1267,7 +1265,7 @@ export function $selectAll(selection?: RangeSelection | null): RangeSelection {
 export function getCachedClassNameArray(
   classNamesTheme: EditorThemeClasses,
   classNameThemeType: string,
-): Array<string> {
+): string[] {
   if (classNamesTheme.__lexicalClassNameCache === undefined) {
     classNamesTheme.__lexicalClassNameCache = {};
   }
@@ -1325,7 +1323,7 @@ export function setMutatedNode(
 /**
  * @deprecated Use {@link LexicalEditor.registerMutationListener} with `skipInitialization: false` instead.
  */
-export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): Array<T> {
+export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): T[] {
   const klassType = klass.getType();
   const editorState = getActiveEditorState();
   if (editorState._readOnly) {
@@ -1335,7 +1333,7 @@ export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): Array<T> {
     return nodes ? Array.from(nodes.values()) : [];
   }
   const nodes = editorState._nodeMap;
-  const nodesOfType: Array<T> = [];
+  const nodesOfType: T[] = [];
   for (const [, node] of nodes) {
     if (
       node instanceof klass &&
@@ -2583,7 +2581,7 @@ export const $findMatchingParent: {
 export function $createChildrenArray(
   element: ElementNode,
   nodeMap: null | NodeMap,
-): Array<NodeKey> {
+): NodeKey[] {
   const children = [];
   let nodeKey = element.__first;
   while (nodeKey !== null) {

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
@@ -70,7 +70,7 @@ function seedTwoParas(editor: LexicalEditor): void {
   );
 }
 
-const OPS: Array<(rng: () => number) => void> = [
+const OPS: ((rng: () => number) => void)[] = [
   // move a child from one paragraph to the end of the other
   rng => {
     const paras = $getRoot().getChildren();

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -193,7 +193,7 @@ describe('LexicalEditor tests', () => {
   function useLexicalEditor(
     rootElementRef: React.RefObject<null | HTMLDivElement>,
     onError?: (error: Error) => void,
-    nodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>,
+    nodes?: readonly (Klass<LexicalNode> | LexicalNodeReplacement)[],
     onWarn?: (error: Error) => void,
   ) {
     const editor = useMemo(
@@ -230,7 +230,7 @@ describe('LexicalEditor tests', () => {
 
   function init(
     onError?: (error: Error) => void,
-    nodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>,
+    nodes?: readonly (Klass<LexicalNode> | LexicalNodeReplacement)[],
     onWarn?: (error: Error) => void,
   ) {
     const ref = createRef<HTMLDivElement>();
@@ -539,7 +539,7 @@ describe('LexicalEditor tests', () => {
     init();
     const onUpdate = vi.fn();
 
-    let log: Array<string> = [];
+    let log: string[] = [];
 
     editor.registerUpdateListener(onUpdate);
     editor.update(() => {
@@ -1096,7 +1096,7 @@ describe('LexicalEditor tests', () => {
         const root = $getRoot();
         const paragraph0 = $createParagraphNode();
         const paragraph1 = $createParagraphNode();
-        const textNodes: Array<LexicalNode> = [];
+        const textNodes: LexicalNode[] = [];
 
         for (let i = 0; i < 6; i++) {
           const node = $createTextNode(String(i)).toggleUnmergeable();
@@ -2736,7 +2736,7 @@ describe('LexicalEditor tests', () => {
 
   it('does not leak a no-op update tag into the next update', () => {
     init();
-    const observedTags: Array<Array<string>> = [];
+    const observedTags: string[][] = [];
     const unregister = editor.registerUpdateListener(({tags}) => {
       observedTags.push([...tags]);
     });
@@ -2789,7 +2789,7 @@ describe('LexicalEditor tests', () => {
       {discrete: true},
     );
 
-    const observed: Array<{content: string; tags: Array<string>}> = [];
+    const observed: {content: string; tags: string[]}[] = [];
     const unregister = editor.registerUpdateListener(({editorState, tags}) => {
       observed.push({
         content: editorState.read(() => $getRoot().getTextContent()),

--- a/packages/lexical/src/__tests__/unit/LexicalGenMap.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalGenMap.test.ts
@@ -11,7 +11,7 @@ import {describe, expect, test} from 'vitest';
 import {cloneMap, GenMap} from '../../LexicalGenMap';
 
 function buildGenMap(
-  entries: ReadonlyArray<[string, number]>,
+  entries: readonly [string, number][],
 ): GenMap<string, number> {
   const g = new GenMap<string, number>();
   for (const [k, v] of entries) {

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -1642,7 +1642,7 @@ describe('Element-anchored selection on old parent (#6031)', () => {
     act: Mover;
     actNoRestore: Mover | null;
   };
-  const methods: ReadonlyArray<MethodSpec> = [
+  const methods: readonly MethodSpec[] = [
     {
       act: (target, mover) => target.insertBefore(mover),
       actNoRestore: (target, mover) => target.insertBefore(mover, false),
@@ -2193,11 +2193,9 @@ describe('LexicalNode.$config() without registration', () => {
         node.getPreviousSibling(),
       ).toEqualTypeOf<LexicalNode | null>();
       expectTypeOf(node.getNextSibling()).toEqualTypeOf<LexicalNode | null>();
-      expectTypeOf(node.getPreviousSiblings()).toEqualTypeOf<
-        Array<LexicalNode>
-      >();
-      expectTypeOf(node.getNextSiblings()).toEqualTypeOf<Array<LexicalNode>>();
-      expectTypeOf(element.getChildren()).toEqualTypeOf<Array<LexicalNode>>();
+      expectTypeOf(node.getPreviousSiblings()).toEqualTypeOf<LexicalNode[]>();
+      expectTypeOf(node.getNextSiblings()).toEqualTypeOf<LexicalNode[]>();
+      expectTypeOf(element.getChildren()).toEqualTypeOf<LexicalNode[]>();
       expectTypeOf(
         element.getChildAtIndex(0),
       ).toEqualTypeOf<LexicalNode | null>();

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -326,7 +326,7 @@ describe('LexicalReconciler', () => {
         });
 
         const decorateSpy = vi.spyOn(TestDecoratorNode.prototype, 'decorate');
-        const events: Array<{klass: string; mutation: NodeMutation}> = [];
+        const events: {klass: string; mutation: NodeMutation}[] = [];
         const recordMutations =
           (klass: string) => (nodes: Map<string, NodeMutation>) => {
             for (const m of nodes.values()) {

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -486,7 +486,7 @@ export function createTestEditor(
     editorState?: EditorState;
     theme?: EditorThemeClasses;
     parentEditor?: LexicalEditor;
-    nodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
+    nodes?: readonly (Klass<LexicalNode> | LexicalNodeReplacement)[];
     onError?: (error: Error) => void;
     onWarn?: (error: Error) => void;
     disableEvents?: boolean;

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -55,7 +55,7 @@ export type SerializedElementNode<
   T extends SerializedLexicalNode = SerializedLexicalNode,
 > = Spread<
   {
-    children: Array<T>;
+    children: T[];
     direction: 'ltr' | 'rtl' | null;
     format: ElementFormatType;
     indent: number;
@@ -151,16 +151,16 @@ export class ElementNode extends LexicalNode {
   /**
    * Returns the children of this node, in document order.
    */
-  getChildren(): Array<LexicalNode>;
+  getChildren(): LexicalNode[];
   /**
    * @deprecated The type parameter is an unchecked and unsafe cast,
-   * equivalent to `element.getChildren() as Array<T>`, and will be
+   * equivalent to `element.getChildren() as T[]`, and will be
    * removed in a future release. Call this method without a type argument
    * and narrow the results with a type guard instead.
    */
-  getChildren<T extends LexicalNode>(): Array<T>;
-  getChildren(): Array<LexicalNode> {
-    const children: Array<LexicalNode> = [];
+  getChildren<T extends LexicalNode>(): T[];
+  getChildren(): LexicalNode[] {
+    const children: LexicalNode[] = [];
     let child = this.getFirstChild();
     while (child !== null) {
       children.push(child);
@@ -168,8 +168,8 @@ export class ElementNode extends LexicalNode {
     }
     return children;
   }
-  getChildrenKeys(): Array<NodeKey> {
-    const children: Array<NodeKey> = [];
+  getChildrenKeys(): NodeKey[] {
+    const children: NodeKey[] = [];
     let child = this.getFirstChild();
     while (child !== null) {
       children.push(child.__key);
@@ -194,7 +194,7 @@ export class ElementNode extends LexicalNode {
     const parentLastChild = this.getParentOrThrow().getLastChild();
     return parentLastChild !== null && parentLastChild.is(self);
   }
-  getAllTextNodes(): Array<TextNode> {
+  getAllTextNodes(): TextNode[] {
     const textNodes = [];
     let child = this.getFirstChild();
     while (child !== null) {
@@ -562,7 +562,7 @@ export class ElementNode extends LexicalNode {
   splice(
     start: number,
     deleteCount: number,
-    nodesToInsert: Array<LexicalNode>,
+    nodesToInsert: LexicalNode[],
   ): this {
     invariant(
       !$isEphemeral(this),

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -106,7 +106,7 @@ export type TextModeType = 'normal' | 'token' | 'segmented';
 
 export type TextMark = {end: null | number; id: string; start: null | number};
 
-export type TextMarks = Array<TextMark>;
+export type TextMarks = TextMark[];
 
 function getElementOuterTag(node: TextNode, format: number): string | null {
   if (format & IS_CODE) {
@@ -967,7 +967,7 @@ export class TextNode extends LexicalNode {
    *
    * @returns an Array containing the newly-created TextNodes.
    */
-  splitText(...splitOffsets: Array<number>): Array<TextNode> {
+  splitText(...splitOffsets: number[]): TextNode[] {
     errorOnReadOnly();
     const self = this.getLatest();
     const textContent = self.getTextContent();

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -363,13 +363,13 @@ describe('LexicalElementNode tests', () => {
       });
     });
 
-    const BASE_INSERTIONS: Array<{
+    const BASE_INSERTIONS: {
       deleteCount: number;
       deleteOnly: boolean | null | undefined;
       expectedText: string;
       name: string;
       start: number;
-    }> = [
+    }[] = [
       // Do nothing
       {
         deleteCount: 0,
@@ -478,7 +478,7 @@ describe('LexicalElementNode tests', () => {
 
     let nodes: Record<string, LexicalNode> = {};
 
-    const NESTED_ELEMENTS_TESTS: Array<{
+    const NESTED_ELEMENTS_TESTS: {
       deleteCount: number;
       deleteOnly?: boolean;
       expectedSelection: () => {
@@ -496,7 +496,7 @@ describe('LexicalElementNode tests', () => {
       expectedText: string;
       name: string;
       start: number;
-    }> = [
+    }[] = [
       {
         deleteCount: 0,
         deleteOnly: true,

--- a/packages/lexical/src/utils/classNames.ts
+++ b/packages/lexical/src/utils/classNames.ts
@@ -8,8 +8,8 @@
 
 /** @internal */
 export function normalizeClassNames(
-  ...classNames: Array<typeof undefined | boolean | null | string>
-): Array<string> {
+  ...classNames: (typeof undefined | boolean | null | string)[]
+): string[] {
   const rval = [];
   for (const className of classNames) {
     if (className && typeof className === 'string') {
@@ -31,7 +31,7 @@ export function normalizeClassNames(
  */
 export function addClassNamesToElement(
   element: HTMLElement,
-  ...classNames: Array<typeof undefined | boolean | null | string>
+  ...classNames: (typeof undefined | boolean | null | string)[]
 ): void {
   const classesToAdd = normalizeClassNames(...classNames);
   if (classesToAdd.length > 0) {
@@ -49,7 +49,7 @@ export function addClassNamesToElement(
  */
 export function removeClassNamesFromElement(
   element: HTMLElement,
-  ...classNames: Array<typeof undefined | boolean | null | string>
+  ...classNames: (typeof undefined | boolean | null | string)[]
 ): void {
   const classesToRemove = normalizeClassNames(...classNames);
   if (classesToRemove.length > 0) {

--- a/packages/lexical/src/utils/mergeRegister.ts
+++ b/packages/lexical/src/utils/mergeRegister.ts
@@ -31,7 +31,7 @@
  * @param func - An array of cleanup functions meant to be executed by the returned function.
  * @returns the function which executes all the passed cleanup functions.
  */
-export function mergeRegister(...func: Array<() => void>): () => void {
+export function mergeRegister(...func: (() => void)[]): () => void {
   return () => {
     for (let i = func.length - 1; i >= 0; i--) {
       func[i]();

--- a/scripts/flow-array-type-codemod.mjs
+++ b/scripts/flow-array-type-codemod.mjs
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+// @ts-check
+
+import fs from 'fs-extra';
+import {globSync} from 'glob';
+import * as hermesParser from 'hermes-parser';
+import minimist from 'minimist';
+
+/**
+ * Codemod that rewrites `Array<T>` type annotations to the shorthand `T[]`
+ * syntax in the manually maintained Flow files. This is the Flow counterpart
+ * of the `@typescript-eslint/array-type` ESLint rule (with its autofix) that
+ * enforces the same style for TypeScript sources.
+ *
+ * Usage:
+ *   node scripts/flow-array-type-codemod.mjs [--check] [files...]
+ *
+ * With no arguments it rewrites all `packages/* /flow/*.js.flow` files and
+ * the Flow libdefs in `libdefs/*.js` in place. With `--check` it reports the
+ * files that would change and exits non-zero instead of writing.
+ */
+
+const DEFAULT_PATTERNS = ['packages/*/flow/*.js.flow', 'libdefs/*.js'];
+
+/**
+ * Type annotation node types that can be suffixed with `[]` directly without
+ * changing how the type parses. Anything else (unions, intersections,
+ * nullable `?T`, function types, `typeof`, conditional types, ...) must be
+ * wrapped in parentheses first, e.g. `Array<A | B>` -> `(A | B)[]`.
+ */
+const POSTFIX_SAFE_TYPES = new Set([
+  'AnyTypeAnnotation',
+  'ArrayTypeAnnotation',
+  'BigIntLiteralTypeAnnotation',
+  'BigIntTypeAnnotation',
+  'BooleanLiteralTypeAnnotation',
+  'BooleanTypeAnnotation',
+  'EmptyTypeAnnotation',
+  'GenericTypeAnnotation',
+  'IndexedAccessType',
+  'MixedTypeAnnotation',
+  'NullLiteralTypeAnnotation',
+  'NumberLiteralTypeAnnotation',
+  'NumberTypeAnnotation',
+  'ObjectTypeAnnotation',
+  'OptionalIndexedAccessType',
+  'StringLiteralTypeAnnotation',
+  'StringTypeAnnotation',
+  'SymbolTypeAnnotation',
+  'TupleTypeAnnotation',
+  'VoidTypeAnnotation',
+]);
+
+/**
+ * @param {string} source
+ * @param {string} sourceFilename
+ * @returns {any} the untyped hermes-estree AST
+ */
+function parse(source, sourceFilename) {
+  return hermesParser.parse(source, {
+    enableExperimentalComponentSyntax: true,
+    flow: 'all',
+    sourceFilename,
+    sourceType: 'module',
+  });
+}
+
+/**
+ * Collect every `Array<T>` GenericTypeAnnotation node in the AST.
+ *
+ * @param {any} ast the untyped hermes-estree AST of a Flow file
+ * @returns {any[]} the matching untyped AST nodes
+ */
+function collectArrayTypeNodes(ast) {
+  /** @type {any[]} */
+  const targets = [];
+  hermesParser.SimpleTraverser.traverse(ast, {
+    /** @param {any} node an untyped hermes-estree AST node */
+    enter: node => {
+      if (
+        node.type === 'GenericTypeAnnotation' &&
+        node.id.type === 'Identifier' &&
+        node.id.name === 'Array' &&
+        node.typeParameters &&
+        node.typeParameters.params.length === 1
+      ) {
+        targets.push(node);
+      }
+    },
+    leave: () => {},
+  });
+  return targets;
+}
+
+/**
+ * Rewrite every `Array<T>` annotation in a Flow source to `T[]`.
+ *
+ * Works innermost-first to a fixed point: each pass rewrites the `Array<T>`
+ * nodes whose type argument contains no nested `Array<...>`, then re-parses
+ * so the offsets of the remaining (outer) nodes are recomputed. Re-parsing
+ * also guarantees the rewritten source is still syntactically valid.
+ *
+ * @param {string} source
+ * @param {string} sourceFilename
+ * @returns {string}
+ */
+function transformSource(source, sourceFilename) {
+  for (;;) {
+    const targets = collectArrayTypeNodes(parse(source, sourceFilename));
+    if (targets.length === 0) {
+      return source;
+    }
+    const innermost = targets.filter(
+      outer =>
+        !targets.some(
+          inner =>
+            inner !== outer &&
+            inner.range[0] >= outer.range[0] &&
+            inner.range[1] <= outer.range[1],
+        ),
+    );
+    for (const node of innermost.sort((a, b) => b.range[0] - a.range[0])) {
+      const param = node.typeParameters.params[0];
+      const inner = source.slice(param.range[0], param.range[1]);
+      const replacement = POSTFIX_SAFE_TYPES.has(param.type)
+        ? `${inner}[]`
+        : `(${inner})[]`;
+      source =
+        source.slice(0, node.range[0]) +
+        replacement +
+        source.slice(node.range[1]);
+    }
+  }
+}
+
+function main() {
+  const argv = minimist(process.argv.slice(2), {boolean: ['check']});
+  const patterns = argv._.length > 0 ? argv._.map(String) : DEFAULT_PATTERNS;
+  const files = globSync(patterns).sort();
+  if (files.length === 0) {
+    console.error(`No files matched: ${patterns.join(' ')}`);
+    process.exit(1);
+  }
+  /** @type {string[]} */
+  const changed = [];
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+    const transformed = transformSource(source, file);
+    if (transformed !== source) {
+      changed.push(file);
+      if (!argv.check) {
+        fs.writeFileSync(file, transformed);
+      }
+    }
+  }
+  if (argv.check && changed.length > 0) {
+    console.error(
+      `${changed.length} file(s) use Array<T> syntax instead of T[]:`,
+    );
+    for (const file of changed) {
+      console.error(`  ${file}`);
+    }
+    console.error('Run `node scripts/flow-array-type-codemod.mjs` to fix.');
+    process.exit(1);
+  }
+  for (const file of changed) {
+    console.log(`Updated ${file}`);
+  }
+}
+
+main();

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -207,7 +207,7 @@ if (isJsdom) {
       get items(): DataTransferItemList {
         throw new Error('Getter not implemented.');
       }
-      get types(): ReadonlyArray<string> {
+      get types(): readonly string[] {
         return [...this._data.keys()];
       }
       clearData(dataType?: string): void {


### PR DESCRIPTION
## Description

- Enable @typescript-eslint/array-type ({default: 'array'}) in eslint.config.mjs and apply its autofix across all TypeScript sources (Array<T> -> T[], ReadonlyArray<T> -> readonly T[])
- Add scripts/flow-array-type-codemod.mjs, a hermes-parser based codemod that rewrites Array<T> to T[] in the hand-maintained packages/*/flow/*.js.flow files and the Flow libdefs in libdefs/*.js (--check reports offenders without writing), and run it

## Test plan

Type-only change