### PR TITLE
[lexical] Bug Fix: Reuse the empty trailing block when typing at root + last-offset selection

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -291,15 +291,28 @@ function $transferStartingElementPointToTextPoint(
   textNode.setStyle(style);
   if ($isParagraphNode(placementNode)) {
     placementNode.splice(0, 0, [textNode]);
-  } else {
+  } else if (placementNode !== null) {
     const target = $isRootNode(element)
       ? $createParagraphNode().append(textNode)
       : textNode;
-    if (placementNode === null) {
-      element.append(target);
+    placementNode.insertBefore(target);
+  } else if ($isRootOrShadowRoot(element)) {
+    // root or shadow-root + last-offset typing: reuse the empty trailing
+    // block when one exists (typical state after a sibling block decorator
+    // was deleted) instead of appending a fresh paragraph. The old behavior
+    // left a phantom empty paragraph above the user's input.
+    const lastChild = element.getLastChild();
+    if (
+      $isElementNode(lastChild) &&
+      !lastChild.isInline() &&
+      lastChild.isEmpty()
+    ) {
+      lastChild.append(textNode);
     } else {
-      placementNode.insertBefore(target);
+      element.append($createParagraphNode().append(textNode));
     }
+  } else {
+    element.append(textNode);
   }
   // Transfer the element point to a text point.
   if (start.is(end)) {

--- a/packages/lexical/src/__tests__/unit/LexicalRootSelectionPhantomParagraph.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalRootSelectionPhantomParagraph.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {describe, expect, test} from 'vitest';
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+} from '../..';
+import {
+  $createTestDecoratorNode,
+  $createTestShadowRootNode,
+  invariant,
+  TestDecoratorNode,
+  TestShadowRootNode,
+} from '../utils';
+
+const testExtension = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '[root]',
+  nodes: [TestDecoratorNode, TestShadowRootNode],
+});
+
+describe('Typing at root + last-offset selection (no phantom paragraph)', () => {
+  test('reuses an empty trailing paragraph instead of appending a new one', () => {
+    using editor = buildEditorFromExtensions(testExtension);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        root.append($createParagraphNode());
+
+        root.select(1, 1).insertText('x');
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(1);
+      const paragraph = children[0];
+      invariant($isParagraphNode(paragraph), 'Expected ParagraphNode');
+      expect(paragraph.getTextContent()).toBe('x');
+    });
+  });
+
+  test('empty root still creates a new paragraph for the typed text', () => {
+    using editor = buildEditorFromExtensions(testExtension);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        root.select(0, 0).insertText('x');
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(1);
+      const paragraph = children[0];
+      invariant($isParagraphNode(paragraph), 'Expected ParagraphNode');
+      expect(paragraph.getTextContent()).toBe('x');
+    });
+  });
+
+  test('reuses an empty trailing paragraph inside a shadow root', () => {
+    using editor = buildEditorFromExtensions(testExtension);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const shadowRoot = $createTestShadowRootNode();
+        shadowRoot.append($createParagraphNode());
+        root.append(shadowRoot);
+
+        shadowRoot.select(1, 1).insertText('x');
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const shadowRoot = $getRoot().getFirstChildOrThrow();
+      invariant(
+        shadowRoot instanceof TestShadowRootNode,
+        'Expected TestShadowRootNode',
+      );
+      const children = shadowRoot.getChildren();
+      expect(children).toHaveLength(1);
+      const paragraph = children[0];
+      invariant($isParagraphNode(paragraph), 'Expected ParagraphNode');
+      expect(paragraph.getTextContent()).toBe('x');
+    });
+  });
+
+  test('falls back to a new paragraph when the trailing child is a DecoratorNode', () => {
+    using editor = buildEditorFromExtensions(testExtension);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        root.append(
+          $createParagraphNode().append($createTextNode('first')),
+          $createTestDecoratorNode().setIsInline(false),
+        );
+
+        root.select(2, 2).insertText('x');
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(3);
+      invariant($isParagraphNode(children[0]), 'Expected first paragraph');
+      expect(children[0].getTextContent()).toBe('first');
+      expect(children[1]).toBeInstanceOf(TestDecoratorNode);
+      const newParagraph = children[2];
+      invariant($isParagraphNode(newParagraph), 'Expected trailing paragraph');
+      expect(newParagraph.getTextContent()).toBe('x');
+    });
+  });
+});


### PR DESCRIPTION
## Description

When a RangeSelection's anchor sits at `{ key: 'root', offset: <root.childrenSize>, type: 'element' }` and `RangeSelection.insertText` runs (i.e. the user types), `$transferStartingElementPointToTextPoint` reaches the `placementNode === null + isRootNode(element)` branch and unconditionally appends `$createParagraphNode().append(textNode)` to root. If root already had an empty trailing paragraph (the typical state after deleting a root-level block decorator), the original paragraph is left behind and the typed character lands in a brand-new paragraph below — a phantom blank line above the user's input. The same root cause is also reachable by selecting the decorator and pressing Backspace/Delete directly instead of the slash-insert + double-Backspace path in the issue; both end up at the same root + last-offset `insertText` call.

Split the original `else` branch into four explicit cases and guard the root + null-placement case: if root's last child is an empty non-inline `ElementNode`, append the text node into that element instead of creating a new paragraph. `DecoratorNode` trailing children (`$isElementNode` is false), empty roots (`getLastChild() === null`), non-empty trailing elements, and non-root element points all fall through to the existing behavior.

Closes #8685

## Test plan

- [x] `pnpm vitest run --project unit` — full unit suite 2989/2990 pass (1 pre-existing skip), including the new `LexicalRootSelectionPhantomParagraph.test.ts`. The new test locks the fix (typing at root + last-offset with an empty trailing paragraph reuses it) and locks two regression guards (an empty root still creates a new paragraph; a `DecoratorNode` trailing child still falls back to creating a new paragraph). Without the fix the first case fails (verified by checking out `origin/main`'s `LexicalSelection.ts`).
- [x] tsc / flow / prettier / eslint clean.
- [x] Manual on Mac (Chrome, Safari, Firefox), comparing playground.lexical.dev (before) vs local `pnpm dev` of `lexical-playground` (after). The "after" recording is attached.
  - `/page break` → Backspace ×2 → typing — typed character lands in the original paragraph (no phantom blank line).
  - `/equation` → Backspace ×2 → typing — same behavior.
  - Empty editor + typing — paragraph created normally (regression guard).
  - `paragraph "hello"` + `PageBreak` + arrow-key to root end + typing — a new paragraph is created after the decorator (regression guard: trailing child is a `DecoratorNode` rather than an empty `ElementNode`).
  - General typing inside a paragraph — unaffected.

https://github.com/user-attachments/assets/5a9a6065-c2a8-4bfa-84e3-3c29f486ee0e


