### PR TITLE
docs: link browser-only quick start options

### DIFF
--- a/packages/lexical-website/docs/getting-started/quick-start.md
+++ b/packages/lexical-website/docs/getting-started/quick-start.md
@@ -7,6 +7,15 @@ sidebar_position: 1
 This section covers how to use Lexical, independently of any framework or library. For those intending to use Lexical in their React applications,
 it's advisable to [check out the Getting Started with React page](../getting-started/react.md).
 
+If you want to try Lexical in the browser without setting up TypeScript, npm, or
+a bundler first, see the [browser-only ESM playground](https://playground.lexical.dev/esm/).
+It uses an HTML import map and regular `<script type="module">` tags; the
+complete source lives in
+[`packages/lexical-playground/esm`](https://github.com/facebook/lexical/tree/main/packages/lexical-playground/esm).
+For a framework-free editor built with Lexical Extensions, see the
+[Extension: Vanilla Tailwind](https://lexical.dev/gallery#extension-vanilla-tailwind)
+gallery example.
+
 ### Creating an editor and using it
 
 When you work with Lexical, you normally work with a single editor instance. An editor instance can be thought of as the one responsible


### PR DESCRIPTION
## Summary

- Link the quick-start guide to the existing browser-only ESM playground for users who want to try Lexical without npm, TypeScript, or a bundler.
- Point readers to the vanilla Tailwind extension gallery example for a maintained framework-free editor example.

Closes #5840

## Test plan

- `git diff --check main...HEAD`
- Verified `packages/lexical-playground/esm` exists locally.
- Verified the `extension-vanilla-tailwind` gallery example slug exists locally.