### PR TITLE
[lexical-utils][lexical-playground] Bug Fix: Double paragraph creation when exiting a nested code block

### DIFF
--- a/packages/lexical-code-core/src/CodeIndentation.ts
+++ b/packages/lexical-code-core/src/CodeIndentation.ts
@@ -515,22 +515,22 @@ export function registerCodeIndentation(
       ? [
           editor.registerCommand(
             KEY_ARROW_DOWN_COMMAND,
-            event => (event.altKey ? false : $onEscapeDown($isCodeNode)),
+            event => (event.altKey ? false : $onEscapeDown($isCodeNode, event)),
             COMMAND_PRIORITY_LOW,
           ),
           editor.registerCommand(
             KEY_ARROW_RIGHT_COMMAND,
-            () => $onEscapeDown($isCodeNode),
+            event => $onEscapeDown($isCodeNode, event),
             COMMAND_PRIORITY_LOW,
           ),
           editor.registerCommand(
             KEY_ARROW_UP_COMMAND,
-            event => (event.altKey ? false : $onEscapeUp($isCodeNode)),
+            event => (event.altKey ? false : $onEscapeUp($isCodeNode, event)),
             COMMAND_PRIORITY_LOW,
           ),
           editor.registerCommand(
             KEY_ARROW_LEFT_COMMAND,
-            () => $onEscapeUp($isCodeNode),
+            event => $onEscapeUp($isCodeNode, event),
             COMMAND_PRIORITY_LOW,
           ),
         ]

--- a/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
@@ -9,6 +9,7 @@
 import {
   moveLeft,
   moveToEditorBeginning,
+  moveToEditorEnd,
   moveToEnd,
   moveToStart,
   pressShiftEnter,
@@ -983,4 +984,116 @@ test.describe('CodeBlock', () => {
       );
     }
   });
+
+  for (const key of ['ArrowRight', 'ArrowDown']) {
+    test(`${key} key should exit from the code block inside the layout`, async ({
+      page,
+      isPlainText,
+      isCollab,
+      browser,
+    }) => {
+      test.skip(isPlainText || isCollab || browser === 'firefox');
+      await initialize({page});
+      await focusEditor(page);
+
+      await page.keyboard.type('/');
+      await click(page, '.typeahead-popover .icon.columns');
+      await click(page, '.Modal__modal .Modal__content .Button__root');
+
+      // remove empty paragraphs around the layout
+      await moveToEditorEnd(page);
+      await page.keyboard.press('Backspace');
+      await moveToEditorBeginning(page);
+      await page.keyboard.press('Backspace');
+
+      // Focus on first column
+      await click(
+        page,
+        '.PlaygroundEditorTheme__layoutContainer .PlaygroundEditorTheme__layoutItem:nth-child(1)',
+      );
+      await page.keyboard.type('```');
+      await page.keyboard.press('Enter');
+
+      // selection at the code
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 0, 0],
+        focusOffset: 0,
+        focusPath: [0, 0, 0],
+      });
+      await assertHTML(
+        page,
+        html`
+          <div
+            class="PlaygroundEditorTheme__layoutContainer"
+            dir="auto"
+            style="grid-template-columns: 1fr 1fr">
+            <div
+              class="PlaygroundEditorTheme__layoutItem"
+              dir="auto"
+              data-lexical-layout-item="true">
+              <code
+                class="PlaygroundEditorTheme__code"
+                dir="auto"
+                spellcheck="false"
+                data-gutter="1">
+                <br />
+              </code>
+            </div>
+            <div
+              class="PlaygroundEditorTheme__layoutItem"
+              dir="auto"
+              data-lexical-layout-item="true">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </div>
+          </div>
+        `,
+      );
+
+      await page.keyboard.press(key);
+
+      // selection at the new paragraph but inside the layout
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 0, 1],
+        focusOffset: 0,
+        focusPath: [0, 0, 1],
+      });
+      await assertHTML(
+        page,
+        html`
+          <div
+            class="PlaygroundEditorTheme__layoutContainer"
+            dir="auto"
+            style="grid-template-columns: 1fr 1fr">
+            <div
+              class="PlaygroundEditorTheme__layoutItem"
+              dir="auto"
+              data-lexical-layout-item="true">
+              <code
+                class="PlaygroundEditorTheme__code"
+                dir="auto"
+                spellcheck="false"
+                data-gutter="1">
+                <br />
+              </code>
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </div>
+            <div
+              class="PlaygroundEditorTheme__layoutItem"
+              dir="auto"
+              data-lexical-layout-item="true">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+                <br />
+              </p>
+            </div>
+          </div>
+        `,
+      );
+    });
+  }
 });

