### PR TITLE
[lexical] Refactor: Improve error messages for invalid node classes and cache getStaticNodeConfig

### DIFF
--- a/packages/lexical-internal/src/version.ts
+++ b/packages/lexical-internal/src/version.ts
@@ -21,4 +21,5 @@ try {
 } catch {
   // `process` is not defined in some browser bundles; use the fallback.
 }
-export const LEXICAL_VERSION: string = envLexicalVersion ?? '0.45.0+source';
+export const LEXICAL_VERSION: string =
+  envLexicalVersion ?? '"<unknown>+source"';

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1808,6 +1808,10 @@ export type SharedNodeState = {
   sharedConfigMap: SharedConfigMap;
   flatKeys: Set<string>;
 };
+export type OwnStaticNodeConfig = {
+  ownNodeType: void | string;
+  ownNodeConfig: void | StaticNodeConfigValue<LexicalNode, string>;
+};
 declare export class NodeState<T extends LexicalNode> {
   readonly node: LexicalNode;
   readonly knownState: KnownStateMap;
@@ -1849,10 +1853,7 @@ declare export function createState<K extends string, V>(
   valueConfig: StateValueConfig<V>,
 ): StateConfig<K, V>;
 declare export function $create<T>(cls: Class<T>): T;
-declare export function getStaticNodeConfig(cls: Class<LexicalNode>): {
-  ownNodeType: void | string;
-  ownNodeConfig: void | StaticNodeConfigValue<LexicalNode, string>;
-};
+declare export function getStaticNodeConfig(cls: Class<LexicalNode>): OwnStaticNodeConfig;
 declare export function getRegisteredSubtypeMap(
   nodes: Iterable<Class<LexicalNode>>,
 ): Map<string, Set<string>>;

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -884,11 +884,32 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
       let replace: RegisteredNode['replace'] = null;
       let replaceWithKlass: RegisteredNode['replaceWithKlass'] = null;
 
-      if (typeof klass !== 'function') {
+      if (klass && typeof klass === 'object') {
         const options = klass;
         klass = options.replace;
         replace = options.with;
         replaceWithKlass = options.withKlass || null;
+      }
+      if (
+        typeof klass !== 'function' ||
+        !klass.prototype ||
+        !(klass === LexicalNode || klass.prototype instanceof LexicalNode)
+      ) {
+        let version = '<unknown>';
+        try {
+          version = JSON.parse(LEXICAL_VERSION);
+        } catch {
+          //
+        }
+        invariant(
+          false,
+          'createEditor: nodes[%s] %s is not a constructor that subclasses LexicalNode from the lexical package used by this editor (%s)',
+          String(i - nodes.length + (config.nodes ? config.nodes.length : 0)),
+          typeof klass === 'function'
+            ? `${klass.name}${typeof klass.getType === 'function' ? ` (type ${String(klass.getType())})` : ''}`
+            : String(klass),
+          String(version),
+        );
       }
       // For the side-effect of filling in the static methods
       void getStaticNodeConfig(klass);

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -3094,13 +3094,25 @@ function isAbstractNodeClass(klass: Klass<LexicalNode>): boolean {
   );
 }
 
-/** @internal */
-export function getStaticNodeConfig(klass: Klass<LexicalNode>): {
+export interface OwnStaticNodeConfig {
   ownNodeType: undefined | string;
   ownNodeConfig:
     | undefined
     | StaticNodeConfigValue<LexicalNode, string | symbol>;
-} {
+}
+const STATIC_NODE_CONFIG_CACHE = new WeakMap<
+  Klass<LexicalNode>,
+  OwnStaticNodeConfig
+>();
+
+/** @internal */
+export function getStaticNodeConfig(
+  klass: Klass<LexicalNode>,
+): OwnStaticNodeConfig {
+  const cache = STATIC_NODE_CONFIG_CACHE.get(klass);
+  if (cache) {
+    return cache;
+  }
   const nodeConfigRecord =
     klass.prototype != null && PROTOTYPE_CONFIG_METHOD in klass.prototype
       ? klass.prototype[PROTOTYPE_CONFIG_METHOD]()
@@ -3183,7 +3195,9 @@ export function getStaticNodeConfig(klass: Klass<LexicalNode>): {
       }
     }
   }
-  return {ownNodeConfig, ownNodeType};
+  const result = {ownNodeConfig, ownNodeType};
+  STATIC_NODE_CONFIG_CACHE.set(klass, result);
+  return result;
 }
 
 /**

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2495,9 +2495,23 @@ describe('LexicalEditor tests', () => {
       }
     }
     expect(() =>
-      createEditor({nodes: [FakeLexicalNode as Klass<LexicalNode>]}),
-    ).toThrowError(
-      /FakeLexicalNode \(type fake-node\) does not subclass LexicalNode from the lexical package used by this editor/,
+      // @ts-expect-error
+      createEditor({nodes: [FakeLexicalNode]}),
+    ).toThrow(
+      /nodes\[0\] FakeLexicalNode \(type fake-node\) is not a constructor that subclasses LexicalNode from the lexical package used by this editor/,
+    );
+  });
+  it('rejects creating an editor with invalid LexicalNode parent class (no getType)', async () => {
+    class FakeLexicalNode {}
+    // @ts-expect-error
+    expect(() => createEditor({nodes: [FakeLexicalNode]})).toThrow(
+      /nodes\[0\] FakeLexicalNode is not a constructor that subclasses LexicalNode from the lexical package used by this editor/,
+    );
+  });
+  it('rejects creating an editor with invalid LexicalNode parent class (undefined)', async () => {
+    // @ts-expect-error
+    expect(() => createEditor({nodes: [undefined]})).toThrow(
+      /nodes\[0\] undefined is not a constructor that subclasses LexicalNode from the lexical package used by this editor/,
     );
   });
   it('mutation listener on newly initialized editor', async () => {

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -20,6 +20,7 @@ import {
   $setState,
   createEditor,
   createState,
+  ElementNode,
   getParentElement,
   getRegisteredSubtypeMap,
   getTextDirection,
@@ -48,6 +49,7 @@ import {
   emptyFunction,
   generateRandomKey,
   getCachedTypeToNodeMap,
+  getStaticNodeConfig,
   isArray,
   isMoveToEnd,
   isMoveToStart,
@@ -125,6 +127,56 @@ describe('LexicalUtils tests', () => {
     test('isArray()', () => {
       expect(isArray).toBeInstanceOf(Function);
       expect(isArray).toBe(Array.isArray);
+    });
+
+    describe('getStaticNodeConfig()', () => {
+      test('derives the type and config from $config()', () => {
+        class StaticConfigNode extends TextNode {
+          $config() {
+            return this.config('static-config-node', {extends: TextNode});
+          }
+        }
+
+        const {ownNodeConfig, ownNodeType} =
+          getStaticNodeConfig(StaticConfigNode);
+
+        expect(ownNodeType).toBe('static-config-node');
+        expect(ownNodeConfig).toMatchObject({
+          extends: TextNode,
+          type: 'static-config-node',
+        });
+        expect(StaticConfigNode.getType()).toBe('static-config-node');
+      });
+
+      test('caches the result for a node class', () => {
+        const $config = vi.fn(function (this: TextNode) {
+          return this.config('cached-static-config-node', {
+            extends: TextNode,
+          });
+        });
+        class CachedStaticConfigNode extends TextNode {
+          $config() {
+            return $config.call(this);
+          }
+        }
+
+        const first = getStaticNodeConfig(CachedStaticConfigNode);
+        const second = getStaticNodeConfig(CachedStaticConfigNode);
+
+        expect(first).toBe(second);
+        expect($config).toHaveBeenCalledTimes(1);
+      });
+
+      test('resolves symbol-keyed config for abstract node classes', () => {
+        const {ownNodeConfig, ownNodeType} = getStaticNodeConfig(ElementNode);
+
+        expect(ownNodeType).toBe(undefined);
+        expect(ownNodeConfig).toMatchObject({
+          // LexicalNode
+          extends: ElementNode.prototype.constructor.prototype,
+        });
+        expect(ownNodeConfig?.$transform).toBeInstanceOf(Function);
+      });
     });
 
     test('isSelectionWithinEditor()', async () => {

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -364,6 +364,7 @@ export {
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
   mountSlotContainer,
+  type OwnStaticNodeConfig,
   removeFromParent,
   resetRandomKey,
   setDOMUnmanaged,


### PR DESCRIPTION
## Description

Follow-up to #8726

Provides a more detailed error message when an invalid object is used in the nodes array of an editor config, some usage patterns have types that make additional runtime validation useful.

Also caches the result of getStaticNodeConfig to ensure that it's only computed at most once per node

## Test plan

New unit tests