### PR TITLE
[lexical-markdown] Bug Fix: keep fence-like lines inside a code block as content

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -969,6 +969,7 @@ export function normalizeMarkdown(
 ): string {
   const lines = input.split('\n');
   let inCodeBlock = false;
+  let codeBlockFenceLength = 0;
   const sanitizedLines: string[] = [];
 
   for (let i = 0; i < lines.length; i++) {
@@ -986,15 +987,29 @@ export function normalizeMarkdown(
       continue;
     }
 
-    // Detect the start or end of a code block
-    if (CODE_START_REGEX.test(line) || CODE_END_REGEX.test(line)) {
-      inCodeBlock = !inCodeBlock;
-      sanitizedLines.push(line);
-      continue;
-    }
-
-    // If we are inside a code block, keep the line unchanged
-    if (inCodeBlock) {
+    if (!inCodeBlock) {
+      // An opening fence may carry an info string (e.g. ```ts)
+      const openMatch = line.match(CODE_START_REGEX);
+      if (openMatch) {
+        inCodeBlock = true;
+        codeBlockFenceLength = openMatch[1].trim().length;
+        sanitizedLines.push(line);
+        continue;
+      }
+    } else {
+      // A code block is closed only by a bare fence (no info string) that is at
+      // least as long as the opening fence. Fence-like lines that carry an info
+      // string (e.g. a nested ```ts) are part of the code block's content.
+      if (
+        CODE_END_REGEX.test(line) &&
+        line.trim().length >= codeBlockFenceLength
+      ) {
+        inCodeBlock = false;
+        codeBlockFenceLength = 0;
+        sanitizedLines.push(line);
+        continue;
+      }
+      // Inside a code block, keep the line unchanged
       sanitizedLines.push(rawLine);
       continue;
     }

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -968,7 +968,6 @@ export function normalizeMarkdown(
   shouldMergeAdjacentLines = false,
 ): string {
   const lines = input.split('\n');
-  let inCodeBlock = false;
   let codeBlockFenceLength = 0;
   const sanitizedLines: string[] = [];
 
@@ -987,11 +986,10 @@ export function normalizeMarkdown(
       continue;
     }
 
-    if (!inCodeBlock) {
+    if (codeBlockFenceLength === 0) {
       // An opening fence may carry an info string (e.g. ```ts)
       const openMatch = line.match(CODE_START_REGEX);
       if (openMatch) {
-        inCodeBlock = true;
         codeBlockFenceLength = openMatch[1].trim().length;
         sanitizedLines.push(line);
         continue;
@@ -1004,7 +1002,6 @@ export function normalizeMarkdown(
         CODE_END_REGEX.test(line) &&
         line.trim().length >= codeBlockFenceLength
       ) {
-        inCodeBlock = false;
         codeBlockFenceLength = 0;
         sanitizedLines.push(line);
         continue;

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -1738,6 +1738,36 @@ inner
     expect(normalizeMarkdown(markdown, true)).toBe(markdown);
   });
 
+  it('closes a shorter opening fence with a longer closing fence', () => {
+    // Per CommonMark a closing fence may be longer than the opening fence:
+    // https://spec.commonmark.org/0.31.2/#code-fences
+    const markdown = `\`\`\`
+line one
+line two
+\`\`\`\`
+after one
+after two`;
+    // The 4-backtick line closes the 3-backtick block, so the lines inside the
+    // block stay verbatim while the prose after the closing fence is merged.
+    expect(normalizeMarkdown(markdown, true)).toBe(`\`\`\`
+line one
+line two
+\`\`\`\`
+after one after two`);
+  });
+
+  it('keeps content unmerged in an unclosed code block', () => {
+    // Per CommonMark a fenced code block is also closed by the end of the
+    // document, even without a closing fence:
+    // https://spec.commonmark.org/0.31.2/#code-fences
+    const markdown = `\`\`\`
+line one
+line two`;
+    // Without a closing fence everything after the opening fence is code
+    // content, so the lines must stay verbatim instead of being merged as prose.
+    expect(normalizeMarkdown(markdown, true)).toBe(markdown);
+  });
+
   it('tables', () => {
     const markdown = `
 | a | b |

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -1711,6 +1711,33 @@ E3
 `);
   });
 
+  it('keeps fence-like lines that carry an info string as code content', () => {
+    const markdown = `
+\`\`\`ts
+const a = 1
+\`\`\`js
+const b = 2
+\`\`\`
+
+After
+`;
+    // The inner ```js carries an info string, so it is part of the code block's
+    // content. The block stays open until the bare ``` fence, and nothing after
+    // it is merged into the fence-like content lines.
+    expect(normalizeMarkdown(markdown, true)).toBe(markdown);
+  });
+
+  it('does not close a longer fence on a shorter inner fence', () => {
+    const markdown = `
+\`\`\`\`
+\`\`\`
+inner
+\`\`\`
+\`\`\`\`
+`;
+    expect(normalizeMarkdown(markdown, true)).toBe(markdown);
+  });
+
   it('tables', () => {
     const markdown = `
 | a | b |
@@ -1877,6 +1904,17 @@ E3
   it('preserves leading whitespace on content lines', () => {
     const md = '   foo\n\nbar';
     expect(normalizeMarkdown(md, false)).toBe('   foo\n\nbar');
+  });
+
+  it('preserves indented fenced code blocks nested inside tags', () => {
+    const markdown = `
+<Banner>
+\`\`\`ts
+  indent 1;
+\`\`\`
+</Banner>
+`;
+    expect(normalizeMarkdown(markdown, false)).toBe(markdown);
   });
 });
 


### PR DESCRIPTION
## Description

`normalizeMarkdown` (used by `$convertFromMarkdownString`) tracks whether it is inside a fenced code block so it can leave code content untouched while merging adjacent prose lines. The detection toggled `inCodeBlock` on **any** fence-like line:

```ts
if (CODE_START_REGEX.test(line) || CODE_END_REGEX.test(line)) {
  inCodeBlock = !inCodeBlock;
  ...
}
```

This means a code block whose content contains a fence-like line is closed too early. For example:

~~~md
```ts
const a = 1
```js
const b = 2
```
~~~

The inner ` ```js ` carries an info string, so per CommonMark it is **content**, not a closing fence. But the toggle flips `inCodeBlock` off there, and `const b = 2` is then treated as prose and merged into the previous line, corrupting the block. The same happens with a shorter inner fence inside a longer one (e.g. a ` ``` ` line inside a ` ```` ` block).

This PR tracks the opening fence length and only closes a block on a **bare closing fence** (no info string) that is **at least as long** as the opening fence, per the CommonMark fenced-code rules (https://spec.commonmark.org/0.31.2/#code-fences). Fence-like lines that carry an info string, or that are shorter than the opening fence, are kept as code content.

This is motivated by downstream usage in Payload's rich text editor, where the current behavior forces a forked copy of `normalizeMarkdown` (https://github.com/payloadcms/payload/pull/17064).

## Test plan

### Before

Fence-like lines inside a fenced code block (an info-string fence such as ` ```js `, or a shorter inner fence) were treated as block terminators, so subsequent code lines were merged as prose and the block was corrupted. There was no unit coverage for nested fences.

### After

Added unit tests in `LexicalMarkdown.test.ts`:
- An info-string fence (` ```js `) inside a code block stays as content.
- A shorter inner fence does not close a longer fence.
- A longer closing fence closes a shorter opening fence (CommonMark §4.5).
- Indented fenced code nested inside block-level tags is preserved.

All 402 `lexical-markdown` unit tests pass:

```sh
pnpm exec vitest --project unit --no-watch LexicalMarkdown
```
