### PR TITLE
[lexical-markdown] Bug Fix: Update ordered list start when typing a marker before it

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -440,6 +440,11 @@ const listReplace = (listType: ListType): ElementTransformer['replace'] => {
         // should never happen, but let's handle gracefully, just in case.
         nextNode.append(listItem);
       }
+      // The new list item lands at index 0, so the typed number becomes the
+      // list's starting value. #8677.
+      if (listType === 'number') {
+        nextNode.setStart(Number(match[2]));
+      }
       parentNode.remove();
     } else if (
       $isListNode(previousNode) &&
@@ -448,6 +453,8 @@ const listReplace = (listType: ListType): ElementTransformer['replace'] => {
       if (listMarker) {
         $setState(previousNode, listMarkerState, listMarker);
       }
+      // The new item is appended at the end and inherits the existing
+      // sequence, so the typed number is intentionally ignored here.
       previousNode.append(listItem);
       parentNode.remove();
     } else {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -2620,3 +2620,153 @@ describe('$convertSelectionToMarkdownString', () => {
     expect(result).toBe('    - Nested A');
   });
 });
+
+describe('Ordered list start adjustment (#8677)', () => {
+  const baseNodes = [
+    HeadingNode,
+    ListNode,
+    ListItemNode,
+    QuoteNode,
+    CodeNode,
+    LinkNode,
+  ];
+
+  it('updates list start when typed marker precedes an existing ordered list', () => {
+    const editor = createHeadlessEditor({nodes: baseNodes});
+    registerMarkdownShortcuts(editor, TRANSFORMERS);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const list = $createListNode('number', 2).append(
+          $createListItemNode().append($createTextNode('A')),
+          $createListItemNode().append($createTextNode('B')),
+        );
+        root.append(paragraph, list);
+        paragraph.selectEnd().insertText('1.');
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertText(' ');
+        }
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $generateHtmlFromNodes(editor))).toBe(
+      '<ol><li value="1"></li><li value="2"><span style="white-space: pre-wrap;">A</span></li><li value="3"><span style="white-space: pre-wrap;">B</span></li></ol>',
+    );
+  });
+
+  it('respects an arbitrary typed start number', () => {
+    const editor = createHeadlessEditor({nodes: baseNodes});
+    registerMarkdownShortcuts(editor, TRANSFORMERS);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const list = $createListNode('number', 2).append(
+          $createListItemNode().append($createTextNode('A')),
+        );
+        root.append(paragraph, list);
+        paragraph.selectEnd().insertText('7.');
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertText(' ');
+        }
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $generateHtmlFromNodes(editor))).toBe(
+      '<ol start="7"><li value="7"></li><li value="8"><span style="white-space: pre-wrap;">A</span></li></ol>',
+    );
+  });
+
+  it('does not change start when typed marker follows an existing ordered list', () => {
+    const editor = createHeadlessEditor({nodes: baseNodes});
+    registerMarkdownShortcuts(editor, TRANSFORMERS);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const list = $createListNode('number', 2).append(
+          $createListItemNode().append($createTextNode('A')),
+        );
+        const paragraph = $createParagraphNode();
+        root.append(list, paragraph);
+        paragraph.selectEnd().insertText('9.');
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertText(' ');
+        }
+      },
+      {discrete: true},
+    );
+
+    // Branch (2) of listReplace: paragraph after the list is appended as the
+    // trailing item and the list start stays at 2. The typed "9." is
+    // overwritten by updateChildrenListItemValue.
+    expect(editor.read(() => $generateHtmlFromNodes(editor))).toBe(
+      '<ol start="2"><li value="2"><span style="white-space: pre-wrap;">A</span></li><li value="3"></li></ol>',
+    );
+  });
+
+  it('creates a fresh ordered list when the next sibling is a different list type', () => {
+    const editor = createHeadlessEditor({nodes: baseNodes});
+    registerMarkdownShortcuts(editor, TRANSFORMERS);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const bullets = $createListNode('bullet').append(
+          $createListItemNode().append($createTextNode('A')),
+        );
+        root.append(paragraph, bullets);
+        paragraph.selectEnd().insertText('5.');
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertText(' ');
+        }
+      },
+      {discrete: true},
+    );
+
+    // Adjacent list is a different type, so listReplace falls through to the
+    // branch that creates a fresh ordered list with the typed start. The
+    // existing bullet list stays intact.
+    expect(editor.read(() => $generateHtmlFromNodes(editor))).toBe(
+      '<ol start="5"><li value="5"></li></ol><ul><li value="1"><span style="white-space: pre-wrap;">A</span></li></ul>',
+    );
+  });
+});


### PR DESCRIPTION
## Description

When the caret was in a paragraph immediately before an existing ordered list, typing `N. ` triggered the `ORDERED_LIST` markdown shortcut and `listReplace` inserted the new list item at the front of the adjacent list — but left the list's `__start` untouched. The typed number was overwritten by the existing start value and every following item shifted by one. Example: list `2. A` / `3. B` with the caret in a paragraph above it, typing `1. ` ended up as `2. (typed)` / `3. A` / `4. B`.

The fix lives in `listReplace`'s branch that targets the next sibling as an ordered list: after inserting the new item at index 0, call `nextNode.setStart(Number(match[2]))` so the typed number becomes the list's new starting value. `ListNode`'s `$transform` then re-runs `updateChildrenListItemValue` and the rest of the items line up under the new start. The other two branches stay as they are:

- Paragraph after the list, item appended at the end. The list's start defines the sequence's first item, not its last, so leaving it alone keeps the typed number deferring to the existing sequence. This matches the original `listReplace` behavior and is now documented inline.
- No adjacent list, a fresh list is created. The existing code already respects the typed number via `$createListNode(listType, Number(match[2]))`.

Closes #8677

## Test plan

- [x] `pnpm vitest run --project unit packages/lexical-markdown/` — 378/378 pass. The new `Ordered list start adjustment (#8677)` describe block adds four scenarios: typed `1. ` updates the adjacent ordered list's start to 1, an arbitrary typed start (`7. `) is respected, a paragraph after the list keeps the start unchanged (branch (2) lock-in), and a typed marker next to a bullet list falls through to the fresh-list branch with the typed start.
- [x] `pnpm vitest run --project unit` — full unit suite 2937/2938 pass (1 pre-existing skip).
- [x] tsc / flow / prettier / eslint clean.
- [x] Manual on Mac (Chrome, Safari, Firefox), comparing playground.lexical.dev (before) vs local `pnpm dev` of `lexical-playground` (after).
  - Numbered list `2. A` / `3. B`, caret in an empty paragraph above, typing `1. ` → list start becomes 1, items render as `1. (new)` / `2. A` / `3. B`.
  - Same setup, typing `5. ` → list start becomes 5.
  - Numbered list `2. A`, caret in an empty paragraph below, typing `9. ` → start stays at 2, items render as `2. A` / `3. (new)`. The typed marker is intentionally ignored (branch (2) is "append to existing sequence", not "reset").