### PR TITLE
[lexical-react][lexical-playground] Refactor: Replace react-error-boundary with a self-contained LexicalErrorBoundary

### DIFF
--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -48,7 +48,6 @@
     "react": "^19.2.5",
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.5",
-    "react-error-boundary": "^6.1.1",
     "y-websocket": "^2.1.0",
     "yjs": "^13.6.31"
   },

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -9,6 +9,7 @@
 import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
@@ -30,7 +31,6 @@ import {
 } from 'lexical';
 import * as React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
-import {ErrorBoundary} from 'react-error-boundary';
 
 import EquationEditor from '../ui/EquationEditor';
 import KatexRenderer from '../ui/KatexRenderer';
@@ -278,13 +278,7 @@ export default function EquationComponent({
           ref={inputRef}
         />
       ) : (
-        <ErrorBoundary
-          onError={e =>
-            editor._onError(
-              e instanceof Error ? e : new Error(String(e), {cause: e}),
-            )
-          }
-          fallback={null}>
+        <LexicalErrorBoundary onError={e => editor._onError(e)} fallback={null}>
           <KatexRenderer
             equation={equationValue}
             inline={inline}
@@ -294,7 +288,7 @@ export default function EquationComponent({
               }
             }}
           />
-        </ErrorBoundary>
+        </LexicalErrorBoundary>
       )}
     </>
   );

--- a/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
+++ b/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
@@ -11,9 +11,9 @@ import type {JSX} from 'react';
 import './KatexEquationAlterer.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 import * as React from 'react';
 import {useCallback, useState} from 'react';
-import {ErrorBoundary} from 'react-error-boundary';
 
 import Button from '../ui/Button';
 import KatexRenderer from './KatexRenderer';
