### PR TITLE
[lexical-playground] Bug Fix: Render PageBreakNode as <hr> so Safari fires beforeinput after paste

### DIFF
--- a/packages/lexical-playground/__tests__/unit/PlaygroundNodeImporters.test.ts
+++ b/packages/lexical-playground/__tests__/unit/PlaygroundNodeImporters.test.ts
@@ -190,6 +190,43 @@ describe('Playground node importers (DOMImportExtension round-trip)', () => {
     );
   });
 
+  // Older playground exports rendered the page break as
+  // `<figure type="page-break">`. ImagesExtension's generic `<figure>`
+  // rule would otherwise swallow the empty figure on import, so the
+  // legacy matcher in PageBreakExtension has to win — verify with
+  // ImagesExtension present in the same test pipeline.
+  it('PageBreakNode legacy <figure type="page-break"> import', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        $initialEditorState: null,
+        dependencies: [
+          PlaygroundImportExtension,
+          ImagesExtension,
+          PageBreakExtension,
+        ],
+        name: '[test-legacy-page-break]',
+      }),
+    );
+    editor.update(
+      () => {
+        $getRoot().clear().select();
+        const dom = new DOMParser().parseFromString(
+          '<figure type="page-break"></figure>',
+          'text/html',
+        );
+        $insertNodes($generateNodesFromDOMViaExtension(dom));
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const node = $findFirst($isPageBreakNode);
+      assert(
+        $isPageBreakNode(node),
+        'expected a PageBreakNode from legacy <figure type="page-break">',
+      );
+    });
+  });
+
   it('TweetNode', () => {
     expectRoundTrip(
       TwitterExtension,

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.css
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.css
@@ -8,7 +8,7 @@
 
 /* @import url('assets/styles/variables.css'); */
 
-[type='page-break'] {
+hr[data-lexical-page-break] {
   position: relative;
   display: block;
   width: calc(100% + var(--editor-input-padding, 28px) * 2);
@@ -23,7 +23,7 @@
   background-color: var(--editor-color-secondary, #eeeeee);
 }
 
-[type='page-break']::before {
+hr[data-lexical-page-break]::before {
   content: '';
 
   position: absolute;
@@ -38,7 +38,7 @@
   height: 16px;
 }
 
-[type='page-break']::after {
+hr[data-lexical-page-break]::after {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -55,16 +55,16 @@
   font-weight: 600;
 }
 
-.selected[type='page-break'] {
+hr[data-lexical-page-break].selected {
   border-color: var(--editor-color-primary, #4766cb);
 }
 
-.selected[type='page-break']::before {
+hr[data-lexical-page-break].selected::before {
   opacity: 1;
 }
 
 @media print {
-  [type='page-break'] {
+  hr[data-lexical-page-break] {
     visibility: hidden;
   }
 }

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -77,9 +77,9 @@ export class PageBreakNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(): HTMLElement {
-    const el = document.createElement('figure');
+    const el = document.createElement('hr');
     el.style.pageBreakAfter = 'always';
-    el.setAttribute('type', this.getType());
+    el.setAttribute('data-lexical-page-break', 'true');
     return el;
   }
 

--- a/packages/lexical-playground/src/plugins/PageBreakExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/PageBreakExtension/index.ts
@@ -25,14 +25,24 @@ export const INSERT_PAGE_BREAK: LexicalCommand<undefined> =
 
 const PageBreakImportRule = /* @__PURE__ */ defineImportRule({
   $import: () => [$createPageBreakNode()],
-  match: sel.tag('figure').attr('type', PageBreakNode.getType()),
+  match: sel.tag('hr').attr('data-lexical-page-break', 'true'),
   name: '@lexical/playground/page-break',
+});
+
+// Backward compatibility: older playground exports rendered the page break
+// as `<figure type="page-break">`. Match that form too so older documents
+// still round-trip into a PageBreakNode instead of being silently dropped
+// by the generic `<figure>` rule from ImagesExtension.
+const PageBreakLegacyImportRule = /* @__PURE__ */ defineImportRule({
+  $import: () => [$createPageBreakNode()],
+  match: sel.tag('figure').attr('type', PageBreakNode.getType()),
+  name: '@lexical/playground/page-break-legacy',
 });
 
 export const PageBreakExtension = /* @__PURE__ */ defineExtension({
   dependencies: [
     /* @__PURE__ */ configExtension(DOMImportExtension, {
-      rules: [PageBreakImportRule],
+      rules: [PageBreakImportRule, PageBreakLegacyImportRule],
     }),
   ],
   name: '@lexical/playground/PageBreak',

--- a/packages/lexical-playground/src/plugins/PageBreakExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/PageBreakExtension/index.ts
@@ -35,7 +35,7 @@ const PageBreakImportRule = /* @__PURE__ */ defineImportRule({
 // by the generic `<figure>` rule from ImagesExtension.
 const PageBreakLegacyImportRule = /* @__PURE__ */ defineImportRule({
   $import: () => [$createPageBreakNode()],
-  match: sel.tag('figure').attr('type', PageBreakNode.getType()),
+  match: sel.tag('figure').attr('type', 'page-break'),
   name: '@lexical/playground/page-break-legacy',
 });
 

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -725,7 +725,7 @@
       var(--page-height) - var(--page-margin-top) - var(--page-margin-bottom)
     );
   }
-  .PlaygroundEditorTheme__page + [type='page-break'] {
+  .PlaygroundEditorTheme__page + hr[data-lexical-page-break] {
     display: none;
   }
 }


### PR DESCRIPTION
## Description

In Safari, copying a PageBreak and pasting it into another paragraph leaves the caret right after the pasted node with `beforeinput` events suppressed at the contentEditable root. Every keystroke is a no-op until the user clicks elsewhere and back. The pasted EditorState is fine (`root` ends in `[..., page-break, page-break]` with a `RangeSelection` at `{ key: root, offset: N, type: element }`); the lazy paragraph-on-typing path in `$transferStartingElementPointToTextPoint` simply never runs because WebKit doesn't fire `beforeinput` when the caret sits at a root element point adjacent to a `contenteditable="false"` block-flow element like `<figure>`. A horizontal rule pasted the same way works in Safari because `<hr>` is a void element and WebKit treats the adjacency differently.

Switches `PageBreakNode.createDOM` from `<figure type="page-break">` to `<hr data-lexical-page-break="true">`. The new tag name avoids WebKit's `<figure>` adjacency quirk, and the `data-lexical-*` attribute name follows the other playground decorators (Tweet, YouTube, Equation, Mention, etc.). CSS selectors and the import-rule matcher move to the new attribute. A legacy `<figure type="page-break">` import rule is kept so older playground exports still round-trip into a `PageBreakNode` instead of being silently absorbed by the generic `<figure>` rule in `ImagesExtension`. The print-mode selector in `PlaygroundEditorTheme.css` (which hides the trailing page break between Pages) is updated to the new tag too.

### Design notes

The same `<figure contenteditable="false">` quirk could hit other root-level block decorators in principle. `ImageNode` in the playground also renders `<figure>` and has not been audited under this exact paste-then-type scenario. Two broader directions exist if you'd prefer:

1. A lexical-core normalization that detects a root element point adjacent to a `contenteditable="false"` block decorator and pre-emptively inserts a trailing paragraph. The trigger has to fire before any keystroke since Safari never sends `beforeinput` here, so scope is meaningful.
2. A playground-wide convention to render every block decorator with a void or replaced element. Scoped per-node but spans many nodes.

This PR keeps the change to PageBreak alone. The DOM swap follows the pattern already in `HorizontalRuleNode` (also `<hr>`), so the playground stays internally consistent without touching core.

Closes #8718

## Test plan

- [x] `pnpm vitest run --project unit -t "PageBreakNode"` — round-trip test still passes against the new `<hr data-lexical-page-break>` shape.
- [x] `pnpm tsc --noEmit -p tsconfig.json`, prettier / eslint clean (via pre-commit hook).
- [x] Manual playground on macOS:
  - Safari: `/page break` → click node → Cmd+C → empty paragraph → Cmd+V → type — character lands, lazy paragraph is created (was a no-op pre-fix).
  - Chrome: same flow — unchanged, regression check.
  - Both: `/page break` menu insert shows the same visual (dashed border, "PAGE BREAK" label, scissors icon).
  - Both: PagesExtension print preview — the trailing page break between pages is hidden, regression check for the print selector update.

### Before

See the reproduction video on the issue: #8718.

### After

https://github.com/user-attachments/assets/220a0dd2-ef92-4b41-90dc-66a8fbce9db2


