### PR TITLE
[lexical] Chore: Remove unused tmp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,6 @@
     "react-dom": "^19.2.5",
     "react-test-renderer": "^19.2.7",
     "rollup": "^4.61.0",
-    "tmp": "^0.2.7",
     "ts-morph": "^28.0.0",
     "typedoc": "^0.28.19",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,9 +259,6 @@ importers:
       rollup:
         specifier: ^4.61.0
         version: 4.61.0
-      tmp:
-        specifier: ^0.2.7
-        version: 0.2.7
       ts-morph:
         specifier: ^28.0.0
         version: 28.0.0
@@ -426,15 +423,15 @@ importers:
       '@lexical/extension':
         specifier: workspace:*
         version: link:../lexical-extension
-      '@lexical/utils':
-        specifier: workspace:*
-        version: link:../lexical-utils
       '@lexical/html':
         specifier: workspace:*
         version: link:../lexical-html
       '@lexical/internal':
         specifier: workspace:*
         version: link:../lexical-internal
+      '@lexical/utils':
+        specifier: workspace:*
+        version: link:../lexical-utils
       lexical:
         specifier: workspace:*
         version: link:../lexical
@@ -9193,11 +9190,6 @@ packages:
   ltgt@2.2.1:
     resolution: {integrity: sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==}
 
-  lucide-react@1.17.0:
-    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
-    peerDependencies:
-      react: 19.2.5
-
   lunr-languages@1.20.0:
     resolution: {integrity: sha512-3LVgE7ekWXt04NBci/hjm+NXJxXZeRXuyClL0kA0HONyBOjxhP3ZQkuWIM4Ok3pbeptUW/rj3XcJcJuJVPwPYA==}
 
@@ -11745,10 +11737,6 @@ packages:
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
-    engines: {node: '>=14.14'}
-
-  tmp@0.2.7:
-    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -14568,7 +14556,7 @@ snapshots:
       browserslist: 4.28.2
       lightningcss: 1.32.0
       semver: 7.7.4
-      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0))
+      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(esbuild@0.27.7))
       tslib: 2.8.1
       webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)
     transitivePeerDependencies:
@@ -23037,10 +23025,6 @@ snapshots:
   ltgt@2.2.1:
     optional: true
 
-  lucide-react@1.17.0(react@19.2.5):
-    dependencies:
-      react: 19.2.5
-
   lunr-languages@1.20.0: {}
 
   lunr@2.3.9: {}
@@ -26017,18 +26001,18 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)):
-    dependencies:
-      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
-      '@swc/counter': 0.1.3
-      webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)
-    optional: true
-
   swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.7)(postcss@8.5.15)):
     dependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       '@swc/counter': 0.1.3
       webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
+
+  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.107.2(esbuild@0.27.7)):
+    dependencies:
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      webpack: 5.107.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
+    optional: true
 
   swr@2.3.8(react@19.2.5):
     dependencies:
@@ -26068,13 +26052,13 @@ snapshots:
       lightningcss: 1.32.0
       postcss: 8.5.15
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(esbuild@0.27.7)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)
+      webpack: 5.107.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       '@swc/html': 1.15.24
@@ -26172,8 +26156,6 @@ snapshots:
       tldts-core: 7.0.30
 
   tmp@0.2.5: {}
-
-  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -26921,7 +26903,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(@swc/html@1.15.24)(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(esbuild@0.27.7))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Description

Remove the unused `tmp` package from devDependencies.

The `tmp` package was added in PR #238 (2021-04-19) as a missing dependency for `scripts/plugins/closure-plugin.js`, which used `tmp.fileSync()` to create temporary files for the Closure Compiler plugin. However, this plugin is no longer part of the build pipeline and there are no current usages of the `tmp` package anywhere in the codebase.

### Changes

- Remove `"tmp": "^0.2.7"` from `package.json` devDependencies
- Update `pnpm-lock.yaml`