### PR TITLE
[lexical] Bug Fix: Normalize non-inline nodes when inserting into inline-only parents

### DIFF
--- a/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {$createCodeNode, CodeExtension} from '@lexical/code';
+import {$createCodeHighlightNode, $isCodeNode} from '@lexical/code-core';
 import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
 import {
@@ -17,9 +18,6 @@ import {
 } from 'lexical';
 import {$assertNodeType} from 'lexical/src/__tests__/utils';
 import {describe, expect, it} from 'vitest';
-
-import {$createCodeHighlightNode} from '../../CodeHighlightNode';
-import {$isCodeNode} from '../../CodeNode';
 
 describe('CodeExtension', () => {
   it('should not escape code block when content has consecutive blank lines (paste scenario)', () => {

--- a/packages/lexical-code-core/src/__tests__/unit/CodeImportExtension.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeImportExtension.test.ts
@@ -6,7 +6,12 @@
  *
  */
 
-import {CodeExtension, CodeImportExtension} from '@lexical/code-core';
+import {
+  $isCodeNode,
+  CodeExtension,
+  CodeImportExtension,
+  CodeNode,
+} from '@lexical/code-core';
 import {
   buildEditorFromExtensions,
   getExtensionDependencyFromEditor,
@@ -23,8 +28,6 @@ import {
   type LexicalNode,
 } from 'lexical';
 import {assert, describe, expect, test} from 'vitest';
-
-import {$isCodeNode, CodeNode} from '../../CodeNode';
 
 function buildEditor() {
   return buildEditorFromExtensions(

--- a/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
@@ -8,11 +8,10 @@
 
 import type {EditorConfig} from 'lexical';
 
+import {$createCodeNode} from '@lexical/code-core';
 import {$getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 import {describe, expect, it} from 'vitest';
-
-import {$createCodeNode} from '../../CodeNode';
 
 const editorConfig = {
   namespace: '',

--- a/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import type {CodeNode} from '@lexical/code';
 import type {LexicalCommand} from 'lexical';
 

--- a/packages/lexical-devtools-core/src/__tests__/unit/generateContentSlots.test.ts
+++ b/packages/lexical-devtools-core/src/__tests__/unit/generateContentSlots.test.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {generateContent} from '@lexical/devtools-core';
 import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {
   $createParagraphNode,
@@ -20,8 +21,6 @@ import {
   TestShadowRootNode,
 } from 'lexical/src/__tests__/utils';
 import {describe, expect, test} from 'vitest';
-
-import {generateContent} from '../../generateContent';
 
 describe('generateContent named slots', () => {
   // A DecoratorNode host reached through the children channel must recurse

--- a/packages/lexical-extension/src/IMEExtension.ts
+++ b/packages/lexical-extension/src/IMEExtension.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
   $getSelection,
@@ -17,6 +16,7 @@ import {
   COMPOSITION_START_TAG,
   defineExtension,
   type LexicalEditor,
+  mergeRegister,
   type NodeKey,
   type TextNode,
 } from 'lexical';

--- a/packages/lexical-extension/src/SelectBlockExtension.ts
+++ b/packages/lexical-extension/src/SelectBlockExtension.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {$isBlockFullySelected, mergeRegister} from '@lexical/utils';
+import {$isBlockFullySelected} from '@lexical/utils';
 import {
   $getRoot,
   $getSelection,
@@ -20,6 +20,7 @@ import {
   COMMAND_PRIORITY_LOW,
   defineExtension,
   LexicalNode,
+  mergeRegister,
   safeCast,
   SELECT_ALL_COMMAND,
 } from 'lexical';

--- a/packages/lexical-extension/src/__tests__/unit/NodeSelectionDataSelected.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/NodeSelectionDataSelected.test.ts
@@ -6,7 +6,10 @@
  *
  */
 
-import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  buildEditorFromExtensions,
+  NodeSelectionDataSelectedExtension,
+} from '@lexical/extension';
 import {
   $create,
   $createNodeSelection,
@@ -20,8 +23,6 @@ import {
   type NodeKey,
 } from 'lexical';
 import {describe, expect, test} from 'vitest';
-
-import {NodeSelectionDataSelectedExtension} from '../../NodeSelectionDataSelectedExtension';
 
 class HostNode extends ElementNode {
   $config() {

--- a/packages/lexical-extension/src/__tests__/unit/deepThemeMergeInPlace.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/deepThemeMergeInPlace.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
+import {} from '@lexical/extension';
 import {describe, expect, it} from 'vitest';
 
 import {deepThemeMergeInPlace} from '../../deepThemeMergeInPlace';

--- a/packages/lexical-hashtag/src/LexicalHashtagExtension.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagExtension.ts
@@ -7,8 +7,7 @@
  */
 
 import {registerLexicalTextEntity} from '@lexical/text';
-import {mergeRegister} from '@lexical/utils';
-import {defineExtension, LexicalEditor} from 'lexical';
+import {defineExtension, LexicalEditor, mergeRegister} from 'lexical';
 
 import {$createHashtagNode, HashtagNode} from './LexicalHashtagNode';
 

--- a/packages/lexical-hashtag/src/LexicalHashtagNode.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagNode.ts
@@ -8,8 +8,7 @@
 
 import type {EditorConfig, LexicalNode, SerializedTextNode} from 'lexical';
 
-import {addClassNamesToElement} from '@lexical/utils';
-import {$applyNodeReplacement, TextNode} from 'lexical';
+import {$applyNodeReplacement, addClassNamesToElement, TextNode} from 'lexical';
 
 /** @noInheritDoc */
 export class HashtagNode extends TextNode {

--- a/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
+++ b/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
@@ -18,6 +18,7 @@
 
 import type {EditorState, LexicalEditor, RangeSelection} from 'lexical';
 
+import {createHeadlessEditor} from '@lexical/headless';
 import {withDOM} from '@lexical/headless/dom';
 import {$generateHtmlFromNodes} from '@lexical/html';
 import {JSDOM} from 'jsdom';
@@ -32,7 +33,6 @@ import {
 } from 'lexical';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
-import {createHeadlessEditor} from '../..';
 import {isEmptyNavigator} from '../utils';
 
 describe('LexicalHeadlessEditor', () => {

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -17,7 +17,6 @@ import {
   Signal,
   signal,
 } from '@lexical/extension';
-import {mergeRegister} from '@lexical/utils';
 import {
   $isRangeSelection,
   $isRootNode,
@@ -35,6 +34,7 @@ import {
   HISTORIC_TAG,
   HISTORY_MERGE_TAG,
   HISTORY_PUSH_TAG,
+  mergeRegister,
   PASTE_TAG,
   REDO_COMMAND,
   safeCast,

--- a/packages/lexical-html/src/__tests__/unit/compileDOMRenderConfigOverrides.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/compileDOMRenderConfigOverrides.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {domOverride} from '@lexical/html';
 import {$isLineBreakNode, isHTMLElement, TextNode} from 'lexical';
 import {describe, expect, test} from 'vitest';

--- a/packages/lexical-link/src/ClickableLinkExtension.ts
+++ b/packages/lexical-link/src/ClickableLinkExtension.ts
@@ -7,8 +7,8 @@
  */
 
 import {namedSignals, NamedSignalsOutput} from '@lexical/extension';
-import {$findMatchingParent, isHTMLAnchorElement} from '@lexical/utils';
 import {
+  $findMatchingParent,
   $getNearestNodeFromDOMNode,
   $getSelection,
   $isElementNode,
@@ -16,6 +16,7 @@ import {
   defineExtension,
   getNearestEditorFromDOMNode,
   isDOMNode,
+  isHTMLAnchorElement,
   LexicalEditor,
   safeCast,
 } from 'lexical';

--- a/packages/lexical-link/src/LexicalAutoLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalAutoLinkExtension.ts
@@ -8,7 +8,6 @@
 
 import type {ElementNode, LexicalEditor, LexicalNode} from 'lexical';
 
-import {mergeRegister} from '@lexical/utils';
 import {
   $createTextNode,
   $getSelection,
@@ -19,6 +18,7 @@ import {
   $isTextNode,
   COMMAND_PRIORITY_LOW,
   defineExtension,
+  mergeRegister,
   shallowMergeConfig,
   TextNode,
 } from 'lexical';

--- a/packages/lexical-link/src/LexicalLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalLinkExtension.ts
@@ -8,7 +8,7 @@
 
 import {effect, namedSignals, NamedSignalsOutput} from '@lexical/extension';
 import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
-import {mergeRegister, objectKlassEquals} from '@lexical/utils';
+import {objectKlassEquals} from '@lexical/utils';
 import {
   $getSelection,
   $isElementNode,
@@ -19,6 +19,7 @@ import {
   configExtension,
   defineExtension,
   LexicalEditor,
+  mergeRegister,
   PASTE_COMMAND,
   shallowMergeConfig,
 } from 'lexical';

--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -24,17 +24,13 @@ import type {
 
 import invariant from '@lexical/internal/invariant';
 import {
-  $findMatchingParent,
-  $insertNodeToNearestRootAtCaret,
-  addClassNamesToElement,
-  isHTMLAnchorElement,
-} from '@lexical/utils';
-import {
   $applyNodeReplacement,
   $caretFromPoint,
   $copyNode,
+  $findMatchingParent,
   $getChildCaret,
   $getSelection,
+  $insertNodeToNearestRootAtCaret,
   $isElementNode,
   $isNodeSelection,
   $isRangeSelection,
@@ -44,8 +40,10 @@ import {
   $rewindSiblingCaret,
   $setPointFromCaret,
   $setSelection,
+  addClassNamesToElement,
   createCommand,
   ElementNode,
+  isHTMLAnchorElement,
   Spread,
 } from 'lexical';
 

--- a/packages/lexical-list/src/LexicalListExtension.ts
+++ b/packages/lexical-list/src/LexicalListExtension.ts
@@ -8,8 +8,12 @@
 
 import {effect, namedSignals} from '@lexical/extension';
 import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
-import {mergeRegister} from '@lexical/utils';
-import {configExtension, defineExtension, safeCast} from 'lexical';
+import {
+  configExtension,
+  defineExtension,
+  mergeRegister,
+  safeCast,
+} from 'lexical';
 
 import {registerCheckList} from './checkList';
 import {ListItemNode} from './LexicalListItemNode';

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -24,16 +24,12 @@ import type {
 
 import invariant from '@lexical/internal/invariant';
 import {
-  $insertNodeToNearestRootAtCaret,
-  addClassNamesToElement,
-  removeClassNamesFromElement,
-} from '@lexical/utils';
-import {
   $applyNodeReplacement,
   $copyNode,
   $createParagraphNode,
   $getSelection,
   $getSiblingCaret,
+  $insertNodeToNearestRootAtCaret,
   $isElementNode,
   $isParagraphNode,
   $isRangeSelection,
@@ -41,12 +37,14 @@ import {
   $rewindSiblingCaret,
   $setDirectionFromDOM,
   $setFormatFromDOM,
+  addClassNamesToElement,
   buildImportMap,
   ElementNode,
   getStyleObjectFromCSS,
   isHTMLElement,
   LexicalEditor,
   normalizeClassNames,
+  removeClassNamesFromElement,
   setDOMStyleFromCSS,
 } from 'lexical';
 

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -7,26 +7,24 @@
  */
 
 import {
-  addClassNamesToElement,
-  isHTMLElement,
-  removeClassNamesFromElement,
-} from '@lexical/utils';
-import {
   $applyNodeReplacement,
   $createTextNode,
   $isElementNode,
   $setDirectionFromDOM,
+  addClassNamesToElement,
   buildImportMap,
   DOMConversionOutput,
   DOMExportOutput,
   EditorConfig,
   EditorThemeClasses,
   ElementNode,
+  isHTMLElement,
   LexicalEditor,
   LexicalNode,
   LexicalUpdateJSON,
   NodeKey,
   normalizeClassNames,
+  removeClassNamesFromElement,
   SerializedElementNode,
   Spread,
 } from 'lexical';

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -5,8 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {$generateNodesFromDOM} from '@lexical/html';
+import {
+  $createListItemNode,
+  $createListNode,
+  $handleListInsertParagraph,
+  $isListItemNode,
+  $isListNode,
+  ListItemNode,
+  ListNode,
+} from '@lexical/list';
 import {
   $createTableCellNode,
   $createTableNode,
@@ -31,15 +39,7 @@ import {
 } from 'lexical/src/__tests__/utils';
 import {assert, beforeEach, describe, expect, it, test} from 'vitest';
 
-import {
-  $createListItemNode,
-  $createListNode,
-  $isListItemNode,
-  $isListNode,
-  ListItemNode,
-  ListNode,
-} from '../..';
-import {$handleIndent, $handleListInsertParagraph} from '../../formatList';
+import {$handleIndent} from '../../formatList';
 
 const editorConfig = Object.freeze({
   namespace: '',

--- a/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
@@ -6,6 +6,7 @@
  *
  */
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {registerListStrictIndentTransform} from '@lexical/list';
 import {$getRoot} from 'lexical';
 import {
   expectHtmlToBeEqual,
@@ -13,8 +14,6 @@ import {
   initializeUnitTest,
 } from 'lexical/src/__tests__/utils';
 import {beforeEach, describe, test} from 'vitest';
-
-import {registerListStrictIndentTransform} from '../../index';
 
 describe('Lexical List StrictIndentTransform tests', () => {
   initializeUnitTest(testEnv => {

--- a/packages/lexical-list/src/__tests__/unit/utils.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/utils.test.ts
@@ -5,12 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import {
+  $createListItemNode,
+  $createListNode,
+  $getListDepth,
+} from '@lexical/list';
 import {$createParagraphNode, $getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 import {describe, expect, test} from 'vitest';
 
-import {$createListItemNode, $createListNode} from '../..';
-import {$getListDepth, $getTopListNode, $isLastItemInList} from '../../utils';
+import {$getTopListNode, $isLastItemInList} from '../../utils';
 
 describe('Lexical List Utils tests', () => {
   initializeUnitTest(testEnv => {

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -10,14 +10,10 @@ import type {ListItemNode} from './LexicalListItemNode';
 import type {ElementNode, LexicalCommand, LexicalEditor} from 'lexical';
 
 import {Signal} from '@lexical/extension';
-import {
-  $findMatchingParent,
-  calculateZoomLevel,
-  isHTMLElement,
-  mergeRegister,
-} from '@lexical/utils';
+import {calculateZoomLevel} from '@lexical/utils';
 import {
   $addUpdateTag,
+  $findMatchingParent,
   $getNearestNodeFromDOMNode,
   $getSelection,
   $isElementNode,
@@ -25,11 +21,13 @@ import {
   COMMAND_PRIORITY_LOW,
   createCommand,
   getNearestEditorFromDOMNode,
+  isHTMLElement,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_UP_COMMAND,
   KEY_ESCAPE_COMMAND,
   KEY_SPACE_COMMAND,
+  mergeRegister,
   SKIP_DOM_SELECTION_TAG,
   SKIP_SELECTION_FOCUS_TAG,
 } from 'lexical';

--- a/packages/lexical-list/src/registerList.ts
+++ b/packages/lexical-list/src/registerList.ts
@@ -8,9 +8,9 @@
 
 import type {LexicalCommand, LexicalEditor, NodeKey} from 'lexical';
 
-import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
   $createParagraphNode,
+  $findMatchingParent,
   $getNodeByKey,
   $getSelection,
   $isDecoratorNode,
@@ -21,6 +21,7 @@ import {
   createCommand,
   INSERT_PARAGRAPH_COMMAND,
   KEY_BACKSPACE_COMMAND,
+  mergeRegister,
   TextNode,
 } from 'lexical';
 

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -9,7 +9,7 @@
 import type {ElementNode, LexicalNode, Spread} from 'lexical';
 
 import invariant from '@lexical/internal/invariant';
-import {$findMatchingParent} from '@lexical/utils';
+import {$findMatchingParent} from 'lexical';
 
 import {$isListItemNode, $isListNode, ListItemNode, ListNode} from './';
 

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -18,10 +18,12 @@ import type {
 } from 'lexical';
 
 import {
+  $applyNodeReplacement,
+  $isRangeSelection,
   addClassNamesToElement,
+  ElementNode,
   removeClassNamesFromElement,
-} from '@lexical/utils';
-import {$applyNodeReplacement, $isRangeSelection, ElementNode} from 'lexical';
+} from 'lexical';
 
 export type SerializedMarkNode = Spread<
   {

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -16,11 +16,11 @@ import type {
 
 import {$isListItemNode, $isListNode, ListItemNode} from '@lexical/list';
 import {$isQuoteNode} from '@lexical/rich-text';
-import {$findMatchingParent} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createTabNode,
   $createTextNode,
+  $findMatchingParent,
   $getRoot,
   $getSelection,
   $isElementNode,

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {$createCodeNode, CodeNode} from '@lexical/code-core';
 import {createHeadlessEditor} from '@lexical/headless';
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
@@ -17,6 +16,21 @@ import {
   ListItemNode,
   ListNode,
 } from '@lexical/list';
+import {
+  $convertFromMarkdownString,
+  $convertSelectionToMarkdownString,
+  $convertToMarkdownString,
+  CHECK_LIST,
+  CODE,
+  ElementTransformer,
+  HEADING,
+  LINK,
+  MultilineElementTransformer,
+  registerMarkdownShortcuts,
+  TextMatchTransformer,
+  Transformer,
+  TRANSFORMERS,
+} from '@lexical/markdown';
 import {$createQuoteNode, HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {
   $addUpdateTag,
@@ -45,25 +59,10 @@ import {
 import {assert, describe, expect, it} from 'vitest';
 
 import {
-  $convertFromMarkdownString,
-  $convertSelectionToMarkdownString,
-  $convertToMarkdownString,
-  LINK,
-  registerMarkdownShortcuts,
-  TextMatchTransformer,
-  Transformer,
-} from '../..';
-import {
-  CHECK_LIST,
-  CODE,
-  ElementTransformer,
   hardLineBreakState,
-  HEADING,
   listMarkerState,
-  MultilineElementTransformer,
   normalizeMarkdown,
   parseMarkdownHardLineBreak,
-  TRANSFORMERS,
 } from '../../MarkdownTransformers';
 
 const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -23,7 +23,7 @@ import {
   $moveCharacter,
   $shouldOverrideDefaultCharacterSelection,
 } from '@lexical/selection';
-import {eventFiles, mergeRegister, objectKlassEquals} from '@lexical/utils';
+import {eventFiles, objectKlassEquals} from '@lexical/utils';
 import {
   $getSelection,
   $getSlotFrame,
@@ -52,6 +52,7 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
+  mergeRegister,
   PASTE_COMMAND,
   PASTE_TAG,
   REMOVE_TEXT_COMMAND,

--- a/packages/lexical-playground/__tests__/unit/Issue8724Collapsible.test.ts
+++ b/packages/lexical-playground/__tests__/unit/Issue8724Collapsible.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createHorizontalRuleNode,
+  buildEditorFromExtensions,
+  HorizontalRuleExtension,
+  HorizontalRuleNode,
+} from '@lexical/extension';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $nodesOfType,
+  defineExtension,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+import {CollapsibleExtension} from '../../src/plugins/CollapsibleExtension';
+import {
+  $createCollapsibleContainerNode,
+  $isCollapsibleContainerNode,
+} from '../../src/plugins/CollapsibleExtension/CollapsibleContainerNode';
+import {
+  $createCollapsibleContentNode,
+  $isCollapsibleContentNode,
+} from '../../src/plugins/CollapsibleExtension/CollapsibleContentNode';
+import {
+  $createCollapsibleTitleNode,
+  $isCollapsibleTitleNode,
+} from '../../src/plugins/CollapsibleExtension/CollapsibleTitleNode';
+
+const ext = defineExtension({
+  $initialEditorState: null,
+  dependencies: [CollapsibleExtension, HorizontalRuleExtension],
+  name: '[8724-collapsible]',
+});
+
+describe('Pasting a HorizontalRuleNode into a CollapsibleTitleNode (#8724)', () => {
+  // Mirrors the reported repro: insert a collapsible (focus lands in the empty
+  // ParagraphNode inside the CollapsibleTitleNode) and paste a copied
+  // HorizontalRuleNode. The title is inline-only and cannot hold the block, so
+  // insertNodes flattens the paste to its inline content; a HorizontalRuleNode
+  // has no inline form, so it is dropped and the collapsible is left intact —
+  // never producing a non-inline child of the title.
+  test('drops the pasted block and keeps the collapsible intact', () => {
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        // Same shape the INSERT_COLLAPSIBLE_COMMAND produces.
+        const title = $createCollapsibleTitleNode();
+        const titleParagraph = $createParagraphNode();
+        $getRoot()
+          .clear()
+          .append(
+            $createCollapsibleContainerNode(true).append(
+              title.append(titleParagraph),
+              $createCollapsibleContentNode().append($createParagraphNode()),
+            ),
+          );
+        titleParagraph.select();
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        // Must not throw and must not nest the block inside the title.
+        selection.insertNodes([$createHorizontalRuleNode()]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const rootChildren = $getRoot().getChildren();
+      // The collapsible is preserved intact (nothing leaked out to the root).
+      expect(rootChildren).toHaveLength(1);
+      const container = rootChildren[0];
+      assert(
+        $isCollapsibleContainerNode(container),
+        'Expected a collapsible container',
+      );
+
+      const containerChildren = container.getChildren();
+      expect(containerChildren).toHaveLength(2);
+      expect($isCollapsibleTitleNode(containerChildren[0])).toBe(true);
+      expect($isCollapsibleContentNode(containerChildren[1])).toBe(true);
+
+      // The block had no inline form, so it was dropped entirely (never
+      // nested in the inline-only title).
+      expect($nodesOfType(HorizontalRuleNode)).toHaveLength(0);
+    });
+  });
+});

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -12,7 +12,6 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
-import {mergeRegister} from '@lexical/utils';
 import {
   $createParagraphNode,
   $getNodeByKey,
@@ -26,6 +25,7 @@ import {
   COMMAND_PRIORITY_LOW,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
+  mergeRegister,
   NodeKey,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -14,12 +14,12 @@ import type {JSX} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   isDOMNode,
+  mergeRegister,
 } from 'lexical';
 import * as React from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -22,7 +22,6 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {LexicalExtensionEditorComposer} from '@lexical/react/LexicalExtensionEditorComposer';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
   $getRoot,
@@ -38,6 +37,7 @@ import {
   DRAGSTART_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
+  mergeRegister,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
@@ -16,8 +16,7 @@ import type {
   Spread,
 } from 'lexical';
 
-import {addClassNamesToElement} from '@lexical/utils';
-import {ElementNode} from 'lexical';
+import {addClassNamesToElement, ElementNode} from 'lexical';
 
 export type SerializedLayoutContainerNode = Spread<
   {

--- a/packages/lexical-playground/src/nodes/LayoutItemNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutItemNode.ts
@@ -8,8 +8,7 @@
 
 import type {EditorConfig, LexicalNode, SerializedElementNode} from 'lexical';
 
-import {addClassNamesToElement} from '@lexical/utils';
-import {$isParagraphNode, ElementNode} from 'lexical';
+import {$isParagraphNode, addClassNamesToElement, ElementNode} from 'lexical';
 
 export type SerializedLayoutItemNode = SerializedElementNode;
 

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -12,12 +12,12 @@ import './index.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
-import {mergeRegister} from '@lexical/utils';
 import {
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   DecoratorNode,
   LexicalNode,
+  mergeRegister,
   NodeKey,
   SerializedLexicalNode,
 } from 'lexical';

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -14,7 +14,6 @@ import './PollNode.css';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
   $getSelection,
@@ -22,6 +21,7 @@ import {
   BaseSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
+  mergeRegister,
   NodeKey,
 } from 'lexical';
 import {useEffect, useMemo, useRef, useState} from 'react';

--- a/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
+++ b/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
@@ -8,8 +8,7 @@
 
 import type {EditorConfig, LexicalNode, SerializedTextNode} from 'lexical';
 
-import {addClassNamesToElement} from '@lexical/utils';
-import {$applyNodeReplacement, TextNode} from 'lexical';
+import {$applyNodeReplacement, addClassNamesToElement, TextNode} from 'lexical';
 
 /** @noInheritDoc */
 export class SpecialTextNode extends TextNode {

--- a/packages/lexical-playground/src/nodes/hostChromeSelection.ts
+++ b/packages/lexical-playground/src/nodes/hostChromeSelection.ts
@@ -8,7 +8,6 @@
 
 import type {LexicalEditor, LexicalNode} from 'lexical';
 
-import {mergeRegister} from '@lexical/utils';
 import {
   $createNodeSelection,
   $getNearestNodeFromDOMNode,
@@ -17,6 +16,7 @@ import {
   COMMAND_PRIORITY_BEFORE_EDITOR,
   getDOMSelection,
   isHTMLElement,
+  mergeRegister,
 } from 'lexical';
 
 /**

--- a/packages/lexical-playground/src/nodes/slotHostEscape.ts
+++ b/packages/lexical-playground/src/nodes/slotHostEscape.ts
@@ -12,7 +12,6 @@ import {
   $insertNodeToNearestRoot,
   $isAtEndOfNode,
   $isAtStartOfNode,
-  mergeRegister,
 } from '@lexical/utils';
 import {
   $createParagraphNode,
@@ -30,6 +29,7 @@ import {
   KEY_ARROW_UP_COMMAND,
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
+  mergeRegister,
 } from 'lexical';
 
 // Find the slot host (Card / Review / PullQuote) that contains `start`. The

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -30,7 +30,6 @@ import {
 } from '@lexical/markdown';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {mergeRegister} from '@lexical/utils';
 import {CONNECTED_COMMAND, TOGGLE_CONNECT_COMMAND} from '@lexical/yjs';
 import {
   $createParagraphNode,
@@ -40,6 +39,7 @@ import {
   CLEAR_EDITOR_COMMAND,
   CLEAR_HISTORY_COMMAND,
   COMMAND_PRIORITY_EDITOR,
+  mergeRegister,
   RootNode,
 } from 'lexical';
 import {

--- a/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
@@ -15,7 +15,6 @@ import {
   watchedSignal,
 } from '@lexical/extension';
 import {$isAtNodeEnd} from '@lexical/selection';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
   $getSelection,
@@ -33,6 +32,7 @@ import {
   KEY_ARROW_RIGHT_COMMAND,
   KEY_TAB_COMMAND,
   type LexicalEditor,
+  mergeRegister,
   type NodeKey,
   safeCast,
   setDOMUnmanaged,

--- a/packages/lexical-playground/src/plugins/CardExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/CardExtension/index.tsx
@@ -17,7 +17,6 @@ import {
   DOMRenderExtension,
   sel,
 } from '@lexical/html';
-import {mergeRegister} from '@lexical/utils';
 import {
   $createNodeSelection,
   $createParagraphNode,
@@ -41,6 +40,7 @@ import {
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_TAB_COMMAND,
+  mergeRegister,
 } from 'lexical';
 
 import {registerHostChromeSelection} from '../../nodes/hostChromeSelection';

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/index.ts
@@ -14,13 +14,10 @@ import {
   DOMImportExtension,
   sel,
 } from '@lexical/html';
-import {
-  $findMatchingParent,
-  $insertNodeToNearestRoot,
-  mergeRegister,
-} from '@lexical/utils';
+import {$insertNodeToNearestRoot} from '@lexical/utils';
 import {
   $createParagraphNode,
+  $findMatchingParent,
   $getSelection,
   $isInlineElementOrDecoratorNode,
   $isLineBreakNode,
@@ -37,6 +34,7 @@ import {
   KEY_ARROW_RIGHT_COMMAND,
   KEY_ARROW_UP_COMMAND,
   type LexicalNode,
+  mergeRegister,
 } from 'lexical';
 
 import {

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -39,7 +39,7 @@ import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 import {createDOMRange, createRectsFromDOMRange} from '@lexical/selection';
 import {$isRootTextContentEmpty, $rootTextContent} from '@lexical/text';
-import {mergeRegister, registerNestedElementResolver} from '@lexical/utils';
+import {registerNestedElementResolver} from '@lexical/utils';
 import {
   $getNodeByKey,
   $getSelection,
@@ -52,6 +52,7 @@ import {
   createCommand,
   getDOMSelection,
   KEY_ESCAPE_COMMAND,
+  mergeRegister,
 } from 'lexical';
 import * as React from 'react';
 import {

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -25,8 +25,8 @@ import {
   TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
+  $findMatchingParent,
   $getSelection,
   $isDecoratorNode,
   $isLineBreakNode,
@@ -40,6 +40,7 @@ import {
   getDOMSelection,
   KEY_ESCAPE_COMMAND,
   LexicalEditor,
+  mergeRegister,
   RangeSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -14,7 +14,6 @@ import {useMergeRefs} from '@floating-ui/react';
 import {$isCodeHighlightNode} from '@lexical/code';
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
   $isParagraphNode,
@@ -24,6 +23,7 @@ import {
   FORMAT_TEXT_COMMAND,
   getDOMSelection,
   LexicalEditor,
+  mergeRegister,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
@@ -20,14 +20,11 @@ import {
   LinkNode,
   TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
-import {
-  $findMatchingParent,
-  $wrapNodeInElement,
-  mergeRegister,
-} from '@lexical/utils';
+import {$wrapNodeInElement} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createRangeSelection,
+  $findMatchingParent,
   $getSelection,
   $insertNodes,
   $isNodeSelection,
@@ -47,6 +44,7 @@ import {
   isHTMLElement,
   LexicalCommand,
   LexicalEditor,
+  mergeRegister,
   SKIP_DOM_SELECTION_TAG,
 } from 'lexical';
 import {useEffect, useRef, useState} from 'react';

--- a/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutExtension/LayoutExtension.tsx
@@ -13,7 +13,6 @@ import {
   $insertNodeToNearestRoot,
   $onEscapeDown,
   $onEscapeUp,
-  mergeRegister,
 } from '@lexical/utils';
 import {
   $createParagraphNode,
@@ -27,6 +26,7 @@ import {
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_ARROW_UP_COMMAND,
+  mergeRegister,
 } from 'lexical';
 
 import {

--- a/packages/lexical-playground/src/plugins/PullQuoteExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/PullQuoteExtension/index.tsx
@@ -15,7 +15,6 @@ import {
   DOMImportExtension,
   sel,
 } from '@lexical/html';
-import {mergeRegister} from '@lexical/utils';
 import {
   $createNodeSelection,
   $createParagraphNode,
@@ -33,6 +32,7 @@ import {
   defineExtension,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
+  mergeRegister,
 } from 'lexical';
 
 import {registerHostChromeSelection} from '../../nodes/hostChromeSelection';

--- a/packages/lexical-playground/src/plugins/ReviewExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/ReviewExtension/index.tsx
@@ -24,7 +24,6 @@ import {
   useSignalValue,
 } from '@lexical/react/useExtensionSignalValue';
 import {useLexicalSlotRef} from '@lexical/react/useLexicalSlotRef';
-import {mergeRegister} from '@lexical/utils';
 import {
   $createParagraphNode,
   $getNodeByKey,
@@ -35,6 +34,7 @@ import {
   configExtension,
   createCommand,
   defineExtension,
+  mergeRegister,
   NODE_STATE_DIRECT,
 } from 'lexical';
 import {useCallback, useState} from 'react';

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -33,7 +33,6 @@ import {
   TableObserver,
   TableSelection,
 } from '@lexical/table';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
   $isElementNode,
@@ -43,6 +42,7 @@ import {
   COMMAND_PRIORITY_CRITICAL,
   getDOMSelection,
   isDOMNode,
+  mergeRegister,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -23,10 +23,11 @@ import {
   getTableElement,
   TableNode,
 } from '@lexical/table';
-import {calculateZoomLevel, mergeRegister} from '@lexical/utils';
+import {calculateZoomLevel} from '@lexical/utils';
 import {
   $getNearestNodeFromDOMNode,
   isHTMLElement,
+  mergeRegister,
   SKIP_SCROLL_INTO_VIEW_TAG,
 } from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableFitNestedTablePlugin/index.tsx
@@ -10,8 +10,13 @@ import type {LexicalNode} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isTableNode, TableNode} from '@lexical/table';
-import {$dfsWithSlots, $findMatchingParent} from '@lexical/utils';
-import {$getNodeByKey, $isRootOrShadowRoot, LexicalEditor} from 'lexical';
+import {$dfsWithSlots} from '@lexical/utils';
+import {
+  $findMatchingParent,
+  $getNodeByKey,
+  $isRootOrShadowRoot,
+  LexicalEditor,
+} from 'lexical';
 import {useEffect} from 'react';
 
 const PIXEL_VALUE_REG_EXP = /^(\d+(?:\.\d+)?)px$/;

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -31,14 +31,13 @@ import {
 } from '@lexical/selection';
 import {$isTableNode, $isTableSelection} from '@lexical/table';
 import {
-  $findMatchingParent,
   $getNearestNodeOfType,
   $isEditorIsNestedEditor,
   IS_APPLE,
-  mergeRegister,
 } from '@lexical/utils';
 import {
   $addUpdateTag,
+  $findMatchingParent,
   $getNodeByKey,
   $getRoot,
   $getSelection,
@@ -58,6 +57,7 @@ import {
   LexicalCommand,
   LexicalEditor,
   LexicalNode,
+  mergeRegister,
   NodeKey,
   OUTDENT_CONTENT_COMMAND,
   REDO_COMMAND,

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -22,7 +22,6 @@ import {
 import {$patchStyleText, $setBlocksType} from '@lexical/selection';
 import {$isTableSelection} from '@lexical/table';
 import {
-  $findMatchingParent,
   $getNearestBlockElementAncestorOrThrow,
   $isBlockFullySelected,
 } from '@lexical/utils';
@@ -30,6 +29,7 @@ import {
   $addUpdateTag,
   $createParagraphNode,
   $createRangeSelection,
+  $findMatchingParent,
   $getSelection,
   $isBlockElementNode,
   $isLineBreakNode,

--- a/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
@@ -9,7 +9,6 @@ import './index.css';
 
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getYChangeState,
   CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL,
@@ -21,6 +20,7 @@ import {
   COMMAND_PRIORITY_EDITOR,
   createCommand,
   LexicalCommand,
+  mergeRegister,
   TextNode,
 } from 'lexical';
 import _ from 'lodash';

--- a/packages/lexical-playground/src/plugins/VisibleNonPrintingExtension.ts
+++ b/packages/lexical-playground/src/plugins/VisibleNonPrintingExtension.ts
@@ -18,8 +18,8 @@ import {
 import {ListItemNode} from '@lexical/list';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {$canShowPlaceholder} from '@lexical/text';
-import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
+  $findMatchingParent,
   $isTabNode,
   configExtension,
   defineExtension,
@@ -27,6 +27,7 @@ import {
   getStyleObjectFromCSS,
   isHTMLElement,
   LineBreakNode,
+  mergeRegister,
   ParagraphNode,
   safeCast,
   TabNode,

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -19,7 +19,6 @@ import {
   MenuOption,
   type MenuRenderFn,
 } from '@lexical/react/LexicalNodeMenuPlugin';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
   $getSelection,
@@ -28,6 +27,7 @@ import {
   createCommand,
   LexicalCommand,
   LexicalEditor,
+  mergeRegister,
   NodeKey,
   PASTE_TAG,
   TextNode,

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -12,10 +12,7 @@ import type {JSX} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isDecoratorBlockNode} from '@lexical/react/LexicalDecoratorBlockNode';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
-import {
-  $getNearestBlockElementAncestorOrThrow,
-  mergeRegister,
-} from '@lexical/utils';
+import {$getNearestBlockElementAncestorOrThrow} from '@lexical/utils';
 import {
   $getNodeByKey,
   $getSelection,
@@ -24,6 +21,7 @@ import {
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   FORMAT_ELEMENT_COMMAND,
+  mergeRegister,
 } from 'lexical';
 import * as React from 'react';
 import {ReactNode, useEffect, useRef} from 'react';

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -10,7 +10,7 @@ import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {eventFiles} from '@lexical/rich-text';
-import {calculateZoomLevel, isHTMLElement, mergeRegister} from '@lexical/utils';
+import {calculateZoomLevel} from '@lexical/utils';
 import {
   $getNearestNodeFromDOMNode,
   $getNodeByKey,
@@ -23,7 +23,9 @@ import {
   DRAGOVER_COMMAND,
   DROP_COMMAND,
   IS_FIREFOX,
+  isHTMLElement,
   LexicalEditor,
+  mergeRegister,
 } from 'lexical';
 import {
   DragEvent as ReactDragEvent,

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -18,14 +18,12 @@ import {
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {
-  addClassNamesToElement,
-  mergeRegister,
-  removeClassNamesFromElement,
-} from '@lexical/utils';
-import {
   $applyNodeReplacement,
+  addClassNamesToElement,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
+  mergeRegister,
+  removeClassNamesFromElement,
 } from 'lexical';
 import * as React from 'react';
 import {useEffect} from 'react';

--- a/packages/lexical-react/src/LexicalNodeEventPlugin.ts
+++ b/packages/lexical-react/src/LexicalNodeEventPlugin.ts
@@ -9,8 +9,7 @@
 import type {Klass, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$findMatchingParent} from '@lexical/utils';
-import {$getNearestNodeFromDOMNode} from 'lexical';
+import {$findMatchingParent, $getNearestNodeFromDOMNode} from 'lexical';
 import {useEffect, useRef} from 'react';
 
 const capturedEvents = new Set<string>(['mouseenter', 'mouseleave']);

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -15,7 +15,7 @@ import {
   TreeView as TreeViewCore,
   useLexicalCommandsLog,
 } from '@lexical/devtools-core';
-import {mergeRegister} from '@lexical/utils';
+import {mergeRegister} from 'lexical';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 

--- a/packages/lexical-react/src/ReactPluginHostExtension.tsx
+++ b/packages/lexical-react/src/ReactPluginHostExtension.tsx
@@ -17,7 +17,6 @@ import {
 import invariant from '@lexical/internal/invariant';
 import {ReactExtension} from '@lexical/react/ReactExtension';
 import {ReactProviderExtension} from '@lexical/react/ReactProviderExtension';
-import {mergeRegister} from '@lexical/utils';
 import {
   type AnyLexicalExtension,
   COMMAND_PRIORITY_CRITICAL,
@@ -27,6 +26,7 @@ import {
   defineExtension,
   type LexicalEditor,
   type LexicalExtensionOutput,
+  mergeRegister,
 } from 'lexical';
 import * as React from 'react';
 import {Suspense, useEffect, useState} from 'react';

--- a/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
@@ -12,7 +12,6 @@ import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
-import {mergeRegister} from '@lexical/utils';
 import {axe, toHaveNoViolations} from 'jest-axe';
 import {
   $applyNodeReplacement,
@@ -28,6 +27,7 @@ import {
   EditorConfig,
   getRegisteredNode,
   LexicalEditor,
+  mergeRegister,
   TextNode,
 } from 'lexical';
 import {

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -9,7 +9,6 @@
 import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
   $isRangeSelection,
@@ -24,6 +23,7 @@ import {
   KEY_TAB_COMMAND,
   LexicalCommand,
   LexicalEditor,
+  mergeRegister,
   TextNode,
 } from 'lexical';
 import {

--- a/packages/lexical-react/src/shared/useCanShowPlaceholder.ts
+++ b/packages/lexical-react/src/shared/useCanShowPlaceholder.ts
@@ -9,7 +9,7 @@
 import type {LexicalEditor} from 'lexical';
 
 import {$canShowPlaceholderCurry} from '@lexical/text';
-import {mergeRegister} from '@lexical/utils';
+import {mergeRegister} from 'lexical';
 import {useState} from 'react';
 
 import useLayoutEffect from './useLayoutEffect';

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -15,13 +15,9 @@ import {
   OverflowNode,
 } from '@lexical/overflow';
 import {$rootTextContent} from '@lexical/text';
+import {$dfsWithSlots, $unwrapNode} from '@lexical/utils';
 import {
-  $dfsWithSlots,
   $findMatchingParent,
-  $unwrapNode,
-  mergeRegister,
-} from '@lexical/utils';
-import {
   $getSelection,
   $getSlotHost,
   $isElementNode,
@@ -32,6 +28,7 @@ import {
   COMMAND_PRIORITY_LOW,
   DELETE_CHARACTER_COMMAND,
   HISTORY_MERGE_TAG,
+  mergeRegister,
 } from 'lexical';
 import {useEffect} from 'react';
 

--- a/packages/lexical-react/src/shared/usePlainTextSetup.ts
+++ b/packages/lexical-react/src/shared/usePlainTextSetup.ts
@@ -10,7 +10,7 @@ import type {LexicalEditor} from 'lexical';
 
 import {registerDragonSupport} from '@lexical/dragon';
 import {registerPlainText} from '@lexical/plain-text';
-import {mergeRegister} from '@lexical/utils';
+import {mergeRegister} from 'lexical';
 
 import useLayoutEffect from './useLayoutEffect';
 

--- a/packages/lexical-react/src/shared/useRichTextSetup.ts
+++ b/packages/lexical-react/src/shared/useRichTextSetup.ts
@@ -10,7 +10,7 @@ import type {LexicalEditor} from 'lexical';
 
 import {registerDragonSupport} from '@lexical/dragon';
 import {registerRichText} from '@lexical/rich-text';
-import {mergeRegister} from '@lexical/utils';
+import {mergeRegister} from 'lexical';
 
 import useLayoutEffect from './useLayoutEffect';
 

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -17,7 +17,6 @@ import type {
 import type {LexicalEditor} from 'lexical';
 import type {JSX} from 'react';
 
-import {mergeRegister} from '@lexical/utils';
 import {
   CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL,
   CONNECTED_COMMAND,
@@ -46,6 +45,7 @@ import {
   COMMAND_PRIORITY_EDITOR,
   FOCUS_COMMAND,
   HISTORY_MERGE_TAG,
+  mergeRegister,
   REDO_COMMAND,
   SKIP_COLLAB_TAG,
   UNDO_COMMAND,

--- a/packages/lexical-react/src/useLexicalTextEntity.ts
+++ b/packages/lexical-react/src/useLexicalTextEntity.ts
@@ -11,7 +11,7 @@ import type {Klass, TextNode} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {registerLexicalTextEntity} from '@lexical/text';
-import {mergeRegister} from '@lexical/utils';
+import {mergeRegister} from 'lexical';
 import {useEffect} from 'react';
 
 /**

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -42,13 +42,9 @@ import {
   $shouldOverrideDefaultCharacterSelection,
 } from '@lexical/selection';
 import {
-  $findMatchingParent,
   $getNearestBlockElementAncestorOrThrow,
   $handleIndentAndOutdent,
-  addClassNamesToElement,
   eventFiles,
-  isHTMLElement,
-  mergeRegister,
   objectKlassEquals,
 } from '@lexical/utils';
 import {
@@ -57,6 +53,7 @@ import {
   $createParagraphNode,
   $createRangeSelection,
   $createTabNode,
+  $findMatchingParent,
   $getAdjacentNode,
   $getNearestNodeFromDOMNode,
   $getRoot,
@@ -75,6 +72,7 @@ import {
   $setDirectionFromDOM,
   $setFormatFromDOM,
   $setSelection,
+  addClassNamesToElement,
   CAN_USE_BEFORE_INPUT,
   CLICK_COMMAND,
   COMMAND_PRIORITY_EDITOR,
@@ -100,6 +98,7 @@ import {
   IS_IOS,
   IS_SAFARI,
   isDOMNode,
+  isHTMLElement,
   isSelectionCapturedInDecoratorInput,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
@@ -111,6 +110,7 @@ import {
   KEY_ESCAPE_COMMAND,
   KEY_SPACE_COMMAND,
   KEY_TAB_COMMAND,
+  mergeRegister,
   MOVE_TO_END,
   MOVE_TO_START,
   OUTDENT_CONTENT_COMMAND,

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -20,13 +20,13 @@ import type {
   Spread,
 } from 'lexical';
 
-import {addClassNamesToElement} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $createParagraphNode,
   $isInlineElementOrDecoratorNode,
   $isLineBreakNode,
   $isTextNode,
+  addClassNamesToElement,
   ElementNode,
   isHTMLElement,
 } from 'lexical';

--- a/packages/lexical-table/src/LexicalTableExtension.ts
+++ b/packages/lexical-table/src/LexicalTableExtension.ts
@@ -8,11 +8,11 @@
 
 import {effect, namedSignals} from '@lexical/extension';
 import {CoreImportExtension, DOMImportExtension} from '@lexical/html';
-import {mergeRegister} from '@lexical/utils';
 import {
   $fullReconcile,
   configExtension,
   defineExtension,
+  mergeRegister,
   safeCast,
 } from 'lexical';
 

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -7,16 +7,12 @@
  */
 
 import invariant from '@lexical/internal/invariant';
-import {
-  $descendantsMatching,
-  addClassNamesToElement,
-  isHTMLElement,
-  removeClassNamesFromElement,
-} from '@lexical/utils';
+import {$descendantsMatching} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $getEditor,
   $getNearestNodeFromDOMNode,
+  addClassNamesToElement,
   BaseSelection,
   DOMConversionMap,
   DOMConversionOutput,
@@ -25,10 +21,12 @@ import {
   ElementDOMSlot,
   type ElementFormatType,
   ElementNode,
+  isHTMLElement,
   LexicalEditor,
   LexicalNode,
   LexicalUpdateJSON,
   NodeKey,
+  removeClassNamesFromElement,
   SerializedElementNode,
   setDOMStyleFromCSS,
   setDOMUnmanaged,

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -8,10 +8,6 @@
 
 import invariant from '@lexical/internal/invariant';
 import {
-  addClassNamesToElement,
-  removeClassNamesFromElement,
-} from '@lexical/utils';
-import {
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
@@ -22,10 +18,12 @@ import {
   $isParagraphNode,
   $isRootNode,
   $setSelection,
+  addClassNamesToElement,
   getDOMSelection,
   INSERT_PARAGRAPH_COMMAND,
   type LexicalEditor,
   type NodeKey,
+  removeClassNamesFromElement,
   SELECTION_CHANGE_COMMAND,
   type TextFormatType,
 } from 'lexical';

--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -10,14 +10,13 @@ import {NamedSignalsOutput, Signal, signal} from '@lexical/extension';
 import invariant from '@lexical/internal/invariant';
 import {
   $dfsWithSlots,
-  $findMatchingParent,
   $insertFirst,
   $insertNodeToNearestRoot,
   $unwrapAndFilterDescendants,
-  mergeRegister,
 } from '@lexical/utils';
 import {
   $createParagraphNode,
+  $findMatchingParent,
   $getNearestNodeFromDOMNode,
   $getPreviousSelection,
   $getRoot,
@@ -34,6 +33,7 @@ import {
   ElementNode,
   isDOMNode,
   LexicalEditor,
+  mergeRegister,
   NodeKey,
   RangeSelection,
   SELECT_ALL_COMMAND,

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -8,9 +8,10 @@
 
 import type {BaseSelection, LexicalUpdateJSON, Spread} from 'lexical';
 
-import {$descendantsMatching, addClassNamesToElement} from '@lexical/utils';
+import {$descendantsMatching} from '@lexical/utils';
 import {
   $applyNodeReplacement,
+  addClassNamesToElement,
   DOMConversionMap,
   DOMConversionOutput,
   EditorConfig,

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -7,9 +7,9 @@
  */
 
 import invariant from '@lexical/internal/invariant';
-import {$findMatchingParent} from '@lexical/utils';
 import {
   $createPoint,
+  $findMatchingParent,
   $getNodeByKey,
   $getSelection,
   $isElementNode,

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -37,18 +37,14 @@ import {
   copyToClipboard,
 } from '@lexical/clipboard';
 import invariant from '@lexical/internal/invariant';
-import {
-  $findMatchingParent,
-  addClassNamesToElement,
-  objectKlassEquals,
-  removeClassNamesFromElement,
-} from '@lexical/utils';
+import {objectKlassEquals} from '@lexical/utils';
 import {
   $caretFromPoint,
   $createParagraphNode,
   $createRangeSelectionFromDom,
   $createTextNode,
   $extendCaretToRange,
+  $findMatchingParent,
   $getAdjacentChildCaret,
   $getChildCaret,
   $getNearestNodeFromDOMNode,
@@ -67,6 +63,7 @@ import {
   $normalizeCaret,
   $setPointFromCaret,
   $setSelection,
+  addClassNamesToElement,
   COMMAND_PRIORITY_HIGH,
   CONTROLLED_TEXT_INSERTION_COMMAND,
   CUT_COMMAND,
@@ -89,6 +86,7 @@ import {
   KEY_DELETE_COMMAND,
   KEY_ESCAPE_COMMAND,
   KEY_TAB_COMMAND,
+  removeClassNamesFromElement,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -10,10 +10,10 @@ import type {TableMapType, TableMapValueType} from './LexicalTableSelection';
 import type {ElementNode, PointType} from 'lexical';
 
 import invariant from '@lexical/internal/invariant';
-import {$findMatchingParent} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createTextNode,
+  $findMatchingParent,
   $getSelection,
   $isParagraphNode,
   $isRangeSelection,

--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -8,6 +8,13 @@
 
 import {$createMarkNode, $isMarkNode} from '@lexical/mark';
 import {
+  $dfs,
+  $firstToLastIterator,
+  $getNextSiblingOrParentSibling,
+  $lastToFirstIterator,
+  $reverseDfs,
+} from '@lexical/utils';
+import {
   $createParagraphNode,
   $createTextNode,
   $getNodeByKey,
@@ -25,14 +32,6 @@ import {
   invariant,
 } from 'lexical/src/__tests__/utils';
 import {beforeEach, describe, expect, test} from 'vitest';
-
-import {
-  $dfs,
-  $firstToLastIterator,
-  $getNextSiblingOrParentSibling,
-  $lastToFirstIterator,
-  $reverseDfs,
-} from '../..';
 
 interface DFSKeyPair {
   depth: number;

--- a/packages/lexical-utils/src/__tests__/unit/LexicalSlotDfs.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalSlotDfs.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {$dfsWithSlots, $reverseDfsWithSlots} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -25,8 +26,6 @@ import {
   TestShadowRootNode,
 } from 'lexical/src/__tests__/utils';
 import {describe, expect, test} from 'vitest';
-
-import {$dfsWithSlots, $reverseDfsWithSlots} from '../..';
 
 // Slots-first preorder traversal: the shape a slot-aware $dfs must produce.
 function* $slotAwareDfs(

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
@@ -9,6 +9,7 @@
 import type {LexicalEditor, LexicalNode} from 'lexical';
 
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {$insertNodeToNearestRoot} from '@lexical/utils';
 import {
   $createRangeSelection,
   $getRoot,
@@ -20,8 +21,6 @@ import {
   createTestEditor,
 } from 'lexical/src/__tests__/utils';
 import {beforeEach, describe, expect, it} from 'vitest';
-
-import {$insertNodeToNearestRoot} from '../..';
 
 describe('LexicalUtils#insertNodeToNearestRoot', () => {
   let editor: LexicalEditor;

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRootAtCaret.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRootAtCaret.test.ts
@@ -15,13 +15,12 @@ import {
   $getRoot,
   $getSiblingCaret,
   $getTextPointCaret,
+  $insertNodeToNearestRootAtCaret,
   $isElementNode,
   LexicalNode,
   SplitAtPointCaretNextOptions,
 } from 'lexical';
 import {describe, expect, test} from 'vitest';
-
-import {$insertNodeToNearestRootAtCaret} from '../..';
 
 function $serialize(node: LexicalNode): string {
   if (!$isElementNode(node)) {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -9,11 +9,10 @@
 import type {ElementNode, LexicalEditor} from 'lexical';
 
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {$splitNode} from '@lexical/utils';
 import {$getRoot, $isElementNode} from 'lexical';
 import {createTestEditor} from 'lexical/src/__tests__/utils';
 import {beforeEach, describe, expect, it} from 'vitest';
-
-import {$splitNode} from '../../index';
 
 describe('LexicalUtils#splitNode', () => {
   let editor: LexicalEditor;

--- a/packages/lexical-utils/src/__tests__/unit/markSelection.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/markSelection.test.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import {markSelection} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createRangeSelection,
@@ -15,8 +16,6 @@ import {
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 import {describe, expect, it, vi} from 'vitest';
-
-import {markSelection} from '../../index';
 
 Range.prototype.getBoundingClientRect = function (): DOMRect {
   const rect = {

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -45,6 +45,7 @@ import {
   $getSlotHost,
   $getSlotNames,
   $getState,
+  $insertNodeToNearestRootAtCaret,
   $isChildCaret,
   $isElementNode,
   $isRangeSelection,
@@ -73,7 +74,6 @@ import {
   type PointType,
   type RangeSelection,
   type SiblingCaret,
-  SplitAtPointCaretNextOptions,
   StateConfig,
   ValueOrUpdater,
 } from 'lexical';
@@ -774,70 +774,8 @@ export function $insertNodeToNearestRoot<T extends LexicalNode>(node: T): T {
   return node.getLatest();
 }
 
-/**
- * If the insertion caret is the root/shadow root node (see {@link lexical!$isRootOrShadowRoot}),
- * the node will be inserted there, otherwise the parent nodes will be split according to the
- * given options.
- * @param node - The node to be inserted
- * @param caret - The location to insert or split from
- * @returns The node after its insertion
- */
-export function $insertNodeToNearestRootAtCaret<
-  T extends LexicalNode,
-  D extends CaretDirection,
->(
-  node: T,
-  caret: PointCaret<D>,
-  options?: SplitAtPointCaretNextOptions,
-): NodeCaret<D> {
-  let insertCaret: PointCaret<'next'> = $getCaretInDirection(caret, 'next');
-  // Normalize boundary cases for TextPointCaret
-  if ($isTextPointCaret(insertCaret)) {
-    if (insertCaret.offset === 0) {
-      insertCaret = $getSiblingCaret(
-        insertCaret.origin,
-        'previous',
-      ).getFlipped();
-    } else if (insertCaret.offset === insertCaret.origin.getTextContentSize()) {
-      insertCaret = $getSiblingCaret(insertCaret.origin, 'next');
-    }
-  }
-  // Make sure we have a distinct node as the origin
-  if (insertCaret.origin.is(node)) {
-    invariant(
-      $isSiblingCaret(insertCaret),
-      '$insertNodeToNearestRootAtCaret node %s of type %s can not be inserted into itself',
-      node.getKey(),
-      node.getType(),
-    );
-    insertCaret = $rewindSiblingCaret(insertCaret);
-  }
-  // Handle split boundary conditions where node is being inserted adjacent to itself
-  if (
-    node.is(insertCaret.getNodeAtCaret()) ||
-    node.is(insertCaret.getFlipped().getNodeAtCaret())
-  ) {
-    node.remove(true);
-  }
-  for (
-    let nextCaret: null | PointCaret<'next'> = insertCaret;
-    nextCaret;
-    nextCaret = $splitAtPointCaretNext(nextCaret, options)
-  ) {
-    insertCaret = nextCaret;
-  }
-  invariant(
-    !$isTextPointCaret(insertCaret),
-    '$insertNodeToNearestRootAtCaret: An unattached TextNode can not be split',
-  );
-  insertCaret.insert(
-    node.isInline() ? $createParagraphNode().append(node) : node,
-  );
-  return $getCaretInDirection(
-    $getSiblingCaret(node.getLatest(), 'next'),
-    caret.direction,
-  );
-}
+// Re-exported from the `lexical` core package for backwards compatibility.
+export {$insertNodeToNearestRootAtCaret};
 
 /**
  * Inserts a node into leaf — the deepest accessible node at the carriage position

--- a/packages/lexical-yjs/src/__tests__/unit/SlotSyncV1.test.ts
+++ b/packages/lexical-yjs/src/__tests__/unit/SlotSyncV1.test.ts
@@ -5,11 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   buildEditorFromExtensions,
   type LexicalEditorWithDispose,
 } from '@lexical/extension';
+import {
+  createBinding,
+  createUndoManager,
+  type Provider,
+  syncLexicalUpdateToYjs,
+  syncYjsChangesToLexical,
+} from '@lexical/yjs';
 import {
   $create,
   $createParagraphNode,
@@ -47,14 +53,8 @@ import {
   type YEvent,
 } from 'yjs';
 
-import {createBinding} from '../../Bindings';
 import {CollabDecoratorNode} from '../../CollabDecoratorNode';
 import {CollabElementNode} from '../../CollabElementNode';
-import {createUndoManager, type Provider} from '../../index';
-import {
-  syncLexicalUpdateToYjs,
-  syncYjsChangesToLexical,
-} from '../../SyncEditorStates';
 import {SLOTS_ATTR_KEY} from '../../Utils';
 
 // V1 (stable, CollabElementNode): serialize a lexical tree with a named slot

--- a/packages/lexical-yjs/src/__tests__/unit/SlotSyncV2.test.ts
+++ b/packages/lexical-yjs/src/__tests__/unit/SlotSyncV2.test.ts
@@ -5,13 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
-import type {Provider} from '../../index';
-
 import {
   buildEditorFromExtensions,
   type LexicalEditorWithDispose,
 } from '@lexical/extension';
+import {
+  createBindingV2__EXPERIMENTAL,
+  type Provider,
+  syncLexicalUpdateToYjsV2__EXPERIMENTAL,
+} from '@lexical/yjs';
 import {
   $create,
   $createParagraphNode,
@@ -46,8 +48,6 @@ import {
   XmlText,
 } from 'yjs';
 
-import {createBindingV2__EXPERIMENTAL} from '../../Bindings';
-import {syncLexicalUpdateToYjsV2__EXPERIMENTAL} from '../../SyncEditorStates';
 import {$createOrUpdateNodeFromYElement, $updateYFragment} from '../../SyncV2';
 import {SLOTS_ATTR_KEY} from '../../Utils';
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1551,6 +1551,11 @@ declare export function $splitAtPointCaretNext(
   pointCaret: PointCaret<'next'>,
   options?: SplitAtPointCaretNextOptions,
 ): null | NodeCaret<'next'>;
+declare export function $insertNodeToNearestRootAtCaret<T: LexicalNode>(
+  node: T,
+  caret: PointCaret<CaretDirection>,
+  options?: SplitAtPointCaretNextOptions,
+): NodeCaret<CaretDirection>;
 
 /**
  * LexicalUpdateTags

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -28,6 +28,7 @@ import {
   $getChildCaret,
   $getSiblingCaret,
   $getTextNodeOffset,
+  $insertNodeToNearestRootAtCaret,
   $isChildCaret,
   $isDecoratorNode,
   $isElementNode,
@@ -1533,6 +1534,59 @@ export class RangeSelection implements BaseSelection {
     // stripped like the input value sanitization strips newlines, and
     // block-only decorators are dropped, having no single-line form).
     if ($isElementNode(firstBlock) && $getSlotHostKey(firstBlock) !== null) {
+      const index = $removeTextAndSplitBlock(this);
+      const inlineNodes = $extractInlineFromBlocks(nodes);
+      firstBlock.splice(index, 0, inlineNodes);
+      const lastInserted = inlineNodes[inlineNodes.length - 1];
+      if (lastInserted !== undefined) {
+        lastInserted.selectEnd();
+      } else {
+        firstBlock.select(index, index);
+      }
+      return;
+    }
+
+    // CASE 3b: there is non-inline content but no block ancestor to insert it
+    // relative to. The element point on a root/shadow root is handled above, so
+    // this is a malformed document where an inline-only element directly holds
+    // a block child (e.g. a HorizontalRuleNode inside a CollapsibleTitleNode,
+    // see #8713) or a non-inline element that reports canBeEmpty() === false.
+    // A non-inline node must never become the child of an inline-only element,
+    // so enforce the document structure rules with
+    // $insertNodeToNearestRootAtCaret, which splits the ancestor chain up to
+    // the nearest node that may contain non-inline children (a root or shadow
+    // root) and inserts the blocks there. Lists are unaffected: a list item is
+    // always a block ancestor, so they fall through to CASE 3 and keep their
+    // existing (ListItemNode-aware) paste behavior.
+    if (firstBlock === null) {
+      const blocksParent = $wrapInlineNodes(nodes);
+      const nodeToSelect = blocksParent.getLastDescendant();
+      // Split the ancestor chain up to the nearest root or shadow root and
+      // insert each block there.
+      let caret: PointCaret<'next'> = $caretFromPoint(this.anchor, 'next');
+      for (const block of blocksParent.getChildren()) {
+        caret = $insertNodeToNearestRootAtCaret(block, caret);
+      }
+      if (nodeToSelect !== null) {
+        nodeToSelect.selectEnd();
+      }
+      return;
+    }
+
+    // CASE 3c: the target block exists but its parent is not a root or shadow
+    // root — the only elements that may contain non-inline children — and the
+    // block does not relocate itself to a valid parent (it is not
+    // parent-required, unlike a ListItemNode, whose insertAfter escapes the
+    // list). Inserting the blocks as siblings here would nest them in an
+    // inline-only element, e.g. a HorizontalRuleNode pasted into the
+    // ParagraphNode of a CollapsibleTitleNode (see #8724). Mirror CASE 3a and
+    // flatten the incoming nodes to their inline content, dropping the
+    // block-level parts that have no inline form.
+    if (
+      $isElementNode(firstBlock) &&
+      !firstBlock.isParentRequired() &&
+      !$isRootOrShadowRoot(firstBlock.getParentOrThrow())
+    ) {
       const index = $removeTextAndSplitBlock(this);
       const inlineNodes = $extractInlineFromBlocks(nodes);
       firstBlock.splice(index, 0, inlineNodes);

--- a/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
+++ b/packages/lexical/src/__tests__/unit/FastPathCrossParent.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {buildEditorFromExtensions} from '@lexical/extension';
 import {$createLinkNode, LinkExtension} from '@lexical/link';
 import {RichTextExtension} from '@lexical/rich-text';

--- a/packages/lexical/src/__tests__/unit/Issue8724Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue8724Repro.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {
+  $createListItemNode,
+  $createListNode,
+  $isListItemNode,
+  $isListNode,
+  ListExtension,
+} from '@lexical/list';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getNodeByKey,
+  $getRoot,
+  $getSelection,
+  $isDecoratorNode,
+  $isElementNode,
+  $isRangeSelection,
+  $isRootNode,
+  type LexicalNode,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+import {
+  $assertNodeType,
+  $createTestDecoratorNode,
+  $createTestElementNode,
+  $createTestShadowRootNode,
+  $isTestShadowRootNode,
+  TestDecoratorNode,
+  TestElementNode,
+  TestShadowRootNode,
+} from '../utils';
+
+const ext = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '[8724]',
+  nodes: [TestDecoratorNode, TestElementNode, TestShadowRootNode],
+});
+
+const listExt = defineExtension({
+  dependencies: [RichTextExtension, ListExtension],
+  name: '[8724-list]',
+  nodes: [TestDecoratorNode],
+});
+
+// A block DecoratorNode must never become the direct child of a ListItemNode.
+function $assertNoBlockInsideListItem(node: LexicalNode): void {
+  if ($isListItemNode(node)) {
+    for (const child of node.getChildren()) {
+      expect(
+        ($isElementNode(child) || $isDecoratorNode(child)) && !child.isInline(),
+        `ListItemNode should not directly hold non-inline ${child.getType()}`,
+      ).toBe($isListNode(child));
+    }
+  }
+  if ($isElementNode(node)) {
+    for (const child of node.getChildren()) {
+      $assertNoBlockInsideListItem(child);
+    }
+  }
+}
+
+describe('Paste normalization of non-inline nodes (#8713, #8724)', () => {
+  // A non-inline ElementNode may only contain inline children (#8724). When a
+  // block cursor sits on such an element that, in a malformed document, holds
+  // a block-level child directly, pasting another block node used to throw
+  // (#8713). It must instead split up to the nearest root/shadow root so the
+  // pasted block never becomes the child of an inline-only element.
+  test('block node at a block cursor inside an inline-only element splits up to the shadow root', () => {
+    using editor = buildEditorFromExtensions(ext);
+    let insertedKey = '';
+    editor.update(
+      () => {
+        const shadow = $createTestShadowRootNode();
+        const element = $createTestElementNode();
+        // A pre-existing (malformed) block child so the block cursor lands on
+        // an element point with no block ancestor.
+        element.append($createTestDecoratorNode().setIsInline(false));
+        shadow.append(element);
+        $getRoot().clear().append(shadow);
+        element.select(1, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        const inserted = $createTestDecoratorNode().setIsInline(false);
+        insertedKey = inserted.getKey();
+        // Must not throw (#8713).
+        selection.insertNodes([inserted]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const inserted = $getNodeByKey(insertedKey);
+      assert(inserted !== null, 'Expected the inserted node to exist');
+      // The pasted block landed in the nearest valid container (the shadow
+      // root), not nested inside the inline-only element.
+      expect($isTestShadowRootNode(inserted.getParent())).toBe(true);
+    });
+  });
+
+  test('block node at a block cursor inside an inline-only element splits up to the root', () => {
+    using editor = buildEditorFromExtensions(ext);
+    let insertedKey = '';
+    editor.update(
+      () => {
+        const element = $createTestElementNode();
+        element.append($createTestDecoratorNode().setIsInline(false));
+        $getRoot().clear().append(element);
+        element.select(1, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        const inserted = $createTestDecoratorNode().setIsInline(false);
+        insertedKey = inserted.getKey();
+        selection.insertNodes([inserted]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const inserted = $getNodeByKey(insertedKey);
+      assert(inserted !== null, 'Expected the inserted node to exist');
+      // The pasted block landed directly in the root.
+      expect($isRootNode(inserted.getParent())).toBe(true);
+    });
+  });
+
+  test('still inserts a block node directly at a block cursor on a shadow root (#8708)', () => {
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const shadow = $createTestShadowRootNode();
+        shadow.append($createTestDecoratorNode().setIsInline(false));
+        $getRoot().clear().append(shadow);
+        shadow.select(1, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const shadow = $assertNodeType(
+        $getRoot().getFirstChild(),
+        $isTestShadowRootNode,
+      );
+      // Both block decorators are direct children of the shadow root.
+      expect(shadow.getChildrenSize()).toBe(2);
+    });
+  });
+});
+
+describe('Paste normalization does not regress lists (#8724)', () => {
+  test('block node pasted in a list item text splits the list (unchanged CASE 3)', () => {
+    using editor = buildEditorFromExtensions(listExt);
+    let insertedKey = '';
+    editor.update(
+      () => {
+        const list = $createListNode('bullet');
+        const item = $createListItemNode();
+        const text = $createTextNode('hello');
+        item.append(text);
+        list.append(item);
+        $getRoot().clear().append(list);
+        text.select(2, 2);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        const inserted = $createTestDecoratorNode().setIsInline(false);
+        insertedKey = inserted.getKey();
+        selection.insertNodes([inserted]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const inserted = $getNodeByKey(insertedKey);
+      assert(inserted !== null, 'Expected the inserted node to exist');
+      // The block landed at the root (between the split lists), never inside a
+      // ListItemNode.
+      expect($isListItemNode(inserted.getParent())).toBe(false);
+      $assertNoBlockInsideListItem($getRoot());
+    });
+  });
+
+  test('block node at an element point on a list item holding a nested list does not crash', () => {
+    using editor = buildEditorFromExtensions(listExt);
+    let insertedKey = '';
+    editor.update(
+      () => {
+        const list = $createListNode('bullet');
+        const firstItem = $createListItemNode();
+        firstItem.append($createTextNode('a'));
+        const nestingItem = $createListItemNode();
+        const nestedList = $createListNode('bullet');
+        const nestedItem = $createListItemNode();
+        nestedItem.append($createTextNode('b'));
+        nestedList.append(nestedItem);
+        nestingItem.append(nestedList);
+        list.append(firstItem, nestingItem);
+        $getRoot().clear().append(list);
+        // Element point on the listitem that holds the nested list: this is an
+        // INTERNAL_$isBlock=false node with no block ancestor.
+        nestingItem.select(0, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        const inserted = $createTestDecoratorNode().setIsInline(false);
+        insertedKey = inserted.getKey();
+        // The editor throws on error by default, so a crash fails the test.
+        selection.insertNodes([inserted]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const inserted = $getNodeByKey(insertedKey);
+      assert(inserted !== null, 'Expected the inserted node to exist');
+      // The block is not nested inside a ListItemNode, and the surrounding
+      // list structure remains valid.
+      expect($isListItemNode(inserted.getParent())).toBe(false);
+      $assertNoBlockInsideListItem($getRoot());
+    });
+  });
+});
+
+describe('Paste flattens non-inline nodes inside an inline-only element (#8724)', () => {
+  // When the target block lives inside a non-inline element that is not a root
+  // or shadow root (so it may only contain inline children, e.g. the
+  // ParagraphNode inside a CollapsibleTitleNode), a pasted block cannot be
+  // placed as its sibling without nesting it in the inline-only element. The
+  // paste is flattened to its inline content; a block with no inline form is
+  // dropped.
+  test('drops a block-only paste with no inline form', () => {
+    using editor = buildEditorFromExtensions(ext);
+    let insertedKey = '';
+    editor.update(
+      () => {
+        const element = $createTestElementNode();
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('abc');
+        paragraph.append(text);
+        element.append(paragraph);
+        $getRoot().clear().append(element);
+        text.select(3, 3);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        const inserted = $createTestDecoratorNode().setIsInline(false);
+        insertedKey = inserted.getKey();
+        // A block DecoratorNode has no inline form, so it is dropped.
+        selection.insertNodes([inserted]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      // The block decorator was dropped entirely; the document is unchanged.
+      expect($getNodeByKey(insertedKey)).toBe(null);
+      const element = $assertNodeType(
+        $getRoot().getFirstChild(),
+        $isElementNode,
+      );
+      expect(element.getTextContent()).toBe('abc');
+    });
+  });
+
+  test('keeps the inline content of a block paste', () => {
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const element = $createTestElementNode();
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('abc');
+        paragraph.append(text);
+        element.append(paragraph);
+        $getRoot().clear().append(element);
+        text.select(3, 3);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        // The paragraph's inline content is kept; the block wrapper is dropped.
+        selection.insertNodes([
+          $createParagraphNode().append($createTextNode('def')),
+        ]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const element = $assertNodeType(
+        $getRoot().getFirstChild(),
+        $isElementNode,
+      );
+      expect(element.getTextContent()).toBe('abcdef');
+    });
+  });
+});

--- a/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   buildEditorFromExtensions,
   defineExtension,

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import type {JSX} from 'react';
 
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   $createParagraphNode,
   $createTextNode,
@@ -14,12 +13,13 @@ import {
   $isParagraphNode,
   $isTextNode,
   ParagraphNode,
+  RootNode,
   TextNode,
 } from 'lexical';
 import {assert, describe, expect, test} from 'vitest';
 
 import {EditorState} from '../../LexicalEditorState';
-import {$createRootNode, RootNode} from '../../nodes/LexicalRootNode';
+import {$createRootNode} from '../../nodes/LexicalRootNode';
 import {initializeUnitTest} from '../utils';
 
 describe('LexicalEditorState tests', () => {

--- a/packages/lexical/src/__tests__/unit/LexicalElementHelpers.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalElementHelpers.test.ts
@@ -6,10 +6,7 @@
  *
  */
 
-import {
-  addClassNamesToElement,
-  removeClassNamesFromElement,
-} from '@lexical/utils';
+import {addClassNamesToElement, removeClassNamesFromElement} from 'lexical';
 import {describe, expect, test} from 'vitest';
 
 describe('LexicalElementHelpers tests', () => {

--- a/packages/lexical/src/__tests__/unit/LexicalGenMap.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalGenMap.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
+import {} from 'lexical';
 import {describe, expect, test} from 'vitest';
 
 import {cloneMap, GenMap} from '../../LexicalGenMap';

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -5,13 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import invariant from '@lexical/internal/invariant';
 import {
   $create,
   $createLineBreakNode,
+  $createParagraphNode,
   $createRangeSelection,
   $createTabNode,
+  $createTextNode,
   $getNodeByKey,
   $getNodeByKeyOrThrow,
   $getRoot,
@@ -44,8 +45,6 @@ import {
 } from 'vitest';
 
 import {LexicalNode} from '../../LexicalNode';
-import {$createParagraphNode} from '../../nodes/LexicalParagraphNode';
-import {$createTextNode} from '../../nodes/LexicalTextNode';
 import {
   $createTestElementNode,
   $createTestInlineElementNode,

--- a/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   $copyNode,
   $create,

--- a/packages/lexical/src/__tests__/unit/LexicalNormalization.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalNormalization.test.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   $createParagraphNode,
   $createTextNode,

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import invariant from '@lexical/internal/invariant';
 import {$createLinkNode, LinkExtension} from '@lexical/link';

--- a/packages/lexical/src/__tests__/unit/LexicalRootSelectionPhantomParagraph.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalRootSelectionPhantomParagraph.test.ts
@@ -7,14 +7,14 @@
  */
 import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
-import {describe, expect, test} from 'vitest';
-
 import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
   $isParagraphNode,
-} from '../..';
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
 import {
   $createTestDecoratorNode,
   $createTestShadowRootNode,

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {$createLinkNode, $isLinkNode, LinkNode} from '@lexical/link';
 import {
   $createListItemNode,

--- a/packages/lexical/src/__tests__/unit/LexicalSelectionResolveLeafPosition.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelectionResolveLeafPosition.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   buildEditorFromExtensions,
   type LexicalEditorWithDispose,

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -5,9 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
-import type {GetStaticNodeOwnConfig} from '../../LexicalNode';
-
 import {
   buildEditorFromExtensions,
   type LexicalEditorWithDispose,
@@ -17,7 +14,9 @@ import {
   $create,
   $createLineBreakNode,
   $createNodeSelection,
+  $createParagraphNode,
   $createRangeSelection,
+  $createTextNode,
   $getChildCaret,
   $getDOMSlot,
   $getNearestRootOrShadowRoot,
@@ -50,10 +49,9 @@ import {
 } from 'lexical';
 import {afterEach, assert, describe, expect, expectTypeOf, test} from 'vitest';
 
+import {type GetStaticNodeOwnConfig} from '../../LexicalNode';
 import {$internalCreateRangeSelection} from '../../LexicalSelection';
 import {$getSlotContainer} from '../../LexicalUtils';
-import {$createParagraphNode} from '../../nodes/LexicalParagraphNode';
-import {$createTextNode} from '../../nodes/LexicalTextNode';
 import {
   $assertNodeType,
   $createTestDecoratorNode,

--- a/packages/lexical/src/__tests__/unit/LexicalSlotSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlotSelection.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   buildEditorFromExtensions,
   type LexicalEditorWithDispose,

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   $applyNodeReplacement,
   $copyNode,
@@ -17,11 +16,14 @@ import {
   $isTokenOrSegmented,
   $nodesOfType,
   $onUpdate,
+  $setCompositionKey,
   $setState,
   createEditor,
   createState,
   getRegisteredSubtypeMap,
+  getTextDirection,
   IS_APPLE,
+  isExactShortcutMatch,
   isSelectionWithinEditor,
   LineBreakNode,
   ParagraphNode,
@@ -33,14 +35,11 @@ import {
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 
 import {
-  $setCompositionKey,
   $updateTextNodeFromDOMContent,
   emptyFunction,
   generateRandomKey,
   getCachedTypeToNodeMap,
-  getTextDirection,
   isArray,
-  isExactShortcutMatch,
   isMoveToEnd,
   isMoveToStart,
   scheduleMicroTask,

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -30,15 +30,19 @@ import {
   $create,
   $isRangeSelection,
   createEditor,
+  CreateEditorArgs,
   DecoratorNode,
   EditorState,
   EditorThemeClasses,
   ElementNode,
+  HTMLConfig,
   Klass,
   LexicalEditor,
   LexicalNode,
+  LexicalNodeReplacement,
   LexicalUpdateJSON,
   RangeSelection,
+  resetRandomKey,
   SerializedElementNode,
   SerializedLexicalNode,
   SerializedTextNode,
@@ -49,13 +53,6 @@ import * as React from 'react';
 import {act, createRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import {afterEach, assert, beforeEach, expect} from 'vitest';
-
-import {
-  CreateEditorArgs,
-  HTMLConfig,
-  LexicalNodeReplacement,
-} from '../../LexicalEditor';
-import {resetRandomKey} from '../../LexicalUtils';
 
 const prettierConfig = prettier.resolveConfig(__filename);
 

--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -35,6 +35,7 @@ import {
   INTERNAL_$isBlock,
 } from '../LexicalUtils';
 import {$isElementNode, type ElementNode} from '../nodes/LexicalElementNode';
+import {$createParagraphNode} from '../nodes/LexicalParagraphNode';
 import {
   $createTextNode,
   $isTextNode,
@@ -744,4 +745,69 @@ export function $splitAtPointCaretNext(
     }
   }
   return parentCaret;
+}
+
+/**
+ * If the insertion caret is the root/shadow root node (see {@link $isRootOrShadowRoot}),
+ * the node will be inserted there, otherwise the parent nodes will be split according to the
+ * given options.
+ * @param node - The node to be inserted
+ * @param caret - The location to insert or split from
+ * @returns The node after its insertion
+ */
+export function $insertNodeToNearestRootAtCaret<
+  T extends LexicalNode,
+  D extends CaretDirection,
+>(
+  node: T,
+  caret: PointCaret<D>,
+  options?: SplitAtPointCaretNextOptions,
+): NodeCaret<D> {
+  let insertCaret: PointCaret<'next'> = $getCaretInDirection(caret, 'next');
+  // Normalize boundary cases for TextPointCaret
+  if ($isTextPointCaret(insertCaret)) {
+    if (insertCaret.offset === 0) {
+      insertCaret = $getSiblingCaret(
+        insertCaret.origin,
+        'previous',
+      ).getFlipped();
+    } else if (insertCaret.offset === insertCaret.origin.getTextContentSize()) {
+      insertCaret = $getSiblingCaret(insertCaret.origin, 'next');
+    }
+  }
+  // Make sure we have a distinct node as the origin
+  if (insertCaret.origin.is(node)) {
+    invariant(
+      $isSiblingCaret(insertCaret),
+      '$insertNodeToNearestRootAtCaret node %s of type %s can not be inserted into itself',
+      node.getKey(),
+      node.getType(),
+    );
+    insertCaret = $rewindSiblingCaret(insertCaret);
+  }
+  // Handle split boundary conditions where node is being inserted adjacent to itself
+  if (
+    node.is(insertCaret.getNodeAtCaret()) ||
+    node.is(insertCaret.getFlipped().getNodeAtCaret())
+  ) {
+    node.remove(true);
+  }
+  for (
+    let nextCaret: null | PointCaret<'next'> = insertCaret;
+    nextCaret;
+    nextCaret = $splitAtPointCaretNext(nextCaret, options)
+  ) {
+    insertCaret = nextCaret;
+  }
+  invariant(
+    !$isTextPointCaret(insertCaret),
+    '$insertNodeToNearestRootAtCaret: An unattached TextNode can not be split',
+  );
+  insertCaret.insert(
+    node.isInline() ? $createParagraphNode().append(node) : node,
+  );
+  return $getCaretInDirection(
+    $getSiblingCaret(node.getLatest(), 'next'),
+    caret.direction,
+  );
 }

--- a/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
+++ b/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
@@ -21,6 +21,7 @@ import {
 } from '@lexical/table';
 import {
   $caretRangeFromSelection,
+  $comparePointCaretNext,
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
@@ -60,7 +61,6 @@ import {
   initializeUnitTest,
   invariant,
 } from '../../../__tests__/utils';
-import {$comparePointCaretNext} from '../../LexicalCaret';
 
 const DIRECTIONS = ['next', 'previous'] as const;
 const BIASES = ['inside', 'outside'] as const;

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -56,6 +56,7 @@ export {
   $getCaretInDirection,
   $getCaretRangeInDirection,
   $getChildCaretAtIndex,
+  $insertNodeToNearestRootAtCaret,
   $isExtendableTextPointCaret,
   $normalizeCaret,
   $removeTextFromCaretRange,

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   $applyNodeReplacement,
   $createParagraphNode,
@@ -15,9 +14,11 @@ import {
   $isElementNode,
   $isRangeSelection,
   createEditor,
+  ElementDOMSlot,
   ElementNode,
   LexicalEditor,
   LexicalNode,
+  SerializedElementNode,
   TextNode,
 } from 'lexical';
 import * as React from 'react';
@@ -38,8 +39,7 @@ import {
   $createTestElementNode,
   createTestEditor,
 } from '../../../__tests__/utils';
-import {ElementDOMSlot, indexPath} from '../../../LexicalDOMSlot';
-import {SerializedElementNode} from '../../LexicalElementNode';
+import {indexPath} from '../../../LexicalDOMSlot';
 
 describe('LexicalElementNode tests', () => {
   let container: HTMLElement;

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   $createParagraphNode,
   $createTextNode,

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   $createParagraphNode,
   $createTextNode,
@@ -20,6 +19,14 @@ import {
   $isTextNode,
   $setState,
   createState,
+  IS_BOLD,
+  IS_CODE,
+  IS_HIGHLIGHT,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+  IS_UNDERLINE,
   LexicalEditor,
   TextFormatType,
   TextModeType,
@@ -36,16 +43,8 @@ import {
   createTestEditor,
 } from '../../../__tests__/utils';
 import {
-  IS_BOLD,
   IS_CAPITALIZE,
-  IS_CODE,
-  IS_HIGHLIGHT,
-  IS_ITALIC,
   IS_LOWERCASE,
-  IS_STRIKETHROUGH,
-  IS_SUBSCRIPT,
-  IS_SUPERSCRIPT,
-  IS_UNDERLINE,
   IS_UPPERCASE,
 } from '../../../LexicalConstants';
 import {


### PR DESCRIPTION
## Description

`RangeSelection.insertNodes` could throw, or produce an invalid document
structure, when the destination block cannot legally contain the inserted
non-inline content.

- Inserting a `DecoratorNode` into the block cursor inside an `ElementNode` threw an exception (#8713).
- Pasting a non-inline node (e.g. a `HorizontalRuleNode`) into an inline-only parent such as a collapsible title produced an invalid tree: a non-inline child nested inside an element that may only contain inline children (#8724).

The document structure rules being enforced are:

- `RootNode` and shadow-root `ElementNode`s may only have non-inline children.
- Other non-inline `ElementNode`s may only contain inline children.
- Inline `ElementNode`s may only contain inline children.
- `ListNode`/`ListItemNode` have their own containment rules and relocate themselves via `isParentRequired()`.

This PR makes `insertNodes` keep the tree valid by splitting/relocating, or dropping content that has no valid inline form, instead of crashing or nesting nodes illegally. Two cases are added:

- **No enclosing block (`firstBlock === null`)** — each top-level inserted block is placed relative to the nearest root using `$insertNodeToNearestRootAtCaret`, rather than splicing a block into a context that cannot hold it.
- **Inline-only enclosing block** — when the enclosing block is a non-inline, non-shadow-root `ElementNode` whose parent is not a root/shadow root and which does not require a specific parent, the inserted nodes are reduced to their inline content and spliced in. Non-inline nodes with no inline form (e.g. `HorizontalRuleNode`) are dropped rather than nested illegally. `isParentRequired()` leaves list structures on the existing code path so list paste behavior is unchanged.

The fix lives entirely in the `lexical` core package and requires no changes to node implementations or their extensions.

This PR also includes preparatory/hygiene changes:

- Moves `$insertNodeToNearestRootAtCaret` from `@lexical/utils` into the `lexical` core package (`caret/LexicalCaretUtils`), exports it from `lexical`, and re-exports it from `@lexical/utils` for backwards compatibility. This lets `insertNodes` use the helper without a circular dependency on `@lexical/utils`.
- Switches internal consumers to import core re-exports directly from `lexical` (e.g. `$insertNodeToNearestRootAtCaret`, `addClassNamesToElement`, `removeClassNamesFromElement`, `mergeRegister`, `$findMatchingParent`, `isHTMLElement`, `isHTMLAnchorElement`, `$splitNode`, `isBlockDomNode`, `isInlineDomNode`, `$getAdjacentSiblingOrParentSiblingCaret`), and replaces relative test imports with package imports where the symbol is public. The `examples/` projects are intentionally left on the published-package imports.

Closes #8713
Closes #8724

## Test plan

### Before

- Following the repro (clear editor → `/divider`, Enter → Backspace, Cut →
  `/collapsible`, Enter → Paste) crashes / leaves the editor with a
  non-inline `HorizontalRuleNode` nested inside the inline-only
  `CollapsibleTitleNode`.
- Inserting a `DecoratorNode` into a block cursor inside an `ElementNode`
  throws.

### After

- New `Issue8724Repro` unit tests cover the no-block and inline-only-parent
  cases with shadow-root, inline-only element, and list parents, using
  decorator and element nodes.
- New `Issue8724Collapsible` playground unit test reproduces the paste-into-
  collapsible-title repro and asserts the collapsible is left intact and the
  block is dropped.
- `tsc`, `eslint`, and `prettier` are clean across the workspace; full unit
  and e2e suites (including the lists and copy/paste suites) pass.