### PR TITLE
[lexical-mark] Chore: Widen MarkNode method return types to boolean

### DIFF
--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -157,7 +157,7 @@ export class MarkNode extends ElementNode {
     return false;
   }
 
-  isInline(): boolean {
+  isInline(): true {
     return true;
   }
 

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -145,19 +145,19 @@ export class MarkNode extends ElementNode {
     return markNode;
   }
 
-  canInsertTextBefore(): false {
+  canInsertTextBefore(): boolean {
     return false;
   }
 
-  canInsertTextAfter(): false {
+  canInsertTextAfter(): boolean {
     return false;
   }
 
-  canBeEmpty(): false {
+  canBeEmpty(): boolean {
     return false;
   }
 
-  isInline(): true {
+  isInline(): boolean {
     return true;
   }
 

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -153,7 +153,7 @@ export class MarkNode extends ElementNode {
     return false;
   }
 
-  canBeEmpty(): boolean {
+  canBeEmpty(): false {
     return false;
   }
 


### PR DESCRIPTION
## Description

`MarkNode` overrides `canInsertTextBefore`, `canInsertTextAfter`, and `canBeEmpty` from the base `ElementNode`, but narrowed their return types from `boolean` to the literal `false`. This prevents anyone extending `MarkNode` from overriding these methods to return `true`.

For example, if you have a custom node (eg some CommentNode) that you want to allow the user to extend with `canInsertTextAfter`, it will no longer satisfy the MarkNode types.

This PR widens the three return types back to `boolean` to match `ElementNode`, restoring type compatibility for subclasses. `MarkNode`'s own behaviour is unchanged: each method still returns `false`.

## Test plan

### Before

A subclass overriding any of these methods to return `true` fails to type-check:

```ts
class CustomMarkNode extends MarkNode {
  canBeEmpty(): boolean {
    return true; // TS error: not assignable to `false`
  }
}
```

### After

The same subclass type-checks successfully, and `MarkNode`'s default behaviour is unchanged (all three still return `false`).
