### PR TITLE
fix(lexical): guard klass.prototype null check in getStaticNodeConfig

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -2666,7 +2666,7 @@ export function getStaticNodeConfig(klass: Klass<LexicalNode>): {
     | StaticNodeConfigValue<LexicalNode, string | symbol>;
 } {
   const nodeConfigRecord =
-    PROTOTYPE_CONFIG_METHOD in klass.prototype
+    klass.prototype != null && PROTOTYPE_CONFIG_METHOD in klass.prototype
       ? klass.prototype[PROTOTYPE_CONFIG_METHOD]()
       : undefined;
   const isAbstract = isAbstractNodeClass(klass);


### PR DESCRIPTION
## Summary

`getStaticNodeConfig()` uses the `in` operator on `klass.prototype` without checking that it is non-null. When the extends-chain traversal reaches a class whose prototype is undefined (e.g. a functional component or exotic constructor), this throws:

```
TypeError: Cannot use 'in' operator to search for '$config' in undefined
```

## Fix

Add a null guard so the lookup safely falls through to `undefined` instead of throwing:

```diff
-    PROTOTYPE_CONFIG_METHOD in klass.prototype
+    klass.prototype != null && PROTOTYPE_CONFIG_METHOD in klass.prototype
```

## Context

This is a regression introduced in #8716 (Named-slot typing). The crash surfaces when `createEditor()` traverses the `$config.extends` chain and walks past a proper class boundary where `klass.prototype` is undefined.