--- a/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
@@ -990,9 +990,8 @@ test.describe('CodeBlock', () => {
       page,
       isPlainText,
       isCollab,
-      browser,
     }) => {
-      test.skip(isPlainText || isCollab || browser === 'firefox');
+      test.skip(isPlainText || isCollab);
       await initialize({page});
       await focusEditor(page);
 

--- a/packages/lexical-playground/__tests__/e2e/ColumnLayoutBackspaceAtEnd.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ColumnLayoutBackspaceAtEnd.spec.mjs
@@ -80,12 +80,13 @@ test('Layout - removes layout completely when both columns are empty and backspa
 });
 
 for (const key of ['ArrowRight', 'ArrowDown']) {
-  test(`Layout - ${key} keys should exit from the layout if the selection is at the end of the element`, async ({
+  test(`Layout - ${key} key should exit from the layout if the selection is at the end of the element`, async ({
     page,
     isPlainText,
     isCollab,
+    browser,
   }) => {
-    test.skip(isPlainText || isCollab);
+    test.skip(isPlainText || isCollab || browser === 'firefox');
     await initialize({page});
     await focusEditor(page);
 

--- a/packages/lexical-playground/__tests__/e2e/ColumnLayoutBackspaceAtEnd.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ColumnLayoutBackspaceAtEnd.spec.mjs
@@ -84,9 +84,8 @@ for (const key of ['ArrowRight', 'ArrowDown']) {
     page,
     isPlainText,
     isCollab,
-    browser,
   }) => {
-    test.skip(isPlainText || isCollab || browser === 'firefox');
+    test.skip(isPlainText || isCollab);
     await initialize({page});
     await focusEditor(page);
 

--- a/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
@@ -106,23 +106,23 @@ export const LayoutExtension = /* @__PURE__ */ defineExtension({
       // work even if a trailing paragraph is accidentally deleted.
       editor.registerCommand(
         KEY_ARROW_DOWN_COMMAND,
-        () => $onEscapeDown($isLayoutContainerNode),
+        event => $onEscapeDown($isLayoutContainerNode, event),
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_ARROW_RIGHT_COMMAND,
-        () => $onEscapeDown($isLayoutContainerNode),
+        event => $onEscapeDown($isLayoutContainerNode, event),
         COMMAND_PRIORITY_LOW,
       ),
       // Inverse: leading paragraph escape on up/left.
       editor.registerCommand(
         KEY_ARROW_UP_COMMAND,
-        () => $onEscapeUp($isLayoutContainerNode),
+        event => $onEscapeUp($isLayoutContainerNode, event),
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_ARROW_LEFT_COMMAND,
-        () => $onEscapeUp($isLayoutContainerNode),
+        event => $onEscapeUp($isLayoutContainerNode, event),
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -1046,11 +1046,20 @@ export function makeStateWrapper<K extends string, V>(
  * A paragraph is inserted if that the cursor is positioned at the beginning inside the container,
  * and the container itself is the first element in the document and has no preceding sibling
  *
+ * When a paragraph is inserted the selection is moved to it and, if the
+ * triggering keyboard event is provided, its default action is prevented so
+ * the browser does not additionally move the selection. Relying on the native
+ * caret movement is not portable: Chromium moves into the freshly inserted
+ * paragraph while Firefox leaves the caret inside the container.
+ *
  * @param $isContainerNode - Type guard identifying the container node type to escape from.
+ * @param event - The keyboard event that triggered the escape, if any. Its
+ *   default action is prevented when a paragraph is inserted.
  * @returns `true` if a paragraph was inserted, `false` otherwise.
  */
 export function $onEscapeUp(
   $isContainerNode: (node?: LexicalNode | null) => node is ElementNode,
+  event?: KeyboardEvent | null,
 ) {
   const selection = $getSelection();
   if (
@@ -1077,7 +1086,10 @@ export function $onEscapeUp(
             ($isElementNode(anchorNode) &&
               anchorNode.getFirstDescendant() === firstDescendant))
         ) {
-          containerNode.insertBefore($createParagraphNode());
+          containerNode.insertBefore($createParagraphNode()).selectEnd();
+          if (event) {
+            event.preventDefault();
+          }
           return true;
         }
       }
@@ -1096,11 +1108,20 @@ export function $onEscapeUp(
  * A paragraph is inserted if that the cursor is positioned at the ending inside the container,
  * and the container itself is the last element in the document and has no next sibling
  *
+ * When a paragraph is inserted the selection is moved to it and, if the
+ * triggering keyboard event is provided, its default action is prevented so
+ * the browser does not additionally move the selection. Relying on the native
+ * caret movement is not portable: Chromium moves into the freshly inserted
+ * paragraph while Firefox leaves the caret inside the container.
+ *
  * @param $isContainerNode - Type guard identifying the container node type to escape from.
+ * @param event - The keyboard event that triggered the escape, if any. Its
+ *   default action is prevented when a paragraph is inserted.
  * @returns `true` if a paragraph was inserted, `false` otherwise.
  */
 export function $onEscapeDown(
   $isContainerNode: (node?: LexicalNode | null) => node is ElementNode,
+  event?: KeyboardEvent | null,
 ) {
   const selection = $getSelection();
   if ($isRangeSelection(selection) && selection.isCollapsed()) {
@@ -1124,7 +1145,10 @@ export function $onEscapeDown(
             ($isElementNode(anchorNode) &&
               anchorNode.getLastDescendant() === lastDescendant))
         ) {
-          containerNode.insertAfter($createParagraphNode());
+          containerNode.insertAfter($createParagraphNode()).selectEnd();
+          if (event) {
+            event.preventDefault();
+          }
           return true;
         }
       }

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -1077,7 +1077,7 @@ export function $onEscapeUp(
             ($isElementNode(anchorNode) &&
               anchorNode.getFirstDescendant() === firstDescendant))
         ) {
-          containerNode.insertBefore($createParagraphNode()).selectEnd();
+          containerNode.insertBefore($createParagraphNode());
           return true;
         }
       }
@@ -1124,7 +1124,7 @@ export function $onEscapeDown(
             ($isElementNode(anchorNode) &&
               anchorNode.getLastDescendant() === lastDescendant))
         ) {
-          containerNode.insertAfter($createParagraphNode()).selectEnd();
+          containerNode.insertAfter($createParagraphNode());
           return true;
         }
       }


### PR DESCRIPTION
## Description

Follow-up https://github.com/facebook/lexical/pull/8393

When inserting new paragraphs, calls to `selectEnd` were added to the `$onEscapeDown` and `$onEscapeUp` handlers as a workaround to pass the tests in Firefox https://github.com/facebook/lexical/pull/8393#issuecomment-4491778470. This resulted in an undesirable effect where, in a nested setup, the selection moved past the inserted paragraph and out of its container (which also has `$onEscapeUp`/`$onEscapeDown` handlers).

The root cause is that the handlers inserted a paragraph and then relied on the browser's **native** arrow-key caret movement to land in it, but that movement is not portable:

- without `selectEnd`, Chromium moves into the freshly inserted paragraph while Firefox leaves the caret inside the container (hence the Firefox skips);
- with `selectEnd` but no `preventDefault`, the native movement fires *on top of* `selectEnd` and overshoots into the adjacent container/column.

Instead of skipping Firefox, this makes the handlers fully own the behavior: when a paragraph is inserted we set the selection explicitly with `selectEnd()` **and** call `event.preventDefault()` so the browser does not additionally move the caret. The keyboard event is now threaded through the code-block and layout arrow-key handlers for this purpose. The caret now lands identically on Chromium, Firefox and WebKit, so the Firefox skips are removed.

## Test plan

Added e2e test for a nested code block inside LayoutContainer. The new test and the existing `ColumnLayoutBackspaceAtEnd` arrow-key tests now pass on Chromium, Firefox and WebKit (no Firefox skip).

### Before

https://github.com/user-attachments/assets/d97ac4a6-5f56-49cd-82f8-5b8e11c9b312

### After

https://github.com/user-attachments/assets/f70c6ced-0dc7-43c4-a5b3-a353765627a8