### PR TITLE
[lexical-markdown] Bug Fix: code spans should bind tighter than text-match transformers

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -418,6 +418,13 @@ describe('Markdown', () => {
       md: '`$$hello`',
     },
     {
+      // Code spans bind tighter than text-match transformers, so the $...$
+      // (HIGHLIGHT_TEXT_MATCH_IMPORT) must not consume across the code spans.
+      // https://github.com/facebook/lexical/issues/8687
+      html: '<p><code spellcheck="false" style="white-space: pre-wrap;"><span>$a</span></code><span style="white-space: pre-wrap;"> </span><code spellcheck="false" style="white-space: pre-wrap;"><span>$b</span></code></p>',
+      md: '`$a` `$b`',
+    },
+    {
       html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;">Hello</span></a><span style="white-space: pre-wrap;"> world</span></p>',
       md: '[Hello](https://lexical.dev) world',
     },

--- a/packages/lexical-markdown/src/importTextFormatTransformer.ts
+++ b/packages/lexical-markdown/src/importTextFormatTransformer.ts
@@ -30,6 +30,10 @@ export function findOutermostTextFormatTransformer(
   endIndex: number;
   transformer: TextFormatTransformer;
   match: RegExpMatchArray;
+  // True when the outermost format is a code span. Code spans are atomic: their
+  // content is never reprocessed and they bind tighter than text-match
+  // transformers, so this is tagged here rather than re-derived by callers.
+  isCodeSpan: boolean;
 } | null {
   const textContent = textNode.getTextContent();
 
@@ -116,6 +120,9 @@ export function findOutermostTextFormatTransformer(
 
   return {
     endIndex: resultMatch.endIndex,
+    // resultTransformer is the registered code transformer (by identity)
+    // exactly when the chosen match is the code span.
+    isCodeSpan: resultTransformer === codeTransformer,
     match: regexMatch,
     startIndex: resultMatch.startIndex,
     transformer: resultTransformer,

--- a/packages/lexical-markdown/src/importTextTransformers.ts
+++ b/packages/lexical-markdown/src/importTextTransformers.ts
@@ -54,8 +54,24 @@ export function importTextTransformers(
   );
 
   if (foundTextFormat && foundTextMatch) {
-    // Find the outermost transformer
-    if (
+    if (foundTextFormat.isCodeSpan) {
+      // Code spans bind tighter than text-match transformers (e.g. equations
+      // or links). A code span must never be partially consumed by a text
+      // match, so prefer the code format unless the text match fully wraps it
+      // (in which case the code span is part of the match's raw content).
+      // https://github.com/facebook/lexical/issues/8687
+      if (
+        foundTextMatch.startIndex <= foundTextFormat.startIndex &&
+        foundTextMatch.endIndex >= foundTextFormat.endIndex
+      ) {
+        // foundTextMatch wraps the code span - apply foundTextMatch
+        foundTextFormat = null;
+      } else {
+        // Apply the code span
+        foundTextMatch = null;
+      }
+    } else if (
+      // Find the outermost transformer
       (foundTextFormat.startIndex <= foundTextMatch.startIndex &&
         foundTextFormat.endIndex >= foundTextMatch.endIndex) ||
       // foundTextMatch is not contained within foundTextFormat


### PR DESCRIPTION
## Description

Inline code (`code`) has the highest inline parsing precedence in Markdown and must never be partially consumed by a text-match transformer. When a code-format match and a text-match (e.g. the playground equation `$...$` or a link) partially overlapped, the importer incorrectly applied the text match. For example `` `$a` `$b` `` parsed into a single equation instead of two code spans.

Prefer the code format whenever it conflicts with a text match, unless the text match fully wraps the code span (in which case the backticks are part of the match's raw content).

Closes #8687

## Test plan

New unit tests