### PR TITLE
[lexical] Bug Fix: Preserve dead keys composed on a fresh paragraph in Firefox

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -772,10 +772,22 @@ export function $updateSelectedTextFromDOM(
     let textContent = getAnchorTextFromDOM(anchorNode);
     const node = $getNearestNodeFromDOMNode(anchorNode);
     if (textContent !== null && $isTextNode(node)) {
+      // The DOM text of a node that was composing still carries the trailing
+      // COMPOSITION_SUFFIX appended by the reconciler, so the placeholder DOM
+      // text is e.g. COMPOSITION_START_CHAR + COMPOSITION_SUFFIX. Strip that
+      // suffix before comparing against the placeholder. Without this, a dead
+      // key composed on a fresh paragraph (where the committed character only
+      // arrives via `data` and is never written into the DOM text node) would
+      // strip down to an empty string and remove the node entirely (#8697).
+      const placeholderTextContent =
+        textContent !== COMPOSITION_SUFFIX &&
+        textContent.endsWith(COMPOSITION_SUFFIX)
+          ? textContent.slice(0, -COMPOSITION_SUFFIX.length)
+          : textContent;
       // Data is intentionally truthy, as we check for boolean, null and empty string.
       if (
-        (textContent === COMPOSITION_SUFFIX ||
-          textContent === COMPOSITION_START_CHAR) &&
+        (placeholderTextContent === COMPOSITION_SUFFIX ||
+          placeholderTextContent === COMPOSITION_START_CHAR) &&
         data
       ) {
         const offset = data.length;

--- a/packages/lexical/src/__tests__/unit/LexicalFirefoxDeadKey.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalFirefoxDeadKey.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {registerRichText} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $getRoot,
+  $setSelection,
+  LexicalEditor,
+} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+vi.mock('lexical/src/environment', () => ({
+  CAN_USE_BEFORE_INPUT: true,
+  CAN_USE_DOM: true,
+  IS_ANDROID: false,
+  IS_ANDROID_CHROME: false,
+  IS_APPLE: false,
+  IS_APPLE_WEBKIT: false,
+  IS_CHROME: false,
+  IS_FIREFOX: true,
+  IS_IOS: false,
+  IS_SAFARI: false,
+}));
+
+function setDOMSelectionInside(textNode: Text, offset: number) {
+  const sel = window.getSelection();
+  if (sel) {
+    const range = document.createRange();
+    range.setStart(textNode, offset);
+    range.setEnd(textNode, offset);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+}
+
+describe('Firefox dead key on empty paragraph (#8697)', () => {
+  let container: HTMLDivElement;
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('data-lexical-editor', 'true');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    editor = createTestEditor();
+    registerRichText(editor);
+    editor.setRootElement(container);
+  });
+
+  afterEach(() => {
+    editor.setRootElement(null);
+    document.body.removeChild(container);
+  });
+
+  test('a dead key composed on a fresh paragraph keeps the typed character', async () => {
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().clear().append(paragraph);
+        const sel = $createRangeSelection();
+        sel.anchor.set(paragraph.getKey(), 0, 'element');
+        sel.focus.set(paragraph.getKey(), 0, 'element');
+        $setSelection(sel);
+      },
+      {discrete: true},
+    );
+
+    // keydown for the dead key
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', {bubbles: true, key: 'Dead'}),
+    );
+
+    // compositionstart — lexical inserts COMPOSITION_START_CHAR (NBSP) into a
+    // brand new text node and the reconciler appends COMPOSITION_SUFFIX (ZWSP),
+    // so the DOM text node is COMPOSITION_START_CHAR + COMPOSITION_SUFFIX.
+    container.dispatchEvent(
+      new CompositionEvent('compositionstart', {bubbles: true, data: ''}),
+    );
+
+    const span = container.querySelector('p span');
+    const domText = (span && span.firstChild) as Text | null;
+    expect(domText).not.toBeNull();
+    // The placeholder + suffix only; the dead-key character is "pending" in the
+    // IME and is NOT written into the DOM text node (this is the dead-key case).
+    expect(domText!.nodeValue).toBe('\u00A0\u200B');
+    setDOMSelectionInside(domText!, 1);
+
+    // compositionend — Firefox commits the dead key. The committed character is
+    // only delivered via `data`; the DOM text node is still the placeholder.
+    container.dispatchEvent(
+      new CompositionEvent('compositionend', {bubbles: true, data: '`'}),
+    );
+
+    // onInput fires after compositionend on Firefox.
+    const inputEvent = new InputEvent('input', {
+      bubbles: true,
+      data: '`',
+      inputType: 'insertCompositionText',
+    });
+    Object.defineProperty(inputEvent, 'isComposing', {value: false});
+    container.dispatchEvent(inputEvent);
+
+    // Allow the deferred (20ms) empty-node removal timer to fire.
+    await new Promise(r => setTimeout(r, 50));
+
+    let text = '';
+    editor.read(() => {
+      text = $getRoot().getTextContent();
+    });
+    expect(text).toBe('`');
+  });
+});


### PR DESCRIPTION


<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

When a dead key is composed on an empty paragraph, lexical inserts a COMPOSITION_START_CHAR placeholder into a new text node and the reconciler appends a COMPOSITION_SUFFIX to its DOM. With dead keys the committed character only arrives via the composition `data` and is never written into the DOM text node, so the placeholder DOM text is COMPOSITION_START_CHAR + COMPOSITION_SUFFIX. The placeholder check in $updateSelectedTextFromDOM compared against COMPOSITION_START_CHAR exactly, missed the trailing suffix, fell through, stripped both characters to an empty string and removed the node entirely (losing the typed character).

Strip a trailing COMPOSITION_SUFFIX before comparing against the placeholder so the composition `data` is used to set the text content instead of the node being removed.

Closes #8697

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*