### PR TITLE
[lexical] Bug Fix: Emit COMPOSITION_END_TAG from the Firefox onInput defer branch

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1164,9 +1164,14 @@ function $handleInput(event: InputEvent): boolean {
     const characterData = data !== null ? data : undefined;
     $updateSelectedTextFromDOM(false, editor, characterData);
 
-    // onInput always fires after onCompositionEnd for FF.
+    // onInput always fires after onCompositionEnd for FF, so the composition
+    // end runs here. Mirror the COMPOSITION_END_TAG that $handleCompositionEnd
+    // adds on Chrome/Webkit so listeners gated on this tag (markdown shortcut
+    // trigger, history merge, autocomplete post-commit) see the same signal on
+    // Firefox.
     if (isFirefoxEndingComposition) {
       $onCompositionEndImpl(editor, data || undefined);
+      $addUpdateTag(COMPOSITION_END_TAG);
       isFirefoxEndingComposition = false;
     }
   }

--- a/packages/lexical/src/__tests__/unit/LexicalFirefoxCompositionEndTag.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalFirefoxCompositionEndTag.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Firefox defers its compositionend handling until the next onInput
+ * (`isFirefoxEndingComposition` flag). The Chrome/Webkit path adds
+ * `COMPOSITION_END_TAG` to that update via `$handleCompositionEnd`; the
+ * Firefox onInput defer branch must mirror it so listeners gated on the tag
+ * (markdown shortcut trigger, history merge, autocomplete post-commit) see the
+ * same signal on Firefox.
+ */
+
+import {registerRichText} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  COMPOSITION_END_TAG,
+  LexicalEditor,
+} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+vi.mock('lexical/src/environment', () => ({
+  CAN_USE_BEFORE_INPUT: true,
+  CAN_USE_DOM: true,
+  IS_ANDROID: false,
+  IS_ANDROID_CHROME: false,
+  IS_APPLE: false,
+  IS_APPLE_WEBKIT: false,
+  IS_CHROME: false,
+  IS_FIREFOX: true,
+  IS_IOS: false,
+  IS_SAFARI: false,
+}));
+
+describe('Firefox composition-end tag forwarding', () => {
+  let container: HTMLDivElement;
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('data-lexical-editor', 'true');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    editor = createTestEditor();
+    registerRichText(editor);
+    editor.setRootElement(container);
+  });
+
+  afterEach(() => {
+    editor.setRootElement(null);
+    document.body.removeChild(container);
+  });
+
+  test('onInput emits COMPOSITION_END_TAG after a deferred compositionend', async () => {
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode().append($createTextNode('-'));
+        $getRoot().clear().append(paragraph);
+        paragraph.selectEnd();
+      },
+      {discrete: true},
+    );
+
+    const observedTagSets: string[][] = [];
+    editor.registerUpdateListener(({tags}) => {
+      observedTagSets.push(Array.from(tags));
+    });
+
+    // Firefox routes compositionend through `isFirefoxEndingComposition`; this
+    // event alone doesn't run $onCompositionEndImpl yet.
+    container.dispatchEvent(
+      new CompositionEvent('compositionend', {bubbles: true, data: ' '}),
+    );
+
+    // The deferred composition end runs inside this onInput. The fix adds
+    // COMPOSITION_END_TAG here.
+    const inputEvent = new InputEvent('input', {
+      bubbles: true,
+      data: ' ',
+      inputType: 'insertCompositionText',
+    });
+    Object.defineProperty(inputEvent, 'isComposing', {value: false});
+    container.dispatchEvent(inputEvent);
+
+    // Update listeners fire on a microtask; let them flush before asserting.
+    await Promise.resolve();
+
+    expect(
+      observedTagSets.some(tags => tags.includes(COMPOSITION_END_TAG)),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Firefox fires `onCompositionEnd` before `onInput`, so `$handleCompositionEnd` never runs synchronously on Firefox. `onCompositionEnd` only sets the `isFirefoxEndingComposition` flag and the deferred composition end runs inside the subsequent `onInput`, where `$onCompositionEndImpl` is called. The Chrome/Webkit path runs `$addUpdateTag(COMPOSITION_END_TAG)` right next to `$onCompositionEndImpl`; the Firefox defer branch in `$handleInput`'s `else` path was missing this call, so listeners gated on `COMPOSITION_END_TAG` never observed the post-commit update on Firefox.

In practice, with a Korean IME active, Firefox routes space through a compositionstart / compositionupdate / compositionend cycle. The markdown shortcut listener in `registerMarkdownShortcuts` gates its space-trigger fall-through on `COMPOSITION_END_TAG`, so typing `- ` (and other shortcut-trigger sequences) silently failed to convert into a list on Firefox + Korean IME.

Mirror the Chrome/Webkit path: call `$addUpdateTag(COMPOSITION_END_TAG)` alongside `$onCompositionEndImpl` in the Firefox `onInput` defer branch. Other listeners gated on the tag (`lexical-history`'s composition-grouped merge, the playground autocomplete plugin's post-commit ghost) regain the same signal as a side effect.

A second `isFirefoxEndingComposition` handler earlier in `$handleInput` (inside the `$shouldPreventDefaultAndInsertText` true branch) has the same shape but is left untouched here. Manual probing on Firefox + Korean IME (drag-select replacement, bold/format toggle, TabNode adjacency, heading + Korean) only ever hit the `else` branch fixed here; the prevent-default branch never fired, consistent with several `!anchorNode.isComposing()` guards inside `$shouldPreventDefaultAndInsertText` that effectively gate it out during composition. If a real Firefox scenario reaches that branch, the same one-line mirror should apply there too.

Closes #8679

## Test plan

- [x] `pnpm vitest run --project unit` — full unit suite 2935/2936 pass (1 pre-existing skip), including the new `LexicalFirefoxCompositionEndTag.test.ts`. The new test mocks `IS_FIREFOX: true`, dispatches a `compositionend` + `insertCompositionText` sequence at the root element, and asserts that an update tagged with `COMPOSITION_END_TAG` is observed after the microtask flush. Without the one-line fix the test fails (verified by checking out `origin/main`'s `LexicalEvents.ts`).
- [x] tsc / flow / prettier / eslint clean.
- [x] Manual on Firefox + Korean IME (macOS), comparing playground.lexical.dev (before) vs local `pnpm dev` of `lexical-playground` (after). The "after" recording is attached.
  - `- ` + space → bullet list created (the issue's repro).
  - `1. ` + space → numbered list.
  - `# ` + Korean text → h1 heading.
  - `` ` `` wrapped text → inline code formatting.
  - Cmd+Z on a Korean-IME-typed word: step-by-step undo. Chrome behaves the same way, so this is Lexical's existing Korean-IME commit policy and unrelated to this fix.
  - Playground autocomplete ghost: post-commit ghost shows on Firefox after the fix, matching Chrome (the `AutocompleteExtension` comment already assumed Firefox fires the tagged update synchronously — this PR makes that assumption hold).