### PR TITLE
[lexical-react] Refactor: Use hook syntax in .js.flow files to better declare intent

### DIFF
--- a/packages/lexical-react/flow/LexicalComposerContext.js.flow
+++ b/packages/lexical-react/flow/LexicalComposerContext.js.flow
@@ -24,4 +24,4 @@ declare export function createLexicalComposerContext(
   parent: ?LexicalComposerContextWithEditor,
   theme: ?EditorThemeClasses,
 ): LexicalComposerContextType;
-declare export function useLexicalComposerContext(): LexicalComposerContextWithEditor;
+declare export hook useLexicalComposerContext(): LexicalComposerContextWithEditor;

--- a/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
@@ -53,7 +53,7 @@ declare export function getScrollParent(
   includeHidden: boolean,
 ): HTMLElement | HTMLBodyElement;
 
-declare export function useBasicTypeaheadTriggerMatch(
+declare export hook useBasicTypeaheadTriggerMatch(
   trigger: string,
   options: {minLength?: number, maxLength?: number},
 ): TriggerFn;

--- a/packages/lexical-react/flow/useLexicalEditable.js.flow
+++ b/packages/lexical-react/flow/useLexicalEditable.js.flow
@@ -9,4 +9,4 @@
 
 import type {LexicalEditor} from 'lexical';
 
-declare export function useLexicalEditable(): boolean;
+declare export hook useLexicalEditable(): boolean;

--- a/packages/lexical-react/flow/useLexicalExtensionSignalValue.js.flow
+++ b/packages/lexical-react/flow/useLexicalExtensionSignalValue.js.flow
@@ -12,7 +12,7 @@ import type {AnyLexicalExtension} from 'lexical';
 
 declare export function useSignalValue<V>(s: ReadonlySignal<V>): V;
 
-declare export function useExtensionSignalValue<V>(
+declare export hook useExtensionSignalValue<V>(
   extension: AnyLexicalExtension,
   prop: string,
 ): V;

--- a/packages/lexical-react/flow/useLexicalIsTextContentEmpty.js.flow
+++ b/packages/lexical-react/flow/useLexicalIsTextContentEmpty.js.flow
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor} from 'lexical';
 
-declare export function useLexicalIsTextContentEmpty(
+declare export hook useLexicalIsTextContentEmpty(
   editor: LexicalEditor,
   trim?: boolean,
 ): boolean;

--- a/packages/lexical-react/flow/useLexicalNodeSelection.js.flow
+++ b/packages/lexical-react/flow/useLexicalNodeSelection.js.flow
@@ -9,6 +9,6 @@
 
 import type {NodeKey} from 'lexical';
 
-declare export function useLexicalNodeSelection(
+declare export hook useLexicalNodeSelection(
   key: NodeKey,
 ): [boolean, (boolean) => void, () => void];

--- a/packages/lexical-react/flow/useLexicalSubscription.js.flow
+++ b/packages/lexical-react/flow/useLexicalSubscription.js.flow
@@ -14,6 +14,6 @@ export type LexicalSubscription<T> = {
   subscribe: (callback: (value: T) => void) => () => void,
 };
 
-declare export function useLexicalSubscription<T>(
+declare export hook useLexicalSubscription<T>(
   subscription: (editor: LexicalEditor) => LexicalSubscription<T>,
 ): T;


### PR DESCRIPTION
## Description

Make it so that when `experimental.component_syntax.hook_compatibility=false` is configured, these hooks can be consumed in react components without error.

## Test plan

flow