### PR TITLE
[lexical] Bug Fix: Refactor class inheritance loops to use an inheritsLoose-safe helper

### DIFF
--- a/packages/lexical-html/src/compileDOMRenderConfigOverrides.ts
+++ b/packages/lexical-html/src/compileDOMRenderConfigOverrides.ts
@@ -13,6 +13,7 @@ import {
   type EditorDOMRenderConfig,
   getRegisteredSubtypeMap,
   InitialEditorConfig,
+  iterStaticNodeConfigChain,
   Klass,
   LexicalEditor,
   type LexicalNode,
@@ -319,12 +320,8 @@ function sortedOverrides(
   const depthOf = (klass: Klass<LexicalNode>): number => {
     let depth = depths.get(klass);
     if (depth === undefined) {
-      depth = 0;
-      for (
-        let k: Klass<LexicalNode> = klass;
-        $isLexicalNode(k.prototype);
-        k = Object.getPrototypeOf(k)
-      ) {
+      depth = -1;
+      for (const _ of iterStaticNodeConfigChain(klass)) {
         depth++;
       }
       depths.set(klass, depth);

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -66,6 +66,7 @@ import {
   getRegisteredNode,
   getStaticNodeConfig,
   hasOwnStaticMethod,
+  iterStaticNodeConfigChain,
   markNodesWithTypesAsDirty,
   setNodeKeyOnDOMNode,
 } from './LexicalUtils';
@@ -787,9 +788,9 @@ export function getTransformSetFromKlass(
 ): Set<Transform<LexicalNode>> {
   const transforms = new Set<Transform<LexicalNode>>();
   const staticTransforms = new Set<(typeof klass)['transform']>();
-  let currentKlass: undefined | typeof klass = klass;
-  while (currentKlass) {
-    const {ownNodeConfig} = getStaticNodeConfig(currentKlass);
+  for (const {klass: currentKlass, ownNodeConfig} of iterStaticNodeConfigChain(
+    klass,
+  )) {
     const staticTransform = currentKlass.transform;
     if (!staticTransforms.has(staticTransform)) {
       staticTransforms.add(staticTransform);
@@ -803,13 +804,6 @@ export function getTransformSetFromKlass(
       if ($transform) {
         transforms.add($transform);
       }
-      currentKlass = ownNodeConfig.extends;
-    } else {
-      const parent = Object.getPrototypeOf(currentKlass);
-      currentKlass =
-        parent.prototype instanceof LexicalNode && parent !== LexicalNode
-          ? parent
-          : undefined;
     }
   }
   return transforms;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -75,6 +75,7 @@ import {
   errorOnInsertTextNodeOnRoot,
   getRegisteredNode,
   getStaticNodeConfig,
+  getSuperclassOf,
   internalMarkNodeAsDirty,
 } from './LexicalUtils';
 
@@ -802,8 +803,7 @@ export class LexicalNode {
     type: string | symbol,
     config: AnyStaticNodeConfigValue,
   ): BaseStaticNodeConfig {
-    const parentKlass =
-      config.extends || Object.getPrototypeOf(this.constructor);
+    const parentKlass = config.extends || getSuperclassOf(this.constructor);
     Object.assign(config, {extends: parentKlass});
     // A concrete node records its string `type`; an abstract base class is
     // keyed by a well-known symbol (e.g. Symbol.for('ElementNode')) and has no

--- a/packages/lexical/src/LexicalNodeState.ts
+++ b/packages/lexical/src/LexicalNodeState.ts
@@ -26,7 +26,10 @@ import {
 } from '.';
 import {PROTOTYPE_CONFIG_METHOD} from './LexicalConstants';
 import {errorOnReadOnly} from './LexicalUpdates';
-import {getRegisteredNodeOrThrow, getStaticNodeConfig} from './LexicalUtils';
+import {
+  getRegisteredNodeOrThrow,
+  iterStaticNodeConfigChain,
+} from './LexicalUtils';
 
 const __DEV__ = process.env.NODE_ENV !== 'production';
 
@@ -509,13 +512,9 @@ export function createSharedNodeState(
 ): SharedNodeState {
   const sharedConfigMap = new Map<string, AnyStateConfig>();
   const flatKeys = new Set<string>();
-  for (
-    let klass =
-      typeof nodeConfig === 'function' ? nodeConfig : nodeConfig.replace;
-    klass.prototype && klass.prototype.getType !== undefined;
-    klass = Object.getPrototypeOf(klass)
-  ) {
-    const {ownNodeConfig} = getStaticNodeConfig(klass);
+  for (const {ownNodeConfig} of iterStaticNodeConfigChain(
+    typeof nodeConfig === 'function' ? nodeConfig : nodeConfig.replace,
+  )) {
     if (ownNodeConfig && ownNodeConfig.stateConfigs) {
       for (const requiredStateConfig of ownNodeConfig.stateConfigs) {
         let stateConfig: AnyStateConfig;

--- a/packages/lexical/src/LexicalSlot.ts
+++ b/packages/lexical/src/LexicalSlot.ts
@@ -20,7 +20,7 @@ import type {ElementNode} from './nodes/LexicalElementNode';
 import invariant from '@lexical/internal/invariant';
 
 import {$getEditor, $getNodeByKey, $isDecoratorNode, $isElementNode} from '.';
-import {$removeFromParent, getStaticNodeConfig} from './LexicalUtils';
+import {$removeFromParent, iterStaticNodeConfigChain} from './LexicalUtils';
 
 const __DEV__ = process.env.NODE_ENV !== 'production';
 
@@ -261,12 +261,7 @@ export function getDeclaredSlots(klass: Klass<LexicalNode>): readonly string[] {
   // Walk the class hierarchy without a runtime LexicalNode import (a
   // module-initialization cycle): past the base class the chain reaches
   // Function.prototype, whose own `prototype` is undefined, ending the loop.
-  for (
-    let current: Klass<LexicalNode> = klass;
-    current != null && current.prototype != null;
-    current = Object.getPrototypeOf(current)
-  ) {
-    const {ownNodeConfig} = getStaticNodeConfig(current);
+  for (const {ownNodeConfig} of iterStaticNodeConfigChain(klass)) {
     const declared = ownNodeConfig && ownNodeConfig.slots;
     if (declared) {
       return declared;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -3095,6 +3095,7 @@ function isAbstractNodeClass(klass: Klass<LexicalNode>): boolean {
 }
 
 export interface OwnStaticNodeConfig {
+  klass: Klass<LexicalNode>;
   ownNodeType: undefined | string;
   ownNodeConfig:
     | undefined
@@ -3195,9 +3196,29 @@ export function getStaticNodeConfig(
       }
     }
   }
-  const result = {ownNodeConfig, ownNodeType};
+  const result = {klass, ownNodeConfig, ownNodeType};
   STATIC_NODE_CONFIG_CACHE.set(klass, result);
   return result;
+}
+
+/**
+ * Collect all configuration for this class and its superclasses
+ *
+ * @internal
+ */
+export function* iterStaticNodeConfigChain(
+  klass: Klass<LexicalNode>,
+): Iterable<OwnStaticNodeConfig> {
+  for (
+    let current: null | Klass<LexicalNode> = klass;
+    current && (current === LexicalNode || $isLexicalNode(current.prototype));
+  ) {
+    const config = getStaticNodeConfig(current);
+    yield config;
+    current =
+      (config.ownNodeConfig && config.ownNodeConfig.extends) ||
+      getSuperclassOf(current);
+  }
 }
 
 /**
@@ -3225,12 +3246,7 @@ export function getRegisteredSubtypeMap(
     }
   }
   for (const [type, klass] of klassByType) {
-    for (
-      let current: Klass<LexicalNode> = klass;
-      $isLexicalNode(current.prototype);
-      current = Object.getPrototypeOf(current)
-    ) {
-      const {ownNodeType} = getStaticNodeConfig(current);
+    for (const {ownNodeType} of iterStaticNodeConfigChain(klass)) {
       const bucket = ownNodeType && subtypes.get(ownNodeType);
       if (bucket) {
         bucket.add(type);
@@ -3319,4 +3335,22 @@ export function $createChildrenArray(
     nodeKey = node.__next;
   }
   return children;
+}
+
+/**
+ * Look up the superclass of this class, prefer
+ * {@link iterStaticNodeConfigChain} when implementing loops.
+ *
+ * @internal
+ */
+export function getSuperclassOf(
+  klass: Klass<LexicalNode>,
+): null | Klass<LexicalNode> {
+  const viaStatic = Object.getPrototypeOf(klass);
+  if (typeof viaStatic === 'function' && viaStatic !== Function.prototype) {
+    return viaStatic; // healthy static chain
+  }
+  // static link severed by the loose transform — use the instance chain
+  const parentProto = klass.prototype && Object.getPrototypeOf(klass.prototype);
+  return parentProto ? parentProto.constructor : null;
 }

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -53,6 +53,7 @@ import {
   isArray,
   isMoveToEnd,
   isMoveToStart,
+  iterStaticNodeConfigChain,
   scheduleMicroTask,
   scrollIntoViewIfNeeded,
 } from '../../LexicalUtils';
@@ -127,56 +128,6 @@ describe('LexicalUtils tests', () => {
     test('isArray()', () => {
       expect(isArray).toBeInstanceOf(Function);
       expect(isArray).toBe(Array.isArray);
-    });
-
-    describe('getStaticNodeConfig()', () => {
-      test('derives the type and config from $config()', () => {
-        class StaticConfigNode extends TextNode {
-          $config() {
-            return this.config('static-config-node', {extends: TextNode});
-          }
-        }
-
-        const {ownNodeConfig, ownNodeType} =
-          getStaticNodeConfig(StaticConfigNode);
-
-        expect(ownNodeType).toBe('static-config-node');
-        expect(ownNodeConfig).toMatchObject({
-          extends: TextNode,
-          type: 'static-config-node',
-        });
-        expect(StaticConfigNode.getType()).toBe('static-config-node');
-      });
-
-      test('caches the result for a node class', () => {
-        const $config = vi.fn(function (this: TextNode) {
-          return this.config('cached-static-config-node', {
-            extends: TextNode,
-          });
-        });
-        class CachedStaticConfigNode extends TextNode {
-          $config() {
-            return $config.call(this);
-          }
-        }
-
-        const first = getStaticNodeConfig(CachedStaticConfigNode);
-        const second = getStaticNodeConfig(CachedStaticConfigNode);
-
-        expect(first).toBe(second);
-        expect($config).toHaveBeenCalledTimes(1);
-      });
-
-      test('resolves symbol-keyed config for abstract node classes', () => {
-        const {ownNodeConfig, ownNodeType} = getStaticNodeConfig(ElementNode);
-
-        expect(ownNodeType).toBe(undefined);
-        expect(ownNodeConfig).toMatchObject({
-          // LexicalNode
-          extends: ElementNode.prototype.constructor.prototype,
-        });
-        expect(ownNodeConfig?.$transform).toBeInstanceOf(Function);
-      });
     });
 
     test('isSelectionWithinEditor()', async () => {
@@ -1220,5 +1171,108 @@ describe('getParentElement', () => {
     expect(getParentElement(text)).toBe(span);
     // From the span, the next call crosses the shadow boundary to the host.
     expect(getParentElement(span)).toBe(host);
+  });
+  describe('getStaticNodeConfig()', () => {
+    test('derives the type and config from $config()', () => {
+      class StaticConfigNode extends TextNode {
+        $config() {
+          return this.config('static-config-node', {extends: TextNode});
+        }
+      }
+
+      const {ownNodeConfig, ownNodeType} =
+        getStaticNodeConfig(StaticConfigNode);
+
+      expect(ownNodeType).toBe('static-config-node');
+      expect(ownNodeConfig).toMatchObject({
+        extends: TextNode,
+        type: 'static-config-node',
+      });
+      expect(StaticConfigNode.getType()).toBe('static-config-node');
+    });
+
+    test('caches the result for a node class', () => {
+      const $config = vi.fn(function (this: TextNode) {
+        return this.config('cached-static-config-node', {
+          extends: TextNode,
+        });
+      });
+      class CachedStaticConfigNode extends TextNode {
+        $config() {
+          return $config.call(this);
+        }
+      }
+
+      const first = getStaticNodeConfig(CachedStaticConfigNode);
+      const second = getStaticNodeConfig(CachedStaticConfigNode);
+
+      expect(first).toBe(second);
+      expect($config).toHaveBeenCalledTimes(1);
+    });
+
+    test('resolves symbol-keyed config for abstract node classes', () => {
+      const {ownNodeConfig, ownNodeType} = getStaticNodeConfig(ElementNode);
+
+      expect(ownNodeType).toBe(undefined);
+      expect(ownNodeConfig).toMatchObject({
+        // LexicalNode
+        extends: ElementNode.prototype.constructor.prototype,
+      });
+      expect(ownNodeConfig?.$transform).toBeInstanceOf(Function);
+    });
+  });
+  describe('iterStaticNodeConfigChain', () => {
+    test('handles a loose transform', () => {
+      // These are from babel's loose class transform without the setPrototypeOf for the static chain
+      // https://github.com/babel/babel/blob/main/packages/babel-helpers/src/helpers/inheritsLoose.ts
+      function inheritsLoose(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+        subClass: Function,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+        superClass: Function,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ): any {
+        subClass.prototype = Object.create(superClass.prototype);
+        subClass.prototype.constructor = subClass;
+        return subClass;
+      }
+      const LooseClassNode = inheritsLoose(
+        function LooseClassNode_() {},
+        Object.getPrototypeOf(ElementNode),
+      );
+      LooseClassNode.prototype.$config = function () {
+        return this.config(Symbol.for('LooseClassNode'), {
+          $transform: () => {},
+        });
+      };
+      const LooseSubclassNode = inheritsLoose(
+        function LooseSubclassNode_() {},
+        LooseClassNode,
+      );
+      LooseSubclassNode.getType = () => 'loose';
+      const looseChain = Array.from(
+        iterStaticNodeConfigChain(LooseSubclassNode),
+      );
+      expect(looseChain.map(cfg => cfg.klass)).toEqual([
+        LooseSubclassNode,
+        LooseClassNode,
+        Object.getPrototypeOf(ElementNode),
+      ]);
+      expect(looseChain).toHaveLength(3);
+      expect(Object.getPrototypeOf(LooseSubclassNode)).not.toBe(LooseClassNode);
+      expect(looseChain[0].ownNodeType).toBe('loose');
+      expect(looseChain[0].ownNodeConfig).toBe(undefined);
+      expect(looseChain[1].ownNodeConfig).not.toBe(undefined);
+    });
+    test('handles a class transform', () => {
+      const paragraphChain = Array.from(
+        iterStaticNodeConfigChain(ParagraphNode),
+      );
+      expect(paragraphChain.map(cfg => cfg.klass)).toEqual([
+        ParagraphNode,
+        ElementNode,
+        Object.getPrototypeOf(ElementNode),
+      ]);
+    });
   });
 });

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -363,6 +363,7 @@ export {
   isModifierMatch,
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
+  iterStaticNodeConfigChain,
   mountSlotContainer,
   type OwnStaticNodeConfig,
   removeFromParent,

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -167,6 +167,7 @@ export class ElementNode
        * up.
        */
       $transform: $normalizeShadowRootChildren,
+      extends: LexicalNode,
     });
   }
 


### PR DESCRIPTION
## Description

Follow-up to #8735

Consolidate all of the inheritance chain walking into an `iterStaticNodeConfigChain` helper and test that it still works even when the static inheritance chain isn't set up correctly

## Test plan

New unit tests
