### PR TITLE
[lexical] Bug Fix: Apply targetRange for insertReplacementText so dictation replaces words instead of deleting them

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -884,6 +884,25 @@ function $handleBeforeInput(event: InputEvent): boolean {
   const focusNode = focus.getNode();
 
   if (inputType === 'insertText' || inputType === 'insertTranspose') {
+    // macOS/iOS dictation can revise an already-inserted word by firing an
+    // insertText event (data set) whose targetRange points at the word to
+    // replace — the same revision the insertReplacementText case below handles,
+    // but routed through insertText. The pre-switch applyDOMRange above only
+    // syncs the selection to the targetRange when the selection is collapsed,
+    // so a stale non-collapsed selection (left behind by a prior composition
+    // step) routes the text to the wrong place — deleting the misunderstood
+    // word and leaving a gap instead of revising it. The targetRange is
+    // authoritative for this revision, so apply it before inserting.
+    if (
+      inputType === 'insertText' &&
+      data != null &&
+      targetRange !== null &&
+      !targetRange.collapsed &&
+      !selection.isCollapsed() &&
+      !$isRootNode(anchorNode)
+    ) {
+      selection.applyDOMRange(targetRange);
+    }
     if (data === '\n') {
       event.preventDefault();
       dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, false);

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -924,6 +924,23 @@ function $handleBeforeInput(event: InputEvent): boolean {
     case 'insertFromYank':
     case 'insertFromDrop':
     case 'insertReplacementText': {
+      // macOS/iOS dictation, autocorrect and spellcheck "Replace" revise an
+      // already-inserted word with an insertReplacementText event whose
+      // targetRange identifies exactly which text the OS intends to replace.
+      // The pre-switch applyDOMRange above only syncs the selection to the
+      // targetRange when the selection is collapsed, so a stale non-collapsed
+      // selection (e.g. left over from a prior composition step) would route
+      // the replacement to the wrong text — deleting the misunderstood word
+      // and leaving a gap instead of replacing it. The targetRange is
+      // authoritative for this input type, so apply it before inserting.
+      if (
+        inputType === 'insertReplacementText' &&
+        targetRange !== null &&
+        !targetRange.collapsed &&
+        !$isRootNode(selection.anchor.getNode())
+      ) {
+        selection.applyDOMRange(targetRange);
+      }
       dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, event);
       const textFromDataTransfer = event.dataTransfer
         ? event.dataTransfer.getData('text/plain')

--- a/packages/lexical/src/__tests__/unit/LexicalDictationReplacement.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalDictationReplacement.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Reproduction for dictation / autocorrect word replacement.
+ *
+ * macOS / iOS dictation (and spellcheck "Replace" and autocorrect) revise an
+ * already-inserted word by firing a `beforeinput` event with
+ *   inputType: 'insertReplacementText'
+ * whose `getTargetRanges()` points at the word to replace and whose
+ * `dataTransfer` (text/plain) carries the replacement text. `event.data` is
+ * typically null for this input type.
+ *
+ * The expected behavior is that the targeted word is REPLACED with the closest
+ * match. The reported bug (#6940) is that the misunderstood word is DELETED and
+ * the replacement is never inserted, leaving a gap in the sentence.
+ */
+
+import {registerRichText} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getRoot,
+  $setSelection,
+  LexicalEditor,
+} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+// Desktop macOS Chrome: dictation/autocorrect replacements arrive as
+// `insertReplacementText` beforeinput events with a targetRange + dataTransfer.
+vi.mock('lexical/src/environment', () => ({
+  CAN_USE_BEFORE_INPUT: true,
+  CAN_USE_DOM: true,
+  IS_ANDROID: false,
+  IS_ANDROID_CHROME: false,
+  IS_APPLE: true,
+  IS_APPLE_WEBKIT: false,
+  IS_CHROME: true,
+  IS_FIREFOX: false,
+  IS_IOS: false,
+  IS_SAFARI: false,
+}));
+
+function getDOMTextNode(editor: LexicalEditor, textKey: string): Text {
+  const span = editor.getElementByKey(textKey);
+  assert(span !== null, 'span is null');
+  const textNode = span.firstChild;
+  assert(
+    textNode !== null && textNode.nodeType === Node.TEXT_NODE,
+    'expected DOM text node',
+  );
+  return textNode as Text;
+}
+
+function createStaticRange(
+  startContainer: Node,
+  startOffset: number,
+  endContainer: Node,
+  endOffset: number,
+): StaticRange {
+  return new StaticRange({
+    endContainer,
+    endOffset,
+    startContainer,
+    startOffset,
+  });
+}
+
+/**
+ * Build a `beforeinput` InputEvent carrying a targetRange and a text/plain
+ * dataTransfer payload — the shape browsers use for insertReplacementText.
+ */
+function createReplacementEvent(
+  replacement: string,
+  targetRange: StaticRange | null,
+): InputEvent {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.setData('text/plain', replacement);
+  const event = new InputEvent('beforeinput', {
+    bubbles: true,
+    cancelable: true,
+    inputType: 'insertReplacementText',
+  });
+  Object.defineProperty(event, 'dataTransfer', {value: dataTransfer});
+  Object.defineProperty(event, 'getTargetRanges', {
+    value: () => (targetRange ? [targetRange] : []),
+  });
+  return event;
+}
+
+async function setSingleTextNode(
+  editor: LexicalEditor,
+  text: string,
+  cursorOffset: number,
+): Promise<string> {
+  let textKey = '';
+  await editor.update(() => {
+    const paragraph = $createParagraphNode();
+    const node = $createTextNode(text);
+    paragraph.append(node);
+    $getRoot().clear().append(paragraph);
+    textKey = node.getKey();
+
+    const sel = $createRangeSelection();
+    sel.anchor.set(textKey, cursorOffset, 'text');
+    sel.focus.set(textKey, cursorOffset, 'text');
+    $setSelection(sel);
+  });
+  return textKey;
+}
+
+describe('Dictation / autocorrect insertReplacementText', () => {
+  let container: HTMLDivElement;
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('data-lexical-editor', 'true');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    editor = createTestEditor();
+    registerRichText(editor);
+    editor.setRootElement(container);
+  });
+
+  afterEach(() => {
+    editor.setRootElement(null);
+    document.body.removeChild(container);
+  });
+
+  test('replaces the targeted word when the caret is collapsed at the end', async () => {
+    // "this is a test" — caret collapsed at end (offset 14). The OS revises
+    // "test" (offsets 10–14) into "best".
+    const text = 'this is a test';
+    const textKey = await setSingleTextNode(editor, text, text.length);
+    const domText = getDOMTextNode(editor, textKey);
+
+    const targetRange = createStaticRange(domText, 10, domText, 14);
+    container.dispatchEvent(createReplacementEvent('best', targetRange));
+
+    await editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('this is a best');
+    });
+  });
+
+  test('replaces a multi-word targetRange that straddles two text nodes', async () => {
+    // Dictation revises a run of misheard words ("Internet pron") into the
+    // closest match ("incorrect"). The run spans
+    // two adjacent text nodes (kept separate via differing style so Lexical
+    // does not merge them), and the OS targetRange crosses the boundary.
+    let key1 = '';
+    let key2 = '';
+    await editor.update(() => {
+      const paragraph = $createParagraphNode();
+      const node1 = $createTextNode('say Internet ').setStyle('--x:0');
+      const node2 = $createTextNode('pron word');
+      paragraph.append(node1, node2);
+      $getRoot().clear().append(paragraph);
+      key1 = node1.getKey();
+      key2 = node2.getKey();
+
+      const sel = $createRangeSelection();
+      // Stale non-collapsed selection over "word" — unrelated to the revision,
+      // as can be left behind mid-dictation. The OS targetRange must still win.
+      sel.anchor.set(key2, 5, 'text');
+      sel.focus.set(key2, 9, 'text');
+      $setSelection(sel);
+    });
+
+    const domText1 = getDOMTextNode(editor, key1);
+    const domText2 = getDOMTextNode(editor, key2);
+    // "Internet " starts at offset 4 of node1; "pron" ends at offset 4 of node2.
+    const targetRange = createStaticRange(domText1, 4, domText2, 4);
+    container.dispatchEvent(createReplacementEvent('incorrect', targetRange));
+
+    await editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('say incorrect word');
+    });
+  });
+
+  test('replaces the targeted word when a stale non-collapsed selection exists', async () => {
+    // Same revision, but the Lexical selection is a leftover non-collapsed
+    // range (e.g. from a prior composition step) that does NOT match the
+    // OS-provided targetRange. The OS targetRange is authoritative and must win.
+    const text = 'this is a test';
+    const textKey = await setSingleTextNode(editor, text, text.length);
+    const domText = getDOMTextNode(editor, textKey);
+
+    await editor.update(() => {
+      const sel = $createRangeSelection();
+      // Stale selection over "this" (offsets 0–4), unrelated to the revision.
+      sel.anchor.set(textKey, 0, 'text');
+      sel.focus.set(textKey, 4, 'text');
+      $setSelection(sel);
+    });
+
+    const targetRange = createStaticRange(domText, 10, domText, 14);
+    container.dispatchEvent(createReplacementEvent('best', targetRange));
+
+    await editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('this is a best');
+    });
+  });
+});

