### PR TITLE
[ci] Bug Fix: grant id-token: write in version.yml release call

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -14,6 +14,12 @@ on:
 
 permissions:
   contents: write
+  # Required because this workflow calls call-release.yml, whose `publish`
+  # job requests `id-token: write` for npm trusted publishing (OIDC). GitHub
+  # validates a reusable workflow's permission requests against the caller
+  # statically — even though this workflow never sets `publish: true`, the
+  # caller must still grant every permission the nested jobs declare.
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## Description

The "Create New Release Branch" workflow (version.yml) failed GitHub's workflow validation with:

  The nested job 'publish' is requesting 'id-token: write', but is only
  allowed 'id-token: none'.

version.yml calls the reusable workflow call-release.yml, whose `publish` job declares `id-token: write` for npm trusted publishing (OIDC). GitHub validates a reusable workflow's permission requests against the caller statically — regardless of `if:` conditions — so even though version.yml never sets `publish: true`, the caller must still grant every permission the nested jobs declare. version.yml only granted `contents: write`.

This adds `id-token: write` to version.yml's permissions block, matching the sibling caller pre-release.yml.

## Test plan

### Before

version.yml rejected by GitHub as an invalid workflow file (see error above); the workflow could not be dispatched.

### After

version.yml passes workflow validation and can be dispatched; the `publish` job's `id-token: write` request is now satisfied by the caller.