### PR TITLE
[*] Refactor: Migrate editor.getEditorState().read(...) to editor.read('latest', ...)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,11 +190,13 @@ When adding/modifying APIs, types must be maintained for both systems.
 ## Important Development Notes
 
 ### Reconciliation and Updates
-- `editor.read()` flushes pending updates first, then provides consistent reconciled state
+- `editor.read(...)`  or `editor.read('force-commit', ...)` flushes pending updates first, then provides consistent reconciled state
+- `editor.read('pending', ...)` reads the pending state (like `editor.update(...)`, but read-only)
+- `editor.read('latest', ...)` reads the latest consistent reconciled state
 - Inside `editor.update()`, you see pending state (transforms/reconciliation not yet run)
-- `editor.getEditorState().read()` always uses latest reconciled state
-- Updates can be nested: `editor.update(() => editor.update(...))` is allowed
-- Do NOT nest reads in updates or vice versa (except read at end of update, which flushes)
+- `editor.getEditorState().read()` always uses latest reconciled state, but prefer `editor.read('latest', ...)` in new code
+- Updates can be nested: `editor.update(() => editor.update(...))` is allowed but strongly discouraged
+- Do NOT nest updates in reads, or use a force-commit in an update
 
 ### Node References
 Always access node properties/methods within read/update context. Nodes automatically resolve to their latest version via their key. Don't store node references across update boundaries.

--- a/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
@@ -362,7 +362,7 @@ export function registerHighlightingOnly(
       editor.registerMutationListener(
         CodeNode,
         mutations => {
-          editor.getEditorState().read(() => {
+          editor.read('latest', () => {
             for (const [key, type] of mutations) {
               if (type !== 'destroyed') {
                 const node = $getNodeByKey(key);

--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -379,7 +379,7 @@ export function registerHighlightingOnly(
       editor.registerMutationListener(
         CodeNode,
         mutations => {
-          editor.getEditorState().read(() => {
+          editor.read('latest', () => {
             for (const [key, type] of mutations) {
               if (type !== 'destroyed') {
                 const node = $getNodeByKey(key);

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
@@ -202,7 +202,7 @@ describe('LexicalCodeNode tests', () => {
         $getSelection()!.insertText('foo');
       });
       expect(
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           return $getNodeByKey(tabKey) !== null;
         }),
       );

--- a/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
+++ b/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
@@ -92,26 +92,23 @@ function shouldClaimClick(
   if (event.target !== rootElement) {
     return false;
   }
-  return editor.getEditorState().read(
-    () => {
-      const lastChild = $getRoot().getLastChild();
-      if (lastChild === null) {
-        return false;
-      }
-      const lastChildDOM = editor.getElementByKey(lastChild.getKey());
-      if (lastChildDOM === null) {
-        return false;
-      }
-      // Exclusive lower edge — clicks at exactly the bottom pixel fall
-      // through to native handling, which is what users expect when
-      // they click on a block's visible bottom border.
-      if (event.clientY <= lastChildDOM.getBoundingClientRect().bottom) {
-        return false;
-      }
-      return $shouldInsertAfter(lastChild);
-    },
-    {editor},
-  );
+  return editor.read('latest', () => {
+    const lastChild = $getRoot().getLastChild();
+    if (lastChild === null) {
+      return false;
+    }
+    const lastChildDOM = editor.getElementByKey(lastChild.getKey());
+    if (lastChildDOM === null) {
+      return false;
+    }
+    // Exclusive lower edge — clicks at exactly the bottom pixel fall
+    // through to native handling, which is what users expect when
+    // they click on a block's visible bottom border.
+    if (event.clientY <= lastChildDOM.getBoundingClientRect().bottom) {
+      return false;
+    }
+    return $shouldInsertAfter(lastChild);
+  });
 }
 
 /**

--- a/packages/lexical-extension/src/IMEExtension.ts
+++ b/packages/lexical-extension/src/IMEExtension.ts
@@ -89,7 +89,7 @@ export const IMEExtension = /* @__PURE__ */ defineExtension({
         composingTextNode.value = null;
         return;
       }
-      composingTextNode.value = editor.getEditorState().read(() => {
+      composingTextNode.value = editor.read('latest', () => {
         const node = $getNodeByKey(key);
         return $isTextNode(node) ? node : null;
       });

--- a/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
+++ b/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
@@ -202,9 +202,9 @@ describe('LexicalHeadlessEditor', () => {
 
     const cleanup = setupDom();
 
-    const html = editor
-      .getEditorState()
-      .read(() => $generateHtmlFromNodes(editor, null), {editor});
+    const html = editor.read('latest', () =>
+      $generateHtmlFromNodes(editor, null),
+    );
 
     cleanup();
 
@@ -229,9 +229,7 @@ describe('LexicalHeadlessEditor', () => {
         ),
       );
       const html = withDOM(() =>
-        editor
-          .getEditorState()
-          .read(() => $generateHtmlFromNodes(editor, null), {editor}),
+        editor.read('latest', () => $generateHtmlFromNodes(editor, null)),
       );
 
       expect(html).toBe(

--- a/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
@@ -89,11 +89,9 @@ describe('HTML', () => {
         discrete: true,
       });
 
-      expect(
-        editor
-          .getEditorState()
-          .read(() => $generateHtmlFromNodes(editor), {editor}),
-      ).toBe(html);
+      expect(editor.read('latest', () => $generateHtmlFromNodes(editor))).toBe(
+        html,
+      );
     });
   }
 

--- a/packages/lexical-link/src/ClickableLinkExtension.ts
+++ b/packages/lexical-link/src/ClickableLinkExtension.ts
@@ -86,7 +86,7 @@ export function registerClickableLink(
     }
 
     // Allow user to select link text without following url
-    const selection = editor.getEditorState().read($getSelection, {editor});
+    const selection = editor.read('latest', $getSelection);
     if ($isRangeSelection(selection) && !selection.isCollapsed()) {
       event.preventDefault();
       return;

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -176,7 +176,7 @@ export function registerCheckList(
     editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_LEFT_COMMAND,
       event => {
-        return editor.getEditorState().read(() => {
+        return editor.read('latest', () => {
           const selection = $getSelection();
 
           if ($isRangeSelection(selection) && selection.isCollapsed()) {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -883,11 +883,9 @@ describe('Markdown', () => {
         },
       );
 
-      expect(
-        editor
-          .getEditorState()
-          .read(() => $generateHtmlFromNodes(editor), {editor}),
-      ).toBe(html);
+      expect(editor.read('latest', () => $generateHtmlFromNodes(editor))).toBe(
+        html,
+      );
     });
   }
 
@@ -929,15 +927,13 @@ describe('Markdown', () => {
       );
 
       expect(
-        editor
-          .getEditorState()
-          .read(() =>
-            $convertToMarkdownString(
-              [...(customTransformers || []), ...TRANSFORMERS],
-              undefined,
-              shouldPreserveNewLines,
-            ),
+        editor.read('latest', () =>
+          $convertToMarkdownString(
+            [...(customTransformers || []), ...TRANSFORMERS],
+            undefined,
+            shouldPreserveNewLines,
           ),
+        ),
       ).toBe(mdAfterExport ?? md);
     });
   }
@@ -983,7 +979,7 @@ describe('Markdown', () => {
         },
       );
 
-      expect(editor.getEditorState().read(() => $getSelection())).toBe(null);
+      expect(editor.read('latest', () => $getSelection())).toBe(null);
     });
   }
 
@@ -1111,9 +1107,7 @@ describe('Markdown', () => {
     );
 
     expect(
-      editor
-        .getEditorState()
-        .read(() => $convertToMarkdownString(TRANSFORMERS)),
+      editor.read('latest', () => $convertToMarkdownString(TRANSFORMERS)),
     ).toBe(markdown);
   });
 
@@ -1148,9 +1142,7 @@ describe('Markdown', () => {
     );
 
     expect(
-      editor
-        .getEditorState()
-        .read(() => $convertToMarkdownString(TRANSFORMERS)),
+      editor.read('latest', () => $convertToMarkdownString(TRANSFORMERS)),
     ).toBe(markdown);
   });
 
@@ -1173,9 +1165,9 @@ describe('Markdown', () => {
     );
 
     // Export should compute fence to be ```` (4 backticks) since content contains ```
-    const exported = editor
-      .getEditorState()
-      .read(() => $convertToMarkdownString(TRANSFORMERS));
+    const exported = editor.read('latest', () =>
+      $convertToMarkdownString(TRANSFORMERS),
+    );
 
     expect(exported).toBe(
       '````markdown\n```js\nconsole.log("hello");\n```\n````',
@@ -1198,7 +1190,7 @@ describe('Markdown', () => {
           ),
         {discrete: true},
       );
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const node = $getRoot().getFirstChild();
         expect(node).toBeInstanceOf(ListNode);
         const marker = node ? $getState(node, listMarkerState) : undefined;
@@ -1271,7 +1263,7 @@ describe('Markdown', () => {
         },
         {discrete: true},
       );
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const markdownString = $convertToMarkdownString(
           [...TRANSFORMERS],
           undefined,
@@ -1897,15 +1889,13 @@ bar`;
     );
 
     expect(
-      editor
-        .getEditorState()
-        .read(() =>
-          $convertToMarkdownString(
-            [...TRANSFORMERS, HIGHLIGHT_TEXT_MATCH_IMPORT],
-            undefined,
-            true,
-          ),
+      editor.read('latest', () =>
+        $convertToMarkdownString(
+          [...TRANSFORMERS, HIGHLIGHT_TEXT_MATCH_IMPORT],
+          undefined,
+          true,
         ),
+      ),
     ).toBe(md);
   });
 
@@ -1937,15 +1927,13 @@ bar`;
     );
 
     expect(
-      editor
-        .getEditorState()
-        .read(() =>
-          $convertToMarkdownString(
-            [...TRANSFORMERS, HIGHLIGHT_TEXT_MATCH_IMPORT],
-            undefined,
-            true,
-          ),
+      editor.read('latest', () =>
+        $convertToMarkdownString(
+          [...TRANSFORMERS, HIGHLIGHT_TEXT_MATCH_IMPORT],
+          undefined,
+          true,
         ),
+      ),
     ).toBe(md);
   });
 });
@@ -1980,14 +1968,12 @@ describe('markdown whitespace import (default mode)', () => {
     );
 
     expect(
-      editor
-        .getEditorState()
-        .read(() =>
-          $convertToMarkdownString([
-            ...TRANSFORMERS,
-            HIGHLIGHT_TEXT_MATCH_IMPORT,
-          ]),
-        ),
+      editor.read('latest', () =>
+        $convertToMarkdownString([
+          ...TRANSFORMERS,
+          HIGHLIGHT_TEXT_MATCH_IMPORT,
+        ]),
+      ),
     ).toBe(md);
   }
 
@@ -2009,7 +1995,7 @@ describe('markdown whitespace import (default mode)', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const block = $getRoot().getFirstChildOrThrow();
       assert($isElementNode(block), 'Expected an element block');
       const lineBreakNode = block
@@ -2028,14 +2014,12 @@ describe('markdown whitespace import (default mode)', () => {
     });
 
     expect(
-      editor
-        .getEditorState()
-        .read(() =>
-          $convertToMarkdownString([
-            ...TRANSFORMERS,
-            HIGHLIGHT_TEXT_MATCH_IMPORT,
-          ]),
-        ),
+      editor.read('latest', () =>
+        $convertToMarkdownString([
+          ...TRANSFORMERS,
+          HIGHLIGHT_TEXT_MATCH_IMPORT,
+        ]),
+      ),
     ).toBe(md);
   }
 
@@ -2054,14 +2038,12 @@ describe('markdown whitespace import (default mode)', () => {
     );
 
     expect(
-      editor
-        .getEditorState()
-        .read(() =>
-          $convertToMarkdownString([
-            ...TRANSFORMERS,
-            HIGHLIGHT_TEXT_MATCH_IMPORT,
-          ]),
-        ),
+      editor.read('latest', () =>
+        $convertToMarkdownString([
+          ...TRANSFORMERS,
+          HIGHLIGHT_TEXT_MATCH_IMPORT,
+        ]),
+      ),
     ).toBe(md);
   });
 
@@ -2079,14 +2061,12 @@ describe('markdown whitespace import (default mode)', () => {
     );
 
     expect(
-      editor
-        .getEditorState()
-        .read(() =>
-          $convertToMarkdownString([
-            ...TRANSFORMERS,
-            HIGHLIGHT_TEXT_MATCH_IMPORT,
-          ]),
-        ),
+      editor.read('latest', () =>
+        $convertToMarkdownString([
+          ...TRANSFORMERS,
+          HIGHLIGHT_TEXT_MATCH_IMPORT,
+        ]),
+      ),
     ).toBe(md);
   });
 
@@ -2132,7 +2112,7 @@ describe('markdown whitespace import (default mode)', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const block = $getRoot().getFirstChildOrThrow();
       assert($isElementNode(block), 'Expected an element block');
       const lineBreakNode = block
@@ -2145,14 +2125,12 @@ describe('markdown whitespace import (default mode)', () => {
     });
 
     expect(
-      editor
-        .getEditorState()
-        .read(() =>
-          $convertToMarkdownString([
-            ...TRANSFORMERS,
-            HIGHLIGHT_TEXT_MATCH_IMPORT,
-          ]),
-        ),
+      editor.read('latest', () =>
+        $convertToMarkdownString([
+          ...TRANSFORMERS,
+          HIGHLIGHT_TEXT_MATCH_IMPORT,
+        ]),
+      ),
     ).toBe(md);
   });
 
@@ -2206,14 +2184,12 @@ describe('markdown whitespace import (default mode)', () => {
     );
 
     expect(
-      editor
-        .getEditorState()
-        .read(() =>
-          $convertToMarkdownString([
-            ...TRANSFORMERS,
-            HIGHLIGHT_TEXT_MATCH_IMPORT,
-          ]),
-        ),
+      editor.read('latest', () =>
+        $convertToMarkdownString([
+          ...TRANSFORMERS,
+          HIGHLIGHT_TEXT_MATCH_IMPORT,
+        ]),
+      ),
     ).toBe('foo   \nbar');
   });
 
@@ -2258,9 +2234,7 @@ describe('markdown Safari compatibility (issue #8012)', () => {
     editor.update(() => $convertFromMarkdownString(md, TRANSFORMERS), {
       discrete: true,
     });
-    return editor
-      .getEditorState()
-      .read(() => $convertToMarkdownString(TRANSFORMERS));
+    return editor.read('latest', () => $convertToMarkdownString(TRANSFORMERS));
   }
 
   it('does not throw when constructing markdown regex patterns', () => {
@@ -2290,9 +2264,9 @@ describe('markdown Safari compatibility (issue #8012)', () => {
       () => $convertFromMarkdownString('\\`not code\\`', TRANSFORMERS),
       {discrete: true},
     );
-    const textContent = editor
-      .getEditorState()
-      .read(() => $getRoot().getTextContent());
+    const textContent = editor.read('latest', () =>
+      $getRoot().getTextContent(),
+    );
     expect(textContent).toBe('`not code`');
   });
 
@@ -2333,12 +2307,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('Hello World');
   });
 
@@ -2355,12 +2326,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('World');
   });
 
@@ -2385,12 +2353,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('Hello **Bold**');
   });
 
@@ -2412,12 +2377,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('');
   });
 
@@ -2434,12 +2396,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('Hello');
   });
 
@@ -2464,12 +2423,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('First paragraph\n\nSecond paragraph');
   });
 
@@ -2496,12 +2452,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('- Item 1\n- Item 2');
   });
 
@@ -2522,12 +2475,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('[link](https://example.com)');
   });
 