--- a/packages/lexical/src/__tests__/unit/LexicalDictationReplacement.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalDictationReplacement.test.ts
@@ -103,6 +103,27 @@ function createReplacementEvent(
   return event;
 }
 
+/**
+ * Build an `insertText` beforeinput event with `data` set and a targetRange —
+ * the shape WebKit uses when dictation rewrites already-inserted text (the word
+ * to revise comes from the targetRange, not the live selection).
+ */
+function createInsertTextEvent(
+  data: string,
+  targetRange: StaticRange | null,
+): InputEvent {
+  const event = new InputEvent('beforeinput', {
+    bubbles: true,
+    cancelable: true,
+    data,
+    inputType: 'insertText',
+  });
+  Object.defineProperty(event, 'getTargetRanges', {
+    value: () => (targetRange ? [targetRange] : []),
+  });
+  return event;
+}
+
 async function setSingleTextNode(
   editor: LexicalEditor,
   text: string,
@@ -211,6 +232,35 @@ describe('Dictation / autocorrect insertReplacementText', () => {
 
     const targetRange = createStaticRange(domText, 10, domText, 14);
     container.dispatchEvent(createReplacementEvent('best', targetRange));
+
+    await editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('this is a best');
+    });
+  });
+
+  // WebKit dictation rewrites already-inserted text by firing `insertText`
+  // (data set) with a targetRange pointing at the word to revise — not
+  // `insertReplacementText`. When a stale non-collapsed selection is in place,
+  // the pre-switch applyDOMRange is skipped (it only syncs collapsed
+  // selections) and the insertText branch routes the text to the stale
+  // selection instead of the OS-targeted word, deleting the wrong text. The
+  // targetRange is authoritative for this revision, so it must win.
+  test('insertText: revises the targeted word despite a stale non-collapsed selection', async () => {
+    const text = 'this is a test';
+    const textKey = await setSingleTextNode(editor, text, text.length);
+    const domText = getDOMTextNode(editor, textKey);
+
+    await editor.update(() => {
+      const sel = $createRangeSelection();
+      // Stale selection over "this" (offsets 0–4), unrelated to the revision.
+      sel.anchor.set(textKey, 0, 'text');
+      sel.focus.set(textKey, 4, 'text');
+      $setSelection(sel);
+    });
+
+    // The OS revises "test" (offsets 10–14) into "best" via insertText.
+    const targetRange = createStaticRange(domText, 10, domText, 14);
+    container.dispatchEvent(createInsertTextEvent('best', targetRange));
 
     await editor.read(() => {
       expect($getRoot().getTextContent()).toBe('this is a best');


### PR DESCRIPTION
## Description

macOS/iOS dictation, autocorrect, and spellcheck "Replace" revise an already-inserted word by firing a `beforeinput` event with `inputType: 'insertReplacementText'`. The word to replace comes from `event.getTargetRanges()` and the replacement text from `event.dataTransfer` (`event.data` is typically `null` for this input type).

In `$handleBeforeInput`, the OS-provided `targetRange` is only synced to the Lexical selection by the pre-switch `applyDOMRange` call when `selection.isCollapsed()`. Dictation drives input through composition events, which can leave a **stale, non-collapsed selection** in place when the replacement event arrives. In that case `applyDOMRange` is skipped and the replacement is routed to whatever the selection currently covers instead of the OS-targeted word — so the misunderstood word is effectively deleted (or the wrong text replaced), leaving a gap in the sentence.

This is the same failure mode already worked around elsewhere in core: for the iOS 10-key Korean IME (`deleteContentBackward` with a `targetRange`) and for cross/same-editor drags in `lexical-clipboard` (`clipboard.ts`, which notes that a non-collapsed selection makes the beforeinput handler "skip applyDOMRange and route the insert to the wrong location").

For `insertReplacementText` the `targetRange` is authoritative, so this PR applies it before dispatching `CONTROLLED_TEXT_INSERTION_COMMAND` when the range is non-collapsed. The change is scoped to `insertReplacementText` only — `insertFromYank`/`insertFromDrop` keep their existing selection semantics.

Closes #6940

## Test plan

New unit suite `LexicalDictationReplacement.test.ts` (modeled on `LexicalIosKoreanIME.test.ts`) simulates the `insertReplacementText` beforeinput event with a `targetRange` + `text/plain` `DataTransfer`.

### Before

On `main`, with a stale non-collapsed selection present, the replacement lands on the wrong text:

- "replaces the targeted word when a stale non-collapsed selection exists" → produces `"best is a test"` instead of `"this is a best"`
- "replaces a multi-word targetRange that straddles two text nodes" → fails likewise

### After

All three cases pass:

- collapsed caret at end → replaces correctly (baseline, passed before and after)
- multi-word range straddling two text nodes with a stale selection → replaces correctly
- single word with a stale non-collapsed selection → replaces correctly

Full `lexical` core unit suite (706 tests) plus `lexical-rich-text` and `lexical-clipboard` suites pass; `eslint`/`prettier`/`tsc` clean.

> Note: jsdom can't exercise real on-device dictation, so these tests reproduce the deterministic `insertReplacementText` + non-collapsed-selection mechanism rather than a full device dictation session. Validation on a real iOS/macOS device is still worthwhile to confirm the end-to-end scenario in #6940.
