### PR TITLE
[lexical][lexical-html] Bug Fix: Preserve the user's last <br> in the block

### DIFF
--- a/packages/lexical-html/src/import/coreImportRules.ts
+++ b/packages/lexical-html/src/import/coreImportRules.ts
@@ -27,6 +27,7 @@ import {
   IS_SUBSCRIPT,
   IS_SUPERSCRIPT,
   IS_UNDERLINE,
+  isAppleInterchangeNewline,
   isBlockDomNode,
   isDOMTextNode,
   isLastChildInBlockNode,
@@ -453,7 +454,8 @@ const LineBreakRule = /* @__PURE__ */ defineImportRule({
   // would otherwise survive as a LineBreakNode and tack an extra blank
   // line onto the imported content.
   $import: (_ctx, el) =>
-    isOnlyChildInBlockNode(el) || isLastChildInBlockNode(el)
+    isOnlyChildInBlockNode(el) ||
+    (isAppleInterchangeNewline(el) && isLastChildInBlockNode(el))
       ? []
       : [$createLineBreakNode()],
   match: sel.tag('br'),

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -737,9 +737,9 @@ describe('LexicalEventHelpers', () => {
         },
         {
           expectedHTML:
-            '<p class="editor-paragraph" dir="auto"><span data-lexical-text="true">1</span></p><p class="editor-paragraph" dir="auto"><span data-lexical-text="true">2</span></p><p class="editor-paragraph" dir="auto"><span data-lexical-text="true">3</span></p>',
+            '<p class="editor-paragraph" dir="auto"><span data-lexical-text="true">1</span></p><p class="editor-paragraph" dir="auto"><span data-lexical-text="true">2</span><br><br data-lexical-managed-linebreak="true"></p><p class="editor-paragraph" dir="auto"><span data-lexical-text="true">3</span></p>',
           inputs: [pasteHTML('1<p>2<br /></p>3')],
-          name: 'last br in a block node is ignored',
+          name: 'last br in a block node is preserved',
         },
       ];
 

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -386,6 +386,7 @@ export type {SerializedLineBreakNode} from './nodes/LexicalLineBreakNode';
 export {
   $createLineBreakNode,
   $isLineBreakNode,
+  isAppleInterchangeNewline,
   isLastChildInBlockNode,
   isOnlyChildInBlockNode,
   LineBreakNode,

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -19,6 +19,7 @@ import {
   $applyNodeReplacement,
   isBlockDomNode,
   isDOMTextNode,
+  isHTMLElement,
 } from '../LexicalUtils';
 
 export type SerializedLineBreakNode = SerializedLexicalNode;
@@ -58,7 +59,10 @@ export class LineBreakNode extends LexicalNode {
   static importDOM(): DOMConversionMap | null {
     return {
       br: (node: Node) => {
-        if (isOnlyChildInBlockNode(node) || isLastChildInBlockNode(node)) {
+        if (
+          isOnlyChildInBlockNode(node) ||
+          (isAppleInterchangeNewline(node) && isLastChildInBlockNode(node))
+        ) {
           return null;
         }
         return {
@@ -149,6 +153,14 @@ export function isLastChildInBlockNode(node: Node): boolean {
     }
   }
   return false;
+}
+
+export function isAppleInterchangeNewline(node: Node): boolean {
+  return (
+    node.nodeName === 'BR' &&
+    isHTMLElement(node) &&
+    node.getAttribute('class') === 'Apple-interchange-newline'
+  );
 }
 
 function isWhitespaceDomTextNode(node: Node): boolean {


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

This PR partially reverts the change made in that https://github.com/facebook/lexical/pull/6395

The problem is that if a user intentionally inserts a line break at the end of a block, it must be preserved for round-trip serialization to HTML to work correctly. Otherwise, the `br` tag is lost, and it is impossible to insert an additional “indent” between two blocks. The only exception is the special line break `<br class="Apple-interchange-newline">` which Safari inserts when copying to the clipboard

## Test plan

### Before

```html
1<p>2<br /></p>3
```
→
```html
<p><span>1</span></p>
<p><span>2</span></p>
<p><span>3</span></p>
```

### After

```html
1<p>2<br /></p>3
```
→
```html
<p><span>1</span></p>
<p><span>2</span><br></p>
<p><span>3</span></p>
```