@@ -74,19 +74,13 @@ export default function KatexEquationAlterer({
       </div>
       <div className="KatexEquationAlterer_defaultRow">Visualization </div>
       <div className="KatexEquationAlterer_centerRow">
-        <ErrorBoundary
-          onError={e =>
-            editor._onError(
-              e instanceof Error ? e : new Error(String(e), {cause: e}),
-            )
-          }
-          fallback={null}>
+        <LexicalErrorBoundary onError={e => editor._onError(e)} fallback={null}>
           <KatexRenderer
             equation={equation}
             inline={false}
             onDoubleClick={() => null}
           />
-        </ErrorBoundary>
+        </LexicalErrorBoundary>
       </div>
       <div className="KatexEquationAlterer_dialogActions">
         <Button onClick={onClick} data-test-id="equation-submit-btn">

--- a/packages/lexical-react/flow/LexicalErrorBoundary.js.flow
+++ b/packages/lexical-react/flow/LexicalErrorBoundary.js.flow
@@ -9,6 +9,7 @@
 
 export type LexicalErrorBoundaryProps = Readonly<{
   children: React.Node,
+  fallback?: React.Node,
   onError: (error: Error) => void,
 }>;
 

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -28,8 +28,7 @@
     "@lexical/text": "workspace:*",
     "@lexical/utils": "workspace:*",
     "@lexical/yjs": "workspace:*",
-    "lexical": "workspace:*",
-    "react-error-boundary": "^6.1.1"
+    "lexical": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=17.x",

--- a/packages/lexical-react/src/LexicalErrorBoundary.tsx
+++ b/packages/lexical-react/src/LexicalErrorBoundary.tsx
@@ -6,53 +6,79 @@
  *
  */
 
-import {type ErrorInfo, type JSX, useCallback} from 'react';
-import {ErrorBoundary} from 'react-error-boundary';
+import {Component, type ErrorInfo, type JSX, type ReactNode} from 'react';
 
 /**
  * Props for the {@link LexicalErrorBoundary} component.
  */
 export type LexicalErrorBoundaryProps = {
   children: JSX.Element;
+  fallback?: ReactNode;
   onError: (error: Error, info: ErrorInfo) => void;
 };
 
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+// React error boundaries must be class components. This one stays private: the
+// exported LexicalErrorBoundary is a function component so that its props keep
+// the variance that lets it satisfy the (single-argument `onError`) boundary
+// prop accepted by RichTextPlugin/PlainTextPlugin.
+class ErrorBoundary extends Component<
+  Required<LexicalErrorBoundaryProps>,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = {hasError: false};
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return {hasError: true};
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo): void {
+    this.props.onError(
+      error instanceof Error ? error : new Error(String(error), {cause: error}),
+      info,
+    );
+  }
+
+  render(): ReactNode {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}
+
 /**
  * An error boundary used by {@link RichTextPlugin} and {@link PlainTextPlugin}
- * to isolate failures thrown while rendering decorator nodes. It renders a
- * small fallback in place of the failed subtree and forwards the error (coerced
- * to an `Error`) along with the React {@link ErrorInfo} to the `onError`
- * callback.
+ * to isolate failures thrown while rendering decorator nodes. It renders
+ * `fallback` in place of the failed subtree and forwards the error (coerced to
+ * an `Error`) along with the React {@link ErrorInfo} to the `onError` callback.
+ * When `fallback` is omitted a small default message is shown; pass
+ * `fallback={null}` to render nothing.
  *
- * @returns The wrapped `children`, or the fallback element if an error is
- * caught.
+ * @returns The wrapped `children`, or the fallback if an error is caught.
  */
 export function LexicalErrorBoundary({
   children,
+  fallback,
   onError,
 }: LexicalErrorBoundaryProps): JSX.Element {
-  const wrappedOnError = useCallback(
-    (err: unknown, info: ErrorInfo) => {
-      onError(
-        err instanceof Error ? err : new Error(String(err), {cause: err}),
-        info,
-      );
-    },
-    [onError],
-  );
   return (
     <ErrorBoundary
       fallback={
-        <div
-          style={{
-            border: '1px solid #f00',
-            color: '#f00',
-            padding: '8px',
-          }}>
-          An error was thrown.
-        </div>
+        fallback === undefined ? (
+          <div
+            style={{
+              border: '1px solid #f00',
+              color: '#f00',
+              padding: '8px',
+            }}>
+            An error was thrown.
+          </div>
+        ) : (
+          fallback
+        )
       }
-      onError={wrappedOnError}>
+      onError={onError}>
       {children}
     </ErrorBoundary>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -970,9 +970,6 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
-      react-error-boundary:
-        specifier: ^6.1.1
-        version: 6.1.1(react@19.2.5)
       y-websocket:
         specifier: ^2.1.0
         version: 2.1.0(yjs@13.6.31)
@@ -1079,9 +1076,6 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
-      react-error-boundary:
-        specifier: ^6.1.1
-        version: 6.1.1(react@19.2.5)
       typescript:
         specifier: '>=5.2'
         version: 6.0.3
@@ -10708,11 +10702,6 @@ packages:
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
-    peerDependencies:
-      react: 19.2.5
-
-  react-error-boundary@6.1.1:
-    resolution: {integrity: sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==}
     peerDependencies:
       react: 19.2.5
 
@@ -24890,10 +24879,6 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
-
-  react-error-boundary@6.1.1(react@19.2.5):
-    dependencies:
-      react: 19.2.5
 
   react-fast-compare@3.2.2: {}
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -151,9 +151,7 @@ const thirdPartyExternals = [
   // inlined by Rollup.
   'shiki',
   '@shikijs',
-  ...(isWWW
-    ? [':server-only-hack:.*']
-    : ['react-error-boundary', '@floating-ui/react']),
+  ...(isWWW ? [':server-only-hack:.*'] : ['@floating-ui/react']),
 ];
 const thirdPartyExternalsRegExp = new RegExp(
   `^(${thirdPartyExternals.join('|')})(\\/|$)`,


### PR DESCRIPTION
## Description

`react-error-boundary` was a trivial dependency. `@lexical/react` and the playground only used its `<ErrorBoundary fallback onError>` variant, so it was not worth taking on a third-party package — dependencies are liabilities.

This folds that small amount of behavior into `LexicalErrorBoundary` and drops the dependency:

- `LexicalErrorBoundary` no longer wraps `react-error-boundary`. It is now a self-contained boundary (a function component over a small private class, since React error boundaries must be class components) and gains an optional `fallback` prop. With `fallback` omitted it shows the existing default message; pass `fallback={null}` to render nothing. Its public type is otherwise unchanged, so it remains usable as the `ErrorBoundary` prop of `RichTextPlugin`/`PlainTextPlugin`. Keeping it a function component preserves the prop variance that contract relies on — as a class component the two-argument `onError` would not be assignable to the single-argument boundary prop.
- The playground equation components (`EquationComponent`, `KatexEquationAlterer`) now use `LexicalErrorBoundary` directly with `fallback={null}` instead of importing `ErrorBoundary` from `react-error-boundary`. The error coercion they did inline now lives in `LexicalErrorBoundary`, so their `onError` simplifies to `editor._onError`.
- `react-error-boundary` is removed from both `package.json` files, the `scripts/build.mjs` externals list, and the lockfile.

No behavior change is intended for existing call sites; the reset features of `react-error-boundary` (`resetKeys`, `fallbackRender`, ...) were unused and are intentionally not reimplemented.

## Test plan

A dependency-removal refactor with no intended behavior change, so there is nothing to compare visually.

### Before

`react-error-boundary` supplied `<ErrorBoundary>`; `LexicalErrorBoundary` wrapped it, and the playground imported it directly.

### After

`LexicalErrorBoundary` is self-contained with an optional `fallback` prop and is used directly everywhere. All green locally:

- `pnpm run tsc` (whole repo)
- `pnpm run flow`
- `pnpm run lint` and `pnpm run prettier`
- Unit tests that mount `LexicalErrorBoundary`: `PlainRichTextPlugin`, `LexicalNestedComposer`, `LexicalCollaborationPlugin`
- `scripts/__tests__/unit/build.test.ts` package.json / exports audits
