### PR TITLE
[lexical-list] Bug Fix: Preserve previous DecoratorNode on Backspace at the start of a top-level list

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/registerListBackspaceDecorator.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/registerListBackspaceDecorator.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {
+  $createListItemNode,
+  $createListNode,
+  $isListNode,
+  ListExtension,
+  ListType,
+} from '@lexical/list';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isParagraphNode,
+  $isRangeSelection,
+  KEY_BACKSPACE_COMMAND,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  invariant,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+class IsolatedTestDecoratorNode extends TestDecoratorNode {
+  $config() {
+    return this.config('isolated_test_decorator', {
+      extends: TestDecoratorNode,
+    });
+  }
+  isIsolated(): boolean {
+    return true;
+  }
+}
+
+function $createIsolatedTestDecoratorNode(): IsolatedTestDecoratorNode {
+  return new IsolatedTestDecoratorNode().setIsInline(false);
+}
+
+function backspaceEvent(): KeyboardEvent {
+  return new KeyboardEvent('keydown', {cancelable: true, key: 'Backspace'});
+}
+
+const testExtension = defineExtension({
+  dependencies: [ListExtension],
+  name: '[root]',
+  nodes: [TestDecoratorNode, IsolatedTestDecoratorNode],
+});
+
+describe('registerList — Backspace adjacent to DecoratorNode (#5072)', () => {
+  describe('preserves the decorator and demotes the first list item', () => {
+    test.for<{name: string; listType: ListType; inline: boolean}>([
+      {
+        inline: false,
+        listType: 'bullet',
+        name: 'block decorator + bullet list',
+      },
+      {
+        inline: false,
+        listType: 'number',
+        name: 'block decorator + numbered list',
+      },
+      {
+        inline: false,
+        listType: 'check',
+        name: 'block decorator + check list',
+      },
+      {
+        inline: true,
+        listType: 'bullet',
+        name: 'inline keyboard-selectable decorator + bullet list',
+      },
+    ])('$name', ({listType, inline}) => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = false;
+      const event = backspaceEvent();
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const decorator = $createTestDecoratorNode().setIsInline(inline);
+          const list = $createListNode(listType).append(
+            $createListItemNode().append($createTextNode('first')),
+            $createListItemNode().append($createTextNode('second')),
+          );
+          root.append(decorator, list);
+          list.getFirstChildOrThrow().selectStart();
+          handled = editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event);
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(true);
+      expect(event.defaultPrevented).toBe(true);
+
+      editor.read(() => {
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(3);
+        invariant(
+          children[0] instanceof TestDecoratorNode,
+          'Expected leading TestDecoratorNode',
+        );
+        const paragraph = children[1];
+        invariant(
+          $isParagraphNode(paragraph),
+          'Expected demoted ParagraphNode',
+        );
+        expect(paragraph.getTextContent()).toBe('first');
+        const tail = children[2];
+        invariant($isListNode(tail), 'Expected trailing ListNode');
+        expect(tail.getListType()).toBe(listType);
+        expect(tail.getChildrenSize()).toBe(1);
+        expect(tail.getTextContent()).toBe('second');
+
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        expect(selection.isCollapsed()).toBe(true);
+        expect(selection.anchor.key).toBe(
+          paragraph.getFirstChildOrThrow().getKey(),
+        );
+        expect(selection.anchor.offset).toBe(0);
+      });
+    });
+
+    test('block decorator + single-item list — list is removed', () => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = false;
+      const event = backspaceEvent();
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const decorator = $createTestDecoratorNode().setIsInline(false);
+          const list = $createListNode('bullet').append(
+            $createListItemNode().append($createTextNode('only')),
+          );
+          root.append(decorator, list);
+          list.getFirstChildOrThrow().selectStart();
+          handled = editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event);
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(true);
+      expect(event.defaultPrevented).toBe(true);
+
+      editor.read(() => {
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(2);
+        invariant(
+          children[0] instanceof TestDecoratorNode,
+          'Expected leading TestDecoratorNode',
+        );
+        invariant(
+          $isParagraphNode(children[1]),
+          'Expected demoted ParagraphNode',
+        );
+        expect(children[1].getTextContent()).toBe('only');
+      });
+    });
+
+    test('two adjacent block decorators + list — both preserved', () => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = false;
+      const event = backspaceEvent();
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const first = $createTestDecoratorNode().setIsInline(false);
+          const second = $createTestDecoratorNode().setIsInline(false);
+          const list = $createListNode('bullet').append(
+            $createListItemNode().append($createTextNode('hello')),
+          );
+          root.append(first, second, list);
+          list.getFirstChildOrThrow().selectStart();
+          handled = editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event);
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(true);
+      expect(event.defaultPrevented).toBe(true);
+
+      editor.read(() => {
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(3);
+        invariant(
+          children[0] instanceof TestDecoratorNode,
+          'Expected first TestDecoratorNode',
+        );
+        invariant(
+          children[1] instanceof TestDecoratorNode,
+          'Expected second TestDecoratorNode',
+        );
+        invariant(
+          $isParagraphNode(children[2]),
+          'Expected demoted ParagraphNode',
+        );
+        expect(children[2].getTextContent()).toBe('hello');
+      });
+    });
+  });
+
+  describe('returns false (defers to the default Backspace path)', () => {
+    test('no decorator before the list', () => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = true;
+      const event = backspaceEvent();
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const paragraph = $createParagraphNode().append(
+            $createTextNode('intro'),
+          );
+          const list = $createListNode('bullet').append(
+            $createListItemNode().append($createTextNode('first')),
+          );
+          root.append(paragraph, list);
+          list.getFirstChildOrThrow().selectStart();
+          handled = editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event);
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(false);
+      expect(event.defaultPrevented).toBe(false);
+
+      editor.read(() => {
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(2);
+        invariant(
+          $isParagraphNode(children[0]),
+          'Expected leading ParagraphNode',
+        );
+        invariant($isListNode(children[1]), 'Expected trailing ListNode');
+      });
+    });
+
+    test('caret on the second list item', () => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = true;
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const decorator = $createTestDecoratorNode().setIsInline(false);
+          const list = $createListNode('bullet').append(
+            $createListItemNode().append($createTextNode('first')),
+            $createListItemNode().append($createTextNode('second')),
+          );
+          root.append(decorator, list);
+          const secondItem = list.getChildAtIndex(1);
+          invariant(secondItem !== null, 'Expected a second list item');
+          secondItem.selectStart();
+          handled = editor.dispatchCommand(
+            KEY_BACKSPACE_COMMAND,
+            backspaceEvent(),
+          );
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(false);
+
+      editor.read(() => {
+        const list = $getRoot().getChildAtIndex(1);
+        invariant($isListNode(list), 'Expected ListNode at index 1');
+        expect(list.getChildrenSize()).toBe(2);
+      });
+    });
+
+    test('caret in the middle of the first list item', () => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = true;
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const decorator = $createTestDecoratorNode().setIsInline(false);
+          const text = $createTextNode('first');
+          const list = $createListNode('bullet').append(
+            $createListItemNode().append(text),
+          );
+          root.append(decorator, list);
+          text.select(2, 2);
+          handled = editor.dispatchCommand(
+            KEY_BACKSPACE_COMMAND,
+            backspaceEvent(),
+          );
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(false);
+
+      editor.read(() => {
+        invariant(
+          $isListNode($getRoot().getChildAtIndex(1)),
+          'Expected ListNode at index 1',
+        );
+      });
+    });
+
+    test('nested list — no decorator before the inner list', () => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = true;
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const decorator = $createTestDecoratorNode().setIsInline(false);
+          const innerLi = $createListItemNode().append(
+            $createTextNode('nested'),
+          );
+          const innerList = $createListNode('bullet').append(innerLi);
+          const outerLi = $createListItemNode().append(innerList);
+          const outerList = $createListNode('bullet').append(outerLi);
+          root.append(decorator, outerList);
+          innerLi.selectStart();
+          handled = editor.dispatchCommand(
+            KEY_BACKSPACE_COMMAND,
+            backspaceEvent(),
+          );
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(false);
+    });
+
+    test('isolated decorator before the list', () => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = true;
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const decorator = $createIsolatedTestDecoratorNode();
+          const list = $createListNode('bullet').append(
+            $createListItemNode().append($createTextNode('first')),
+          );
+          root.append(decorator, list);
+          list.getFirstChildOrThrow().selectStart();
+          handled = editor.dispatchCommand(
+            KEY_BACKSPACE_COMMAND,
+            backspaceEvent(),
+          );
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(false);
+
+      editor.read(() => {
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(2);
+        invariant(
+          children[0] instanceof IsolatedTestDecoratorNode,
+          'Expected leading IsolatedTestDecoratorNode',
+        );
+        invariant($isListNode(children[1]), 'Expected trailing ListNode');
+      });
+    });
+
+    test('empty first list item — defers to core for decorator NodeSelection', () => {
+      using editor = buildEditorFromExtensions(testExtension);
+
+      let handled = true;
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          const decorator = $createTestDecoratorNode().setIsInline(false);
+          const emptyItem = $createListItemNode();
+          const list = $createListNode('bullet').append(
+            emptyItem,
+            $createListItemNode().append($createTextNode('second')),
+          );
+          root.append(decorator, list);
+          emptyItem.select();
+          handled = editor.dispatchCommand(
+            KEY_BACKSPACE_COMMAND,
+            backspaceEvent(),
+          );
+        },
+        {discrete: true},
+      );
+
+      expect(handled).toBe(false);
+
+      editor.read(() => {
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(2);
+        invariant(
+          children[0] instanceof TestDecoratorNode,
+          'Expected leading TestDecoratorNode',
+        );
+        const list = children[1];
+        invariant($isListNode(list), 'Expected trailing ListNode');
+        expect(list.getChildrenSize()).toBe(2);
+      });
+    });
+  });
+});

