### PR TITLE
[lexical-playground] Bug Fix: CodeBlock layout-exit e2e expected HTML

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
@@ -1042,7 +1042,7 @@ test.describe('CodeBlock', () => {
                 dir="auto"
                 spellcheck="false"
                 data-gutter="1">
-                <br />
+                <br data-lexical-managed-linebreak="true" />
               </code>
             </div>
             <div
@@ -1050,7 +1050,7 @@ test.describe('CodeBlock', () => {
               dir="auto"
               data-lexical-layout-item="true">
               <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                <br />
+                <br data-lexical-managed-linebreak="true" />
               </p>
             </div>
           </div>
@@ -1082,10 +1082,10 @@ test.describe('CodeBlock', () => {
                 dir="auto"
                 spellcheck="false"
                 data-gutter="1">
-                <br />
+                <br data-lexical-managed-linebreak="true" />
               </code>
               <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                <br />
+                <br data-lexical-managed-linebreak="true" />
               </p>
             </div>
             <div
@@ -1093,7 +1093,7 @@ test.describe('CodeBlock', () => {
               dir="auto"
               data-lexical-layout-item="true">
               <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-                <br />
+                <br data-lexical-managed-linebreak="true" />
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Description

#8615 ([Breaking Change] add `data-lexical-managed-linebreak` to managed `<br>` nodes) ships the attribute on the runtime DOM but doesn't update the expected HTML in `CodeBlock.spec.mjs`'s "ArrowRight / ArrowDown key should exit from the code block inside the layout" tests. CI on main has failed those two tests on every push since #8615 landed (see the run on the #8615 merge commit `9f3c1dbed`).

Update the five `<br />` placeholders across the two `assertHTML` templates to carry the attribute, matching the actual rendered DOM.

## Test plan

- [x] `pnpm test-e2e-chromium CodeBlock` — 16 / 16 on this branch (previously 14 / 16 on main; both ArrowRight and ArrowDown layout-exit cases now pass)
- [x] Verified at `9f3c1dbed^` (`708459f7a`) the original spec + lexical core pass the same 16 / 16, bisecting the regression to #8615

## Backwards compatibility

Test-only change. No runtime impact.