### PR TITLE
[lexical] Bug Fix: Recheck text node contents on deletion with composition

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -836,16 +836,19 @@ export function $updateTextNodeFromDOMContent(
       }
     }
     const prevTextContent = node.getTextContent();
-
     if (compositionEnd || normalizedTextContent !== prevTextContent) {
+      const selection = $getSelection();
+
       if (normalizedTextContent === '') {
         $setCompositionKey(null);
         if (!IS_SAFARI && !IS_IOS && !IS_APPLE_WEBKIT) {
           // For composition (mainly Android), we have to remove the node on a later update
           const editor = getActiveEditor();
+          $setTextContentWithSelection(node, '', selection);
+
           setTimeout(() => {
             editor.update(() => {
-              if (node.isAttached()) {
+              if (node.isAttached() && node.getTextContent() === '') {
                 node.remove();
               }
             });
@@ -884,7 +887,6 @@ export function $updateTextNodeFromDOMContent(
         node.markDirty();
         return;
       }
-      const selection = $getSelection();
 
       if (
         !$isRangeSelection(selection) ||

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -28,9 +28,11 @@ import {
   SerializedTextNode,
   TextNode,
 } from 'lexical';
-import {describe, expect, test, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 
 import {
+  $setCompositionKey,
+  $updateTextNodeFromDOMContent,
   emptyFunction,
   generateRandomKey,
   getCachedTypeToNodeMap,
@@ -964,6 +966,96 @@ describe('$copyNode', () => {
       expect($getState(copiedParagraph, STRING_STATE)).toBe('non-default');
       expect(initialParagraph.__string).toBe('not-aliased');
       expect(copiedParagraph.__string).toBe('non-default');
+    });
+  });
+});
+
+describe('$updateTextNodeFromDOMContent', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createEditorWithTextNode(initialText: string) {
+    const editor = createEditor({
+      namespace: 'test',
+      nodes: [ParagraphNode, TextNode],
+      onError(error) {
+        throw error;
+      },
+    });
+
+    let textNode!: TextNode;
+    editor.update(
+      () => {
+        textNode = $createTextNode(initialText).toggleUnmergeable();
+        $getRoot().append($createParagraphNode().append(textNode));
+      },
+      {discrete: true},
+    );
+
+    return {editor, textNode};
+  }
+
+  test('removes delayed composition text node if it stays empty', () => {
+    const {editor, textNode} = createEditorWithTextNode('ツ');
+
+    editor.update(
+      () => {
+        $setCompositionKey(textNode.getKey());
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        $updateTextNodeFromDOMContent(textNode.getLatest(), '', 0, 0, false);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect(textNode.getLatest().getTextContent()).toBe('');
+    });
+
+    vi.runOnlyPendingTimers();
+
+    editor.read(() => {
+      expect(() => textNode.getLatest()).toThrow();
+    });
+  });
+
+  test('does not remove delayed composition text node if IME repopulates it', () => {
+    const {editor, textNode} = createEditorWithTextNode('ツ');
+
+    editor.update(
+      () => {
+        $setCompositionKey(textNode.getKey());
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        $updateTextNodeFromDOMContent(textNode.getLatest(), '', 0, 0, false);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        $updateTextNodeFromDOMContent(textNode.getLatest(), 'ツ', 1, 1, false);
+      },
+      {discrete: true},
+    );
+
+    vi.runOnlyPendingTimers();
+
+    editor.read(() => {
+      expect(textNode.getLatest().getTextContent()).toBe('ツ');
     });
   });
 });


### PR DESCRIPTION
## Description
This is an attempt to fix https://github.com/facebook/lexical/issues/8697.

On non-Apple devices, if the user is typing a new paragraph via IME composition (in my case, dead keys) and then deletes the character, the text node is scheduled for deletion in `#updateTextNodeFromDOMContent`. However, if this key is typed again very quickly, the node is still removed despite having text in it.

This is almost impossible to repro on Android, as the 20ms delay is too small. But in KDE this issue surfaced because [it incorrectly emits a new, empty `compositionupdate` event incorrectly](https://discussion.fedoraproject.org/t/dead-key-input-fails-on-first-character-on-firefox/183565/7).

You can emulate this on Android by increasing the removal delay to around 200ms, triggering composition with kanji, and then deleting and typing the same character again very fast.

## Test plan
Added two unit tests:
- the first checks that the node is still deleted if it stays empty
- the second checks that the node is kept if characters were inserted before the 20ms timer

### Before
[before.webm](https://github.com/user-attachments/assets/722a1d10-ad7b-406e-a3dc-a2d9c916121d)

### After
[after.webm](https://github.com/user-attachments/assets/1faf80b5-204b-4b3b-b6f9-14e080224ba0)