### PR TITLE
[lexical][lexical-rich-text][lexical-clipboard] Bug Fix: Named-slot typing / Backspace / Copy / hydrate paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "js/ts.validate.enabled": false,
+  "js/ts.validate.enabled": true,
   "[javascript][typescript]": {
     "editor.codeActionsOnSave": [
       // Run ESLint fixers _before_ prettier to ensure the user doesn't need to do multiple saves

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "javascript.validate.enable": false,
+  "js/ts.validate.enabled": false,
   "[javascript][typescript]": {
     "editor.codeActionsOnSave": [
       // Run ESLint fixers _before_ prettier to ensure the user doesn't need to do multiple saves
       "source.fixAll.eslint",
       "source.fixAll.format"
     ]
-  }
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/packages/lexical-clipboard/src/__tests__/unit/SlotClipboardExport.test.ts
+++ b/packages/lexical-clipboard/src/__tests__/unit/SlotClipboardExport.test.ts
@@ -15,6 +15,7 @@ import {buildEditorFromExtensions} from '@lexical/extension';
 import {$generateHtmlFromNodes} from '@lexical/html';
 import {
   $create,
+  $createNodeSelection,
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
@@ -336,6 +337,58 @@ describe('slot clipboard export', () => {
       expect(html).toContain('Bo');
       expect(html).not.toContain('Body');
       expect(html).not.toContain('UNSELECTED');
+    });
+  });
+
+  // Regression for facebook/lexical#8712: the slot-frame redirect that lets
+  // a selection inside a slot subtree export through its frame (instead of
+  // root, which is shadow-isolated from the slot) only ran for
+  // RangeSelection. A NodeSelection on a node nested inside a slot
+  // resolved to a null frame, the root-children walk missed the selected
+  // node, and the export produced `{nodes: []}` — empty clipboard, cut =
+  // silent data loss. Now anchors the frame redirect on the first selected
+  // node when the selection is a NodeSelection.
+  test('a NodeSelection on a node inside a slot exports the node, not an empty list', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        $initialEditorState: null,
+        name: '[slot-node-selection]',
+        nodes: [PlainShadowRootNode],
+      }),
+    );
+    let innerParaKey = '';
+    editor.update(
+      () => {
+        const host = $createParagraphNode();
+        const slot = $createPlainShadowRootNode();
+        const innerPara = $createParagraphNode().append(
+          $createTextNode('SlotNodeTarget'),
+        );
+        slot.append(innerPara);
+        $setSlot(host, 'media', slot);
+        $getRoot().append(host);
+        innerParaKey = innerPara.getKey();
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const innerPara = $getNodeByKey(innerParaKey);
+        assert(innerPara !== null);
+        const nodeSelection = $createNodeSelection();
+        nodeSelection.add(innerPara.getKey());
+        $setSelection(nodeSelection);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const selection = $getSelection();
+      const json = $generateJSONFromSelectedNodes(editor, selection);
+      // Pre-fix: nodes.length === 0 and the cut path silently dropped the
+      // selected node. Post-fix: the redirected walk through the slot's
+      // frame finds the selected paragraph.
+      expect(json.nodes.length).toBeGreaterThan(0);
+      expect(JSON.stringify(json.nodes)).toContain('SlotNodeTarget');
     });
   });
 

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -620,13 +620,20 @@ export function $generateJSONFromSelectedNodes<
 } {
   const nodes: SerializedNode[] = [];
   const root = $getRoot();
-  // A RangeSelection wholly inside a slot subtree never includes its host
-  // (slots are shadow-root isolated), so a root-children walk would miss the
+  // A selection wholly inside a slot subtree never includes its host (slots
+  // are shadow-root isolated), so a root-children walk would miss the
   // selected nodes entirely and export an empty payload (cut = data loss).
   // Walk the selection's slot frame instead; outside slots this is the root.
-  const slotFrame = $isRangeSelection(selection)
-    ? $getSlotFrame(selection.anchor.getNode())
-    : null;
+  // NodeSelection participates here too — a click that selects a decorator
+  // nested in a slot needs the same frame redirect, otherwise its export
+  // pipeline silently produces an empty clipboard.
+  const slotFrameAnchor = $isRangeSelection(selection)
+    ? selection.anchor.getNode()
+    : $isNodeSelection(selection)
+      ? (selection.getNodes()[0] ?? null)
+      : null;
+  const slotFrame =
+    slotFrameAnchor !== null ? $getSlotFrame(slotFrameAnchor) : null;
   const topLevelChildren = (
     $isElementNode(slotFrame) ? slotFrame : root
   ).getChildren();

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -627,6 +627,14 @@ export function $generateJSONFromSelectedNodes<
   // NodeSelection participates here too — a click that selects a decorator
   // nested in a slot needs the same frame redirect, otherwise its export
   // pipeline silently produces an empty clipboard.
+  //
+  // NodeSelection.getNodes()[0] is the first node by insertion order (the
+  // internal _nodes Set's iteration order), not document order. For the
+  // common single-decorator case this is the only node and the frame is
+  // unambiguous. A multi-node NodeSelection that straddles a slot boundary
+  // is currently undefined — slots are shadow-isolated, so straddling is
+  // already invalid construction, and we pick the first inserted node's
+  // frame rather than asserting.
   const slotFrameAnchor = $isRangeSelection(selection)
     ? selection.anchor.getNode()
     : $isNodeSelection(selection)

--- a/packages/lexical-list/src/__tests__/unit/registerListBackspaceDecorator.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/registerListBackspaceDecorator.test.ts
@@ -27,7 +27,7 @@ import {
   invariant,
   TestDecoratorNode,
 } from 'lexical/src/__tests__/utils';
-import {describe, expect, test} from 'vitest';
+import {assert, describe, expect, test} from 'vitest';
 
 class IsolatedTestDecoratorNode extends TestDecoratorNode {
   $config() {
@@ -104,10 +104,20 @@ describe('registerList — Backspace adjacent to DecoratorNode (#5072)', () => {
       editor.read(() => {
         const children = $getRoot().getChildren();
         expect(children).toHaveLength(3);
-        invariant(
-          children[0] instanceof TestDecoratorNode,
-          'Expected leading TestDecoratorNode',
-        );
+        if (inline) {
+          assert(
+            $isParagraphNode(children[0]),
+            'Expected leading ParagraphNode wrapping inline TestDecoratorNode',
+          );
+          expect(
+            children[0].getChildren().map(n => n instanceof TestDecoratorNode),
+          ).toEqual([true]);
+        } else {
+          invariant(
+            children[0] instanceof TestDecoratorNode,
+            'Expected leading TestDecoratorNode',
+          );
+        }
         const paragraph = children[1];
         invariant(
           $isParagraphNode(paragraph),

--- a/packages/lexical-playground/__tests__/e2e/CardSlot.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CardSlot.spec.mjs
@@ -120,8 +120,8 @@ async function assertCardIntact(page, {title, body}) {
 }
 
 // Place the caret at the start of the block immediately after the card (the
-// trailing paragraph $insertNodeToNearestRoot leaves behind), for the
-// "backspace from after the card" deletion case.
+// trailing paragraph $insertNodeToNearestRoot leaves behind), to verify
+// Backspace from there leaves the host alone (#8712).
 async function selectStartAfterCard(page) {
   await evaluate(page, () => {
     const editor = window.lexicalEditor;
@@ -235,7 +235,7 @@ test.describe('Card slot deletion boundaries', () => {
     expect(await cardCount(page)).toBe(0);
   });
 
-  test('backspace from the block after an empty card deletes the card', async ({
+  test('backspace from the block after an empty card leaves the card alone (#8712)', async ({
     page,
   }) => {
     await focusEditor(page);
@@ -246,7 +246,12 @@ test.describe('Card slot deletion boundaries', () => {
     await page.keyboard.press('Backspace');
     await sleep(120);
 
-    expect(await cardCount(page)).toBe(0);
+    // Per #8712: the caret sits in the next block, not the host, so
+    // Backspace leaves the host alone — the trailing paragraph is dropped
+    // and the caret lands inside the card body. The inside-host escape
+    // gesture (caret at the start of the empty title) still removes the
+    // card; covered above.
+    expect(await cardCount(page)).toBe(1);
   });
 
   test('select-all + Backspace replaces a first-block card with a paragraph', async ({

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.css
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.css
@@ -11,9 +11,9 @@
 [type='page-break'] {
   position: relative;
   display: block;
-  width: calc(100% + var(--editor-input-padding, 28px) * 2);
+  width: 100%;
   overflow: unset;
-  margin-left: calc(var(--editor-input-padding, 28px) * -1);
+  margin-left: 0;
   margin-top: var(--editor-input-padding, 28px);
   margin-bottom: var(--editor-input-padding, 28px);
 
@@ -21,6 +21,11 @@
   border-top: 1px dashed var(--editor-color-secondary, #eeeeee);
   border-bottom: 1px dashed var(--editor-color-secondary, #eeeeee);
   background-color: var(--editor-color-secondary, #eeeeee);
+}
+
+.ContentEditable__root > [type='page-break'] {
+  width: calc(100% + var(--editor-input-padding, 28px) * 2);
+  margin-left: calc(var(--editor-input-padding, 28px) * -1);
 }
 
 [type='page-break']::before {

--- a/packages/lexical-playground/src/nodes/slotHostEscape.ts
+++ b/packages/lexical-playground/src/nodes/slotHostEscape.ts
@@ -23,7 +23,6 @@ import {
   $isElementNode,
   $isParagraphNode,
   $isRangeSelection,
-  $isRootOrShadowRoot,
   COMMAND_PRIORITY_BEFORE_EDITOR,
   COMMAND_PRIORITY_LOW,
   isModifierMatch,
@@ -346,13 +345,15 @@ function $reanchorRangeBeforeHost<T extends LexicalNode>(
  *   paragraph rather than only clearing its contents (see
  *   {@link $reanchorRangeBeforeHost}) — on both Backspace and forward Delete.
  * - On Backspace, a collapsed caret at the start of an *empty* host's first
- *   region (the Card's `title` slot, the Review's body), or at the start of the
- *   block immediately after an *empty* host, deletes the host — the analog of
- *   backspacing an empty block away.
+ *   region (the Card's `title` slot, the Review's body) escapes the host by
+ *   deleting it — the analog of backspacing an empty block away.
  *
  * A non-empty host is otherwise left to the default handler, so the slots'
  * shadow-root boundary still protects their content (backspace at a non-empty
- * slot start stays a no-op).
+ * slot start stays a no-op). Backspace at the start of a block *after* an
+ * empty host is also left alone: the user's caret is in the next block, so
+ * silently deleting the previous host crosses a node boundary the user did
+ * not point at (issue #8712).
  */
 export function registerSlotHostBackspace<T extends LexicalNode>(
   editor: LexicalEditor,
@@ -373,44 +374,21 @@ export function registerSlotHostBackspace<T extends LexicalNode>(
         }
         const anchor = selection.anchor;
         const inner = $findSlotHost(anchor.getNode(), $isHost);
-        if (inner !== null) {
-          // Inside the host: only delete from the start of its first region.
-          const first = $orderedRegions(editor, inner)[0];
-          if (
-            first !== undefined &&
-            $isElementNode(first.startNode) &&
-            $isAtStartOfNode(anchor, first.startNode) &&
-            $isEmpty(inner)
-          ) {
-            $deleteEmptyHost(inner);
-            if (event) {
-              event.preventDefault();
-            }
-            return true;
-          }
+        if (inner === null) {
+          // Caret is outside the host. Let the default handler take it; we
+          // do not silently delete the previous empty host, which would
+          // cross a node boundary the user did not point at.
           return false;
         }
-        // Outside the host: delete when the caret is at the start of the block
-        // immediately after an empty host.
-        let block: LexicalNode | null = anchor.getNode();
-        while (block !== null) {
-          const parent: LexicalNode | null = block.getParent();
-          if (parent !== null && $isRootOrShadowRoot(parent)) {
-            break;
-          }
-          block = parent;
-        }
-        if (block === null || !$isElementNode(block)) {
-          return false;
-        }
-        const prev = block.getPreviousSibling();
+        // Inside the host: only delete from the start of its first region.
+        const first = $orderedRegions(editor, inner)[0];
         if (
-          $isHost(prev) &&
-          $isEmpty(prev) &&
-          $isAtStartOfNode(anchor, block)
+          first !== undefined &&
+          $isElementNode(first.startNode) &&
+          $isAtStartOfNode(anchor, first.startNode) &&
+          $isEmpty(inner)
         ) {
-          prev.remove();
-          block.selectStart();
+          $deleteEmptyHost(inner);
           if (event) {
             event.preventDefault();
           }

--- a/packages/lexical-react/src/__tests__/unit/ExtensionComponent.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/ExtensionComponent.test.tsx
@@ -17,8 +17,8 @@ import {
 } from '@lexical/react/useExtensionComponent';
 import {defineExtension, type LexicalExtensionDependency} from 'lexical';
 import * as React from 'react';
+import {act} from 'react';
 import {createRoot, Root} from 'react-dom/client';
-import {act} from 'react-dom/test-utils';
 import {assertType, describe, expect, it} from 'vitest';
 
 interface RequiredProps {

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionBackspace.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionBackspace.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createNodeSelection,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $setSelection,
+  KEY_BACKSPACE_COMMAND,
+  KEY_DELETE_COMMAND,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+function makeKey(key: 'Backspace' | 'Delete'): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+}
+
+function createEditor(inline: boolean) {
+  return buildEditorFromExtensions({
+    $initialEditorState: () => {
+      $getRoot().append(
+        $createParagraphNode().append($createTextNode('before')),
+        $createTestDecoratorNode().setIsInline(inline),
+      );
+    },
+    dependencies: [RichTextExtension],
+    name: 'test',
+    nodes: [TestDecoratorNode],
+  });
+}
+
+describe('KEY_BACKSPACE_COMMAND on a single-decorator NodeSelection', () => {
+  // Regression for facebook/lexical#8712: the early "target within decorator"
+  // pass-through used to fire even when the active selection was a
+  // NodeSelection on the decorator itself, so a click that selected a block
+  // decorator followed by Backspace was a silent no-op. We now skip the
+  // pass-through when the active selection is a NodeSelection.
+  test('block decorator: deletes the node', () => {
+    using editor = createEditor(false);
+
+    editor.update(
+      () => {
+        const decorator = $getRoot().getLastChild()!;
+        const selection = $createNodeSelection();
+        selection.add(decorator.getKey());
+        $setSelection(selection);
+      },
+      {discrete: true},
+    );
+
+    // Synthesize a target inside the decorator's DOM range — the
+    // pass-through reads event.target.
+    const decoratorKey = editor.getEditorState().read(() => {
+      return $getRoot().getLastChild()!.getKey();
+    });
+    const decoratorDOM = editor.getElementByKey(decoratorKey)!;
+    const event = makeKey('Backspace');
+    Object.defineProperty(event, 'target', {value: decoratorDOM});
+
+    const handled = editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event);
+    expect(handled).toBe(true);
+
+    editor.read(() => {
+      const root = $getRoot();
+      expect(root.getChildrenSize()).toBe(1);
+      expect(root.getChildren()[0]).not.toBeInstanceOf(TestDecoratorNode);
+      const selection = $getSelection();
+      // Selection collapses to a RangeSelection at the sibling.
+      expect($isRangeSelection(selection)).toBe(true);
+    });
+  });
+});
+
+describe('KEY_DELETE_COMMAND on a single-decorator NodeSelection', () => {
+  // Symmetric to the KEY_BACKSPACE_COMMAND fix above. The same pass-through
+  // gap existed for forward-Delete and is closed by the same NodeSelection
+  // guard.
+  test('block decorator: deletes the node', () => {
+    using editor = createEditor(false);
+
+    editor.update(
+      () => {
+        const decorator = $getRoot().getLastChild()!;
+        const selection = $createNodeSelection();
+        selection.add(decorator.getKey());
+        $setSelection(selection);
+      },
+      {discrete: true},
+    );
+
+    const decoratorKey = editor.getEditorState().read(() => {
+      return $getRoot().getLastChild()!.getKey();
+    });
+    const decoratorDOM = editor.getElementByKey(decoratorKey)!;
+    const event = makeKey('Delete');
+    Object.defineProperty(event, 'target', {value: decoratorDOM});
+
+    const handled = editor.dispatchCommand(KEY_DELETE_COMMAND, event);
+    expect(handled).toBe(true);
+
+    editor.read(() => {
+      const root = $getRoot();
+      expect(root.getChildrenSize()).toBe(1);
+      expect(root.getChildren()[0]).not.toBeInstanceOf(TestDecoratorNode);
+    });
+  });
+});

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionEnter.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionEnter.test.ts
@@ -12,6 +12,8 @@ import {
   $createNodeSelection,
   $getRoot,
   $getSelection,
+  $isNodeSelection,
+  $isParagraphNode,
   $isRangeSelection,
   $setSelection,
   KEY_ENTER_COMMAND,
@@ -63,8 +65,15 @@ describe('KEY_ENTER_COMMAND on a single-decorator NodeSelection', () => {
 
     editor.read(() => {
       const root = $getRoot();
-      expect(root.getChildrenSize()).toBe(1);
-      expect(root.getChildren()[0]).toBeInstanceOf(TestDecoratorNode);
+      // inline nodes are wrapped
+      const children = root.getChildren();
+      expect(children).toHaveLength(1);
+      assert(children.every($isParagraphNode));
+      const paragraphChildren = children[0].getChildren();
+      expect(paragraphChildren).toHaveLength(1);
+      expect(paragraphChildren[0]).toBeInstanceOf(TestDecoratorNode);
+      const selection = $getSelection();
+      assert($isNodeSelection(selection));
     });
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1081,10 +1081,15 @@ export function registerRichText(
     editor.registerCommand<KeyboardEvent>(
       KEY_DELETE_COMMAND,
       event => {
-        if ($isTargetWithinDecorator(event.target as HTMLElement)) {
-          return false;
-        }
         const selection = $getSelection();
+        // Same NodeSelection bypass as KEY_BACKSPACE_COMMAND above: a click
+        // that selected a block decorator is the user's "delete this node"
+        // gesture, even though the click target lives inside a decorator.
+        if (!$isNodeSelection(selection)) {
+          if ($isTargetWithinDecorator(event.target as HTMLElement)) {
+            return false;
+          }
+        }
         if (!($isRangeSelection(selection) || $isNodeSelection(selection))) {
           return false;
         }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1047,10 +1047,18 @@ export function registerRichText(
     editor.registerCommand<KeyboardEvent>(
       KEY_BACKSPACE_COMMAND,
       event => {
-        if ($isTargetWithinDecorator(event.target as HTMLElement)) {
-          return false;
-        }
         const selection = $getSelection();
+        // A NodeSelection (e.g. a click that selected a block decorator) is
+        // the user's explicit "delete this node" gesture. The decorator
+        // pass-through below is meant to keep keystrokes flowing into an
+        // editable nested inside a decorator (image caption, etc.), but a
+        // NodeSelection is exactly the case where the user wants us to
+        // handle backspace ourselves.
+        if (!$isNodeSelection(selection)) {
+          if ($isTargetWithinDecorator(event.target as HTMLElement)) {
+            return false;
+          }
+        }
         if ($isRangeSelection(selection)) {
           if ($isSelectionCollapsedAtFrontOfIndentedBlock(selection)) {
             event.preventDefault();

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -41,7 +41,6 @@ import {GenMap} from './LexicalGenMap';
 import {flushRootMutations, initMutationObserver} from './LexicalMutations';
 import {LexicalNode} from './LexicalNode';
 import {createSharedNodeState, SharedNodeState} from './LexicalNodeState';
-import {$normalizeShadowRootChildrenInTree} from './LexicalSelection';
 import {$isSlotHost} from './LexicalSlot';
 import {
   $commitPendingUpdates,
@@ -1688,21 +1687,21 @@ export class LexicalEditor {
     // children violate the `Children of root nodes must be elements or
     // decorators` invariant set by `getTopLevelElement`. In-editor mutation
     // paths still fail-fast on the invariant — this only catches shapes
-    // that were parsed in from outside. Tagged with HISTORY_MERGE_TAG so
-    // the normalize folds into the setEditorState history entry instead of
-    // creating a separate undo step.
-    // Cost: ~1.4μs per node, linear (measured 0.3ms @ 207 nodes,
-    // 2.9ms @ 2007 nodes). Runs on every setEditorState once _slotsUsed
-    // latches — URL load, undo/redo, SSR hydration, test setup. Reactive
-    // listeners fire twice per setEditorState (the input commit + this
-    // follow-up); for large editors with collab adapters that swap state
-    // on every remote sync, a tighter gate (e.g. flagging parsed-from-JSON
-    // states only, or skipping when the input is a clone of the current
-    // state) is the natural next step.
+    // that were parsed in from outside.
+    //
+    // Drives the existing dirty-node transform cycle: dirty-mark the slot
+    // hosts so `ElementNode.static transform()` (which calls
+    // `$normalizeShadowRootChildren`) picks them up. Tagged with
+    // HISTORY_MERGE_TAG so the normalize folds into the setEditorState
+    // history entry instead of creating a separate undo step.
     if (!this._updating && this._slotsUsed) {
       this.update(
         () => {
-          $normalizeShadowRootChildrenInTree($getRoot());
+          for (const node of this._editorState._nodeMap.values()) {
+            if ($isElementNode(node) && node.isShadowRoot()) {
+              node.getWritable();
+            }
+          }
         },
         {discrete: true, tag: HISTORY_MERGE_TAG},
       );

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1653,35 +1653,38 @@ export class LexicalEditor {
     this._compositionKey = null;
     this._slotsUsed = this._slotsUsed || editorState._slotsUsed;
 
-    if (tag != null) {
-      this._updateTags.add(tag);
-    }
-
     // Only commit pending updates if not already in an editor.update
     // (e.g. dispatchCommand) otherwise this will cause a second commit
     // with an already read-only state and selection
-    updateEditorSync(this, () => {
-      if (editorState._parsed) {
-        for (const [key, node] of writableEditorState._nodeMap.entries()) {
-          // Mark all nodes as dirty with a freshly parsed EditorState
-          // hydrate-time normalize: external inputs (URL doc payloads, imported
-          // JSON, paste round-trips) may carry shadow-root slot frames whose
-          // children violate the `Children of root nodes must be elements or
-          // decorators` invariant set by `getTopLevelElement`. In-editor mutation
-          // paths still fail-fast on the invariant — this only catches shapes
-          // that were parsed in from outside.
-          //
-          // Drives the existing dirty-node transform cycle: dirty-mark the slot
-          // hosts so `ElementNode`'s `$config` `$transform` (which calls
-          // `$normalizeShadowRootChildren`) picks them up.
-          if ($isElementNode(node)) {
-            this._dirtyElements.set(key, true);
-          } else {
-            this._dirtyLeaves.add(key);
+    updateEditorSync(
+      this,
+      () => {
+        if (tag) {
+          this._updateTags.add(tag);
+        }
+        if (editorState._parsed) {
+          for (const [key, node] of writableEditorState._nodeMap.entries()) {
+            // Mark all nodes as dirty with a freshly parsed EditorState
+            // hydrate-time normalize: external inputs (URL doc payloads, imported
+            // JSON, paste round-trips) may carry shadow-root slot frames whose
+            // children violate the `Children of root nodes must be elements or
+            // decorators` invariant set by `getTopLevelElement`. In-editor mutation
+            // paths still fail-fast on the invariant — this only catches shapes
+            // that were parsed in from outside.
+            //
+            // Drives the existing dirty-node transform cycle: dirty-mark the slot
+            // hosts so `ElementNode`'s `$config` `$transform` (which calls
+            // `$normalizeShadowRootChildren`) picks them up.
+            if ($isElementNode(node)) {
+              this._dirtyElements.set(key, true);
+            } else {
+              this._dirtyLeaves.add(key);
+            }
           }
         }
-      }
-    });
+      },
+      {discrete: this._updating ? undefined : true},
+    );
   }
 
   /**

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1691,6 +1691,14 @@ export class LexicalEditor {
     // that were parsed in from outside. Tagged with HISTORY_MERGE_TAG so
     // the normalize folds into the setEditorState history entry instead of
     // creating a separate undo step.
+    // Cost: ~1.4μs per node, linear (measured 0.3ms @ 207 nodes,
+    // 2.9ms @ 2007 nodes). Runs on every setEditorState once _slotsUsed
+    // latches — URL load, undo/redo, SSR hydration, test setup. Reactive
+    // listeners fire twice per setEditorState (the input commit + this
+    // follow-up); for large editors with collab adapters that swap state
+    // on every remote sync, a tighter gate (e.g. flagging parsed-from-JSON
+    // states only, or skipping when the input is a clone of the current
+    // state) is the natural next step.
     if (!this._updating && this._slotsUsed) {
       this.update(
         () => {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -41,6 +41,7 @@ import {GenMap} from './LexicalGenMap';
 import {flushRootMutations, initMutationObserver} from './LexicalMutations';
 import {LexicalNode} from './LexicalNode';
 import {createSharedNodeState, SharedNodeState} from './LexicalNodeState';
+import {$normalizeShadowRootChildrenInTree} from './LexicalSelection';
 import {$isSlotHost} from './LexicalSlot';
 import {
   $commitPendingUpdates,
@@ -1680,6 +1681,23 @@ export class LexicalEditor {
     // with an already read-only state and selection
     if (!this._updating) {
       $commitPendingUpdates(this);
+    }
+
+    // hydrate-time normalize: external inputs (URL doc payloads, imported
+    // JSON, paste round-trips) may carry shadow-root slot frames whose
+    // children violate the `Children of root nodes must be elements or
+    // decorators` invariant set by `getTopLevelElement`. In-editor mutation
+    // paths still fail-fast on the invariant — this only catches shapes
+    // that were parsed in from outside. Tagged with HISTORY_MERGE_TAG so
+    // the normalize folds into the setEditorState history entry instead of
+    // creating a separate undo step.
+    if (!this._updating && this._slotsUsed) {
+      this.update(
+        () => {
+          $normalizeShadowRootChildrenInTree($getRoot());
+        },
+        {discrete: true, tag: HISTORY_MERGE_TAG},
+      );
     }
   }
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -41,7 +41,6 @@ import {GenMap} from './LexicalGenMap';
 import {flushRootMutations, initMutationObserver} from './LexicalMutations';
 import {LexicalNode} from './LexicalNode';
 import {createSharedNodeState, SharedNodeState} from './LexicalNodeState';
-import {$isSlotHost} from './LexicalSlot';
 import {
   $commitPendingUpdates,
   $fullReconcile,
@@ -1652,24 +1651,7 @@ export class LexicalEditor {
     this._dirtyType = FULL_RECONCILE;
     this._dirtyElements.set('root', false);
     this._compositionKey = null;
-
-    // `_slotsUsed` is normally latched by `$setSlot`, but `setEditorState`
-    // swaps in a parsed state without walking it. If the incoming state
-    // already contains slot nodes (e.g. SSR + hydration, cross-editor state
-    // transfer), latch on so the selection clamps still kick in on this
-    // editor.
-    if (!this._slotsUsed) {
-      for (const node of writableEditorState._nodeMap.values()) {
-        if (
-          $isSlotHost(node) &&
-          node.__slots !== null &&
-          node.__slots.size > 0
-        ) {
-          this._slotsUsed = true;
-          break;
-        }
-      }
-    }
+    this._slotsUsed = this._slotsUsed || editorState._slotsUsed;
 
     if (tag != null) {
       this._updateTags.add(tag);
@@ -1678,34 +1660,28 @@ export class LexicalEditor {
     // Only commit pending updates if not already in an editor.update
     // (e.g. dispatchCommand) otherwise this will cause a second commit
     // with an already read-only state and selection
-    if (!this._updating) {
-      $commitPendingUpdates(this);
-    }
-
-    // hydrate-time normalize: external inputs (URL doc payloads, imported
-    // JSON, paste round-trips) may carry shadow-root slot frames whose
-    // children violate the `Children of root nodes must be elements or
-    // decorators` invariant set by `getTopLevelElement`. In-editor mutation
-    // paths still fail-fast on the invariant — this only catches shapes
-    // that were parsed in from outside.
-    //
-    // Drives the existing dirty-node transform cycle: dirty-mark the slot
-    // hosts so `ElementNode.static transform()` (which calls
-    // `$normalizeShadowRootChildren`) picks them up. Tagged with
-    // HISTORY_MERGE_TAG so the normalize folds into the setEditorState
-    // history entry instead of creating a separate undo step.
-    if (!this._updating && this._slotsUsed) {
-      this.update(
-        () => {
-          for (const node of this._editorState._nodeMap.values()) {
-            if ($isElementNode(node) && node.isShadowRoot()) {
-              node.getWritable();
-            }
+    updateEditorSync(this, () => {
+      if (editorState._parsed) {
+        for (const [key, node] of writableEditorState._nodeMap.entries()) {
+          // Mark all nodes as dirty with a freshly parsed EditorState
+          // hydrate-time normalize: external inputs (URL doc payloads, imported
+          // JSON, paste round-trips) may carry shadow-root slot frames whose
+          // children violate the `Children of root nodes must be elements or
+          // decorators` invariant set by `getTopLevelElement`. In-editor mutation
+          // paths still fail-fast on the invariant — this only catches shapes
+          // that were parsed in from outside.
+          //
+          // Drives the existing dirty-node transform cycle: dirty-mark the slot
+          // hosts so `ElementNode`'s `$config` `$transform` (which calls
+          // `$normalizeShadowRootChildren`) picks them up.
+          if ($isElementNode(node)) {
+            this._dirtyElements.set(key, true);
+          } else {
+            this._dirtyLeaves.add(key);
           }
-        },
-        {discrete: true, tag: HISTORY_MERGE_TAG},
-      );
-    }
+        }
+      }
+    });
   }
 
   /**

--- a/packages/lexical/src/LexicalEditorState.ts
+++ b/packages/lexical/src/LexicalEditorState.ts
@@ -48,11 +48,11 @@ export function editorStateHasDirtySelection(
 }
 
 export function cloneEditorState(current: EditorState): EditorState {
-  return new EditorState(cloneMap(current._nodeMap));
+  return new EditorState(cloneMap(current._nodeMap), null, current._slotsUsed);
 }
 
 export function createEmptyEditorState(): EditorState {
-  return new EditorState(new Map([['root', $createRootNode()]]));
+  return new EditorState(new Map([['root', $createRootNode()]]), null, false);
 }
 
 function $exportNodeToJSON<SerializedNode extends SerializedLexicalNode>(
@@ -131,12 +131,27 @@ export class EditorState {
   _selection: null | BaseSelection;
   _flushSync: boolean;
   _readOnly: boolean;
+  /**
+   * True if this EditorState was parsed without running transforms
+   */
+  _parsed: boolean;
+  /**
+   * True if this EditorState or the LexicalEditor that created it has
+   * ever used slots
+   */
+  _slotsUsed: boolean;
 
-  constructor(nodeMap: NodeMap, selection?: null | BaseSelection) {
+  constructor(
+    nodeMap: NodeMap,
+    selection: null | BaseSelection = null,
+    slotsUsed: boolean = false,
+  ) {
     this._nodeMap = nodeMap;
     this._selection = selection || null;
     this._flushSync = false;
     this._readOnly = false;
+    this._parsed = false;
+    this._slotsUsed = slotsUsed;
   }
 
   isEmpty(): boolean {
@@ -155,6 +170,7 @@ export class EditorState {
     const editorState = new EditorState(
       this._nodeMap,
       selection === undefined ? this._selection : selection,
+      this._slotsUsed,
     );
     editorState._readOnly = true;
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -301,7 +301,15 @@ function $transferStartingElementPointToTextPoint(
   if ($isParagraphNode(placementNode)) {
     placementNode.splice(0, 0, [textNode]);
   } else if (placementNode !== null) {
-    const target = $isRootNode(element)
+    // root or shadow-root + element-mode anchor before a non-paragraph
+    // child (typically a sibling block decorator): wrap the new text in
+    // a paragraph so it stays a valid block-level child of the root or
+    // slot frame. The last-offset branch below already covers shadow
+    // roots; the in-the-middle case used to drop a raw text node next
+    // to the decorator, which leaves the text without a block ancestor
+    // and breaks every downstream getTopLevelElement / $findMatchingParent
+    // walk (Cmd+A, Enter, etc.).
+    const target = $isRootOrShadowRoot(element)
       ? $createParagraphNode().append(textNode)
       : textNode;
     placementNode.insertBefore(target);
@@ -1424,10 +1432,26 @@ export class RangeSelection implements BaseSelection {
       // block-shaped value (virtual shadow root around a single block) needs
       // no seeding: it IS the block, so the block-finding walk below lands
       // on it directly.
-      const firstChild = anchorNode.isShadowRoot()
+      let firstChild = anchorNode.isShadowRoot()
         ? (anchorNode.getFirstChild() ??
           anchorNode.append($createParagraphNode()).getFirstChild())
         : anchorNode.getFirstChild();
+      // A shadow-root slot whose first child is a non-element (typically a
+      // decorator like HorizontalRuleNode) would re-enter this same branch
+      // forever: `firstChild.selectStart()` resolves back to the slot value's
+      // own element-mode caret (no sibling, parent = the slot value root),
+      // which matches the entry condition above. Seed a paragraph before the
+      // non-element first child so the redirected selection lands in a block
+      // and the recursion terminates.
+      if (
+        anchorNode.isShadowRoot() &&
+        firstChild !== null &&
+        !$isElementNode(firstChild)
+      ) {
+        const seed = $createParagraphNode();
+        firstChild.insertBefore(seed);
+        firstChild = seed;
+      }
       if (firstChild !== null) {
         firstChild.selectStart();
         const redirected = $getSelection();
@@ -4055,4 +4079,57 @@ function $modifySelectionAroundDecoratorsAndBlocks(
   }
   $setPointFromCaret(selection.focus, focus);
   return checkForBlock || !isLineBoundary;
+}
+
+/**
+ * Walk a subtree and wrap any shadow-root child that is neither an
+ * ElementNode nor a DecoratorNode in a paragraph, so the slot-frame
+ * invariant set by `getTopLevelElement` continues to hold for external
+ * inputs (URL doc payloads, imported JSON, paste round-trips) that may
+ * carry shapes the in-editor mutation paths can no longer produce.
+ *
+ * The in-editor mutation paths (insertText, insertNodes, append/splice via
+ * the public API) are still guarded by the invariant — this helper only
+ * runs on external entry points like `setEditorState` where the parsed
+ * state can carry pre-existing invalid shapes.
+ *
+ * @internal
+ */
+export function $normalizeShadowRootChildrenInTree(node: LexicalNode): void {
+  // Both ElementNode and DecoratorNode can host slots — DecoratorNode is the
+  // typical "atomic" host shape (e.g. PullQuote, Card before its ElementNode
+  // conversion). Leaf nodes (TextNode etc.) are not slot hosts and have no
+  // children to walk, so they short-circuit here.
+  if (!$isElementNode(node) && !$isDecoratorNode(node)) {
+    return;
+  }
+  const slotMap = $getSlotMap(node);
+  if ($isElementNode(node)) {
+    if (node.isShadowRoot()) {
+      for (const child of node.getChildren()) {
+        if (!$isElementNode(child) && !$isDecoratorNode(child)) {
+          const para = $createParagraphNode();
+          child.insertBefore(para);
+          para.append(child);
+        }
+      }
+    }
+    // Walk normal children (only ElementNode has them — DecoratorNode is leaf
+    // in the child-tree sense, even when it hosts slots).
+    for (const child of node.getChildren()) {
+      $normalizeShadowRootChildrenInTree(child);
+    }
+  }
+  // Walk slot values too — they are kept in `__slots` and are not reachable
+  // through `getChildren()`. Slot values are themselves shadow roots in most
+  // host shapes, so this is where the bulk of the normalization actually
+  // happens.
+  if (slotMap.size > 0) {
+    for (const slotKey of slotMap.values()) {
+      const slotValue = $getNodeByKey<LexicalNode>(slotKey);
+      if (slotValue !== null) {
+        $normalizeShadowRootChildrenInTree(slotValue);
+      }
+    }
+  }
 }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -4107,30 +4107,3 @@ function $modifySelectionAroundDecoratorsAndBlocks(
   $setPointFromCaret(selection.focus, focus);
   return checkForBlock || !isLineBoundary;
 }
-
-/**
- * Wrap any shadow-root child of `node` that is neither an ElementNode nor a
- * DecoratorNode in a paragraph, so the slot-frame invariant set by
- * `getTopLevelElement` continues to hold for external inputs (URL doc
- * payloads, imported JSON, paste round-trips) that may carry shapes the
- * in-editor mutation paths can no longer produce.
- *
- * Single-node helper: runs as the static `transform()` on ElementNode so
- * the existing dirty-node transform cycle drives the normalization. The
- * in-editor mutation paths (insertText, insertNodes, append/splice via the
- * public API) still fail-fast on the invariant.
- *
- * @internal
- */
-export function $normalizeShadowRootChildren(node: ElementNode): void {
-  if (!node.isShadowRoot()) {
-    return;
-  }
-  for (const child of node.getChildren()) {
-    if (!$isElementNode(child) && !$isDecoratorNode(child)) {
-      const para = $createParagraphNode();
-      child.insertBefore(para);
-      para.append(child);
-    }
-  }
-}

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1981,6 +1981,24 @@ export class RangeSelection implements BaseSelection {
             } else if ($isDecoratorNode(caret.origin)) {
               if (caret.origin.isIsolated()) {
                 // do nothing, shouldn't delete an isolated decorator
+              } else if ($getSlotNames(caret.origin).length > 0) {
+                // A slot-bearing decorator is removed only as a unit by an
+                // explicit host deletion, never silently via backspace —
+                // same policy as the merge-block branch below for
+                // ElementNode-as-host. When the anchor is an empty
+                // paragraph next to the host, drop the paragraph and
+                // select the host (matches the shadow-root ElementNode
+                // path at line 1951–1962 above); otherwise leave both in
+                // place.
+                if (
+                  $isElementNode(initialRange.anchor.origin) &&
+                  initialRange.anchor.origin.isEmpty()
+                ) {
+                  initialRange.anchor.origin.remove();
+                  const nodeSelection = $createNodeSelection();
+                  nodeSelection.add(caret.origin.getKey());
+                  $setSelection(nodeSelection);
+                }
               } else if (
                 state.type === 'merge-next-block' &&
                 (caret.origin.isKeyboardSelectable() ||

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -4109,56 +4109,28 @@ function $modifySelectionAroundDecoratorsAndBlocks(
 }
 
 /**
- * Walk a subtree and wrap any shadow-root child that is neither an
- * ElementNode nor a DecoratorNode in a paragraph, so the slot-frame
- * invariant set by `getTopLevelElement` continues to hold for external
- * inputs (URL doc payloads, imported JSON, paste round-trips) that may
- * carry shapes the in-editor mutation paths can no longer produce.
+ * Wrap any shadow-root child of `node` that is neither an ElementNode nor a
+ * DecoratorNode in a paragraph, so the slot-frame invariant set by
+ * `getTopLevelElement` continues to hold for external inputs (URL doc
+ * payloads, imported JSON, paste round-trips) that may carry shapes the
+ * in-editor mutation paths can no longer produce.
  *
- * The in-editor mutation paths (insertText, insertNodes, append/splice via
- * the public API) are still guarded by the invariant — this helper only
- * runs on external entry points like `setEditorState` where the parsed
- * state can carry pre-existing invalid shapes.
+ * Single-node helper: runs as the static `transform()` on ElementNode so
+ * the existing dirty-node transform cycle drives the normalization. The
+ * in-editor mutation paths (insertText, insertNodes, append/splice via the
+ * public API) still fail-fast on the invariant.
  *
  * @internal
  */
-export function $normalizeShadowRootChildrenInTree(node: LexicalNode): void {
-  // Both ElementNode and DecoratorNode can host slots: DecoratorNode is the
-  // typical "atomic" host shape (PullQuote, etc.) where the host itself is
-  // leaf in the child-tree sense but still carries a `__slots` map whose
-  // values are normalized below. Leaf nodes (TextNode etc.) are neither —
-  // they short-circuit here.
-  if (!$isElementNode(node) && !$isDecoratorNode(node)) {
+export function $normalizeShadowRootChildren(node: ElementNode): void {
+  if (!node.isShadowRoot()) {
     return;
   }
-  if ($isElementNode(node)) {
-    if (node.isShadowRoot()) {
-      for (const child of node.getChildren()) {
-        if (!$isElementNode(child) && !$isDecoratorNode(child)) {
-          const para = $createParagraphNode();
-          child.insertBefore(para);
-          para.append(child);
-        }
-      }
-    }
-    // Walk normal children (only ElementNode has them — DecoratorNode is leaf
-    // in the child-tree sense, even when it hosts slots).
-    for (const child of node.getChildren()) {
-      $normalizeShadowRootChildrenInTree(child);
-    }
-  }
-  // Walk slot values too — they are kept in `__slots` and are not reachable
-  // through `getChildren()`. Slot values are themselves shadow roots in most
-  // host shapes, so this is where the bulk of the normalization actually
-  // happens. Read the slot map here (after the children walk above) so the
-  // leaf-element short-circuit doesn't pay for an empty map lookup.
-  const slotMap = $getSlotMap(node);
-  if (slotMap.size > 0) {
-    for (const slotKey of slotMap.values()) {
-      const slotValue = $getNodeByKey<LexicalNode>(slotKey);
-      if (slotValue !== null) {
-        $normalizeShadowRootChildrenInTree(slotValue);
-      }
+  for (const child of node.getChildren()) {
+    if (!$isElementNode(child) && !$isDecoratorNode(child)) {
+      const para = $createParagraphNode();
+      child.insertBefore(para);
+      para.append(child);
     }
   }
 }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1443,6 +1443,15 @@ export class RangeSelection implements BaseSelection {
       // which matches the entry condition above. Seed a paragraph before the
       // non-element first child so the redirected selection lands in a block
       // and the recursion terminates.
+      //
+      // The seed paragraph is the redirect target only — if `nodes` carries
+      // inline content the recursion fills the paragraph in place, and if it
+      // carries block content the recursion's root/shadow-root branch
+      // (`splice` after `$wrapInlineNodes`) inserts the new blocks before the
+      // existing non-element first child while the seed sits at offset 0 as
+      // the new shadow-root first child. In either case the seed ends up
+      // hosting either the inserted content or an empty leading line, never
+      // a stranded paragraph next to the original non-element child.
       if (
         anchorNode.isShadowRoot() &&
         firstChild !== null &&
@@ -4096,14 +4105,14 @@ function $modifySelectionAroundDecoratorsAndBlocks(
  * @internal
  */
 export function $normalizeShadowRootChildrenInTree(node: LexicalNode): void {
-  // Both ElementNode and DecoratorNode can host slots — DecoratorNode is the
-  // typical "atomic" host shape (e.g. PullQuote, Card before its ElementNode
-  // conversion). Leaf nodes (TextNode etc.) are not slot hosts and have no
-  // children to walk, so they short-circuit here.
+  // Both ElementNode and DecoratorNode can host slots: DecoratorNode is the
+  // typical "atomic" host shape (PullQuote, etc.) where the host itself is
+  // leaf in the child-tree sense but still carries a `__slots` map whose
+  // values are normalized below. Leaf nodes (TextNode etc.) are neither —
+  // they short-circuit here.
   if (!$isElementNode(node) && !$isDecoratorNode(node)) {
     return;
   }
-  const slotMap = $getSlotMap(node);
   if ($isElementNode(node)) {
     if (node.isShadowRoot()) {
       for (const child of node.getChildren()) {
@@ -4123,7 +4132,9 @@ export function $normalizeShadowRootChildrenInTree(node: LexicalNode): void {
   // Walk slot values too — they are kept in `__slots` and are not reachable
   // through `getChildren()`. Slot values are themselves shadow roots in most
   // host shapes, so this is where the bulk of the normalization actually
-  // happens.
+  // happens. Read the slot map here (after the children walk above) so the
+  // leaf-element short-circuit doesn't pay for an empty map lookup.
+  const slotMap = $getSlotMap(node);
   if (slotMap.size > 0) {
     for (const slotKey of slotMap.values()) {
       const slotValue = $getNodeByKey<LexicalNode>(slotKey);

--- a/packages/lexical/src/LexicalSlot.ts
+++ b/packages/lexical/src/LexicalSlot.ts
@@ -487,8 +487,16 @@ export function $setSlot<T extends LexicalNode & SlotHostNode>(
   writableNode.__slotHost = writableSelf.__key;
   slots.set(name, writableNode.__key);
   $canonicalizeSlotOrder(writableSelf);
-  $getEditor()._slotsUsed = true;
+  $setSlotsUsed();
   return writableSelf;
+}
+
+function $setSlotsUsed() {
+  const editor = $getEditor();
+  editor._slotsUsed = true;
+  if (editor._pendingEditorState) {
+    editor._pendingEditorState._slotsUsed = true;
+  }
 }
 
 /**

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -493,6 +493,7 @@ export function parseEditorState(
 
     // Make the editorState immutable
     editorState._readOnly = true;
+    editorState._parsed = true;
 
     if (__DEV__) {
       handleDEVOnlyPendingUpdateGuarantees(editorState);

--- a/packages/lexical/src/__tests__/unit/Issue7876Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7876Repro.test.ts
@@ -12,7 +12,6 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
-  LexicalEditor,
   TextNode,
 } from 'lexical';
 import {describe, expect, test} from 'vitest';
@@ -28,7 +27,7 @@ import {describe, expect, test} from 'vitest';
 const PARSED_TEXT = 'hello {{name}}';
 const TRANSFORMED_TEXT = 'VARIABLE';
 
-function buildEditor(onTransform?: (node: TextNode) => void): LexicalEditor {
+function buildEditor(onTransform?: (node: TextNode) => void) {
   const editor = buildEditorFromExtensions({
     dependencies: [RichTextExtension],
     name: 'issue-7876-repro',

--- a/packages/lexical/src/__tests__/unit/Issue7876Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7876Repro.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  LexicalEditor,
+  TextNode,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+// Reproduction for https://github.com/facebook/lexical/issues/7876
+//
+// `editor.setEditorState(parsedState)` historically avoided dirtying nodes,
+// so user-registered transforms did not run against text parsed from JSON.
+// Carrying `_parsed` on EditorState and dirty-marking every node when that
+// flag is set lets the transform fire after setEditorState, with the flag
+// consumed in place so a history rollback to that state does not re-trigger.
+
+const PARSED_TEXT = 'hello {{name}}';
+const TRANSFORMED_TEXT = 'VARIABLE';
+
+function buildEditor(onTransform?: (node: TextNode) => void): LexicalEditor {
+  const editor = buildEditorFromExtensions({
+    dependencies: [RichTextExtension],
+    name: 'issue-7876-repro',
+    onError: e => {
+      throw e;
+    },
+  });
+  if (onTransform) {
+    editor.registerNodeTransform(TextNode, onTransform);
+  }
+  return editor;
+}
+
+function makeParsedJSON(text: string): string {
+  using src = buildEditor();
+  src.update(
+    () => {
+      $getRoot()
+        .clear()
+        .append($createParagraphNode().append($createTextNode(text)));
+    },
+    {discrete: true},
+  );
+  return JSON.stringify(src.getEditorState());
+}
+
+describe('Issue #7876: setEditorState triggers transforms on parsed state', () => {
+  test('text-node transform fires for a JSON state passed to setEditorState', () => {
+    using editor = buildEditor(node => {
+      const text = node.getTextContent();
+      if (text.includes('{{') && text !== TRANSFORMED_TEXT) {
+        node.setTextContent(TRANSFORMED_TEXT);
+      }
+    });
+
+    const parsed = editor.parseEditorState(makeParsedJSON(PARSED_TEXT));
+    expect(parsed._parsed).toBe(true);
+
+    editor.setEditorState(parsed);
+
+    expect(editor.read(() => $getRoot().getTextContent())).toBe(
+      TRANSFORMED_TEXT,
+    );
+  });
+
+  test('setEditorState consumes the `_parsed` flag so re-applying the resulting state does not re-trigger transforms', () => {
+    let transformCalls = 0;
+    using editor = buildEditor(node => {
+      transformCalls++;
+      const text = node.getTextContent();
+      if (text.includes('{{') && text !== TRANSFORMED_TEXT) {
+        node.setTextContent(TRANSFORMED_TEXT);
+      }
+    });
+
+    editor.setEditorState(editor.parseEditorState(makeParsedJSON(PARSED_TEXT)));
+    expect(transformCalls).toBeGreaterThanOrEqual(1);
+
+    const currentState = editor.getEditorState();
+    expect(currentState._parsed).toBeFalsy();
+
+    const callsBeforeReapply = transformCalls;
+    editor.setEditorState(currentState);
+    expect(transformCalls - callsBeforeReapply).toBe(0);
+  });
+
+  test('a non-idempotent transform stabilises in two passes on a parsed state', () => {
+    const SENTINEL = '#done:';
+    let transformCalls = 0;
+    using editor = buildEditor(node => {
+      transformCalls++;
+      const text = node.getTextContent();
+      if (!text.startsWith(SENTINEL)) {
+        node.setTextContent(SENTINEL + text);
+      }
+    });
+
+    editor.setEditorState(editor.parseEditorState(makeParsedJSON(PARSED_TEXT)));
+
+    expect(editor.read(() => $getRoot().getTextContent())).toBe(
+      SENTINEL + PARSED_TEXT,
+    );
+    expect(transformCalls).toBeLessThanOrEqual(2);
+  });
+
+  test('setEditorState completes within bound on a 1000-paragraph parsed state', () => {
+    let transformCalls = 0;
+    using editor = buildEditor(() => {
+      transformCalls++;
+    });
+
+    using src = buildEditor();
+    const NUM_PARAS = 1000;
+    src.update(
+      () => {
+        const root = $getRoot().clear();
+        for (let i = 0; i < NUM_PARAS; i++) {
+          root.append(
+            $createParagraphNode().append($createTextNode(`line ${i}`)),
+          );
+        }
+      },
+      {discrete: true},
+    );
+    const json = JSON.stringify(src.getEditorState());
+
+    const parsed = editor.parseEditorState(json);
+
+    const start = performance.now();
+    editor.setEditorState(parsed);
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+    expect(transformCalls).toBeGreaterThanOrEqual(NUM_PARAS);
+  });
+});

--- a/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
@@ -318,7 +318,7 @@ describe('ElementDOMSlot integration: leading decoration (slot.after)', () => {
 
   class LeadingDecorElementNode extends ElementNode {
     $config() {
-      return this.config('leading-decor', {});
+      return this.config('leading-decor', {extends: ElementNode});
     }
     createDOM() {
       const el = document.createElement('div');
@@ -525,7 +525,7 @@ describe('ElementDOMSlot integration: trailing decoration (slot.before)', () => 
 
   class TrailingDecorElementNode extends ElementNode {
     $config() {
-      return this.config('trailing-decor', {});
+      return this.config('trailing-decor', {extends: ElementNode});
     }
     createDOM() {
       const el = document.createElement('div');
@@ -674,7 +674,7 @@ describe('ElementDOMSlot block cursor handling', () => {
   // `getDOMSlot().withElement(...)`, so the keyed DOM is a wrapper.
   class InnerWrapElementNode extends ElementNode {
     $config() {
-      return this.config('inner-wrap', {});
+      return this.config('inner-wrap', {extends: ElementNode});
     }
     createDOM(): HTMLElement {
       const el = document.createElement('div');

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -86,6 +86,24 @@ class InlineDecoratorNode extends DecoratorNode<string> {
   }
 }
 
+class BlockDecoratorNode extends DecoratorNode<string> {
+  $config() {
+    return this.config('block-decorator', {extends: DecoratorNode});
+  }
+
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  isInline(): false {
+    return false;
+  }
+
+  decorate() {
+    return 'block-decorator';
+  }
+}
+
 describe('LexicalNode tests', () => {
   beforeAll(() => {
     // Give the abstract base a concrete type for `new LexicalNode()` tests, but
@@ -577,7 +595,7 @@ describe('LexicalNode tests', () => {
         });
         expect(() => textNode.getTopLevelElement()).toThrow();
         await editor.update(() => {
-          const node = new InlineDecoratorNode();
+          const node = new BlockDecoratorNode();
           expect(node.getTopLevelElement()).toBe(null);
           $getRoot().append(node);
           expect(node.getTopLevelElement()).toBe(node);
@@ -1605,7 +1623,7 @@ describe('LexicalNode tests', () => {
     },
     {
       namespace: '',
-      nodes: [LexicalNode, TestNode, InlineDecoratorNode],
+      nodes: [LexicalNode, TestNode, InlineDecoratorNode, BlockDecoratorNode],
       theme: {},
     },
   );

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -533,7 +533,7 @@ describe('LexicalReconciler', () => {
     // TableNode that wrap their keyed DOM in a scrollable container.
     class BlockWrapperElementNode extends ElementNode {
       $config() {
-        return this.config('audit_block_wrapper', {});
+        return this.config('audit_block_wrapper', {extends: ElementNode});
       }
       createDOM(): HTMLElement {
         const el = document.createElement('div');

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -3400,7 +3400,10 @@ describe('named-slots: hydrate-time normalize (#8712)', () => {
         $getRoot().getFirstChild(),
         $isParagraphNode,
       );
-      const slot = $assertNodeType($getSlot(host, 'title'), $isElementNode);
+      const slot = $assertNodeType(
+        $getSlot(host, 'title'),
+        $isTestShadowRootNode,
+      );
       const children = slot.getChildren();
       // Post-fix: the raw text is wrapped in a paragraph (the slot's only
       // child is now a paragraph that holds the original text). Pre-fix

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -3337,7 +3337,7 @@ describe('named-slots: hydrate-time normalize (#8712)', () => {
   // subsequent block-ancestor walk throws — SELECT_ALL, Enter, indent,
   // etc. The hydrate-time follow-up dirty-marks slot hosts so the
   // existing dirty-node transform cycle picks them up and `ElementNode`'s
-  // `static transform()` runs `$normalizeShadowRootChildren`, wrapping any
+  // `$transform` runs `$normalizeShadowRootChildren`, wrapping any
   // raw text the parsed state carried as a direct shadow-root slot child.
   test('a slot value with a raw TextNode child gets a paragraph wrap on setEditorState', () => {
     using editor = createSlotEditor();
@@ -3430,7 +3430,7 @@ describe('named-slots: typing-path paragraph wrap (#8712)', () => {
       () => {
         const host = $createParagraphNode();
         const slot = $createTestShadowRootNode();
-        slot.append($createTestDecoratorNode());
+        slot.append($createTestDecoratorNode().setIsInline(false));
         $getRoot().append(host);
         $setSlot(host, 'title', slot);
         slotKey = slot.getKey();
@@ -3483,7 +3483,7 @@ describe('named-slots: insertNodes redirect termination (#8712)', () => {
       () => {
         const host = $createParagraphNode();
         const slot = $createTestShadowRootNode();
-        slot.append($createTestDecoratorNode());
+        slot.append($createTestDecoratorNode().setIsInline(false));
         $getRoot().append(host);
         $setSlot(host, 'title', slot);
         hostKey = host.getKey();

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -3328,3 +3328,202 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
     });
   });
 });
+
+describe('named-slots: hydrate-time normalize (#8712)', () => {
+  // Regression for facebook/lexical#8712: parsed inputs (URL doc payloads,
+  // imported JSON, paste round-trips) can carry slot frames whose
+  // children violate `getTopLevelElement`'s invariant
+  // (`Children of root nodes must be elements or decorators`). Any
+  // subsequent block-ancestor walk throws — SELECT_ALL, Enter, indent,
+  // etc. The hydrate-time follow-up runs `$normalizeShadowRootChildrenInTree`
+  // after every `setEditorState`, wrapping any raw text the parsed state
+  // carried as a direct shadow-root slot child.
+  test('a slot value with a raw TextNode child gets a paragraph wrap on setEditorState', () => {
+    using editor = createSlotEditor();
+
+    // Hand-craft an invalid state: a host whose 'title' slot value is a
+    // TestShadowRootNode whose direct child is a TextNode. The in-editor
+    // mutation paths can no longer produce this shape, but external
+    // sources (raw URL doc state, hand-written JSON) might.
+    const invalidJSON = {
+      editorState: {
+        root: {
+          children: [
+            {
+              $slots: {
+                title: {
+                  children: [
+                    {
+                      detail: 0,
+                      format: 0,
+                      mode: 'normal',
+                      style: '',
+                      text: 'raw',
+                      type: 'text',
+                      version: 1,
+                    },
+                  ],
+                  direction: null,
+                  format: '',
+                  indent: 0,
+                  type: TestShadowRootNode.getType(),
+                  version: 1,
+                },
+              },
+              children: [],
+              direction: null,
+              format: '',
+              indent: 0,
+              textFormat: 0,
+              textStyle: '',
+              type: 'paragraph',
+              version: 1,
+            },
+          ],
+          direction: null,
+          format: '',
+          indent: 0,
+          type: 'root',
+          version: 1,
+        },
+      },
+    };
+
+    const parsedState = editor.parseEditorState(
+      JSON.stringify(invalidJSON.editorState),
+    );
+    editor.setEditorState(parsedState);
+
+    editor.read(() => {
+      const host = $assertNodeType(
+        $getRoot().getFirstChild(),
+        $isParagraphNode,
+      );
+      const slot = $assertNodeType($getSlot(host, 'title'), $isElementNode);
+      const children = slot.getChildren();
+      // Post-fix: the raw text is wrapped in a paragraph (the slot's only
+      // child is now a paragraph that holds the original text). Pre-fix
+      // the slot held the TextNode directly and any block-ancestor walk
+      // on the text would have thrown.
+      expect(children).toHaveLength(1);
+      const firstChild = $assertNodeType(children[0], $isParagraphNode);
+      expect(firstChild.getTextContent()).toBe('raw');
+    });
+  });
+});
+
+describe('named-slots: typing-path paragraph wrap (#8712)', () => {
+  // Regression for facebook/lexical#8712: the in-the-middle branch of
+  // $transferStartingElementPointToTextPoint used to wrap the new text in
+  // a paragraph only when the parent was a RootNode. A block-cursor caret
+  // before a non-paragraph child of a shadow-root slot frame dropped a
+  // raw TextNode as a direct shadow-root child, breaking the slot-frame
+  // invariant (`Children of root nodes must be elements or decorators`).
+  // The widening to $isRootOrShadowRoot in the in-the-middle branch wraps
+  // the new text the same way the last-offset branch already did.
+  test('element-mode caret before a decorator wraps the inserted text in a paragraph', () => {
+    using editor = createSlotEditor();
+    let slotKey = '';
+
+    editor.update(
+      () => {
+        const host = $createParagraphNode();
+        const slot = $createTestShadowRootNode();
+        slot.append($createTestDecoratorNode());
+        $getRoot().append(host);
+        $setSlot(host, 'title', slot);
+        slotKey = slot.getKey();
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const slot = $getNodeByKey(slotKey);
+        assert(slot !== null && $isElementNode(slot));
+        // Element-mode caret at offset 0 — the placement node is the
+        // existing decorator (non-paragraph), the in-the-middle branch
+        // of $transferStartingElementPointToTextPoint.
+        slot.select(0, 0);
+        const selection = $getSelection();
+        assert($isRangeSelection(selection));
+        selection.insertText('typed');
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const slot = $getNodeByKey(slotKey);
+      assert(slot !== null && $isElementNode(slot));
+      const children = slot.getChildren();
+      // Post-fix: a paragraph is inserted before the decorator, holding
+      // the typed text. Pre-fix the typed text would have been a raw
+      // TextNode that the slot frame is not allowed to host directly.
+      const firstChild = $assertNodeType(children[0], $isParagraphNode);
+      expect(firstChild.getTextContent()).toBe('typed');
+    });
+  });
+});
+
+describe('named-slots: insertNodes redirect termination (#8712)', () => {
+  // Regression for facebook/lexical#8712: when the slot value's first child
+  // is a non-element (typically a block decorator like HorizontalRuleNode),
+  // `firstChild.selectStart()` resolves back to the slot value's own
+  // element-mode caret (no sibling, parent = the slot value root), which
+  // matches the entry condition and the branch re-enters itself forever
+  // (browser tab freeze). Seeding a paragraph before the non-element first
+  // child terminates the recursion.
+  test('seeds a paragraph when the slot value starts with a decorator', () => {
+    using editor = createSlotEditor();
+    let hostKey = '';
+    let slotKey = '';
+
+    editor.update(
+      () => {
+        const host = $createParagraphNode();
+        const slot = $createTestShadowRootNode();
+        slot.append($createTestDecoratorNode());
+        $getRoot().append(host);
+        $setSlot(host, 'title', slot);
+        hostKey = host.getKey();
+        slotKey = slot.getKey();
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const slot = $getNodeByKey(slotKey);
+        assert(slot !== null && $isElementNode(slot));
+        // Element-mode caret at the slot value's offset 0 — the entry
+        // condition for the insertNodes slot-host redirect branch.
+        slot.select(0, 0);
+        const selection = $getSelection();
+        assert($isRangeSelection(selection));
+        // The actual insert: pre-fix this never returned, the editor.update
+        // would never commit. Post-fix the redirect lands in the seeded
+        // paragraph and the text gets inserted there.
+        selection.insertNodes([$createTextNode('inserted')]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const slot = $getNodeByKey(slotKey);
+      assert(slot !== null && $isElementNode(slot));
+      const children = slot.getChildren();
+      // Slot now holds the seeded paragraph + original decorator. The
+      // exact ordering and host of the inserted text depends on the
+      // recursion's continuation (text node lands inside the seeded
+      // paragraph since `insertNodes` of an inline run picks a paragraph
+      // parent via $wrapInlineNodes); the regression we are pinning is
+      // that the call returns at all.
+      expect(children.length).toBeGreaterThanOrEqual(2);
+      // The slot value's text content holds the inserted text.
+      expect(slot.getTextContent()).toContain('inserted');
+      // Host is intact.
+      const host = $assertNodeType($getNodeByKey(hostKey), $isParagraphNode);
+      expect($getSlot(host, 'title')!.is(slot)).toBe(true);
+    });
+  });
+});

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -2742,12 +2742,11 @@ describe('named-slots: audit hardening (insertNodes, cycles, idempotent setSlot)
         const slotValue = $createTestShadowRootNode(); // no children
         $getRoot().append(host);
         $setSlot(host, 'title', slotValue);
-        slotValue.select();
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
-        selection.insertNodes([
-          $createParagraphNode().append($createTextNode('pasted')),
-        ]);
+        slotValue
+          .select()
+          .insertNodes([
+            $createParagraphNode().append($createTextNode('pasted')),
+          ]);
       },
       {discrete: true},
     );
@@ -3124,9 +3123,8 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
         lineKey = line.getKey();
         const text = line.getFirstChild();
         assert(text !== null && $isTextNode(text));
-        text.select(5, 5);
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
+
+        const selection = text.select(5, 5);
         selection.insertText('!');
         selection.insertNodes([$createTextNode('?')]);
       },
@@ -3151,10 +3149,7 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
         hostKey = host.getKey();
         const text = line.getFirstChild();
         assert(text !== null && $isTextNode(text));
-        text.select(2, 2);
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
-        expect(selection.insertParagraph()).toBe(null);
+        expect(text.select(2, 2).insertParagraph()).toBe(null);
       },
       {discrete: true},
     );
@@ -3177,10 +3172,7 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
         lineKey = line.getKey();
         const text = line.getFirstChild();
         assert(text !== null && $isTextNode(text));
-        text.select(5, 5);
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
-        selection.insertNodes([
+        text.select(5, 5).insertNodes([
           $createParagraphNode().append(
             $createTextNode('A'),
             $createLineBreakNode(),
@@ -3215,12 +3207,11 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
         const line = $createParagraphNode(); // empty single-line value
         $setSlot(host, 'title', line);
         lineKey = line.getKey();
-        line.select();
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
-        selection.insertNodes([
-          $createParagraphNode().append($createTextNode('pasted')),
-        ]);
+        line
+          .select()
+          .insertNodes([
+            $createParagraphNode().append($createTextNode('pasted')),
+          ]);
       },
       {discrete: true},
     );
@@ -3247,9 +3238,7 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
         // getTopLevelElement stops at the slotted value
         expect(text.getTopLevelElement()!.is(line)).toBe(true);
         // $selectAll scopes to the value's contents
-        text.select(2, 2);
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
+        const selection = text.select(2, 2);
         const scoped = $selectAll(selection);
         // normalization may descend the element points into the text; the
         // scope is what matters: exactly the value's content, nothing outside
@@ -3311,10 +3300,7 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
         assert(line !== null && $isParagraphNode(line));
         const text = line.getFirstChild();
         assert(text !== null && $isTextNode(text));
-        text.select(0, 0);
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
-        selection.deleteCharacter(true);
+        text.select(0, 0).deleteCharacter(true);
       },
       {discrete: true},
     );
@@ -3448,10 +3434,7 @@ describe('named-slots: typing-path paragraph wrap (#8712)', () => {
         // Element-mode caret at offset 0 — the placement node is the
         // existing decorator (non-paragraph), the in-the-middle branch
         // of $transferStartingElementPointToTextPoint.
-        slot.select(0, 0);
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
-        selection.insertText('typed');
+        slot.select(0, 0).insertText('typed');
       },
       {discrete: true},
     );
@@ -3501,13 +3484,10 @@ describe('named-slots: insertNodes redirect termination (#8712)', () => {
         assert(slot !== null && $isElementNode(slot));
         // Element-mode caret at the slot value's offset 0 — the entry
         // condition for the insertNodes slot-host redirect branch.
-        slot.select(0, 0);
-        const selection = $getSelection();
-        assert($isRangeSelection(selection));
         // The actual insert: pre-fix this never returned, the editor.update
         // would never commit. Post-fix the redirect lands in the seeded
         // paragraph and the text gets inserted there.
-        selection.insertNodes([$createTextNode('inserted')]);
+        slot.select(0, 0).insertNodes([$createTextNode('inserted')]);
       },
       {discrete: true},
     );

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -3335,9 +3335,10 @@ describe('named-slots: hydrate-time normalize (#8712)', () => {
   // children violate `getTopLevelElement`'s invariant
   // (`Children of root nodes must be elements or decorators`). Any
   // subsequent block-ancestor walk throws — SELECT_ALL, Enter, indent,
-  // etc. The hydrate-time follow-up runs `$normalizeShadowRootChildrenInTree`
-  // after every `setEditorState`, wrapping any raw text the parsed state
-  // carried as a direct shadow-root slot child.
+  // etc. The hydrate-time follow-up dirty-marks slot hosts so the
+  // existing dirty-node transform cycle picks them up and `ElementNode`'s
+  // `static transform()` runs `$normalizeShadowRootChildren`, wrapping any
+  // raw text the parsed state carried as a direct shadow-root slot child.
   test('a slot value with a raw TextNode child gets a paragraph wrap on setEditorState', () => {
     using editor = createSlotEditor();
 

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -48,7 +48,7 @@ import {
 import * as React from 'react';
 import {act, createRef} from 'react';
 import {createRoot} from 'react-dom/client';
-import {afterEach, beforeEach, expect} from 'vitest';
+import {afterEach, assert, beforeEach, expect} from 'vitest';
 
 import {
   CreateEditorArgs,
@@ -513,12 +513,13 @@ export function $assertRangeSelection(selection: unknown): RangeSelection {
  */
 export function $assertNodeType<T extends LexicalNode>(
   node: LexicalNode | null | undefined,
-  guard: (value: LexicalNode | null) => value is T,
+  $guard: (value: LexicalNode | null) => value is T,
 ): T {
   const resolved = node ?? null;
-  if (!guard(resolved)) {
-    throw new Error(`Expected node to match type guard, got ${node}`);
-  }
+  assert(
+    $guard(resolved),
+    `Expected node to match type guard ${$guard.name}, got ${node ? node.constructor.name : null}`,
+  );
   return resolved;
 }
 

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -41,7 +41,6 @@ import {
   $getSelection,
   $internalMakeRangeSelection,
   $isRangeSelection,
-  $normalizeShadowRootChildren,
   moveSelectionPointToSibling,
 } from '../LexicalSelection';
 import {
@@ -84,6 +83,33 @@ export type ElementFormatType =
   | 'justify'
   | '';
 
+/**
+ * Wrap any shadow-root child of `node` that is neither an ElementNode nor a
+ * DecoratorNode in a paragraph, so the slot-frame invariant set by
+ * `getTopLevelElement` continues to hold for external inputs (URL doc
+ * payloads, imported JSON, paste round-trips) that may carry shapes the
+ * in-editor mutation paths can no longer produce.
+ *
+ * Single-node helper: runs as the `$config` `$transform` on ElementNode so
+ * the existing dirty-node transform cycle drives the normalization. The
+ * in-editor mutation paths (insertText, insertNodes, append/splice via the
+ * public API) still fail-fast on the invariant.
+ *
+ * @internal
+ */
+function $normalizeShadowRootChildren(node: ElementNode): void {
+  if ($isRootOrShadowRoot(node)) {
+    let block: ElementNode | null = null;
+    for (const child of node.getChildren()) {
+      block = child.isInline()
+        ? (block || child.replace(child.createParentElementNode())).append(
+            child,
+          )
+        : null;
+    }
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ElementNode {
   getTopLevelElement(): ElementNode | null;
@@ -120,6 +146,25 @@ export class ElementNode
   __slotHost: null | NodeKey;
   /** @internal */
   __slots: null | Map<string, NodeKey>;
+
+  $config() {
+    return this.config(Symbol.for('ElementNode'), {
+      /*
+       * Built-in normalize for shadow-root ElementNodes: wraps any direct child
+       * that is neither an ElementNode nor a DecoratorNode in a paragraph, so
+       * the slot-frame invariant set by `getTopLevelElement` continues to hold
+       * for external inputs (URL doc payloads, imported JSON, paste round-trips)
+       * that may carry shapes the in-editor mutation paths can no longer
+       * produce. In-editor mutation paths still fail-fast on the invariant.
+       *
+       * Runs as a static transform so the existing dirty-node transform cycle
+       * drives it — typing paths cover their own dirty bookkeeping, hydrate
+       * paths (`setEditorState`) dirty-mark slot hosts so the cycle picks them
+       * up.
+       */
+      $transform: $normalizeShadowRootChildren,
+    });
+  }
 
   constructor(key?: NodeKey) {
     super(key);
@@ -947,25 +992,6 @@ export class ElementNode
 
       currentDOM = currentDOM.nextSibling;
     }
-  }
-
-  /**
-   * Built-in normalize for shadow-root ElementNodes: wraps any direct child
-   * that is neither an ElementNode nor a DecoratorNode in a paragraph, so
-   * the slot-frame invariant set by `getTopLevelElement` continues to hold
-   * for external inputs (URL doc payloads, imported JSON, paste round-trips)
-   * that may carry shapes the in-editor mutation paths can no longer
-   * produce. In-editor mutation paths still fail-fast on the invariant.
-   *
-   * Runs as a static transform so the existing dirty-node transform cycle
-   * drives it — typing paths cover their own dirty bookkeeping, hydrate
-   * paths (`setEditorState`) dirty-mark slot hosts so the cycle picks them
-   * up.
-   *
-   * Experimental — use at your own risk.
-   */
-  static transform(): (node: LexicalNode) => void {
-    return $normalizeShadowRootChildren as (node: LexicalNode) => void;
   }
 }
 

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -41,6 +41,7 @@ import {
   $getSelection,
   $internalMakeRangeSelection,
   $isRangeSelection,
+  $normalizeShadowRootChildren,
   moveSelectionPointToSibling,
 } from '../LexicalSelection';
 import {
@@ -946,6 +947,25 @@ export class ElementNode
 
       currentDOM = currentDOM.nextSibling;
     }
+  }
+
+  /**
+   * Built-in normalize for shadow-root ElementNodes: wraps any direct child
+   * that is neither an ElementNode nor a DecoratorNode in a paragraph, so
+   * the slot-frame invariant set by `getTopLevelElement` continues to hold
+   * for external inputs (URL doc payloads, imported JSON, paste round-trips)
+   * that may carry shapes the in-editor mutation paths can no longer
+   * produce. In-editor mutation paths still fail-fast on the invariant.
+   *
+   * Runs as a static transform so the existing dirty-node transform cycle
+   * drives it — typing paths cover their own dirty bookkeeping, hydrate
+   * paths (`setEditorState`) dirty-mark slot hosts so the cycle picks them
+   * up.
+   *
+   * Experimental — use at your own risk.
+   */
+  static transform(): (node: LexicalNode) => void {
+    return $normalizeShadowRootChildren as (node: LexicalNode) => void;
   }
 }
 

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -19,6 +19,7 @@ import type {
   RangeSelection,
 } from '../LexicalSelection';
 import type {
+  BaseStaticNodeConfig,
   KlassConstructor,
   LexicalEditor,
   LexicalUpdateJSON,
@@ -147,7 +148,10 @@ export class ElementNode
   /** @internal */
   __slots: null | Map<string, NodeKey>;
 
-  $config() {
+  // Specific type information is discarded for backwards compatibility,
+  // there is nothing meaninful to gain from requiring `{extends: ElementNode}`
+  // with the current shape here (just a `$transform`)
+  $config(): BaseStaticNodeConfig {
     return this.config(Symbol.for('ElementNode'), {
       /*
        * Built-in normalize for shadow-root ElementNodes: wraps any direct child


### PR DESCRIPTION
## Description

All five named-slot paths reported in #8712. The first four sit on the same underlying shape — a non-element child landing as a direct shadow-root slot value child, or a NodeSelection on a node nested inside a slot. The fifth (`An empty slot element is removed if an empty paragraph is removed after it`) is a separate empty-host deletion policy and is now fixed too — details in that section below.

### Copying a decorator from outside and pasting it into a slot shadow-root in block cursor

`RangeSelection.insertNodes` redirects an element-mode anchor on a slot value into the slot subtree by calling `firstChild.selectStart()`. When the slot value's first child was a non-element (typically a block decorator like `HorizontalRuleNode`), the resolved selection landed back on the slot value's own element-mode caret (no sibling, parent = the slot value root), which matched the redirect's entry condition again. The branch re-entered itself forever and the tab froze — the same path #8707 reported. Seeding a paragraph before the non-element first child lets the redirect land in a block and terminates the recursion.

### SELECT_ALL_COMMAND in slot-root-container with decorator and text

Two routes lead to the same `getTopLevelElement` invariant throw. Typing: `$transferStartingElementPointToTextPoint` wrapped the new text in a paragraph only when the parent was a `RootNode`, so an element-mode caret before a decorator inside a shadow-root slot dropped a raw `TextNode` as a direct shadow-root child. Hydrating: external inputs (URL doc payloads, imported JSON, paste round-trips) carried the same invalid shape directly. The first throws `Children of root nodes must be elements or decorators` on Cmd+A and `Expected ancestor to be a block ElementNode` on Enter; the second carries the shape into the editor without the throw, but every walk through `getTopLevelElement` / `$findMatchingParent` then fails.

Widening the typing-path branch to `$isRootOrShadowRoot` matches the symmetric guard #8686 added on the last-offset branch of the same function. The hydrate path runs as a static transform on `ElementNode` — `$normalizeShadowRootChildren` wraps any non-element / non-decorator child of a shadow-root ElementNode in a paragraph, and typing paths inherit it through the normal dirty-node transform cycle. The setEditorState follow-up update walks `_nodeMap` once to dirty-mark every shadow-root ElementNode via `getWritable()`, then `$applyAllTransforms` picks them up — no inline normalize call inside the follow-up update.

### Selected DecoratoreNode is not deleted via Backspace

`KEY_BACKSPACE_COMMAND` in lexical-rich-text starts with a "target within decorator" pass-through that keeps keystrokes flowing into editables nested inside a decorator (an Image caption, etc.). Clicking a decorator inside a slot produced a NodeSelection on it, but the click target was still the decorator's own DOM, so the pass-through fired and Backspace was a silent no-op. Skipping the pass-through when the active selection is a NodeSelection makes the explicit "delete this node" gesture work. `KEY_DELETE_COMMAND` had the symmetric gap (forward-Delete on the same NodeSelection was also a no-op) and is fixed by the same guard.

### Copying a DecoratoreNode from slot shadow-root to an external document

`$generateJSONFromSelectedNodes` already redirects exports through the slot frame for a RangeSelection inside the slot subtree, but only for RangeSelection. A NodeSelection on a node nested inside a slot resolved to a null frame, the root-children walk missed it, and the export produced `{nodes: []}` — empty clipboard, cut silently dropped the node. Anchoring the frame redirect on the first selected node when the selection is a NodeSelection makes copy and cut export the actual content. `getNodes()[0]` is insertion order, not document order; the comment in the diff spells out what that means for the multi-node case (slots are shadow-isolated, so a multi-node NodeSelection straddling a slot boundary is already invalid by construction).

### An empty slot element is removed if an empty paragraph is removed after it

@levensta's reply on the issue thread reframes the policy: from the user's perspective, an empty heading next to an empty paragraph isn't pulled in when the paragraph is backspaced, and the same should hold for a slot host. The caret sits in the *next* block, so silently deleting the previous host crosses a node boundary the user did not point at.

Two changes carry that. `registerSlotHostBackspace` in the playground drops its `outside the host` branch — the inside-host escape gesture (Backspace at the start of an empty host's first region) stays, since the caret is inside the host being deleted. And `deleteCharacter` extends the slot-host guard from the `merge-block` branch (`LexicalSelection.ts:2004-2008`) to the decorator branch above, so a DecoratorNode-as-host (PullQuote) gets the same protection an ElementNode-as-host (Card, Review) already has — when the anchor is an empty paragraph next to the host, the paragraph is dropped and the host is left as a NodeSelection.

Closes #8712
Closes #7876

## Test plan

- [x] `pnpm tsc --noEmit -p tsconfig.json` clean
- [x] `pnpm flow` — No errors!
- [x] `pnpm vitest run --project unit` — 175 files / 3264 pass. Reverting any of the production changes turns the corresponding test red; the redirect-termination one becomes a runner timeout since the seed is what stops the otherwise-infinite redirect.
- [x] New unit coverage:
  - `packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionBackspace.test.ts` — Backspace + forward-Delete on a single-decorator NodeSelection delete the decorator and collapse to a sibling.
  - `packages/lexical-clipboard/src/__tests__/unit/SlotClipboardExport.test.ts` — a NodeSelection on a node nested inside a slot exports a non-empty payload (was `{nodes: []}` pre-fix).
  - `packages/lexical/src/__tests__/unit/LexicalSlot.test.ts` — three new `#8712`-tagged suites for the hydrate-time normalize, the typing-path wrap, and the `insertNodes` redirect termination.
- [x] Manual playground (Chrome, macOS):
  - `#8712` link 4 (text + HR in a slot) → Cmd+A no longer throws; Enter on the text no longer throws.
  - `#8712` link 1 (HR in a slot) → click + Backspace deletes the HR; Cmd+C + paste in an external editor lands the HR.
  - `#8712` link 3 (HR in slot + external HR) → click external HR, Cmd+C, click slot HR, ArrowLeft/Right, Cmd+V — no tab freeze, paste completes.
  - Card / Review / PullQuote: empty host + trailing empty paragraph + Backspace → paragraph only is removed; the host stays.
  - PullQuote + trailing non-empty paragraph + Backspace → no-op (host preserved, paragraph preserved).
  - HorizontalRule (non-slot decorator) + trailing empty paragraph + Backspace → paragraph dropped, decorator becomes a NodeSelection (existing behavior, regression check).
  - Image caption + Backspace inside the caption still goes through the decorator pass-through (regression check).