### PR TITLE
[lexical-markdown] Bug Fix: Preserve inline formatting when wrapping already-formatted text with matching markers

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -33,6 +33,7 @@ import {
   HISTORY_PUSH_TAG,
   KEY_ENTER_COMMAND,
   mergeRegister,
+  TEXT_TYPE_TO_FORMAT,
 } from 'lexical';
 
 import {canContainTransformableMarkdown} from './importTextTransformers';
@@ -349,13 +350,8 @@ function $runTextFormatTransformers(
     nextSelection.focus.set(closeNode.__key, newOffset, 'text');
 
     // Apply formatting to selected text
-    const extractedNodes = nextSelection.extract();
     for (const format of matcher.format) {
-      for (const node of extractedNodes) {
-        if ($isTextNode(node) && !node.hasFormat(format)) {
-          node.toggleFormat(format);
-        }
-      }
+      nextSelection.formatText(format, TEXT_TYPE_TO_FORMAT[format]);
     }
 
     // Collapse selection up to the focus point

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -349,9 +349,12 @@ function $runTextFormatTransformers(
     nextSelection.focus.set(closeNode.__key, newOffset, 'text');
 
     // Apply formatting to selected text
+    const extractedNodes = nextSelection.extract();
     for (const format of matcher.format) {
-      if (!nextSelection.hasFormat(format)) {
-        nextSelection.formatText(format);
+      for (const node of extractedNodes) {
+        if ($isTextNode(node) && !node.hasFormat(format)) {
+          node.toggleFormat(format);
+        }
       }
     }
 

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
@@ -244,6 +244,72 @@ describe('CODE_SPAN_PRECEDENCE', () => {
   });
 });
 
+describe('WRAPPING_PRESERVES_FORMAT', () => {
+  test('**...** around already-bold text preserves bold', () => {
+    // https://github.com/facebook/lexical/issues/8727
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    editor.update(
+      () => {
+        const textNode = $createTextNode('**bold*');
+        textNode.toggleFormat('bold');
+        $getRoot()
+          .selectEnd()
+          .insertNodes([$createParagraphNode().append(textNode)]);
+        textNode.select(7, 7);
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.setFormat(textNode.getFormat());
+        }
+      },
+      {discrete: true},
+    );
+    typeMarkdown(editor, '*');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const children = paragraph.getChildren();
+      expect(children).toHaveLength(1);
+      const textNode = children[0];
+      assert($isTextNode(textNode), 'Child must be a TextNode');
+      expect(textNode.getTextContent()).toBe('bold');
+      expect(textNode.hasFormat('bold')).toBe(true);
+    });
+  });
+
+  test('**...** around mixed-format text formats every wrapped node bold', () => {
+    // https://github.com/facebook/lexical/issues/8727
+    using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    editor.update(
+      () => {
+        const plainNode = $createTextNode('**foo');
+        const boldNode = $createTextNode('bar*');
+        boldNode.toggleFormat('bold');
+        $getRoot()
+          .selectEnd()
+          .insertNodes([
+            $createParagraphNode().append(plainNode).append(boldNode),
+          ]);
+        boldNode.select(4, 4);
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.setFormat(boldNode.getFormat());
+        }
+      },
+      {discrete: true},
+    );
+    typeMarkdown(editor, '*');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      expect(paragraph.getTextContent()).toBe('foobar');
+      const textNodes = paragraph
+        .getChildren()
+        .filter(node => $isTextNode(node));
+      expect(textNodes.every(node => node.hasFormat('bold'))).toBe(true);
+    });
+  });
+});
+
 describe('HISTORY', () => {
   test('undo after markdown format transform preserves typed markdown text', () => {
     using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
@@ -250,16 +250,11 @@ describe('WRAPPING_PRESERVES_FORMAT', () => {
     using editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
     editor.update(
       () => {
-        const textNode = $createTextNode('**bold*');
-        textNode.toggleFormat('bold');
+        const textNode = $createTextNode('**bold*').toggleFormat('bold');
         $getRoot()
           .selectEnd()
           .insertNodes([$createParagraphNode().append(textNode)]);
-        textNode.select(7, 7);
-        const selection = $getSelection();
-        if ($isRangeSelection(selection)) {
-          selection.setFormat(textNode.getFormat());
-        }
+        textNode.selectEnd().setFormat(textNode.getFormat());
       },
       {discrete: true},
     );
@@ -289,11 +284,7 @@ describe('WRAPPING_PRESERVES_FORMAT', () => {
           .insertNodes([
             $createParagraphNode().append(plainNode).append(boldNode),
           ]);
-        boldNode.select(4, 4);
-        const selection = $getSelection();
-        if ($isRangeSelection(selection)) {
-          selection.setFormat(boldNode.getFormat());
-        }
+        boldNode.selectEnd().setFormat(boldNode.getFormat());
       },
       {discrete: true},
     );


### PR DESCRIPTION
Closes #8727

## Description

The apply-formatting loop in `$runTextFormatTransformers` (after the markers are stripped) had two issues:

1. The `nextSelection.hasFormat(format)` guard was a no-op. `nextSelection` is a freshly-created `$createRangeSelection()` whose `format` is initialised to `0`, so the check always returned `false` regardless of the actual node format.
2. `nextSelection.formatText(format)` was called with `alignWithFormat = null`, which XOR-toggles the bit. For nodes that already had the format, this cleared it.

Replaced the loop with a per-node "set ON, never toggle" pass over `nextSelection.extract()`: for each node, set the bit only if `hasFormat(format)` is false. This mirrors the existing pattern used on the import side (https://github.com/facebook/lexical/blob/main/packages/lexical-markdown/src/importTextFormatTransformer.ts#L455-L461).

## Test plan

### Before

Reproduces via the Steps To Reproduce in issue #8727, or via the minimal reproduction environment:

- Demo: https://koki-develop.github.io/lexical-markdown-wrap-untoggle-repro
- Source: https://github.com/koki-develop/lexical-markdown-wrap-untoggle-repro/blob/main/src/App.tsx

### After

Verified in the Lexical playground that every inline format marker (`**`, `__`, `*`, `_`, `~~`, `==`, `***`, `___`) preserves the formatting when wrapping already-formatted text.