### PR TITLE
[lexical] Modernize Flow type-stub syntax rejected by fb-www flow strict

### DIFF
--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -104,19 +104,17 @@ export type ClickableLinkConfig = {
   disabled: boolean;
 }
 
-type AddEventListenerOptions = Exclude<EventListenerOptionsOrUseCapture, boolean>;
-
 declare export function registerClickableLink(
   editor: LexicalEditor,
   stores: NamedSignalsOutput<ClickableLinkConfig>,
-  eventOptions?: Pick<AddEventListenerOptions, 'signal'>,
+  eventOptions?: {signal?: AbortSignal, ...},
 ): () => void;
 
 declare export var ClickableLinkExtension: LexicalExtension<ClickableLinkConfig, "@lexical/link/ClickableLink", NamedSignalsOutput<ClickableLinkConfig>, void>;
 declare export function registerClickableLink(
   editor: LexicalEditor,
   stores: NamedSignalsOutput<ClickableLinkConfig>,
-  eventOptions?: Pick<AddEventListenerOptions, 'signal'>,
+  eventOptions?: {signal?: AbortSignal, ...},
 ): () => void;
 
 export type AutoLinkConfig = {

--- a/packages/lexical-react/flow/useLexicalSlotRef.js.flow
+++ b/packages/lexical-react/flow/useLexicalSlotRef.js.flow
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor, NodeKey} from 'lexical';
 
-declare export function useLexicalSlotRef<T: HTMLElement = HTMLElement>(
+declare export function useLexicalSlotRef<T extends HTMLElement = HTMLElement>(
   editor: LexicalEditor,
   nodeKey: NodeKey,
   slotName: string,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1241,11 +1241,11 @@ declare export var DEFAULT_EDITOR_DOM_CONFIG: EditorDOMRenderConfig;
 // Flow's built-in DOM lib doesn't expose StaticRange yet; declare the
 // minimal shape we need for the shadow-aware selection helpers below.
 declare type StaticRange = {
-  +startContainer: Node,
-  +startOffset: number,
-  +endContainer: Node,
-  +endOffset: number,
-  +collapsed: boolean,
+  readonly startContainer: Node,
+  readonly startOffset: number,
+  readonly endContainer: Node,
+  readonly endOffset: number,
+  readonly collapsed: boolean,
 };
 
 export type DOMSelectionBoundaryPoints = {
@@ -1255,7 +1255,7 @@ export type DOMSelectionBoundaryPoints = {
   focusNode: Node | null,
   focusOffset: number,
 };
-declare export function isDOMShadowRoot(node: mixed): boolean;
+declare export function isDOMShadowRoot(node: unknown): boolean;
 declare export function findAllLexicalElementsDeep(root: Document | ShadowRoot): Generator<Element, void, void>;
 declare export function getDOMShadowRoots(node: Node): ShadowRoot[];
 declare export function getParentElement(node: Node): HTMLElement | null;
@@ -1595,7 +1595,7 @@ declare export function $splitAtPointCaretNext(
   pointCaret: PointCaret<'next'>,
   options?: SplitAtPointCaretNextOptions,
 ): null | NodeCaret<'next'>;
-declare export function $insertNodeToNearestRootAtCaret<T: LexicalNode>(
+declare export function $insertNodeToNearestRootAtCaret<T extends LexicalNode>(
   node: T,
   caret: PointCaret<CaretDirection>,
   options?: SplitAtPointCaretNextOptions,


### PR DESCRIPTION
## Description

Three OSS Flow type-stub (`.js.flow`) files contain a few stragglers using older Flow syntax (and one lib-dependent type) that fb-www `@flow strict` rejects — this is what breaks `flow-check` on the www Lexical sync. The rest of these same files already use the modern equivalents (`readonly` / `unknown` / `extends`), so this just makes the recent additions (mostly from #8694 shadow-root work) consistent with the prevailing style. Mirrors internal www fix D109526234.

## Changes

**1) `packages/lexical/flow/Lexical.js.flow`**
- `StaticRange` declared shape: property variance sigils (`+`) → `readonly`
- `isDOMShadowRoot(node: mixed)` → `node: unknown`
- `$insertNodeToNearestRootAtCaret<T: LexicalNode>` → `<T extends LexicalNode>`

**2) `packages/lexical-link/flow/LexicalLink.js.flow`** (affects both `registerClickableLink` overloads)
- Delete `type AddEventListenerOptions = Exclude<EventListenerOptionsOrUseCapture, boolean>;`
- `eventOptions?: Pick<AddEventListenerOptions, 'signal'>` → `eventOptions?: {signal?: AbortSignal, ...}`
- The `Pick` chain resolves through a DOM lib union that includes the primitive `boolean`, which fb-www flow can't `Pick`; the inline object is portable and equivalent.

**3) `packages/lexical-react/flow/useLexicalSlotRef.js.flow`**
- `useLexicalSlotRef<T: HTMLElement = HTMLElement>` → `<T extends HTMLElement = HTMLElement>`

## Notes

- These are `.js.flow` type stubs only — no runtime/source code changes.
- The actual file paths are under the `flow/` subdirectory of each package (the request listed them without the `flow/` segment; corrected here).