--- a/packages/lexical-list/src/registerList.ts
+++ b/packages/lexical-list/src/registerList.ts
@@ -10,13 +10,17 @@ import type {LexicalCommand, LexicalEditor, NodeKey} from 'lexical';
 
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
+  $createParagraphNode,
   $getNodeByKey,
   $getSelection,
+  $isDecoratorNode,
   $isRangeSelection,
   $isTextNode,
+  COMMAND_PRIORITY_BEFORE_EDITOR,
   COMMAND_PRIORITY_LOW,
   createCommand,
   INSERT_PARAGRAPH_COMMAND,
+  KEY_BACKSPACE_COMMAND,
   TextNode,
 } from 'lexical';
 
@@ -97,6 +101,21 @@ export function registerList(
         return $handleListInsertParagraph(!!shouldRestore);
       },
       COMMAND_PRIORITY_LOW,
+    ),
+    // Runs just before the rich-text handler at COMMAND_PRIORITY_EDITOR that
+    // calls deleteCharacter. Lower-priority handlers (link, mark, etc.) still
+    // see Backspace first; only the editor-priority merge-block path is what
+    // we intercept here.
+    editor.registerCommand(
+      KEY_BACKSPACE_COMMAND,
+      event => {
+        if ($handleListItemBackspaceAdjacentToDecorator()) {
+          event.preventDefault();
+          return true;
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_BEFORE_EDITOR,
     ),
     editor.registerNodeTransform(ListItemNode, node => {
       const firstChild = node.getFirstChild();
@@ -226,4 +245,64 @@ function $findChildrenEndListItemNode(
   }
 
   return current;
+}
+
+/**
+ * #5072: When the first list item of a top-level list is adjacent to a
+ * non-isolated decorator that is either keyboard-selectable or a block, and
+ * the caret sits at the start of that list item, Backspace previously fell
+ * through `deleteCharacter`'s merge-block path and deleted the decorator
+ * outright. Convert the first list item into a paragraph inserted before the
+ * list instead, keeping the decorator and the list item's content intact.
+ */
+function $handleListItemBackspaceAdjacentToDecorator(): boolean {
+  const selection = $getSelection();
+  if (
+    !$isRangeSelection(selection) ||
+    !selection.isCollapsed() ||
+    selection.anchor.offset !== 0
+  ) {
+    return false;
+  }
+  const anchorNode = selection.anchor.getNode();
+  const listItem = $findMatchingParent(anchorNode, $isListItemNode);
+  if (!$isListItemNode(listItem)) {
+    return false;
+  }
+  // Empty list item: defer to deleteCharacter's merge-next-block + decorator
+  // branch in LexicalSelection.ts, which already removes the empty element and
+  // places a NodeSelection on the adjacent decorator.
+  const firstDescendant = listItem.getFirstDescendant();
+  if (firstDescendant === null) {
+    return false;
+  }
+  // The caret must be at the very start of the list item — either the anchor
+  // is the list item itself, or it is the list item's first descendant.
+  if (!listItem.is(anchorNode) && !firstDescendant.is(anchorNode)) {
+    return false;
+  }
+  const list = listItem.getParent();
+  if (!$isListNode(list) || !listItem.is(list.getFirstChild())) {
+    return false;
+  }
+  // Nested lists fall through: their parent is a ListItemNode, not a
+  // DecoratorNode, so the previous-sibling check below returns false and the
+  // existing outdent path runs.
+  const previousBlock = list.getPreviousSibling();
+  if (
+    !$isDecoratorNode(previousBlock) ||
+    previousBlock.isIsolated() ||
+    !(previousBlock.isKeyboardSelectable() || !previousBlock.isInline())
+  ) {
+    return false;
+  }
+  // Demote the first list item to a paragraph and slot it in before the list.
+  const paragraph = $createParagraphNode().append(...listItem.getChildren());
+  list.insertBefore(paragraph);
+  listItem.remove();
+  if (list.isEmpty()) {
+    list.remove();
+  }
+  paragraph.selectStart();
+  return true;
 }


### PR DESCRIPTION
## Description

When a top-level list sat next to a `DecoratorBlockNode` (and the bug also fires for any non-isolated decorator that's keyboard-selectable or block-level), Backspace at the start of the first list item fell through `deleteCharacter`'s merge-block path and removed the decorator outright. The same path also fires when two block decorators are adjacent and the user deletes the trailing list-item-side caret.

`@lexical/list` now registers a `KEY_BACKSPACE_COMMAND` handler at `COMMAND_PRIORITY_LOW` — sitting ahead of `lexical-rich-text`'s `EDITOR`-priority handler that calls `deleteCharacter`. When the caret is at the start of the first list item of a top-level list and the previous sibling is a non-isolated decorator that is either keyboard-selectable or a block, the handler demotes that first list item to a paragraph inserted before the list. The list item's content is preserved, the rest of the list keeps its items, and the decorator stays intact. The issue author asked for "the `ListNode` be replaced by a `ParagraphNode`" so the behavior matches other editors — that is what this PR does.

Empty list items, nested lists, and the no-decorator case all return `false`, leaving the existing `NodeSelection`, outdent, and merge-block paths in place. In particular, empty list items still hit `LexicalSelection.ts`'s merge-next-block + decorator branch, which removes the empty element and places a `NodeSelection` on the adjacent decorator.

Closes #5072

## Test plan

- [x] `pnpm vitest run --project unit packages/lexical-list/` — 110/110 pass. The new `registerListBackspaceDecorator.test.ts` covers six positive cases (block decorator + bullet / number / check lists, inline keyboard-selectable decorator, single-item list removal, two adjacent block decorators) and six negative cases (no decorator before the list, caret on the second list item, caret in the middle of the first list item, nested list with no decorator before the inner list, isolated decorator, and the empty-first-list-item path that defers to core).
- [x] `pnpm vitest run --project unit` — full unit suite 2946/2947 pass (1 pre-existing skip).
- [x] tsc / flow / prettier / eslint clean.
- [x] Manual on Mac, comparing playground.lexical.dev (before) vs local `pnpm dev` of `lexical-playground` (after). Verified on Chrome, Safari, Firefox.
  - `HorizontalRule` + bullet list "hello", caret at start, Backspace → HR preserved, "hello" sits as a paragraph between the HR and the rest of the list (or replaces the list outright if "hello" was the only item).
  - `PageBreak` + numbered list "hello" → same behavior.
  - `HorizontalRule` + bullet list with an empty first item, "second" below, caret on the empty first item, Backspace → `NodeSelection` on the HR (core's existing branch), no paragraph demotion side effect; a second Backspace then removes the HR.
  - Nested list: `outer` + Tab-indented `inner`, caret at start of `inner`, Backspace → `inner` outdents to the outer level (unchanged from the existing path).
  - Plain paragraph "intro" + bullet list "hello", caret at start of "hello", Backspace → merges into "intro" (existing merge-block path unchanged).
  - Two bullet items "first" / "second", caret at start of "second", Backspace → merges into "first" (existing merge-with-previous-item path unchanged).