### PR TITLE
[lexical] Feature: Replace LexicalEditor.readPending with editor.read(mode, fn) overload

### DIFF
--- a/packages/lexical-extension/src/SelectBlockExtension.ts
+++ b/packages/lexical-extension/src/SelectBlockExtension.ts
@@ -79,11 +79,11 @@ export const SelectBlockExtension = /* @__PURE__ */ defineExtension({
                 if (!stores.cascadeSelection.peek()) {
                   return false;
                 }
-                // readPending() reflects an update in progress or queued
+                // read('pending') reflects an update in progress or queued
                 // in the nested editor (such as its initial state) without
                 // flushing it, which would not be safe if its update is
                 // still in progress
-                const isAllSelected = triggerEditor.readPending(() => {
+                const isAllSelected = triggerEditor.read('pending', () => {
                   const nestedSelection = $getSelection();
                   return (
                     $isRangeSelection(nestedSelection) &&

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -296,8 +296,8 @@ declare export class LexicalEditor {
     maybeStringifiedEditorState: string | SerializedEditorState,
     updateFn?: () => void,
   ): EditorState;
-  read<V>(callbackFn: () => V, options?: EditorReadOptions): V;
-  readPending<V>(callbackFn: () => V): V;
+  read<V>(callbackFn: () => V): V;
+  read<V>(mode: EditorReadMode, callbackFn: () => V): V;
   update(updateFn: () => void, options?: EditorUpdateOptions): boolean;
   focus(callbackFn?: () => void, options?: EditorFocusOptions): void;
   blur(): void;
@@ -305,9 +305,7 @@ declare export class LexicalEditor {
   setEditable(editable: boolean): void;
   toJSON(): SerializedEditor;
 }
-type EditorReadOptions = {
-  pending?: boolean,
-};
+export type EditorReadMode = 'force-commit' | 'pending' | 'latest';
 export type EditorUpdateOptions = {
   onUpdate?: () => void,
   tag?: string | string[],

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -137,6 +137,21 @@ export type EditorSetOptions = {
   tag?: string;
 };
 
+/**
+ * Controls which editor state {@link LexicalEditor.read} observes and whether
+ * pending updates are flushed before the read.
+ *
+ * - `'force-commit'` (the default) flushes any pending updates immediately
+ *   before the read, so it always observes a fully committed and reconciled
+ *   state.
+ * - `'pending'` reads the pending state if it exists, otherwise the committed
+ *   state, without flushing. This is safe to call when an update may already
+ *   be in progress at the cost of possibly observing an uncommitted state.
+ * - `'latest'` reads the latest committed state without flushing pending
+ *   updates, equivalent to `editor.getEditorState().read(callbackFn, {editor})`.
+ */
+export type EditorReadMode = 'force-commit' | 'pending' | 'latest';
+
 export interface EditorFocusOptions {
   /**
    * Where to move selection when the editor is
@@ -1635,28 +1650,36 @@ export class LexicalEditor {
    * Executes a read of the editor's state, with the
    * editor context available (useful for exporting and read-only DOM
    * operations). Much like update, but prevents any mutation of the
-   * editor's state. Any pending updates will be flushed immediately before
-   * the read.
+   * editor's state.
+   *
+   * When called with a single argument the `mode` defaults to
+   * `'force-commit'`, which flushes any pending updates immediately before the
+   * read so it always observes a fully committed and reconciled state. See
+   * {@link EditorReadMode} for the behavior of the other modes (`'pending'`
+   * and `'latest'`).
    * @param callbackFn - A function that has access to read-only editor state.
    */
-  read<T>(callbackFn: () => T): T {
-    $commitPendingUpdates(this);
-    return this.getEditorState().read(callbackFn, {editor: this});
-  }
-
+  read<T>(callbackFn: () => T): T;
   /**
-   * Executes a read of the editor's pending state if it exists, otherwise
-   * the committed state, with the editor context available. Unlike
-   * {@link LexicalEditor.read}, pending updates are not flushed before the
-   * read, so this is safe to call when an update may already be in
-   * progress (such as from another editor's command listener) at the cost
-   * of possibly observing a state that has not been committed yet.
+   * Executes a read of the editor's state in the given `mode`, with the editor
+   * context available. See {@link EditorReadMode} for the available modes.
+   * @param mode - Which editor state to read and whether to flush first.
    * @param callbackFn - A function that has access to read-only editor state.
    */
-  readPending<T>(callbackFn: () => T): T {
-    return (this._pendingEditorState || this._editorState).read(callbackFn, {
-      editor: this,
-    });
+  read<T>(mode: EditorReadMode, callbackFn: () => T): T;
+  read<T>(...args: [() => T] | [EditorReadMode, () => T]): T {
+    const [mode, callbackFn]: [EditorReadMode, () => T] =
+      args.length === 1 ? ['force-commit', args[0]] : args;
+    if (mode === 'force-commit') {
+      $commitPendingUpdates(this);
+    }
+    // 'pending' observes an in-progress or queued update without flushing it;
+    // 'force-commit' and 'latest' read the committed (reconciled) state.
+    const editorState =
+      mode === 'pending'
+        ? this._pendingEditorState || this._editorState
+        : this.getEditorState();
+    return editorState.read(callbackFn, {editor: this});
   }
 
   /**

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
@@ -33,8 +33,9 @@ describe('LexicalEditorState tests', () => {
       expect(editorState._selection).toBe(null);
     });
 
-    test('readPending()', () => {
+    test("read('pending' | 'latest' | 'force-commit')", () => {
       const {editor} = testEnv;
+      const $textContent = () => $getRoot().getTextContent();
 
       // a regular update is processed synchronously but committed
       // asynchronously
@@ -43,18 +44,21 @@ describe('LexicalEditorState tests', () => {
           $createParagraphNode().append($createTextNode('foo')),
         );
       });
-      expect(
-        editor.getEditorState().read(() => $getRoot().getTextContent()),
-      ).toBe('');
-      // readPending() observes the pending state without flushing it
-      expect(editor.readPending(() => $getRoot().getTextContent())).toBe('foo');
-      expect(
-        editor.getEditorState().read(() => $getRoot().getTextContent()),
-      ).toBe('');
-      // read() flushes the pending state
-      expect(editor.read(() => $getRoot().getTextContent())).toBe('foo');
-      // without a pending state, readPending() reads the committed state
-      expect(editor.readPending(() => $getRoot().getTextContent())).toBe('foo');
+      expect(editor.getEditorState().read($textContent)).toBe('');
+      // read('pending') observes the pending state without flushing it
+      expect(editor.read('pending', $textContent)).toBe('foo');
+      // read('latest') reads the committed state without flushing the pending
+      // state, equivalent to editor.getEditorState().read(fn, {editor})
+      expect(editor.read('latest', $textContent)).toBe('');
+      // neither 'pending' nor 'latest' commits the pending state
+      expect(editor.getEditorState().read($textContent)).toBe('');
+      // read() defaults to 'force-commit', which flushes the pending state
+      expect(editor.read($textContent)).toBe('foo');
+      expect(editor.getEditorState().read($textContent)).toBe('foo');
+      // without a pending state, all modes read the committed state
+      expect(editor.read('pending', $textContent)).toBe('foo');
+      expect(editor.read('latest', $textContent)).toBe('foo');
+      expect(editor.read('force-commit', $textContent)).toBe('foo');
     });
 
     test('read()', async () => {

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -144,6 +144,7 @@ export type {
   EditableListener,
   EditorConfig,
   EditorDOMRenderConfig,
+  EditorReadMode,
   EditorSetOptions,
   EditorThemeClasses,
   EditorThemeClassName,


### PR DESCRIPTION
## Description

Remove `LexicalEditor.readPending` in favor of an overloaded `read` whose optional first argument is an `EditorReadMode`:

- `'force-commit'` (the default, equivalent to the previous single-argument `read`) flushes pending updates before reading the committed state.
- `'pending'` reads the pending state without flushing (the previous `readPending` behavior); `editor.readPending(fn)` becomes `editor.read('pending', fn)`.
- `'latest'` reads the committed state without flushing, equivalent to `editor.getEditorState().read(fn, {editor})`.

Update the flow types (dropping the stale `EditorReadOptions` that had drifted from the implementation), export the new `EditorReadMode` type, and migrate the SelectBlockExtension call site and unit tests.

While this does remove an existing API, this shouldn't be considered a breaking change because readPending was added in https://github.com/facebook/lexical/pull/8532 which has not made it into a release yet (merged after 0.45.0).

## Test plan

New unit tests