@@ -2557,12 +2507,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('- Item 2\n- It');
   });
 
@@ -2581,12 +2528,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('> Line 2');
   });
 
@@ -2618,12 +2562,9 @@ describe('$convertSelectionToMarkdownString', () => {
       },
       {discrete: true},
     );
-    const result = editor
-      .getEditorState()
-      .read(
-        () => $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
-        {editor},
-      );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
     expect(result).toBe('    - Nested A');
   });
 });

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -268,7 +268,7 @@ export default function ImageComponent({
   const isInNodeSelection = useMemo(
     () =>
       isSelected &&
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
         return $isNodeSelection(selection) && selection.has(nodeKey);
       }),
@@ -349,7 +349,7 @@ export default function ImageComponent({
 
   const onRightClick = useCallback(
     (event: MouseEvent): void => {
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const latestSelection = $getSelection();
         const domElement = event.target as HTMLElement;
         if (

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -250,7 +250,7 @@ export default function ActionsPlugin({
 
   useEffect(() => {
     return editor.registerUpdateListener(() => {
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
         const children = root.getChildren();
 

--- a/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
@@ -540,31 +540,24 @@ export const AutocompleteExtension = /* @__PURE__ */ defineExtension({
       if (!isEditorFocused()) {
         return;
       }
-      editor.getEditorState().read(
-        () => {
-          const selection = $getSelection();
-          const [hasMatch, match] = $search(selection);
-          if (
-            !hasMatch ||
-            match !== lastMatch ||
-            !$isRangeSelection(selection)
-          ) {
-            return;
-          }
-          const node = selection.getNodes()[0];
-          if (!$isTextNode(node)) {
-            return;
-          }
-          activeTextNodeKey = node.getKey();
-          lastSuggestion = newSuggestion;
-          syncGhost(
-            editor,
-            activeTextNodeKey,
-            formatSuggestionText(newSuggestion),
-          );
-        },
-        {editor},
-      );
+      editor.read('latest', () => {
+        const selection = $getSelection();
+        const [hasMatch, match] = $search(selection);
+        if (!hasMatch || match !== lastMatch || !$isRangeSelection(selection)) {
+          return;
+        }
+        const node = selection.getNodes()[0];
+        if (!$isTextNode(node)) {
+          return;
+        }
+        activeTextNodeKey = node.getKey();
+        lastSuggestion = newSuggestion;
+        syncGhost(
+          editor,
+          activeTextNodeKey,
+          formatSuggestionText(newSuggestion),
+        );
+      });
     }
 
     function handleUpdate({

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
@@ -116,7 +116,7 @@ function CodeActionMenuContainer({
     return editor.registerMutationListener(
       CodeNode,
       mutations => {
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           for (const [key, type] of mutations) {
             switch (type) {
               case 'created':

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
@@ -82,7 +82,7 @@ export class CollapsibleContainerNode extends ElementNode {
       const detailsDom = document.createElement('details');
       detailsDom.open = this.__open;
       detailsDom.addEventListener('toggle', () => {
-        const open = editor.getEditorState().read(() => this.getOpen());
+        const open = editor.read('latest', () => this.getOpen());
         if (open !== detailsDom.open) {
           editor.update(() => this.toggleOpen());
         }

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContentNode.ts
@@ -34,7 +34,7 @@ export class CollapsibleContentNode extends ElementNode {
     const dom = document.createElement('div');
     dom.classList.add('Collapsible__content');
     if (IS_CHROME || IS_FIREFOX) {
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const containerNode = this.getParentOrThrow();
         if (!$isCollapsibleContainerNode(containerNode)) {
           throw new Error(

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -235,7 +235,7 @@ function CommentInputBox({
   const author = useCollabAuthorName();
 
   const updateLocation = useCallback(() => {
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const selection = $getSelection();
 
       if ($isRangeSelection(selection)) {
@@ -328,7 +328,7 @@ function CommentInputBox({
 
   const submitComment = () => {
     if (canSubmit) {
-      let quote = editor.getEditorState().read(() => {
+      let quote = editor.read('latest', () => {
         const selection = selectionRef.current;
         return selection ? selection.getTextContent() : '';
       });
@@ -858,7 +858,7 @@ export default function CommentPlugin({
       editor.registerMutationListener(
         MarkNode,
         mutations => {
-          editor.getEditorState().read(() => {
+          editor.read('latest', () => {
             for (const [key, mutation] of mutations) {
               const node = $getNodeByKey(key);
               let ids: NodeKey[] = [];

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -248,7 +248,7 @@ function FloatingLinkEditor({
   }, [editor, $updateLinkEditor, setIsLink, isLink]);
 
   useEffect(() => {
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       $updateLinkEditor();
     });
   }, [editor, $updateLinkEditor]);

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -155,7 +155,7 @@ function TextFormatFloatingToolbar({
     const scrollerElem = anchorElem.parentElement;
 
     const update = () => {
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         $updateTextFormatFloatingToolbar();
       });
     };
@@ -174,7 +174,7 @@ function TextFormatFloatingToolbar({
   }, [editor, $updateTextFormatFloatingToolbar, anchorElem]);
 
   useEffect(() => {
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       $updateTextFormatFloatingToolbar();
     });
     return mergeRegister(
@@ -340,7 +340,7 @@ function useFloatingTextFormatToolbar(
   const [isCode, setIsCode] = useState(false);
 
   const updatePopup = useCallback(() => {
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       // Should not to pop up the floating toolbar when using IME input
       if (editor.isComposing()) {
         return;

--- a/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
@@ -49,7 +49,7 @@ export interface PagesConfig {
 
 export const PagesExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config) => {
-    const getPageSetup = () => editor.getEditorState().read($getPageSetup);
+    const getPageSetup = () => editor.read('latest', $getPageSetup);
 
     return {
       ...namedSignals({disabled: config.disabled}),
@@ -287,7 +287,7 @@ export const PagesExtension = /* @__PURE__ */ defineExtension({
       // the corresponding CSS custom properties to the root element, or removes
       // them when paged mode is disabled.
       const updatePageDimensions = () => {
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           const pageSetup = $getPageSetup();
           const rootElement = editor.getRootElement();
           if (!rootElement) return;
@@ -699,7 +699,7 @@ export const PagesExtension = /* @__PURE__ */ defineExtension({
               RootNode,
               (_mutations, {prevEditorState}) => {
                 const change = $getStateChange(
-                  editor.getEditorState().read($getRoot),
+                  editor.read('latest', $getRoot),
                   prevEditorState.read($getRoot),
                   pageSetupState,
                 );

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -89,7 +89,7 @@ function $selectLastDescendant(node: ElementNode): void {
 }
 
 function currentCellBackgroundColor(editor: LexicalEditor): null | string {
-  return editor.getEditorState().read(() => {
+  return editor.read('latest', () => {
     const selection = $getSelection();
     if ($isRangeSelection(selection) || $isTableSelection(selection)) {
       const [cell] = $getNodeTriplet(selection.anchor);
@@ -142,7 +142,7 @@ function TableActionMenu({
           nodeMutations.get(tableCellNode.getKey()) === 'updated';
 
         if (nodeUpdated) {
-          editor.getEditorState().read(() => {
+          editor.read('latest', () => {
             updateTableCellNode(tableCellNode.getLatest());
           });
           setBackgroundColor(currentCellBackgroundColor(editor) || '');
@@ -153,7 +153,7 @@ function TableActionMenu({
   }, [editor, tableCellNode]);
 
   useEffect(() => {
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const selection = $getSelection();
       // Merge cells
       if ($isTableSelection(selection)) {
@@ -853,7 +853,7 @@ function TableCellActionMenuContainer({
     let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
     const callback = () => {
       timeoutId = undefined;
-      editor.getEditorState().read($moveMenu, {editor});
+      editor.read('latest', $moveMenu);
     };
     const delayedCallback = () => {
       if (timeoutId === undefined) {

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -134,30 +134,27 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
         const cell = getDOMCellFromTarget(target);
 
         if (cell && activeCell !== cell) {
-          editor.getEditorState().read(
-            () => {
-              const tableCellNode = $getNearestNodeFromDOMNode(cell.elem);
-              if (!tableCellNode) {
-                throw new Error('TableCellResizer: Table cell node not found.');
-              }
+          editor.read('latest', () => {
+            const tableCellNode = $getNearestNodeFromDOMNode(cell.elem);
+            if (!tableCellNode) {
+              throw new Error('TableCellResizer: Table cell node not found.');
+            }
 
-              const tableNode =
-                $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
-              const tableElement = getTableElement(
-                tableNode,
-                editor.getElementByKey(tableNode.getKey()),
-              );
+            const tableNode =
+              $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
+            const tableElement = getTableElement(
+              tableNode,
+              editor.getElementByKey(tableNode.getKey()),
+            );
 
-              if (!tableElement) {
-                throw new Error('TableCellResizer: Table element not found.');
-              }
+            if (!tableElement) {
+              throw new Error('TableCellResizer: Table element not found.');
+            }
 
-              targetRef.current = target;
-              tableRectRef.current = tableElement.getBoundingClientRect();
-              updateActiveCell(cell);
-            },
-            {editor},
-          );
+            targetRef.current = target;
+            tableRectRef.current = tableElement.getBoundingClientRect();
+            updateActiveCell(cell);
+          });
         } else if (cell == null) {
           resetState();
         }

--- a/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
@@ -126,7 +126,7 @@ export default function TableFitNestedTablePlugin(): null {
 
   useEffect(() => {
     return editor.registerMutationListener(TableNode, nodeMutations => {
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const modifiedTables = new Set<TableNode>();
         for (const [nodeKey, mutation] of nodeMutations) {
           if (mutation === 'created' || mutation === 'updated') {

--- a/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
@@ -378,13 +378,10 @@ function TableHoverActionsV2({
       setCanReorder(false);
       return;
     }
-    editor.getEditorState().read(
-      () => {
-        const tableNode = $getNearestNodeFromDOMNode(hoveredTable);
-        setCanReorder($isTableNode(tableNode) && $isSimpleTable(tableNode));
-      },
-      {editor},
-    );
+    editor.read('latest', () => {
+      const tableNode = $getNearestNodeFromDOMNode(hoveredTable);
+      setCanReorder($isTableNode(tableNode) && $isSimpleTable(tableNode));
+    });
   }, [editor, hoveredTable]);
 
   useEffect(() => {

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -54,7 +54,7 @@ function TableOfContentsList({
   const [editor] = useLexicalComposerContext();
 
   function scrollToNode(key: NodeKey, currIndex: number) {
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const domElement = editor.getElementByKey(key);
       if (domElement !== null) {
         domElement.scrollIntoView({behavior: 'smooth', block: 'center'});

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -801,12 +801,9 @@ export default function ToolbarPlugin({
   }, [editor, $updateToolbar, setActiveEditor]);
 
   useEffect(() => {
-    activeEditor.getEditorState().read(
-      () => {
-        $updateToolbar();
-      },
-      {editor: activeEditor},
-    );
+    activeEditor.read('latest', () => {
+      $updateToolbar();
+    });
   }, [activeEditor, $updateToolbar]);
 
   useEffect(() => {

--- a/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
@@ -145,7 +145,7 @@ export function VersionsPlugin({id}: {id: string}) {
           userToColor.set(user, color);
           return color;
         };
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           for (const [nodeKey, mutation] of nodes.entries()) {
             if (mutation === 'destroyed') {
               continue;

--- a/packages/lexical-playground/src/plugins/VisibleNonPrintingExtension.ts
+++ b/packages/lexical-playground/src/plugins/VisibleNonPrintingExtension.ts
@@ -211,9 +211,9 @@ export const VisibleNonPrintingExtension = /* @__PURE__ */ defineExtension({
         }
         nextRoot.setAttribute(VISIBLE_NON_PRINTING_ACTIVE_ATTR, 'true');
         const syncEmptyRootAttr = () => {
-          const showPlaceholder = editor
-            .getEditorState()
-            .read(() => $canShowPlaceholder(editor.isComposing()));
+          const showPlaceholder = editor.read('latest', () =>
+            $canShowPlaceholder(editor.isComposing()),
+          );
           nextRoot.toggleAttribute(
             VISIBLE_NON_PRINTING_EMPTY_ROOT_ATTR,
             showPlaceholder,

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -164,7 +164,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
 
   const checkIfLinkNodeIsEmbeddable = useCallback(
     async (key: NodeKey) => {
-      const url = editor.getEditorState().read(function () {
+      const url = editor.read('latest', function () {
         const linkNode = $getNodeByKey(key);
         if ($isLinkNode(linkNode)) {
           return linkNode.getURL();
@@ -232,7 +232,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
   const embedLinkViaActiveEmbedConfig = useCallback(
     async function () {
       if (activeEmbedConfig != null && nodeKey != null) {
-        const linkNode = editor.getEditorState().read(() => {
+        const linkNode = editor.read('latest', () => {
           const node = $getNodeByKey(nodeKey);
           if ($isLinkNode(node)) {
             return node;

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -61,7 +61,7 @@ function getCurrentIndex(keysLength: number): number {
 }
 
 function getTopLevelNodeKeys(editor: LexicalEditor): string[] {
-  return editor.getEditorState().read(() => $getRoot().getChildrenKeys());
+  return editor.read('latest', () => $getRoot().getChildrenKeys());
 }
 
 function getCollapsedMargins(elem: HTMLElement): {
@@ -106,7 +106,7 @@ function getBlockElement(
 
   let blockElem: HTMLElement | null = null;
 
-  editor.getEditorState().read(() => {
+  editor.read('latest', () => {
     if (useEdgeAsDefault) {
       const [firstNode, lastNode] = [
         editor.getElementByKey(topLevelNodeKeys[0]),

--- a/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
@@ -150,7 +150,7 @@ export function TableOfContentsPlugin({children}: Props): JSX.Element {
   useEffect(() => {
     // Set table of contents initial state
     let currentTableOfContents: TableOfContentsEntry[] = [];
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const updateCurrentTableOfContents = (node: ElementNode) => {
         for (const child of node.getChildren()) {
           if ($isHeadingNode(child)) {
@@ -204,7 +204,7 @@ export function TableOfContentsPlugin({children}: Props): JSX.Element {
     const removeHeaderMutationListener = editor.registerMutationListener(
       HeadingNode,
       (mutatedNodes: Map<string, NodeMutation>) => {
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           for (const [nodeKey, mutation] of mutatedNodes) {
             if (mutation === 'created') {
               const newHeading = $getNodeByKey(nodeKey);
@@ -244,7 +244,7 @@ export function TableOfContentsPlugin({children}: Props): JSX.Element {
     const removeTextNodeMutationListener = editor.registerMutationListener(
       TextNode,
       (mutatedNodes: Map<string, NodeMutation>) => {
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           for (const [nodeKey, mutation] of mutatedNodes) {
             if (mutation === 'updated') {
               const currNode = $getNodeByKey(nodeKey);

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -78,7 +78,7 @@ function tryToPositionRange(
 
 function getQueryTextForSearch(editor: LexicalEditor): string | null {
   let text = null;
-  editor.getEditorState().read(() => {
+  editor.read('latest', () => {
     const selection = $getSelection();
     if (!$isRangeSelection(selection)) {
       return;
@@ -95,7 +95,7 @@ function isSelectionOnEntityBoundary(
   if (offset !== 0) {
     return false;
   }
-  return editor.getEditorState().read(() => {
+  return editor.read('latest', () => {
     const selection = $getSelection();
     if ($isRangeSelection(selection)) {
       const anchor = selection.anchor;
@@ -266,7 +266,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
 
   useEffect(() => {
     const updateListener = () => {
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         // Check if editor is in read-only mode
         if (!editor.isEditable()) {
           closeTypeahead();

--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -816,7 +816,7 @@ describe('Collaboration', () => {
         });
       });
 
-      let editor2State = client2.getEditorState().read(() => {
+      let editor2State = client2.getEditor().read('latest', () => {
         const paragraph = $assertNodeType(
           $getRoot().getFirstChild(),
           $isParagraphNode,
@@ -835,7 +835,7 @@ describe('Collaboration', () => {
         });
       });
 
-      editor2State = client2.getEditorState().read(() => {
+      editor2State = client2.getEditor().read('latest', () => {
         const paragraph = $assertNodeType(
           $getRoot().getFirstChild(),
           $isParagraphNode,

--- a/packages/lexical-react/src/__tests__/unit/CollaborationConcurrentReconcile.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationConcurrentReconcile.test.ts
@@ -280,7 +280,7 @@ async function runProgram(cids: number[], ops: Op[]): Promise<string[]> {
       },
       {discrete: true},
     );
-    return ed.getEditorState().read(() =>
+    return ed.read('latest', () =>
       $getRoot()
         .getChildren()
         .map(c => '<' + c.getTextContent() + '>')

--- a/packages/lexical-react/src/__tests__/unit/CollaborationLocalEditAfterRemoteSync.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationLocalEditAfterRemoteSync.test.ts
@@ -233,7 +233,7 @@ function execEdit(peer: Peer, k: number, off: number, ch: string) {
 // A structural snapshot that distinguishes "no children" from "one empty
 // paragraph" (plain text content cannot).
 function liveSnapshot(peer: Peer): string {
-  return peer.editor.getEditorState().read(() =>
+  return peer.editor.read('latest', () =>
     $getRoot()
       .getChildren()
       .map(c => `${c.getType()}(${JSON.stringify(c.getTextContent())})`)
@@ -260,7 +260,7 @@ function reloadSnapshot(peer: Peer): string {
     },
     {discrete: true},
   );
-  return ed.getEditorState().read(() =>
+  return ed.read('latest', () =>
     $getRoot()
       .getChildren()
       .map(c => `${c.getType()}(${JSON.stringify(c.getTextContent())})`)

--- a/packages/lexical-react/src/__tests__/unit/CollaborationSnapshot.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationSnapshot.test.ts
@@ -52,7 +52,7 @@ describe('CollaborationSnapshot', () => {
     editor2 = client2.getEditor();
 
     const mutationListener: MutationListener = mutations => {
-      editor1.getEditorState().read(() => {
+      editor1.read('latest', () => {
         for (const [nodeKey, mutation] of mutations) {
           if (mutation === 'destroyed') {
             continue;

--- a/packages/lexical-react/src/__tests__/unit/CollaborationUndoEcho.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationUndoEcho.test.ts
@@ -233,9 +233,10 @@ function persistedParagraphCount(peer: Peer): number {
     },
     {discrete: true},
   );
-  return editor
-    .getEditorState()
-    .read(() => $getRoot().getChildren().filter($isElementNode).length);
+  return editor.read(
+    'latest',
+    () => $getRoot().getChildren().filter($isElementNode).length,
+  );
 }
 
 describe('Collaborative undo empty-paragraph echo (#8651)', () => {
@@ -250,7 +251,7 @@ describe('Collaborative undo empty-paragraph echo (#8651)', () => {
     const undoB = createUndoManager(B.binding, B.binding.root.getSharedType());
 
     const firstText = (peer: Peer) =>
-      peer.editor.getEditorState().read(() => {
+      peer.editor.read('latest', () => {
         const p = $getRoot().getFirstChild();
         const t = $isElementNode(p) ? p.getFirstChild() : null;
         return $isTextNode(t) ? t : null;

--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
@@ -157,7 +157,7 @@ describe('LexicalComposer tests', () => {
           // otherwise you could see 'initial stateinitial state'.
           expect([
             i,
-            editor.getEditorState().read(() => $getRoot().getTextContent()),
+            editor.read('latest', () => $getRoot().getTextContent()),
           ]).toEqual([i, 'initial state']);
         });
         // Only one context is created in both cases though!

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -112,7 +112,7 @@ describe('LexicalNodeHelpers tests', () => {
         reactRoot.render(<App />);
       });
 
-      const text = editor!.getEditorState().read($rootTextContent);
+      const text = editor!.read('latest', $rootTextContent);
       expect(text).toBe('foo');
     });
   }
@@ -165,7 +165,7 @@ describe('LexicalNodeHelpers tests', () => {
 
       await editor!.focus();
 
-      await editor!.getEditorState().read(() => {
+      await editor!.read('latest', () => {
         expect($rootTextContent()).toBe('foo');
 
         const selection = $getSelection();

--- a/packages/lexical-react/src/shared/useCanShowPlaceholder.ts
+++ b/packages/lexical-react/src/shared/useCanShowPlaceholder.ts
@@ -17,9 +17,10 @@ import useLayoutEffect from './useLayoutEffect';
 function canShowPlaceholderFromCurrentEditorState(
   editor: LexicalEditor,
 ): boolean {
-  const currentCanShowPlaceholder = editor
-    .getEditorState()
-    .read($canShowPlaceholderCurry(editor.isComposing()));
+  const currentCanShowPlaceholder = editor.read(
+    'latest',
+    $canShowPlaceholderCurry(editor.isComposing()),
+  );
 
   return currentCanShowPlaceholder;
 }

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -62,7 +62,7 @@ export function useCharacterLimit(
   }, [editor]);
 
   useEffect(() => {
-    let text = editor.getEditorState().read($rootTextContent, {editor});
+    let text = editor.read('latest', $rootTextContent);
     let lastComputedTextLength = 0;
 
     return mergeRegister(

--- a/packages/lexical-react/src/useLexicalIsTextContentEmpty.ts
+++ b/packages/lexical-react/src/useLexicalIsTextContentEmpty.ts
@@ -18,9 +18,10 @@ export function useLexicalIsTextContentEmpty(
   trim?: boolean,
 ): boolean {
   const [isEmpty, setIsEmpty] = useState(
-    editor
-      .getEditorState()
-      .read($isRootTextContentEmptyCurry(editor.isComposing(), trim)),
+    editor.read(
+      'latest',
+      $isRootTextContentEmptyCurry(editor.isComposing(), trim),
+    ),
   );
 
   useLayoutEffect(() => {

--- a/packages/lexical-react/src/useLexicalNodeSelection.ts
+++ b/packages/lexical-react/src/useLexicalNodeSelection.ts
@@ -27,7 +27,7 @@ import {useCallback, useEffect, useState} from 'react';
  */
 
 function isNodeSelected(editor: LexicalEditor, key: NodeKey): boolean {
-  return editor.getEditorState().read(() => {
+  return editor.read('latest', () => {
     const node = $getNodeByKey(key);
 
     if (node === null) {

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -288,7 +288,7 @@ describe('LexicalSelection tests', () => {
 
     await applySelectionInputs([insertText('x')], update, editor!);
 
-    editor!.getEditorState().read(() => {
+    editor!.read('latest', () => {
       const xNode = $getRoot()
         .getAllTextNodes()
         .find(node => node.getTextContent() === 'x');
@@ -2026,7 +2026,7 @@ describe('LexicalSelection tests', () => {
 
           listNode.remove();
         });
-        await editor!.getEditorState().read(() => {
+        await editor!.read('latest', () => {
           const selection = $assertRangeSelection($getSelection());
           expect(selection.anchor.key).toBe(paragraphNodeKey);
           expect(selection.focus.key).toBe(paragraphNodeKey);

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -320,7 +320,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -396,7 +396,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -457,7 +457,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -523,7 +523,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -599,7 +599,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -675,7 +675,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -1189,7 +1189,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -1260,7 +1260,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -2677,7 +2677,7 @@ describe('insertNodes', () => {
       );
       selection.insertNodes([newHeading, $createLineBreakNode()]);
     });
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       expect(element.innerHTML).toBe(
         // the lone trailing LineBreakNode collapses to an empty paragraph,
         // rendered with only the managed linebreak

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -194,15 +194,13 @@ export function $trimTextContentFromAnchor(
     } else {
       const key = currentNode.getKey();
       // See if we can just revert it to what was in the last editor state
-      const prevTextContent: string | null = editor
-        .getEditorState()
-        .read(() => {
-          const prevNode = $getNodeByKey(key);
-          if ($isTextNode(prevNode) && prevNode.isSimpleText()) {
-            return prevNode.getTextContent();
-          }
-          return null;
-        });
+      const prevTextContent: string | null = editor.read('latest', () => {
+        const prevNode = $getNodeByKey(key);
+        if ($isTextNode(prevNode) && prevNode.isSimpleText()) {
+          return prevNode.getTextContent();
+        }
+        return null;
+      });
       const offset = currentNodeSize - remaining;
       const slicedText = text.slice(0, offset);
       if (prevTextContent !== null && prevTextContent !== text) {

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -283,48 +283,42 @@ export class TableObserver {
 
   trackTable() {
     const observer = new MutationObserver(records => {
-      this.editor.getEditorState().read(
-        () => {
-          let gridNeedsRedraw = false;
+      this.editor.read('latest', () => {
+        let gridNeedsRedraw = false;
 
-          for (let i = 0; i < records.length; i++) {
-            const record = records[i];
-            const target = record.target;
-            const nodeName = target.nodeName;
+        for (let i = 0; i < records.length; i++) {
+          const record = records[i];
+          const target = record.target;
+          const nodeName = target.nodeName;
 
-            if (
-              nodeName === 'TABLE' ||
-              nodeName === 'TBODY' ||
-              nodeName === 'THEAD' ||
-              nodeName === 'TR'
-            ) {
-              gridNeedsRedraw = true;
-              break;
-            }
+          if (
+            nodeName === 'TABLE' ||
+            nodeName === 'TBODY' ||
+            nodeName === 'THEAD' ||
+            nodeName === 'TR'
+          ) {
+            gridNeedsRedraw = true;
+            break;
           }
+        }
 
-          if (!gridNeedsRedraw) {
-            return;
-          }
+        if (!gridNeedsRedraw) {
+          return;
+        }
 
-          const {tableNode, tableElement} = this.$lookup();
-          this.table = getTable(tableNode, tableElement);
-        },
-        {editor: this.editor},
-      );
-    });
-    this.editor.getEditorState().read(
-      () => {
         const {tableNode, tableElement} = this.$lookup();
         this.table = getTable(tableNode, tableElement);
-        observer.observe(tableElement, {
-          attributes: true,
-          childList: true,
-          subtree: true,
-        });
-      },
-      {editor: this.editor},
-    );
+      });
+    });
+    this.editor.read('latest', () => {
+      const {tableNode, tableElement} = this.$lookup();
+      this.table = getTable(tableNode, tableElement);
+      observer.observe(tableElement, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+    });
   }
 
   $clearHighlight(setEmptySelection: boolean = true): void {

--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -353,27 +353,24 @@ export function registerTableSelectionObserver(
     editor.registerMutationListener(
       TableNode,
       nodeMutations => {
-        editor.getEditorState().read(
-          () => {
-            for (const [nodeKey, mutation] of nodeMutations) {
-              const tableSelection = tableObservers.observers.get(nodeKey);
-              if (mutation === 'created' || mutation === 'updated') {
-                const {tableNode, tableElement} =
-                  $getTableAndElementByKey(nodeKey);
-                if (tableSelection === undefined) {
-                  initializeTableNode(tableNode, nodeKey, tableElement);
-                } else if (tableElement !== tableSelection[1]) {
-                  // The update created a new DOM node, destroy the existing TableObserver
-                  tableObservers.removeObserver(nodeKey);
-                  initializeTableNode(tableNode, nodeKey, tableElement);
-                }
-              } else if (mutation === 'destroyed') {
+        editor.read('latest', () => {
+          for (const [nodeKey, mutation] of nodeMutations) {
+            const tableSelection = tableObservers.observers.get(nodeKey);
+            if (mutation === 'created' || mutation === 'updated') {
+              const {tableNode, tableElement} =
+                $getTableAndElementByKey(nodeKey);
+              if (tableSelection === undefined) {
+                initializeTableNode(tableNode, nodeKey, tableElement);
+              } else if (tableElement !== tableSelection[1]) {
+                // The update created a new DOM node, destroy the existing TableObserver
                 tableObservers.removeObserver(nodeKey);
+                initializeTableNode(tableNode, nodeKey, tableElement);
               }
+            } else if (mutation === 'destroyed') {
+              tableObservers.removeObserver(nodeKey);
             }
-          },
-          {editor},
-        );
+          }
+        });
       },
       {skipInitialization: false},
     ),

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -162,7 +162,7 @@ describe('TableExtension', () => {
     );
 
     // Verify no nested table was created
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const root = $getRoot();
       const table = root.getFirstChild();
       assert($isTableNode(table), 'Expected table node');
@@ -205,7 +205,7 @@ describe('TableExtension', () => {
     );
 
     // Verify nested table was created
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const root = $getRoot();
       const table = root.getFirstChild();
       assert($isTableNode(table), 'Expected table node');
@@ -257,7 +257,7 @@ describe('TableExtension', () => {
       );
 
       // Verify no nested table was created
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
         const table = root.getFirstChild();
         assert($isTableNode(table), 'Expected table node');
@@ -313,7 +313,7 @@ describe('TableExtension', () => {
       );
 
       // Verify a nested table was created
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
         const table = root.getFirstChild();
         assert($isTableNode(table), 'Expected table node');
@@ -370,7 +370,7 @@ describe('TableExtension', () => {
       );
 
       // Verify the table was extended
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
         const table = root.getFirstChild();
         assert($isTableNode(table), 'Expected table node');
@@ -415,7 +415,7 @@ describe('TableExtension', () => {
         {discrete: true},
       );
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
         const table = $assertNodeType(root.getFirstChild(), $isTableNode);
         expect(table.getColWidths()).toBe(undefined);
@@ -437,7 +437,7 @@ describe('TableExtension', () => {
         {discrete: true},
       );
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
         const table = $assertNodeType(root.getFirstChild(), $isTableNode);
         expect(table.getColWidths()).toEqual([10, 20, 20]);
@@ -459,7 +459,7 @@ describe('TableExtension', () => {
         {discrete: true},
       );
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
         const table = $assertNodeType(root.getFirstChild(), $isTableNode);
         expect(table.getColWidths()).toEqual([10, 20]);
@@ -496,7 +496,7 @@ describe('TableExtension', () => {
       );
 
       // Verify TableSelection was created and all cells are selected
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
         assert(
           $isTableSelection(selection),
@@ -593,7 +593,7 @@ describe('TableExtension', () => {
       );
 
       // Verify TableSelection was created and all cells are selected
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
         assert(
           $isTableSelection(selection),
@@ -680,7 +680,7 @@ describe('TableExtension', () => {
       );
 
       // Verify RangeSelection was created (not TableSelection) since cursor is outside table
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
         assert(
           $isRangeSelection(selection),
@@ -723,7 +723,7 @@ describe('TableExtension', () => {
       );
 
       // Verify RangeSelection was created (not TableSelection) since there's paragraph after table
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const selection = $getSelection();
         assert(
           $isRangeSelection(selection),

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableMobileSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableMobileSelection.test.tsx
@@ -127,7 +127,7 @@ describe('LexicalTableMobileSelection', () => {
         pointerType: 'mouse',
       });
 
-      await testEnv.editor.getEditorState().read(() => {
+      await testEnv.editor.read('latest', () => {
         // For mouse events, anchor should still be set (existing behavior)
         // This test mainly ensures no errors occur
         expect(true).toBe(true); // This test mainly ensures no errors occur
@@ -153,7 +153,7 @@ describe('LexicalTableMobileSelection', () => {
         pointerType: 'touch',
       });
 
-      await testEnv.editor.getEditorState().read(() => {
+      await testEnv.editor.read('latest', () => {
         const selection = $getSelection();
         // Should remain a range selection, not become a table selection
         expect($isRangeSelection(selection)).toBe(true);
@@ -190,7 +190,7 @@ describe('LexicalTableMobileSelection', () => {
         pointerType: 'touch',
       });
 
-      await testEnv.editor.getEditorState().read(() => {
+      await testEnv.editor.read('latest', () => {
         const selection = $getSelection();
         // Should remain a range selection, not become a table selection
         expect($isRangeSelection(selection)).toBe(true);
@@ -231,7 +231,7 @@ describe('LexicalTableMobileSelection', () => {
       // Note: This test verifies that intentional drag operations still work
       // The actual table selection creation depends on the internal state management
       // which is complex to fully simulate in a unit test
-      await testEnv.editor.getEditorState().read(() => {
+      await testEnv.editor.read('latest', () => {
         // For now, we just verify no errors occur
         // In a real implementation, you might need more sophisticated simulation
         expect(true).toBe(true);
@@ -263,7 +263,7 @@ describe('LexicalTableMobileSelection', () => {
         pointerType: 'touch',
       });
 
-      await testEnv.editor.getEditorState().read(() => {
+      await testEnv.editor.read('latest', () => {
         // Should handle mixed input gracefully without errors
         expect(true).toBe(true);
       });
@@ -308,7 +308,7 @@ describe('LexicalTableMobileSelection', () => {
         pointerType: 'mouse',
       });
 
-      await testEnv.editor.getEditorState().read(() => {
+      await testEnv.editor.read('latest', () => {
         const selection = $getSelection();
         // After mouse re-enters with buttons: 0, selection should be cleaned up
         // and should not be a table selection (drag was interrupted)

--- a/packages/lexical-table/src/__tests__/unit/LexicalTablePlugin.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTablePlugin.test.tsx
@@ -53,7 +53,7 @@ describe('LexicalTablePlugin', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const root = $getRoot();
       const table = root.getFirstChild();
 
@@ -95,7 +95,7 @@ describe('LexicalTablePlugin', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const root = $getRoot();
       const table = root.getFirstChild();
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -90,7 +90,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -122,7 +122,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -154,7 +154,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -186,7 +186,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -218,7 +218,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -250,7 +250,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -282,7 +282,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -314,7 +314,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -348,7 +348,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -402,7 +402,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -442,7 +442,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');
@@ -475,7 +475,7 @@ describe('$moveTableColumn', () => {
       {discrete: true},
     );
 
-    editor.getEditorState().read(() => {
+    editor.read('latest', () => {
       const table = $getRoot().getFirstChild();
       if (!$isTableNode(table)) {
         throw new Error('Expected table node');

--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -143,7 +143,7 @@ describe('LexicalNodeHelpers tests', () => {
 
       test('DFS node order', async () => {
         const editor: LexicalEditor = testEnv.editor;
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           const expectedNodes = expectedKeys.map(({depth, node: nodeKey}) => ({
             depth,
             node: $getNodeByKey(nodeKey)!.getLatest(),
@@ -165,7 +165,7 @@ describe('LexicalNodeHelpers tests', () => {
 
       test('Reverse DFS node order', async () => {
         const editor: LexicalEditor = testEnv.editor;
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           const expectedNodes = reverseExpectedKeys.map(
             ({depth, node: nodeKey}) => ({
               depth,

--- a/packages/lexical-utils/src/__tests__/unit/LexicalRootHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalRootHelpers.test.ts
@@ -20,7 +20,7 @@ describe('LexicalRootHelpers tests', () => {
     it('textContent', async () => {
       const editor = testEnv.editor;
 
-      expect(editor.getEditorState().read($rootTextContent)).toBe('');
+      expect(editor.read('latest', $rootTextContent)).toBe('');
 
       await editor.update(() => {
         const root = $getRoot();
@@ -32,16 +32,17 @@ describe('LexicalRootHelpers tests', () => {
         expect($rootTextContent()).toBe('foo');
       });
 
-      expect(editor.getEditorState().read($rootTextContent)).toBe('foo');
+      expect(editor.read('latest', $rootTextContent)).toBe('foo');
     });
 
     it('isBlank', async () => {
       const editor = testEnv.editor;
 
       expect(
-        editor
-          .getEditorState()
-          .read($isRootTextContentEmptyCurry(editor.isComposing())),
+        editor.read(
+          'latest',
+          $isRootTextContentEmptyCurry(editor.isComposing()),
+        ),
       ).toBe(true);
 
       await editor.update(() => {
@@ -55,9 +56,10 @@ describe('LexicalRootHelpers tests', () => {
       });
 
       expect(
-        editor
-          .getEditorState()
-          .read($isRootTextContentEmptyCurry(editor.isComposing())),
+        editor.read(
+          'latest',
+          $isRootTextContentEmptyCurry(editor.isComposing()),
+        ),
       ).toBe(false);
     });
   });

--- a/packages/lexical-website/docs/concepts/commands.md
+++ b/packages/lexical-website/docs/concepts/commands.md
@@ -73,8 +73,8 @@ editor.registerCommand(
 You can register a command from anywhere you have access to the `editor` object, but it's important that you remember to clean up the listener with its remove listener callback when it's no longer needed.
 
 The command listener will always be called from an `editor.update`, so you may use dollar functions. You should not use
-`editor.update` (and *never* call `editor.read`) synchronously from within a command listener. It is safe to call
-`editor.getEditorState().read` if you need to read the previous state after updates have already been made.
+`editor.update` (and *never* call `editor.read(...)` or `editor.read('force-commit', ...)`) synchronously from within a command listener. It is safe to call
+`editor.read('latest', ...)` or `editor.getEditorState().read` if you need to read the previous state after updates have already been made.
 
 ```js
 const removeListener = editor.registerCommand(

--- a/packages/lexical-website/docs/intro.md
+++ b/packages/lexical-website/docs/intro.md
@@ -62,7 +62,7 @@ Editor States are also fully serializable to JSON and can easily be serialized b
 ### Reading and Updating Editor State
 
 When you want to read and/or update the Lexical node tree, you must do it via `editor.update(() => {...})`. You may also do
-read-only operations with the editor state via `editor.read(() => {...})` or `editor.getEditorState().read(() => {...})`.
+read-only operations with the editor state via `editor.read(mode, () => {...})` or `editor.getEditorState().read(() => {...})`.
 The closure passed to the update or read call is important, and must be synchronous. It's the only place where you have full
 "lexical" context of the active editor state, and providing you with access to the Editor State's node tree. We promote using
 the convention of using `$` prefixed functions (such as `$getRoot()`) to convey that these functions must be called in this
@@ -79,10 +79,18 @@ For those familiar with React Hooks, you can think of these $functions as having
 
 Node Transforms and Command Listeners are called with an implicit `editor.update(() => {...})` context.
 
-It is permitted to do nested updates, or nested reads, but an update should not be nested in a read
-or vice versa. For example, `editor.update(() => editor.update(() => {...}))` is allowed. It is permitted
-to nest an `editor.read` at the end of an `editor.update`, but this will immediately flush the update
-and any additional update in that callback will throw an error.
+It is permitted to do nested updates, or nested reads, but updates should never be nested in reads.
+
+Nested updates are very strongly discouraged because they execute in a very
+unintuitive deferred manner. When a nested update is scheduled, it returns
+immediately with no effect, and then executes some time after the parent
+update has returned.
+
+Reads can be nested, and can be called inside of an update
+(e.g. to read the previous version of a node), but you should not
+call `editor.read(...)` or `editor.read('force-commit', ...)` inside of an
+update because it will immediately flush the update and any additional
+code in that update may throw an error.
 
 All Lexical Nodes are dependent on the associated Editor State. With few exceptions, you should only call methods
 and access properties of a Lexical Node while in a read or update call (just like `$` functions). Methods
@@ -99,11 +107,15 @@ having Lexical Nodes always refer to the editor state allows for a simpler and l
 
 :::tip
 
-If you use `editor.read(() => { /* callback */ })` it will first flush any pending updates, so you will
-always see a consistent state. When you are in an `editor.update`, you will always be working with the
-pending state, where node transforms and DOM reconciliation may not have run yet.
-`editor.getEditorState().read()` will use the latest reconciled `EditorState` (after any node transforms,
-DOM reconciliation, etc. have already run), any pending `editor.update` mutations will not yet be visible.
+If you use `editor.read(() => { /* callback */ })` or
+`editor.read('force-commit', () => { /* callback */ })` it will first flush
+any pending updates, so you will always see a consistent state. When you are
+in an `editor.update` or `editor.read('pending', ...)`, you will always be
+working with the pending state, where node transforms and DOM reconciliation
+may not have run yet. `editor.read('latest', ...)` or
+`editor.getEditorState().read()` will use the latest reconciled `EditorState`
+(after any node transforms, DOM reconciliation, etc. have already run), any
+pending `editor.update` mutations will not yet be visible.
 
 :::
 

--- a/packages/lexical-yjs/src/__tests__/unit/SyncCursorsOutOfRange.test.ts
+++ b/packages/lexical-yjs/src/__tests__/unit/SyncCursorsOutOfRange.test.ts
@@ -249,7 +249,7 @@ function setupCaretOnEmptyFinalLine(client: TestClient): string {
 function readAnchor(
   editor: LexicalEditor,
 ): {key: string; offset: number; type: 'element' | 'text'} | null {
-  return editor.getEditorState().read(() => {
+  return editor.read('latest', () => {
     const selection = $getSelection();
     if (!$isRangeSelection(selection)) {
       return null;
@@ -297,9 +297,10 @@ describe('SyncCursors out-of-range relative position (PR #8652)', () => {
     // public binding-level API. Before the fix this collapsed to offset 0 (the
     // start of the paragraph); after the fix it resolves to the element end
     // (the number of children == 2).
-    const {anchorKey, anchorOffset, focusKey, focusOffset} = local.editor
-      .getEditorState()
-      .read(() => $getAnchorAndFocusForUserState(local.binding, userState!));
+    const {anchorKey, anchorOffset, focusKey, focusOffset} = local.editor.read(
+      'latest',
+      () => $getAnchorAndFocusForUserState(local.binding, userState!),
+    );
 
     expect(anchorKey).toBe(paragraphKey);
     expect(focusKey).toBe(paragraphKey);
@@ -333,7 +334,7 @@ describe('SyncCursors out-of-range relative position (PR #8652)', () => {
 
     // The remote edit must have arrived.
     expect(
-      local.editor.getEditorState().read(() => $getRoot().getChildrenSize()),
+      local.editor.read('latest', () => $getRoot().getChildrenSize()),
     ).toBe(2);
 
     // The local caret must remain on the empty final line. Before the fix it

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -146,7 +146,8 @@ export type EditorSetOptions = {
  *   state.
  * - `'pending'` reads the pending state if it exists, otherwise the committed
  *   state, without flushing. This is safe to call when an update may already
- *   be in progress at the cost of possibly observing an uncommitted state.
+ *   be in progress at the cost of possibly observing an uncommitted state
+ *   before node transforms, DOM reconciliation, etc. have run.
  * - `'latest'` reads the latest committed state without flushing pending
  *   updates, equivalent to `editor.getEditorState().read(callbackFn, {editor})`.
  */

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -70,7 +70,7 @@ function isManagedLineBreak(
 }
 
 function getLastSelection(editor: LexicalEditor): null | BaseSelection {
-  return editor.getEditorState().read(() => {
+  return editor.read('latest', () => {
     const selection = $getSelection();
     return selection !== null ? selection.clone() : null;
   });

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParentTextCache.test.ts
@@ -139,19 +139,16 @@ describe('children fast path: cross-parent move and sibling text cache', () => {
     // does not use the root cache). Read from the committed editor state (not
     // `editor.read`, which would flush any pending update first) so this
     // observation is the same snapshot the reconcile just produced.
-    const {cached, fresh} = editor.getEditorState().read(
-      () => {
-        const root = $getRoot();
-        return {
-          cached: root.getTextContent(),
-          fresh: root
-            .getChildren()
-            .map(child => child.getTextContent())
-            .join('\n\n'),
-        };
-      },
-      {editor},
-    );
+    const {cached, fresh} = editor.read('latest', () => {
+      const root = $getRoot();
+      return {
+        cached: root.getTextContent(),
+        fresh: root
+          .getChildren()
+          .map(child => child.getTextContent())
+          .join('\n\n'),
+      };
+    });
 
     expect(cached).toBe(fresh);
   });
@@ -219,19 +216,16 @@ describe('children fast path: cross-parent move and sibling text cache', () => {
 
     expect(errors).toEqual([]);
 
-    const {cached, fresh} = editor.getEditorState().read(
-      () => {
-        const root = $getRoot();
-        return {
-          cached: root.getTextContent(),
-          fresh: root
-            .getChildren()
-            .map(child => child.getTextContent())
-            .join('\n\n'),
-        };
-      },
-      {editor},
-    );
+    const {cached, fresh} = editor.read('latest', () => {
+      const root = $getRoot();
+      return {
+        cached: root.getTextContent(),
+        fresh: root
+          .getChildren()
+          .map(child => child.getTextContent())
+          .join('\n\n'),
+      };
+    });
 
     expect(cached).toBe(fresh);
   });

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -696,9 +696,9 @@ describe('LexicalEditor tests', () => {
 
     await Promise.resolve().then();
 
-    const textContent = editor
-      .getEditorState()
-      .read(() => $getRoot().getTextContent());
+    const textContent = editor.read('latest', () =>
+      $getRoot().getTextContent(),
+    );
     expect(textContent).toBe('Sync update');
     expect(onUpdate).toHaveBeenCalledTimes(1);
     // Calculate an expected update listener paylaod
@@ -1810,7 +1810,7 @@ describe('LexicalEditor tests', () => {
       // Wait for update to complete
       await Promise.resolve().then();
 
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
         const paragraph = root.getFirstChild()!;
         expect(root).toEqual({
@@ -3343,9 +3343,9 @@ describe('LexicalEditor tests', () => {
       },
     );
 
-    const textContent = editor
-      .getEditorState()
-      .read(() => $getRoot().getTextContent());
+    const textContent = editor.read('latest', () =>
+      $getRoot().getTextContent(),
+    );
     expect(textContent).toBe('Sync update');
     expect(onUpdate).toHaveBeenCalledTimes(1);
     // Calculate an expected update listener paylaod
@@ -3374,9 +3374,9 @@ describe('LexicalEditor tests', () => {
       },
     );
 
-    const textContent = headless
-      .getEditorState()
-      .read(() => $getRoot().getTextContent());
+    const textContent = headless.read('latest', () =>
+      $getRoot().getTextContent(),
+    );
     expect(textContent).toBe('Async update\n\nSync update');
     expect(onUpdate).toHaveBeenCalledTimes(1);
   });
@@ -3405,9 +3405,9 @@ describe('LexicalEditor tests', () => {
         discrete: true,
       },
     );
-    const textContent = headless
-      .getEditorState()
-      .read(() => $getRoot().getTextContent());
+    const textContent = headless.read('latest', () =>
+      $getRoot().getTextContent(),
+    );
     expect(textContent).toBe('Async update\n\nSync update');
   });
 
@@ -3431,9 +3431,9 @@ describe('LexicalEditor tests', () => {
       );
     });
 
-    const textContent = editor
-      .getEditorState()
-      .read(() => $getRoot().getTextContent());
+    const textContent = editor.read('latest', () =>
+      $getRoot().getTextContent(),
+    );
     expect(textContent).toBe('Async update\n\nSync update');
     expect(onUpdate).toHaveBeenCalledTimes(1);
   });
@@ -3606,7 +3606,7 @@ describe('LexicalEditor tests', () => {
         expect(text.getTextContent()).toBe('123');
       });
 
-      await newEditor.getEditorState().read(() => {
+      await newEditor.read('latest', () => {
         expect(mockTransform).toHaveBeenCalledTimes(0);
       });
 
@@ -3654,7 +3654,7 @@ describe('LexicalEditor tests', () => {
         expect(text.getTextContent()).toBe('123');
       });
 
-      await newEditor.getEditorState().read(() => {
+      await newEditor.read('latest', () => {
         expect(mockTransform).toHaveBeenCalledTimes(1);
       });
 

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -148,6 +148,8 @@ describe('LexicalNode tests', () => {
           expect(node.__parent).toBe(null);
         });
 
+        // Intentionally read without an active editor (no {editor} context)
+        // so that constructing a keyed node throws via getActiveEditor().
         await editor.getEditorState().read(() => {
           expect(() => new LexicalNode()).toThrow();
           expect(() => new LexicalNode('__custom_key__')).toThrow();
@@ -260,7 +262,7 @@ describe('LexicalNode tests', () => {
           node = new LexicalNode('__custom_key__');
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(node.isAttached()).toBe(false);
           expect(textNode.isAttached()).toBe(true);
           expect(paragraphNode.isAttached()).toBe(true);
@@ -277,7 +279,7 @@ describe('LexicalNode tests', () => {
           node = new LexicalNode('__custom_key__');
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(node.isSelected()).toBe(false);
           expect(textNode.isSelected()).toBe(false);
           expect(paragraphNode.isSelected()).toBe(false);
@@ -287,7 +289,7 @@ describe('LexicalNode tests', () => {
           textNode.select(0, 0);
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.isSelected()).toBe(true);
         });
 
@@ -297,7 +299,7 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.isSelected(): selected text node', async () => {
         const {editor} = testEnv;
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(paragraphNode.isSelected()).toBe(false);
           expect(textNode.isSelected()).toBe(false);
         });
@@ -306,7 +308,7 @@ describe('LexicalNode tests', () => {
           textNode.select(0, 0);
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.isSelected()).toBe(true);
           expect(paragraphNode.isSelected()).toBe(false);
         });
@@ -563,7 +565,7 @@ describe('LexicalNode tests', () => {
           expect(node.getParent()).toBe(null);
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           const rootNode = $getRoot();
           expect(textNode.getParent()).toBe(paragraphNode);
           expect(paragraphNode.getParent()).toBe(rootNode);
@@ -579,7 +581,7 @@ describe('LexicalNode tests', () => {
           expect(() => node.getParentOrThrow()).toThrow();
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           const rootNode = $getRoot();
           expect(textNode.getParent()).toBe(paragraphNode);
           expect(paragraphNode.getParent()).toBe(rootNode);
@@ -595,7 +597,7 @@ describe('LexicalNode tests', () => {
           expect(node.getTopLevelElement()).toBe(null);
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.getTopLevelElement()).toBe(paragraphNode);
           expect(paragraphNode.getTopLevelElement()).toBe(paragraphNode);
         });
@@ -606,7 +608,7 @@ describe('LexicalNode tests', () => {
           $getRoot().append(node);
           expect(node.getTopLevelElement()).toBe(node);
         });
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           const elementNodes: ElementNode[] = [];
           const decoratorNodes: DecoratorNode<unknown>[] = [];
           for (const child of $getRoot().getChildren()) {
@@ -634,7 +636,7 @@ describe('LexicalNode tests', () => {
           expect(() => node.getTopLevelElementOrThrow()).toThrow();
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.getTopLevelElementOrThrow()).toBe(paragraphNode);
           expect(paragraphNode.getTopLevelElementOrThrow()).toBe(paragraphNode);
         });
@@ -659,7 +661,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           const rootNode = $getRoot();
           expect(textNode.getParents()).toEqual([paragraphNode, rootNode]);
           expect(paragraphNode.getParents()).toEqual([rootNode]);
@@ -681,7 +683,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">bar</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(barTextNode.getPreviousSibling()).toEqual({
             ...textNode,
             __next: '3',
@@ -708,7 +710,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">bar</span><span data-lexical-text="true">baz</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(bazTextNode.getPreviousSiblings()).toEqual([
             {
               ...textNode,
@@ -744,7 +746,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">bar</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(barTextNode.getNextSibling()).toEqual(null);
           expect(textNode.getNextSibling()).toEqual(barTextNode);
         });
@@ -768,7 +770,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">bar</span><span data-lexical-text="true">baz</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(bazTextNode.getNextSiblings()).toEqual([]);
           expect(barTextNode.getNextSiblings()).toEqual([bazTextNode]);
           expect(textNode.getNextSiblings()).toEqual([
@@ -816,7 +818,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">qux</span></p><p dir="auto"><span data-lexical-text="true">bar</span></p><p dir="auto"><span data-lexical-text="true">baz</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           const rootNode = $getRoot();
           expect(textNode.getCommonAncestor(rootNode)).toBe(rootNode);
           expect(quxTextNode.getCommonAncestor(rootNode)).toBe(rootNode);
@@ -849,7 +851,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">bar</span><span data-lexical-text="true">baz</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.isBefore(textNode)).toBe(false);
           expect(textNode.isBefore(barTextNode)).toBe(true);
           expect(textNode.isBefore(bazTextNode)).toBe(true);
@@ -863,7 +865,7 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.isParentOf()', async () => {
         const {editor} = testEnv;
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           const rootNode = $getRoot();
           expect(rootNode.isParentOf(textNode)).toBe(true);
           expect(rootNode.isParentOf(paragraphNode)).toBe(true);
@@ -900,7 +902,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">bar</span><span data-lexical-text="true">baz</span></p><p dir="auto"><span data-lexical-text="true">qux</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.getNodesBetween(textNode)).toEqual([textNode]);
           expect(textNode.getNodesBetween(barTextNode)).toEqual([
             textNode,
@@ -936,7 +938,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">token</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.isToken()).toBe(false);
           expect(tokenTextNode.isToken()).toBe(true);
         });
@@ -956,7 +958,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">segmented</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.isSegmented()).toBe(false);
           expect(segmentedTextNode.isSegmented()).toBe(true);
         });
@@ -979,7 +981,7 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">foo</span><span data-lexical-text="true">directionless</span></p></div>',
         );
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.isDirectionless()).toBe(false);
           expect(directionlessTextNode.isDirectionless()).toBe(true);
         });
@@ -989,7 +991,7 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.getLatest()', async () => {
         const {editor} = testEnv;
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.getLatest()).toBe(textNode);
         });
         expect(() => textNode.getLatest()).toThrow();
@@ -1025,7 +1027,7 @@ describe('LexicalNode tests', () => {
           expect(node.getTextContent()).toBe('');
         });
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.getTextContent()).toBe('foo');
         });
         expect(() => textNode.getTextContent()).toThrow();
@@ -1034,7 +1036,7 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.getTextContentSize()', async () => {
         const {editor} = testEnv;
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(textNode.getTextContentSize()).toBe('foo'.length);
         });
         expect(() => textNode.getTextContentSize()).toThrow();
@@ -1070,7 +1072,7 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.remove()', async () => {
         const {editor} = testEnv;
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           expect(() => textNode.remove()).toThrow();
         });
 
@@ -1096,7 +1098,7 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.replace()', async () => {
         const {editor} = testEnv;
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           // @ts-expect-error
           expect(() => textNode.replace()).toThrow();
         });
@@ -1230,7 +1232,7 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.insertAfter()', async () => {
         const {editor} = testEnv;
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           // @ts-expect-error
           expect(() => textNode.insertAfter()).toThrow();
         });
@@ -1390,7 +1392,7 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.insertBefore()', async () => {
         const {editor} = testEnv;
 
-        await editor.getEditorState().read(() => {
+        await editor.read('latest', () => {
           // @ts-expect-error
           expect(() => textNode.insertBefore()).toThrow();
         });

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -824,7 +824,7 @@ describe('LexicalSelection tests', () => {
             },
             {discrete: true},
           );
-          testEnv.editor.getEditorState().read(() => {
+          testEnv.editor.read('latest', () => {
             const allTextNodes = $getRoot().getAllTextNodes();
             // These should get merged in reconciliation
             expect(allTextNodes.map(node => node.getTextContent())).toEqual([

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -391,7 +391,7 @@ describe('LexicalUtils tests', () => {
         rootNode.append(paragraphNode);
       });
 
-      await editor.getEditorState().read(() => {
+      await editor.read('latest', () => {
         expect($getNodeByKey('1')).toBe(paragraphNode);
         expect($getNodeByKey('2')).toBe(textNode);
         expect($getNodeByKey('3')).toBe(null);
@@ -421,7 +421,7 @@ describe('LexicalUtils tests', () => {
           expect.arrayContaining(paragraphKeys),
         );
       });
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const currentParagraphKeys = $paragraphKeys();
         expect(currentParagraphKeys).toHaveLength(paragraphKeys.length);
         expect(currentParagraphKeys).toEqual(

--- a/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
+++ b/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
@@ -844,7 +844,7 @@ describe('LexicalCaret', () => {
             {discrete: true},
           );
           // Reconciliation has happened
-          testEnv.editor.getEditorState().read(() => {
+          testEnv.editor.read('latest', () => {
             const allTextNodes = $getRoot().getAllTextNodes();
             // These should get merged in reconciliation
             expect(allTextNodes.map(node => node.getTextContent())).toEqual([
@@ -1682,7 +1682,7 @@ describe('LexicalCaret', () => {
             },
             {discrete: true},
           );
-          testEnv.editor.getEditorState().read(() => {
+          testEnv.editor.read('latest', () => {
             const allTextNodes = $getRoot().getAllTextNodes();
             // These should get merged in reconciliation
             expect(allTextNodes.map(node => node.getTextContent())).toEqual([

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
@@ -35,7 +35,7 @@ describe('LexicalRootNode tests', () => {
 
     function expectRootTextContentToBe(text: string): void {
       const {editor} = testEnv;
-      editor.getEditorState().read(() => {
+      editor.read('latest', () => {
         const root = $getRoot();
 
         expect(root.__cachedText).toBe(text);
@@ -127,7 +127,7 @@ describe('LexicalRootNode tests', () => {
       });
 
       expect(
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           return $getRoot().getTextContent();
         }),
       ).toBe('Hello world');

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -171,7 +171,7 @@ describe('LexicalTextNode tests', () => {
       });
 
       expect(
-        editor.getEditorState().read(() => {
+        editor.read('latest', () => {
           const root = $getRoot();
           return root.__cachedText;
         }),


### PR DESCRIPTION
## Description

Follow-up to #8702

Refactor existing internal call sites of `editor.getEditorState().read(...)` to `editor.read('latest', ...)` and add some more documentation about the various modes.

## Test plan

Existing tests should show that the refactor is sound