### PR TITLE
[lexical-utils] Add dedupeSelectionRects: fix duplicate/extra selection rects on WebKit (#7106, #7492)

### DIFF
--- a/flow-typed/environments/bom.js
+++ b/flow-typed/environments/bom.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 09630545c584c3b212588a2390c257d0
-// flow-typed version: baae4b8bcc/bom/flow_>=v0.261.x
+// flow-typed signature: b6e924fee0c3aabc47b3e089cc9ff0a7
+// flow-typed version: 74bef415fd/bom/flow_>=v0.261.x
 
 /* BOM */
 
@@ -37,6 +37,9 @@ declare interface Crypto {
     T: Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | BigInt64Array | BigUint64Array
   >(typedArray: T) => T;
   randomUUID: () => string;
+  subtle: {
+    digest(algorithm: string, data: Uint8Array): Promise<ArrayBuffer>
+  },
 }
 declare var crypto: Crypto;
 
@@ -826,6 +829,7 @@ declare class SharedWorker extends EventTarget {
 declare function importScripts(...urls: Array<string | TrustedScriptURL>): void;
 
 declare class WorkerGlobalScope extends EventTarget {
+    // $FlowExpectedError[incompatible-variance]
     self: this;
     location: WorkerLocation;
     navigator: WorkerNavigator;

--- a/flow-typed/environments/dom.js
+++ b/flow-typed/environments/dom.js
@@ -1,5 +1,5 @@
-// flow-typed signature: c126209a0e678d121655f21a36219841
-// flow-typed version: f998bd7c46/dom/flow_>=v0.261.x
+// flow-typed signature: cf23703830440a242ae9f9850dc4b882
+// flow-typed version: 7c14103836/dom/flow_>=v0.261.x
 
 /* Files */
 
@@ -154,41 +154,34 @@ type StorageEventTypes = 'storage';
 type SecurityPolicyViolationEventTypes = 'securitypolicyviolation';
 type USBConnectionEventTypes = 'connect' | 'disconnect';
 type ToggleEventTypes = 'beforetoggle' | 'toggle';
-
-type AddEventListenerOptionsOrUseCapture =
-  | boolean
-  | $ReadOnly<{
-      capture?: boolean,
-      once?: boolean,
-      passive?: boolean,
-      signal?: AbortSignal,
-    }>;
-type EventListenerOptionsOrUseCapture =
-  | boolean
-  | $ReadOnly<{
-      capture?: boolean,
-    }>;
+type EventListenerOptionsOrUseCapture = boolean | {
+       capture?: boolean,
+       once?: boolean,
+       passive?: boolean,
+       signal?: AbortSignal,
+       ...
+};
 
 declare class EventTarget {
-  addEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: InputEventTypes, listener: InputEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: AbortProgressEventTypes, listener: AbortProgressEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: ProgressEventTypes, listener: ProgressEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: DragEventTypes, listener: DragEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: PointerEventTypes, listener: PointerEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: AnimationEventTypes, listener: AnimationEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: ClipboardEventTypes, listener: ClipboardEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: TransitionEventTypes, listener: TransitionEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: MessageEventTypes, listener: MessageEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: BeforeUnloadEventTypes, listener: BeforeUnloadEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: StorageEventTypes, listener: StorageEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: SecurityPolicyViolationEventTypes, listener: SecurityPolicyViolationEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: USBConnectionEventTypes, listener: USBConnectionEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
-  addEventListener(type: string, listener: EventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: InputEventTypes, listener: InputEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: AbortProgressEventTypes, listener: AbortProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: ProgressEventTypes, listener: ProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: DragEventTypes, listener: DragEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: PointerEventTypes, listener: PointerEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: AnimationEventTypes, listener: AnimationEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: ClipboardEventTypes, listener: ClipboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: TransitionEventTypes, listener: TransitionEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: MessageEventTypes, listener: MessageEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: BeforeUnloadEventTypes, listener: BeforeUnloadEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: StorageEventTypes, listener: StorageEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: SecurityPolicyViolationEventTypes, listener: SecurityPolicyViolationEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: USBConnectionEventTypes, listener: USBConnectionEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: string, listener: EventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
 
   removeEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
@@ -837,11 +830,11 @@ declare class TaskSignal extends AbortSignal {
   +priority: number;
 }
 
-type SchedulerPostTaskOptions = {
+type SchedulerPostTaskOptions = {|
   priority?: "user-blocking" | "user-visible" | "background",
   signal?: TaskSignal | AbortSignal,
   delay?: number,
-};
+|};
 
 declare class Scheduler {
   postTask<T>(
@@ -973,6 +966,7 @@ declare class HTMLCollection<+Elem: Element> {
   length: number;
   item(nameOrIndex?: any, optionalIndex?: any): Elem | null;
   namedItem(name: string): Elem | null;
+  // $FlowExpectedError[incompatible-variance]
   [index: number | string]: Elem;
 }
 
@@ -1396,6 +1390,7 @@ declare class Element extends Node mixins mixin$Animatable {
   scrollLeft: number;
   scrollTop: number;
   scrollWidth: number;
+  role: string | null;
   +tagName: string;
 
   // TODO: a lot more ARIA properties

--- a/flow-typed/environments/html.js
+++ b/flow-typed/environments/html.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 760aeea3b9b767e808097fe22b68a20f
-// flow-typed version: 8584579196/html/flow_>=v0.261.x
+// flow-typed signature: b876b0c754b533b8b6d83f6166e66d8e
+// flow-typed version: 84d934abce/html/flow_>=v0.261.x
 
 /* DataTransfer */
 
@@ -808,6 +808,7 @@ declare class HTMLImageElement extends HTMLElement {
   isMap: boolean;
   naturalHeight: number; // readonly
   naturalWidth: number; // readonly
+  fetchPriority: "high" | "low" | "auto";
   sizes: string;
   src: string;
   srcset: string;
@@ -1280,6 +1281,7 @@ declare class HTMLLinkElement extends HTMLElement {
   href: string;
   hreflang: string;
   media: string;
+  fetchPriority: "high" | "low" | "auto";
   rel: string;
   sizes: DOMTokenList;
   type: string;
@@ -1292,6 +1294,7 @@ declare class HTMLScriptElement extends HTMLElement {
   charset: string;
   crossOrigin?: string;
   defer: boolean;
+  fetchPriority: "high" | "low" | "auto";
   // flowlint unsafe-getters-setters:off
   get src(): string;
   set src(value: string | TrustedScriptURL): void;

--- a/flow-typed/environments/jsx.js
+++ b/flow-typed/environments/jsx.js
@@ -1,5 +1,5 @@
-// flow-typed signature: e51684b7f9618ccda34e09816ddb01da
-// flow-typed version: bb4cb83b7a/jsx/flow_>=v0.261.x
+// flow-typed signature: 4e0586c675a57bbe33b81cc8cedd32ba
+// flow-typed version: 284fb57107/jsx/flow_>=v0.261.x
 
 // https://www.w3.org/TR/uievents-key/#keys-modifier
 type ModifierKey =
@@ -27,7 +27,7 @@ declare class SyntheticEvent<+T: EventTarget = EventTarget, +E: Event = Event> {
   isDefaultPrevented(): boolean;
   isPropagationStopped(): boolean;
   isTrusted: boolean;
-  nativeEvent: E;
+  +nativeEvent: E;
   persist(): void;
   preventDefault(): void;
   stopPropagation(): void;

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -104,7 +104,7 @@ export type ClickableLinkConfig = {
   disabled: boolean;
 }
 
-type AddEventListenerOptions = Exclude<AddEventListenerOptionsOrUseCapture, boolean>;
+type AddEventListenerOptions = Exclude<EventListenerOptionsOrUseCapture, boolean>;
 
 declare export function registerClickableLink(
   editor: LexicalEditor,

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -23,14 +23,14 @@ import {useEffect, useLayoutEffect, useRef} from 'react';
 import {createWebsocketProvider} from '../collaboration';
 import {$isStickyNode} from './StickyNode';
 
-type Positioning = {
+interface Positioning {
   isDragging: boolean;
   offsetX: number;
   offsetY: number;
-  rootElementRect: null | ClientRect;
+  rootElementRect: null | DOMRect;
   x: number;
   y: number;
-};
+}
 
 function positionSticky(
   stickyElem: HTMLElement,

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -56,7 +56,7 @@ const ACTIVE_RESIZER_COLOR = '#76b6ff';
 function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
   const targetRef = useRef<HTMLElement | null>(null);
   const resizerRef = useRef<HTMLDivElement | null>(null);
-  const tableRectRef = useRef<ClientRect | null>(null);
+  const tableRectRef = useRef<DOMRect | null>(null);
   const [hasTable, setHasTable] = useState(false);
 
   const pointerStartPosRef = useRef<PointerPosition | null>(null);

--- a/packages/lexical-selection/src/__tests__/browser/dedupeSelectionRectsUnderpaint.test.ts
+++ b/packages/lexical-selection/src/__tests__/browser/dedupeSelectionRectsUnderpaint.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalEditor} from 'lexical';
+
+import {createRectsFromDOMRange} from '@lexical/selection';
+import {dedupeSelectionRects} from '@lexical/utils';
+import {describe, expect, it, onTestFinished} from 'vitest';
+
+/**
+ * Characterizes the documented KNOWN LIMITATION of dedupeSelectionRects' keep-smaller
+ * rule (see its docstring): for OVERLAPPING inline content it can drop a wide rect
+ * that covers real selected text, under-painting the glyphs it uniquely covered.
+ * Uses real browser layout (Chromium + WebKit) and the real createRectsFromDOMRange +
+ * dedupeSelectionRects — the root is a real, laid-out element so getBoundingClientRect
+ * / getComputedStyle are real; only `editor` is a getRootElement shim, which is all the
+ * helper reads off it.
+ */
+
+type Rect = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+const ROOT_WIDTH = 600;
+
+function setupRoot(): HTMLDivElement {
+  const root = document.createElement('div');
+  root.style.position = 'absolute';
+  root.style.left = '0px';
+  root.style.top = '0px';
+  root.style.width = `${ROOT_WIDTH}px`;
+  root.style.padding = '0px';
+  root.style.margin = '0px';
+  root.style.font = '16px/1.5 monospace';
+  document.body.style.margin = '0px';
+  document.body.appendChild(root);
+  return root;
+}
+
+function editorFor(root: HTMLElement): LexicalEditor {
+  return {getRootElement: () => root} as unknown as LexicalEditor;
+}
+
+const toRect = (r: DOMRect | Rect): Rect => ({
+  bottom: r.bottom,
+  height: r.height,
+  left: r.left,
+  right: r.right,
+  top: r.top,
+  width: r.width,
+});
+
+// Containment predicate matching dedupeSelectionRects (1px tolerance), used only to
+// assert the survivors really are contained; the dedupe itself uses the REAL function.
+function contains(a: Rect, b: Rect): boolean {
+  return (
+    b.left >= a.left - 1 &&
+    b.top >= a.top - 1 &&
+    b.right <= a.right + 1 &&
+    b.bottom <= a.bottom + 1
+  );
+}
+
+function selectAll(root: HTMLElement): Range {
+  const r = document.createRange();
+  r.selectNodeContents(root);
+  return r;
+}
+
+describe('dedupeSelectionRects under-paints real text for overlapping inline content', () => {
+  it('drops the wide text-run rect that uniquely covers selected glyphs', () => {
+    const root = setupRoot();
+    onTestFinished(() => root.remove());
+
+    // "aaaaaaaaaa" then an inline-block pulled back 70px over it and raised 0.5px via
+    // vertical-align (a plain CSS sub-pixel offset — no transform needed), then "cccc".
+    // The negative margin makes content overlap; the raise defeats the asymmetric guard
+    // so the overlapped rects all survive createRectsFromDOMRange.
+    root.innerHTML = `<p style="margin:0">aaaaaaaaaa<span style="display:inline-block;width:10px;height:18px;margin-left:-70px;vertical-align:0.5px;background:rgba(255,0,0,.4)">N</span>cccc</p>`;
+    void root.offsetHeight;
+
+    const range = selectAll(root);
+    const survivors = (
+      createRectsFromDOMRange(editorFor(root), range) as unknown as DOMRect[]
+    ).map(toRect);
+
+    // createRectsFromDOMRange keeps the wide real-text run AND narrower contained rects.
+    const wide = survivors.find(r => r.left <= 2 && r.width > 90);
+    expect(
+      wide,
+      'wide text-run rect survived createRectsFromDOMRange',
+    ).toBeTruthy();
+    const contained = survivors.filter(
+      r => r !== wide && wide != null && contains(wide, r),
+    );
+    expect(
+      contained.length,
+      'narrower rects are contained in the wide text rect, on the same row',
+    ).toBeGreaterThan(0);
+
+    // The REAL dedupeSelectionRects then drops the wide text-run rect (keep-smaller)...
+    const deduped = dedupeSelectionRects(survivors);
+    expect(
+      deduped.every(r => r.width < 90),
+      'the wide text-run rect was dropped by keep-smaller dedupe',
+    ).toBe(true);
+
+    // ...leaving BOTH edges of the run uncovered: the leading glyphs before the
+    // pulled-back box (left 0..~26) and the trailing glyphs past it (right ~74..96)
+    // get no rect at all → real selected text goes unpainted on both sides.
+    const leftmostCovered = Math.min(...deduped.map(r => r.left));
+    const rightmostCovered = Math.max(...deduped.map(r => r.right));
+    expect(
+      leftmostCovered,
+      'leading glyphs at the line start are left uncovered (under-paint)',
+    ).toBeGreaterThan(18);
+    expect(
+      rightmostCovered,
+      'trailing glyphs at the line end are left uncovered (under-paint)',
+    ).toBeLessThan(90);
+  });
+});

--- a/packages/lexical-selection/src/__tests__/browser/dedupeSelectionRectsUnderpaint.test.ts
+++ b/packages/lexical-selection/src/__tests__/browser/dedupeSelectionRectsUnderpaint.test.ts
@@ -14,12 +14,16 @@ import {describe, expect, it, onTestFinished} from 'vitest';
 
 /**
  * Characterizes the documented KNOWN LIMITATION of dedupeSelectionRects' keep-smaller
- * rule (see its docstring): for OVERLAPPING inline content it can drop a wide rect
- * that covers real selected text, under-painting the glyphs it uniquely covered.
- * Uses real browser layout (Chromium + WebKit) and the real createRectsFromDOMRange +
- * dedupeSelectionRects — the root is a real, laid-out element so getBoundingClientRect
- * / getComputedStyle are real; only `editor` is a getRootElement shim, which is all the
- * helper reads off it.
+ * rule (see its docstring): for OVERLAPPING inline content it can drop a wider rect
+ * that covers real selected area, under-painting the part it uniquely covered.
+ *
+ * Uses real browser layout (Chromium / Firefox / WebKit) and the real
+ * createRectsFromDOMRange + dedupeSelectionRects. The construction uses
+ * explicit-width inline boxes and a fixed sub-pixel transform so the geometry is
+ * identical across platforms (no dependence on font glyph metrics), and the
+ * assertions are structural (no hard-coded pixel thresholds): the root is a real,
+ * laid-out element so getBoundingClientRect / getComputedStyle are real; only
+ * `editor` is a getRootElement shim, which is all the helper reads off it.
  */
 
 type Rect = {
@@ -41,7 +45,7 @@ function setupRoot(): HTMLDivElement {
   root.style.width = `${ROOT_WIDTH}px`;
   root.style.padding = '0px';
   root.style.margin = '0px';
-  root.style.font = '16px/1.5 monospace';
+  root.style.font = '16px/1 monospace';
   document.body.style.margin = '0px';
   document.body.appendChild(root);
   return root;
@@ -60,8 +64,7 @@ const toRect = (r: DOMRect | Rect): Rect => ({
   width: r.width,
 });
 
-// Containment predicate matching dedupeSelectionRects (1px tolerance), used only to
-// assert the survivors really are contained; the dedupe itself uses the REAL function.
+// Containment predicate matching dedupeSelectionRects (1px tolerance).
 function contains(a: Rect, b: Rect): boolean {
   return (
     b.left >= a.left - 1 &&
@@ -71,22 +74,36 @@ function contains(a: Rect, b: Rect): boolean {
   );
 }
 
+const sameRect = (a: Rect, b: Rect): boolean =>
+  Math.abs(a.left - b.left) < 1 &&
+  Math.abs(a.right - b.right) < 1 &&
+  Math.abs(a.top - b.top) < 1 &&
+  Math.abs(a.bottom - b.bottom) < 1;
+
 function selectAll(root: HTMLElement): Range {
   const r = document.createRange();
   r.selectNodeContents(root);
   return r;
 }
 
-describe('dedupeSelectionRects under-paints real text for overlapping inline content', () => {
-  it('drops the wide text-run rect that uniquely covers selected glyphs', () => {
+describe('dedupeSelectionRects under-paints real content for overlapping inline boxes', () => {
+  it('drops the wider rect that uniquely covers part of the selection', () => {
     const root = setupRoot();
     onTestFinished(() => root.remove());
 
-    // "aaaaaaaaaa" then an inline-block pulled back 70px over it and raised 0.5px via
-    // vertical-align (a plain CSS sub-pixel offset — no transform needed), then "cccc".
-    // The negative margin makes content overlap; the raise defeats the asymmetric guard
-    // so the overlapped rects all survive createRectsFromDOMRange.
-    root.innerHTML = `<p style="margin:0">aaaaaaaaaa<span style="display:inline-block;width:10px;height:18px;margin-left:-70px;vertical-align:0.5px;background:rgba(255,0,0,.4)">N</span>cccc</p>`;
+    // A wide run of text, then an inline box pulled back over it with a negative
+    // margin so it overlaps the run, and raised 0.5px (vertical-align) so its top
+    // sits a hair above the text run's. The selection's client rects follow the
+    // glyphs, so the text run is a genuinely wide rect; the raise defeats
+    // createRectsFromDOMRange's asymmetric overlap guard (`prevRect.top <= cur.top`),
+    // so the wide text rect AND the contained box rect both survive; keep-smaller
+    // then drops the wide one. (The box stands in for any overlapping inline content,
+    // e.g. a baseline-shifted inline decorator.) Assertions are structural — no
+    // pixel thresholds — so they hold whatever the monospace glyph width is.
+    root.innerHTML =
+      `<p style="margin:0">aaaaaaaaaaaaaaaa` +
+      `<span style="display:inline-block;width:12px;height:18px;margin-left:-100px;vertical-align:0.5px;background:rgba(255,0,0,.4)">N</span>` +
+      `</p>`;
     void root.offsetHeight;
 
     const range = selectAll(root);
@@ -94,39 +111,50 @@ describe('dedupeSelectionRects under-paints real text for overlapping inline con
       createRectsFromDOMRange(editorFor(root), range) as unknown as DOMRect[]
     ).map(toRect);
 
-    // createRectsFromDOMRange keeps the wide real-text run AND narrower contained rects.
-    const wide = survivors.find(r => r.left <= 2 && r.width > 90);
+    // createRectsFromDOMRange leaves a same-row contained pair: a wider rect that
+    // strictly contains a narrower survivor.
+    let wide: Rect | undefined;
+    let narrow: Rect | undefined;
+    for (const a of survivors) {
+      for (const b of survivors) {
+        if (
+          a !== b &&
+          contains(a, b) &&
+          a.width > b.width + 2 &&
+          !contains(b, a)
+        ) {
+          wide = a;
+          narrow = b;
+        }
+      }
+    }
     expect(
-      wide,
-      'wide text-run rect survived createRectsFromDOMRange',
+      wide && narrow,
+      'createRectsFromDOMRange left a same-row contained pair (wider ⊇ narrower)',
     ).toBeTruthy();
-    const contained = survivors.filter(
-      r => r !== wide && wide != null && contains(wide, r),
-    );
-    expect(
-      contained.length,
-      'narrower rects are contained in the wide text rect, on the same row',
-    ).toBeGreaterThan(0);
+    if (!wide || !narrow) return;
 
-    // The REAL dedupeSelectionRects then drops the wide text-run rect (keep-smaller)...
+    // dedupeSelectionRects drops the wider rect (keep-smaller)...
     const deduped = dedupeSelectionRects(survivors);
     expect(
-      deduped.every(r => r.width < 90),
-      'the wide text-run rect was dropped by keep-smaller dedupe',
-    ).toBe(true);
+      deduped.some(r => sameRect(r, wide as Rect)),
+      'the wider rect was dropped by keep-smaller dedupe',
+    ).toBe(false);
 
-    // ...leaving BOTH edges of the run uncovered: the leading glyphs before the
-    // pulled-back box (left 0..~26) and the trailing glyphs past it (right ~74..96)
-    // get no rect at all → real selected text goes unpainted on both sides.
-    const leftmostCovered = Math.min(...deduped.map(r => r.left));
-    const rightmostCovered = Math.max(...deduped.map(r => r.right));
+    // ...and nothing left covers the wide rect's left edge, so the area it uniquely
+    // covered (left of the pulled-back box) goes unpainted — the under-paint.
+    const probeX = wide.left + 1;
+    const probeY = wide.top + wide.height / 2;
+    const covered = deduped.some(
+      r =>
+        r.left <= probeX &&
+        r.right >= probeX &&
+        r.top <= probeY &&
+        r.bottom >= probeY,
+    );
     expect(
-      leftmostCovered,
-      'leading glyphs at the line start are left uncovered (under-paint)',
-    ).toBeGreaterThan(18);
-    expect(
-      rightmostCovered,
-      'trailing glyphs at the line end are left uncovered (under-paint)',
-    ).toBeLessThan(90);
+      covered,
+      'the wide rect left edge is left unpainted after dedupe',
+    ).toBe(false);
   });
 });

--- a/packages/lexical-selection/src/__tests__/browser/dedupeSelectionRectsUnderpaint.test.ts
+++ b/packages/lexical-selection/src/__tests__/browser/dedupeSelectionRectsUnderpaint.test.ts
@@ -6,8 +6,6 @@
  *
  */
 
-import type {LexicalEditor} from 'lexical';
-
 import {createRectsFromDOMRange} from '@lexical/selection';
 import {dedupeSelectionRects} from '@lexical/utils';
 import {describe, expect, it, onTestFinished} from 'vitest';
@@ -26,15 +24,6 @@ import {describe, expect, it, onTestFinished} from 'vitest';
  * `editor` is a getRootElement shim, which is all the helper reads off it.
  */
 
-type Rect = {
-  left: number;
-  top: number;
-  right: number;
-  bottom: number;
-  width: number;
-  height: number;
-};
-
 const ROOT_WIDTH = 600;
 
 function setupRoot(): HTMLDivElement {
@@ -51,21 +40,8 @@ function setupRoot(): HTMLDivElement {
   return root;
 }
 
-function editorFor(root: HTMLElement): LexicalEditor {
-  return {getRootElement: () => root} as unknown as LexicalEditor;
-}
-
-const toRect = (r: DOMRect | Rect): Rect => ({
-  bottom: r.bottom,
-  height: r.height,
-  left: r.left,
-  right: r.right,
-  top: r.top,
-  width: r.width,
-});
-
 // Containment predicate matching dedupeSelectionRects (1px tolerance).
-function contains(a: Rect, b: Rect): boolean {
+function contains(a: DOMRect, b: DOMRect): boolean {
   return (
     b.left >= a.left - 1 &&
     b.top >= a.top - 1 &&
@@ -74,7 +50,7 @@ function contains(a: Rect, b: Rect): boolean {
   );
 }
 
-const sameRect = (a: Rect, b: Rect): boolean =>
+const sameRect = (a: DOMRect, b: DOMRect): boolean =>
   Math.abs(a.left - b.left) < 1 &&
   Math.abs(a.right - b.right) < 1 &&
   Math.abs(a.top - b.top) < 1 &&
@@ -107,14 +83,15 @@ describe('dedupeSelectionRects under-paints real content for overlapping inline 
     void root.offsetHeight;
 
     const range = selectAll(root);
-    const survivors = (
-      createRectsFromDOMRange(editorFor(root), range) as unknown as DOMRect[]
-    ).map(toRect);
+    const survivors = createRectsFromDOMRange(
+      {getRootElement: () => root},
+      range,
+    );
 
     // createRectsFromDOMRange leaves a same-row contained pair: a wider rect that
     // strictly contains a narrower survivor.
-    let wide: Rect | undefined;
-    let narrow: Rect | undefined;
+    let wide: DOMRect | undefined;
+    let narrow: DOMRect | undefined;
     for (const a of survivors) {
       for (const b of survivors) {
         if (
@@ -137,7 +114,7 @@ describe('dedupeSelectionRects under-paints real content for overlapping inline 
     // dedupeSelectionRects drops the wider rect (keep-smaller)...
     const deduped = dedupeSelectionRects(survivors);
     expect(
-      deduped.some(r => sameRect(r, wide as Rect)),
+      deduped.some(r => sameRect(r, wide)),
       'the wider rect was dropped by keep-smaller dedupe',
     ).toBe(false);
 

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -125,9 +125,9 @@ export function createDOMRange(
  * @returns The selectionRects as an array.
  */
 export function createRectsFromDOMRange(
-  editor: LexicalEditor,
+  editor: Pick<LexicalEditor, 'getRootElement'>,
   range: Range,
-): ClientRect[] {
+): DOMRect[] {
   const rootElement = editor.getRootElement();
 
   if (rootElement === null) {

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -86,6 +86,9 @@ declare export function $findMatchingParent(
   findFn: (LexicalNode) => boolean,
 ): LexicalNode | null;
 declare export function mergeRegister(...func: (() => void)[]): () => void;
+declare export function dedupeSelectionRects(
+  rects: Iterable<ClientRect>,
+): ClientRect[];
 declare export function markSelection(
   editor: LexicalEditor,
   onReposition?: (node: HTMLElement[]) => void,

--- a/packages/lexical-utils/src/__tests__/unit/dedupeSelectionRects.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/dedupeSelectionRects.test.ts
@@ -6,6 +6,9 @@
  *
  */
 
+import type {LexicalEditor} from 'lexical';
+
+import {createRectsFromDOMRange} from '@lexical/selection';
 import {dedupeSelectionRects} from '@lexical/utils';
 import {describe, expect, it} from 'vitest';
 
@@ -106,5 +109,80 @@ describe('dedupeSelectionRects', () => {
       rect(180, 44, 120, 18),
     ];
     expect(dedupeSelectionRects(rows)).toHaveLength(3);
+  });
+});
+
+// The consumer pipeline in positionNodeOnRange is
+// `dedupeSelectionRects(createRectsFromDOMRange(editor, range))`.
+// createRectsFromDOMRange already runs its own dedupe — single-pass and
+// adjacent-only: it sorts by top (3px tolerance) then left, drops a rect only when
+// it overlaps the immediately-preceding KEPT rect, and drops rects spanning the
+// full editor width. So the common #7106 block-width spurious rect is removed
+// before dedupe; what can still reach dedupe is a same-row CONTAINED pair whose
+// inner rect carries a sub-pixel-smaller top (as overlapping inline content
+// produces), which the asymmetric filter lets through. These tests run the REAL
+// createRectsFromDOMRange against a faked root + range to characterize that.
+type Rect = ReturnType<typeof rect>;
+
+function fakeEditorWithRoot(rootWidth: number): LexicalEditor {
+  const root = document.createElement('div');
+  root.style.paddingLeft = '0px';
+  root.style.paddingRight = '0px';
+  root.getBoundingClientRect = () => ({width: rootWidth}) as DOMRect;
+  return {getRootElement: () => root} as unknown as LexicalEditor;
+}
+
+function createRects(editor: LexicalEditor, rects: Rect[]): Rect[] {
+  // .slice() so createRectsFromDOMRange's in-place sort/splice cannot mutate input.
+  const range = {getClientRects: () => rects.slice()} as unknown as Range;
+  return createRectsFromDOMRange(editor, range) as unknown as Rect[];
+}
+
+const widths = (rects: Rect[]): number[] =>
+  rects.map(r => r.width).sort((a, b) => a - b);
+
+describe('dedupeSelectionRects + createRectsFromDOMRange', () => {
+  // A narrower text rect and a wider rect on the same visual row, the wider carrying
+  // a sub-pixel-smaller top (wider.top 90.0 vs text.top 90.5) — the split overlapping
+  // inline content produces. They group within createRectsFromDOMRange's 3px row
+  // tolerance, but its overlap test is asymmetric — it drops the current rect only
+  // when `prevRect.top <= cur.top` — so with the text rect kept first (the larger
+  // top) the wider rect is NOT dropped, and both reach dedupe. (The full-block-width
+  // #7106 rect would instead be dropped upstream by selectionSpansElement.)
+  const text = (): Rect => rect(128, 90.5, 368, 18);
+  const wider = (): Rect => rect(128, 90.0, 900, 18); // ≠ editor width (1200): not dropped as full-width
+
+  it('createRectsFromDOMRange leaves the contained pair (its adjacent-only pass does not catch it)', () => {
+    const editor = fakeEditorWithRoot(1200);
+    expect(widths(createRects(editor, [text(), wider()]))).toEqual([368, 900]);
+  });
+
+  it('dedupeSelectionRects collapses that survivor pair to the text-hugging rect', () => {
+    const editor = fakeEditorWithRoot(1200);
+    expect(
+      widths(dedupeSelectionRects(createRects(editor, [text(), wider()]))),
+    ).toEqual([368]);
+  });
+
+  it('dedupeSelectionRects is order-independent where createRectsFromDOMRange is not', () => {
+    const editor = fakeEditorWithRoot(1200);
+    // createRectsFromDOMRange keeps whichever rect streams first → order-dependent.
+    expect(widths(createRects(editor, [text(), wider()]))).not.toEqual(
+      widths(createRects(editor, [wider(), text()])),
+    );
+    // dedupeSelectionRects always keeps the smaller → same result either way.
+    expect(widths(dedupeSelectionRects([text(), wider()]))).toEqual([368]);
+    expect(widths(dedupeSelectionRects([wider(), text()]))).toEqual([368]);
+  });
+
+  it('keeps the smaller (text) rect by design — keeping the wider one re-introduces the #7106 extra-area paint', () => {
+    // The pair is geometrically ambiguous: a spurious wide rect containing the real
+    // text rect is indistinguishable from a (hypothetical) real wide rect containing
+    // a redundant sub-fragment. A single dedupe must pick one; keeping the smaller
+    // resolves toward the reproduced bug (#7106) — never the wider rect.
+    const editor = fakeEditorWithRoot(1200);
+    const kept = dedupeSelectionRects(createRects(editor, [text(), wider()]));
+    expect(kept).toHaveLength(1);
+    expect(kept[0].width).toBe(368);
   });
 });

--- a/packages/lexical-utils/src/__tests__/unit/dedupeSelectionRects.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/dedupeSelectionRects.test.ts
@@ -80,4 +80,31 @@ describe('dedupeSelectionRects', () => {
     ]);
     expect(kept).toHaveLength(1);
   });
+
+  it('keeps horizontally disjoint rects on the same row (no false containment)', () => {
+    // Two inline boxes tiled on one line: neither contains the other.
+    const kept = dedupeSelectionRects([
+      rect(0, 0, 50, 18),
+      rect(100, 0, 50, 18),
+    ]);
+    expect(kept).toHaveLength(2);
+  });
+
+  it('does not clip a wide rect (e.g. trailing whitespace) against a disjoint narrower row', () => {
+    // A wide first row plus a narrower second row: different rows, neither contained.
+    const wideRow = rect(0, 0, 300, 18);
+    const narrowRow = rect(0, 22, 80, 18);
+    const kept = dedupeSelectionRects([wideRow, narrowRow]);
+    expect(kept).toHaveLength(2);
+    expect(kept.map(r => r.width).sort((a, b) => a - b)).toEqual([80, 300]);
+  });
+
+  it('keeps every row of a ragged multi-row selection (varying offsets, e.g. RTL)', () => {
+    const rows = [
+      rect(200, 0, 100, 18),
+      rect(150, 22, 150, 18),
+      rect(180, 44, 120, 18),
+    ];
+    expect(dedupeSelectionRects(rows)).toHaveLength(3);
+  });
 });

--- a/packages/lexical-utils/src/__tests__/unit/dedupeSelectionRects.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/dedupeSelectionRects.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {dedupeSelectionRects} from '@lexical/utils';
+import {describe, expect, it} from 'vitest';
+
+function rect(left: number, top: number, width: number, height: number) {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+  };
+}
+
+describe('dedupeSelectionRects', () => {
+  it('keeps one of two identical rects (the doubled-opacity duplicate)', () => {
+    const kept = dedupeSelectionRects([
+      rect(128, 166, 394, 18),
+      rect(128, 166, 394, 18),
+    ]);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].width).toBe(394);
+  });
+
+  it('keeps the smaller text rect when a wider rect contains it (#7106 extra area)', () => {
+    const text = rect(128, 90, 368, 40);
+    const wider = rect(128, 90, 1024, 40);
+    const kept = dedupeSelectionRects([text, wider]);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].width).toBe(368);
+  });
+
+  it('keeps the smaller rect regardless of input order', () => {
+    const text = rect(128, 90, 368, 40);
+    const wider = rect(128, 90, 1024, 40);
+    expect(dedupeSelectionRects([wider, text])[0].width).toBe(368);
+    expect(dedupeSelectionRects([text, wider])[0].width).toBe(368);
+  });
+
+  it('preserves genuine multi-line rects (different rows are not contained)', () => {
+    const row1 = rect(128, 90, 368, 18);
+    const row2 = rect(128, 112, 200, 18);
+    const kept = dedupeSelectionRects([row1, row1, row2, row2]);
+    expect(kept).toHaveLength(2);
+    expect(kept.map(r => r.top).sort((a, b) => a - b)).toEqual([90, 112]);
+  });
+
+  it('drops zero-area rects', () => {
+    const kept = dedupeSelectionRects([
+      rect(0, 0, 0, 18),
+      rect(0, 0, 100, 0),
+      rect(0, 0, 100, 18),
+    ]);
+    expect(kept).toHaveLength(1);
+  });
+
+  it('returns empty for an empty list', () => {
+    expect(dedupeSelectionRects([])).toHaveLength(0);
+  });
+
+  it('treats near-identical rects within 1px as duplicates', () => {
+    const kept = dedupeSelectionRects([
+      rect(128, 166, 394, 18),
+      {
+        bottom: 184.5,
+        height: 18.2,
+        left: 128.4,
+        right: 522.1,
+        top: 166.3,
+        width: 393.7,
+      },
+    ]);
+    expect(kept).toHaveLength(1);
+  });
+});

--- a/packages/lexical-utils/src/dedupeSelectionRects.ts
+++ b/packages/lexical-utils/src/dedupeSelectionRects.ts
@@ -14,12 +14,12 @@ type RectLike = Pick<
 /**
  * Dedupe a list of selection client-rects before they are drawn as fills.
  *
- * `Range.getClientRects()` and `createRectsFromDOMRange` can return rects that
- * are duplicated or contained within another, and WebKit in particular emits a
- * spurious wider rect alongside the real text rect on some blocks (balanced or
- * letter-spaced headings are the reproducible case). Drawn as semi-transparent
- * fills, duplicates read brighter than a single rect, and the wider rect paints
- * the "extra empty selection area" reported in facebook/lexical#7106.
+ * `Range.getClientRects()` can return rects that are duplicated or contained
+ * within another, and WebKit in particular emits a spurious wider rect alongside
+ * the real text rect on some blocks (balanced or letter-spaced headings are the
+ * reproducible case). Drawn as semi-transparent fills, duplicates read brighter
+ * than a single rect, and the wider rect paints the "extra empty selection area"
+ * reported in facebook/lexical#7106.
  *
  * This drops zero-area rects and any rect that contains another, keeping the
  * smaller text-hugging one, with a 1px tolerance for sub-pixel jitter. The
@@ -27,6 +27,22 @@ type RectLike = Pick<
  * per visual row; inline boxes on a row tile side by side), so containment only
  * holds for the duplicate or spurious-wider cases, never for a legitimate
  * sub-fragment that should be kept.
+ *
+ * On the `createRectsFromDOMRange` path (e.g. `positionNodeOnRange`): that
+ * helper's own `selectionSpansElement` filter already drops the full-block-width
+ * spurious rect, so there this mainly prevents the duplicate-doubling. The #7106
+ * extra-area paint is addressed for consumers that feed raw `getClientRects()`,
+ * where `selectionSpansElement` does not run — that is the path that needs it.
+ *
+ * Known limitation: the disjoint assumption holds for normal flow. Overlapping
+ * inline content — a negative margin, a transform, or a baseline-shifted inline
+ * decorator — can place a real sub-fragment inside a wider real-text rect on the
+ * same row; if a sub-pixel top offset also lets both clear
+ * `createRectsFromDOMRange`'s asymmetric overlap filter, keep-smaller drops the
+ * wider rect and under-paints the glyphs it uniquely covered. There is no
+ * rect-only fix: that wider rect is geometrically indistinguishable from the
+ * spurious-wider (#7106) rect, so keeping it would re-introduce the extra-area
+ * paint. See the under-paint characterization browser test.
  *
  * Typed on the structural subset of `ClientRect` it reads, so it accepts a live
  * `DOMRectList` from `getClientRects()` as well as the `ClientRect[]` returned by

--- a/packages/lexical-utils/src/dedupeSelectionRects.ts
+++ b/packages/lexical-utils/src/dedupeSelectionRects.ts
@@ -6,8 +6,8 @@
  *
  */
 
-type RectLike = Pick<
-  ClientRect,
+export type RectLike = Pick<
+  DOMRect,
   'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'
 >;
 
@@ -44,8 +44,8 @@ type RectLike = Pick<
  * spurious-wider (#7106) rect, so keeping it would re-introduce the extra-area
  * paint. See the under-paint characterization browser test.
  *
- * Typed on the structural subset of `ClientRect` it reads, so it accepts a live
- * `DOMRectList` from `getClientRects()` as well as the `ClientRect[]` returned by
+ * Typed on the structural subset of `DOMRect` it reads, so it accepts a live
+ * `DOMRectList` from `getClientRects()` as well as the `DOMRect[]` returned by
  * `createRectsFromDOMRange`, and is unit-testable without a DOM.
  */
 export default function dedupeSelectionRects<Rect extends RectLike>(

--- a/packages/lexical-utils/src/dedupeSelectionRects.ts
+++ b/packages/lexical-utils/src/dedupeSelectionRects.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+type RectLike = Pick<
+  ClientRect,
+  'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'
+>;
+
+/**
+ * Dedupe a list of selection client-rects before they are drawn as fills.
+ *
+ * `Range.getClientRects()` and `createRectsFromDOMRange` can return rects that
+ * are duplicated or contained within another, and WebKit in particular emits a
+ * spurious wider rect alongside the real text rect on some blocks (balanced or
+ * letter-spaced headings are the reproducible case). Drawn as semi-transparent
+ * fills, duplicates read brighter than a single rect, and the wider rect paints
+ * the "extra empty selection area" reported in facebook/lexical#7106.
+ *
+ * This drops zero-area rects and any rect that contains another, keeping the
+ * smaller text-hugging one, with a 1px tolerance for sub-pixel jitter. The
+ * assumption is that genuine same-line rects are horizontally disjoint (one rect
+ * per visual row; inline boxes on a row tile side by side), so containment only
+ * holds for the duplicate or spurious-wider cases, never for a legitimate
+ * sub-fragment that should be kept.
+ *
+ * Typed on the structural subset of `ClientRect` it reads, so it accepts a live
+ * `DOMRectList` from `getClientRects()` as well as the `ClientRect[]` returned by
+ * `createRectsFromDOMRange`, and is unit-testable without a DOM.
+ */
+export default function dedupeSelectionRects<Rect extends RectLike>(
+  rects: Iterable<Rect>,
+): Rect[] {
+  const contains = (a: RectLike, b: RectLike): boolean =>
+    b.left >= a.left - 1 &&
+    b.top >= a.top - 1 &&
+    b.right <= a.right + 1 &&
+    b.bottom <= a.bottom + 1;
+  const kept: Rect[] = [];
+  for (const rect of Array.from(rects)) {
+    if (rect.width < 0.5 || rect.height < 0.5) {
+      continue;
+    }
+    // `rect` contains a smaller rect already kept: keep the smaller one.
+    if (kept.some(keptRect => contains(rect, keptRect))) {
+      continue;
+    }
+    // A kept rect contains `rect`: drop the larger, keep the smaller `rect`.
+    for (let i = kept.length - 1; i >= 0; i--) {
+      if (contains(kept[i], rect)) {
+        kept.splice(i, 1);
+      }
+    }
+    kept.push(rect);
+  }
+  return kept;
+}

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -78,6 +78,7 @@ import {
   ValueOrUpdater,
 } from 'lexical';
 
+export {default as dedupeSelectionRects} from './dedupeSelectionRects';
 export {default as markSelection} from './markSelection';
 export {default as positionNodeOnRange} from './positionNodeOnRange';
 export {default as selectionAlwaysOnDisplay} from './selectionAlwaysOnDisplay';

--- a/packages/lexical-utils/src/positionNodeOnRange.ts
+++ b/packages/lexical-utils/src/positionNodeOnRange.ts
@@ -10,6 +10,7 @@ import invariant from '@lexical/internal/invariant';
 import {createRectsFromDOMRange} from '@lexical/selection';
 import {isHTMLElement, type LexicalEditor} from 'lexical';
 
+import dedupeSelectionRects from './dedupeSelectionRects';
 import px from './px';
 
 const mutationObserverConfig = {
@@ -52,7 +53,7 @@ export default function mlcPositionNodeOnRange(
     invariant(parentDOMNode !== null, 'Unexpected null parentDOMNode');
     const {left: parentLeft, top: parentTop} =
       parentDOMNode.getBoundingClientRect();
-    const rects = createRectsFromDOMRange(editor, range);
+    const rects = dedupeSelectionRects(createRectsFromDOMRange(editor, range));
     if (!wrapperNode.isConnected) {
       prependDOMNode(parentDOMNode, wrapperNode);
     }


### PR DESCRIPTION
## What

`Range.getClientRects()` can return rects that are duplicated or contained within another, and WebKit emits a spurious wider rect alongside the real text rect on some blocks (balanced or letter-spaced headings are the reproducible case). Drawn as semi-transparent fills, the duplicates read brighter than a single rect, and the wider rect paints the "extra empty selection area" reported in #7106.

This adds `dedupeSelectionRects` to `@lexical/utils` and runs the rects through it in `positionNodeOnRange`, so every fake-selection consumer (`markSelection`, `selectionAlwaysOnDisplay`, the Extension) gets clean rects on WebKit.

```ts
const rects = dedupeSelectionRects(createRectsFromDOMRange(editor, range));
```

It drops zero-area rects and any rect that contains another, keeping the smaller text-hugging one, with a 1px tolerance for sub-pixel jitter. Pure, exported, no API change. Typed on the structural subset of `ClientRect` it reads, so it also accepts a live `DOMRectList` from `getClientRects()` and is unit-testable without a DOM.

<img width="968" height="358" alt="image" src="https://github.com/user-attachments/assets/0d032385-943a-41e8-bd85-3579afa79a80" />

## What it actually does on each path (measured in Chromium + WebKit)

Being precise about scope:

- **`positionNodeOnRange` path (this PR's wiring):** `createRectsFromDOMRange`'s own `selectionSpansElement` filter already drops the full-block-width spurious rect for the reproducible #7106 shapes (short / tracked / balanced headings). So here `dedupeSelectionRects` mainly prevents the **duplicate-doubling** that survives that helper's asymmetric, adjacent-only pass.
- **Raw `getClientRects()` path:** consumers feeding raw rects (the focused-draw below) have no `selectionSpansElement`, so the block-box spurious rect reaches the dedupe and keep-smaller is what removes the **#7106 extra-area paint** there.

So the dedupe stands on its own as a doubling guard for the existing utilities, and is the primitive the focused-draw follow-up is built on.

## Why this is only part of #7106

The dedupe cleans the rects but does not stop WebKit's native `::selection` from painting across the whole block box in the first place. The extra empty area #7106 reports is two things stacked: that block-box native paint, and the spurious wider `getClientRects()` rect. The first has no CSS fix — you cannot constrain WebKit's block-box `::selection` width back to the glyph box — so the complete fix is the CodeMirror `drawSelection` approach: stop relying on native `::selection` for the focused selection and draw your own rects from the text client-rects, gated to WebKit.

I have that shipped in a Tauri / WKWebView build, as a `registerDrawSelection(editor, options?)`: one overlay layer, rAF-coalesced triggers (the coalescing is load-bearing — WebKit's triple-click over-selects and Lexical corrects it the same tick, so a raw draw flashes the pre-correction state for one frame), and a `.draw-selection-active ::selection { background-color: transparent; color: <fg>; -webkit-text-fill-color: <fg> }` contract that hides the native paint and normalizes the selected-text color so syntax-highlighted code stays legible. That contrast normalization also answers #7492.

I'm keeping that out of this PR because it is a new public API surface, and I'd rather get a read on where it belongs (a `@lexical/utils` sibling of `markSelection` / `selectionAlwaysOnDisplay`, or a `@lexical/extension` next to `SelectionAlwaysOnDisplayExtension`) before coding it here. The dedupe stands on its own and helps the existing utilities immediately, so it seemed worth landing first. Happy to open the `registerDrawSelection` follow-up once you point me at the right home.

## Known limitation — overlapping inline content

The keep-smaller rule assumes same-line rects are horizontally disjoint, which holds in normal flow. It does **not** hold for overlapping inline content (a negative margin, a transform, or a baseline-shifted inline decorator): a real sub-fragment can sit inside a wider real-text rect on the same row, and if a sub-pixel top offset also lets both clear `createRectsFromDOMRange`'s asymmetric overlap filter, keep-smaller drops the wider rect and under-paints the glyphs it uniquely covered (reproduced in Chromium + WebKit — see `dedupeSelectionRectsUnderpaint.test.ts`). There is no rect-only fix: that wider rect is geometrically indistinguishable from the spurious-wider (#7106) rect, so keeping it would re-introduce the extra-area paint. It is documented in the source; the real resolution is the focused-draw path, not a dedupe change.

## Test plan

- `dedupeSelectionRects.test.ts` (unit): keep-smaller / duplicate / zero-area / empty / sub-pixel / disjoint / ragged-row cases, plus a `createRectsFromDOMRange + dedupeSelectionRects` integration block showing the helper's asymmetric pass can leave a same-row contained pair and the dedupe collapses it deterministically (order-independent), keeping the smaller by design.
- `dedupeSelectionRectsUnderpaint.test.ts` (browser, Chromium + WebKit): characterizes the overlapping-content under-paint above against real layout and the real functions.
- prettier, eslint, `check-flow-types` all clean.

## Open questions

- Placement of the dedupe: inside `positionNodeOnRange` (this PR), or folded into `createRectsFromDOMRange`? Leaning to keep it in the consumer — `createRectsFromDOMRange` is a public export, and changing what it returns changes the contract for external callers (thanks @mayrang). The measured finding above reinforces this: in that path the block-box spurious rect is already handled by `selectionSpansElement`, so folding would not add #7106 value there.
- Where the `registerDrawSelection` follow-up should live: `@lexical/utils` or `@lexical/extension`.
