### PR TITLE
[lexical-utils] Add a colors option to markSelection / selectionAlwaysOnDisplay (#7492)

### DIFF
--- a/packages/lexical-extension/src/SelectionAlwaysOnDisplayExtension.ts
+++ b/packages/lexical-extension/src/SelectionAlwaysOnDisplayExtension.ts
@@ -6,7 +6,10 @@
  *
  */
 
-import {selectionAlwaysOnDisplay} from '@lexical/utils';
+import {
+  type MarkSelectionColors,
+  selectionAlwaysOnDisplay,
+} from '@lexical/utils';
 import {defineExtension, safeCast} from 'lexical';
 
 import {namedSignals} from './namedSignals';
@@ -15,6 +18,7 @@ import {effect} from './signals';
 export interface SelectionAlwaysOnDisplayConfig {
   disabled: boolean;
   onReposition: undefined | ((node: readonly HTMLElement[]) => void);
+  colors: undefined | MarkSelectionColors;
 }
 
 /**
@@ -25,6 +29,7 @@ export const SelectionAlwaysOnDisplayExtension =
   /* @__PURE__ */ defineExtension({
     build: (editor, config, state) => namedSignals(config),
     config: /* @__PURE__ */ safeCast<SelectionAlwaysOnDisplayConfig>({
+      colors: undefined,
       disabled: false,
       onReposition: undefined,
     }),
@@ -33,7 +38,11 @@ export const SelectionAlwaysOnDisplayExtension =
       const stores = state.getOutput();
       return effect(() => {
         if (!stores.disabled.value) {
-          return selectionAlwaysOnDisplay(editor, stores.onReposition.value);
+          return selectionAlwaysOnDisplay(
+            editor,
+            stores.onReposition.value,
+            stores.colors.value,
+          );
         }
       });
     },

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -86,9 +86,16 @@ declare export function $findMatchingParent(
   findFn: (LexicalNode) => boolean,
 ): LexicalNode | null;
 declare export function mergeRegister(...func: (() => void)[]): () => void;
+export type MarkSelectionColors = {
+  background?: string,
+};
+declare export function createDefaultOnReposition(
+  colors?: MarkSelectionColors,
+): (nodes: HTMLElement[]) => void;
 declare export function markSelection(
   editor: LexicalEditor,
   onReposition?: (node: HTMLElement[]) => void,
+  colors?: MarkSelectionColors,
 ): () => void;
 declare export function positionNodeOnRange(
   editor: LexicalEditor,
@@ -98,6 +105,7 @@ declare export function positionNodeOnRange(
 declare export function selectionAlwaysOnDisplay(
   editor: LexicalEditor,
   onReposition?: (node: HTMLElement[]) => void,
+  colors?: MarkSelectionColors,
 ): () => void;
 declare export function $getNearestBlockElementAncestorOrThrow(
   startNode: LexicalNode,

--- a/packages/lexical-utils/src/__tests__/unit/createDefaultOnReposition.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/createDefaultOnReposition.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {createDefaultOnReposition} from '@lexical/utils';
+import {describe, expect, it} from 'vitest';
+
+describe('createDefaultOnReposition', () => {
+  it('defaults the rect background to the system Highlight color', () => {
+    const defaultNode = document.createElement('div');
+    createDefaultOnReposition()([defaultNode]);
+    const explicitNode = document.createElement('div');
+    createDefaultOnReposition({background: 'Highlight'})([explicitNode]);
+    expect(defaultNode.style.background).toBe(explicitNode.style.background);
+  });
+
+  it('applies a custom background color when one is given', () => {
+    const node = document.createElement('div');
+    createDefaultOnReposition({background: 'rgb(0, 100, 200)'})([node]);
+    expect(node.style.background).toBe('rgb(0, 100, 200)');
+  });
+
+  it('keeps the margin and padding offsets regardless of color', () => {
+    const node = document.createElement('div');
+    createDefaultOnReposition({background: 'Highlight'})([node]);
+    expect(node.style.marginTop).toBe('-1.5px');
+    expect(node.style.paddingTop).toBe('4px');
+    expect(node.style.paddingBottom).toBe('0px');
+  });
+});

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -78,7 +78,11 @@ import {
   ValueOrUpdater,
 } from 'lexical';
 
-export {default as markSelection} from './markSelection';
+export {
+  createDefaultOnReposition,
+  default as markSelection,
+  type MarkSelectionColors,
+} from './markSelection';
 export {default as positionNodeOnRange} from './positionNodeOnRange';
 export {default as selectionAlwaysOnDisplay} from './selectionAlwaysOnDisplay';
 export {

--- a/packages/lexical-utils/src/markSelection.ts
+++ b/packages/lexical-utils/src/markSelection.ts
@@ -65,26 +65,46 @@ function $rangeFromPoints(
   return range;
 }
 
-function defaultOnReposition(domNodes: readonly HTMLElement[]): void {
-  for (const domNode of domNodes) {
-    const domNodeStyle = domNode.style;
+export interface MarkSelectionColors {
+  /**
+   * CSS color for the selection rect background. Defaults to the system
+   * `'Highlight'` color, which preserves the previous behavior.
+   */
+  background?: string;
+}
 
-    if (domNodeStyle.background !== 'Highlight') {
-      domNodeStyle.background = 'Highlight';
+/**
+ * Build the default `onReposition` styler used by {@link markSelection},
+ * optionally overriding the selection rect color. Exposed so a consumer that
+ * passes its own `onReposition` can reuse the default rect styling with a
+ * different color, instead of re-deriving the margin and padding offsets.
+ */
+export function createDefaultOnReposition(
+  colors?: MarkSelectionColors,
+): (domNodes: readonly HTMLElement[]) => void {
+  const background =
+    colors && colors.background != null ? colors.background : 'Highlight';
+  return domNodes => {
+    for (const domNode of domNodes) {
+      const domNodeStyle = domNode.style;
+
+      if (domNodeStyle.background !== background) {
+        domNodeStyle.background = background;
+      }
+      if (domNodeStyle.color !== 'HighlightText') {
+        domNodeStyle.color = 'HighlightText';
+      }
+      if (domNodeStyle.marginTop !== px(-1.5)) {
+        domNodeStyle.marginTop = px(-1.5);
+      }
+      if (domNodeStyle.paddingTop !== px(4)) {
+        domNodeStyle.paddingTop = px(4);
+      }
+      if (domNodeStyle.paddingBottom !== px(0)) {
+        domNodeStyle.paddingBottom = px(0);
+      }
     }
-    if (domNodeStyle.color !== 'HighlightText') {
-      domNodeStyle.color = 'HighlightText';
-    }
-    if (domNodeStyle.marginTop !== px(-1.5)) {
-      domNodeStyle.marginTop = px(-1.5);
-    }
-    if (domNodeStyle.paddingTop !== px(4)) {
-      domNodeStyle.paddingTop = px(4);
-    }
-    if (domNodeStyle.paddingBottom !== px(0)) {
-      domNodeStyle.paddingBottom = px(0);
-    }
-  }
+  };
 }
 
 /**
@@ -97,8 +117,10 @@ function defaultOnReposition(domNodes: readonly HTMLElement[]): void {
  */
 export default function markSelection(
   editor: LexicalEditor,
-  onReposition: (node: readonly HTMLElement[]) => void = defaultOnReposition,
+  onReposition?: (node: readonly HTMLElement[]) => void,
+  colors?: MarkSelectionColors,
 ): () => void {
+  const reposition = onReposition ?? createDefaultOnReposition(colors);
   let previousAnchorNode: null | TextNode | ElementNode = null;
   let previousAnchorNodeDOM: null | HTMLElement = null;
   let previousAnchorOffset: null | number = null;
@@ -154,11 +176,7 @@ export default function markSelection(
             currentEndNodeDOM,
           );
           removeRangeListener();
-          removeRangeListener = positionNodeOnRange(
-            editor,
-            range,
-            onReposition,
-          );
+          removeRangeListener = positionNodeOnRange(editor, range, reposition);
         }
         previousAnchorNode = currentStartNode;
         previousAnchorNodeDOM = currentStartNodeDOM;

--- a/packages/lexical-utils/src/selectionAlwaysOnDisplay.ts
+++ b/packages/lexical-utils/src/selectionAlwaysOnDisplay.ts
@@ -8,11 +8,12 @@
 
 import {LexicalEditor} from 'lexical';
 
-import markSelection from './markSelection';
+import markSelection, {type MarkSelectionColors} from './markSelection';
 
 export default function selectionAlwaysOnDisplay(
   editor: LexicalEditor,
   onReposition?: (node: readonly HTMLElement[]) => void,
+  colors?: MarkSelectionColors,
 ): () => void {
   let removeSelectionMark: (() => void) | null = null;
 
@@ -33,7 +34,7 @@ export default function selectionAlwaysOnDisplay(
       }
     } else {
       if (removeSelectionMark === null) {
-        removeSelectionMark = markSelection(editor, onReposition);
+        removeSelectionMark = markSelection(editor, onReposition, colors);
       }
     }
   };


### PR DESCRIPTION
## What

`markSelection`'s `defaultOnReposition` hardcodes `background: 'Highlight'`, so a consumer that wants a different selection color has to re-derive the whole styler (copying its `marginTop` / `paddingTop` / `paddingBottom` offsets). That is the configurability #7492 asks for.

This adds an optional `colors` argument (`{ background }`) to `markSelection`, `selectionAlwaysOnDisplay`, and `SelectionAlwaysOnDisplayExtension`, and exports a `createDefaultOnReposition(colors)` factory so a consumer passing its own `onReposition` can reuse the default rect styling with a different color:

```ts
markSelection(editor, undefined, {background: 'var(--selection)'});
selectionAlwaysOnDisplay(editor, undefined, {background: 'var(--selection)'});
// or, to keep the default offsets but change the color from a custom onReposition:
const onReposition = createDefaultOnReposition({background: 'var(--selection)'});
```

`background` defaults to `'Highlight'`, so every current call site is byte-identical. Covered by `createDefaultOnReposition.test.ts`; the existing `markSelection` test still passes.

## The harder half of #7492 (not coded here, asking first)

The reporter's other case is the fake selection going invisible over text that carries its own background, and that one is a paint-order problem, not a color choice. `positionNodeOnRange` prepends its `position: relative` wrapper to `root.parentElement`, so the rects sit *behind* the glyphs and *below* the editable. When a span has its own opaque background (inline code, a code block), that background paints over the behind-text rect and the selection disappears for the length of that span. A different `background` color cannot fix that, the rect is occluded, not mis-colored.

The way to make it visible is to lift the rect above the content (`z-index`). But a translucent rect lifted over syntax-highlighted code then washes the token colors out. I measured this by canvas-compositing each token color over the rect versus over the code background, in dark mode:

| token   | native (over code bg) | over the lifted rect |
| ------- | --------------------- | -------------------- |
| keyword | 3-6:1                 | 1.97:1               |
| string  | 3-6:1                 | 2.72:1               |
| number  | 3-6:1                 | 2.16:1               |
| comment | 3-6:1                 | 1.96:1               |

Below ~2:1 selected code is hard to read, so lifting the rect makes the selection visible but the code less legible, a net loss for exactly the code-block case the issue is about.

One correction, since I had this muddled at first: the clean way to recover the contrast is to recolor the *selected text* to one foreground color via a `::selection` rule, but that only works for a focused native selection. `markSelection` / `selectionAlwaysOnDisplay` draw the fake selection when the editor is **blurred** (the real selection is elsewhere), so there is no native `::selection` on the editor text to override. That `::selection` normalization belongs to the *focused* selection, which is the separate WebKit drawSelection work in facebook/lexical#8709, not here. Recoloring the blurred fake selection's text would mean touching the actual nodes, which this path deliberately leaves alone.

So the honest scope: `colors.background` (this PR) is the clean answer to the literal "make the color configurable" ask. Making the blurred fake selection both visible and legible over an opaque code background is a genuine open problem, the z-index lift buys visibility but the contrast can't be bought back the same way, and I'd rather hear how you'd want to approach it (lift behind an option, a documented limitation) than guess.

## Test plan

- `createDefaultOnReposition.test.ts`: default color, custom color, offsets preserved. `pnpm vitest --project unit` green; existing `markSelection.test.tsx` unaffected.
- prettier, eslint, `check-flow-types` all clean.

## Open questions

- Util or Extension, or both? This threads `colors` through `markSelection`, `selectionAlwaysOnDisplay`, and the Extension config for parity.
- Positional `colors?` (zero-churn back-compat, what this PR does) or an options bag (`markSelection(editor, {onReposition, colors})`) that soft-deprecates the positional `onReposition`?
- Export `createDefaultOnReposition`, or keep it internal? It lets a custom-`onReposition` consumer reuse the default styling, at the cost of a slightly wider public surface.
- The visible-over-opaque-background case above: worth a `z-index` lift behind an option here, or better left to the focused-selection path (#8709) and documented as a limitation of the blurred fake selection? Open to either.
