### PR TITLE
[lexical-code][lexical-playground] Bug Fix: Prevent formatting on TabNode inside code blocks

### DIFF
--- a/packages/lexical-code-core/src/CodeExtension.ts
+++ b/packages/lexical-code-core/src/CodeExtension.ts
@@ -14,6 +14,8 @@ import {
   configExtension,
   defineExtension,
   KEY_ENTER_COMMAND,
+  mergeRegister,
+  TabNode,
 } from 'lexical';
 
 import {CodeHighlightNode} from './CodeHighlightNode';
@@ -21,7 +23,7 @@ import {
   $installVscodeCodePasteOverlay,
   CodeImportRules,
 } from './CodeImportExtension';
-import {$exitCodeNodeOnEnter, CodeNode} from './CodeNode';
+import {$exitCodeNodeOnEnter, $isCodeNode, CodeNode} from './CodeNode';
 
 /**
  * Add code blocks to the editor (syntax highlighting provided separately)
@@ -40,17 +42,24 @@ export const CodeExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/code',
   nodes: () => [CodeNode, CodeHighlightNode],
   register(editor) {
-    return editor.registerCommand<KeyboardEvent>(
-      KEY_ENTER_COMMAND,
-      event => {
-        const selection = $getSelection();
-        if ($isRangeSelection(selection) && $exitCodeNodeOnEnter(selection)) {
-          event.preventDefault();
-          return true;
+    return mergeRegister(
+      editor.registerCommand<KeyboardEvent>(
+        KEY_ENTER_COMMAND,
+        event => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection) && $exitCodeNodeOnEnter(selection)) {
+            event.preventDefault();
+            return true;
+          }
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerNodeTransform(TabNode, node => {
+        if (node.getFormat() !== 0 && $isCodeNode(node.getParent())) {
+          node.setFormat(0);
         }
-        return false;
-      },
-      COMMAND_PRIORITY_LOW,
+      }),
     );
   },
 });

--- a/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeExtension.test.ts
@@ -12,8 +12,10 @@ import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
 import {
   $createLineBreakNode,
+  $createTabNode,
   $getRoot,
   $isElementNode,
+  $isTabNode,
   KEY_ENTER_COMMAND,
 } from 'lexical';
 import {$assertNodeType} from 'lexical/src/__tests__/utils';
@@ -132,6 +134,34 @@ describe('CodeExtension', () => {
       },
       {discrete: true},
     );
+  });
+
+  it('should strip format from TabNode inside CodeNode', () => {
+    const ext = defineExtension({
+      $initialEditorState: () => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append($createCodeHighlightNode('x'), $createTabNode());
+        $getRoot().append(codeNode);
+      },
+      dependencies: [CodeExtension, RichTextExtension],
+      name: '[tab-format]',
+    });
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const codeNode = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isCodeNode,
+        );
+        $assertNodeType(codeNode.getLastChild(), $isTabNode).setFormat(1);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const codeNode = $assertNodeType($getRoot().getFirstChild(), $isCodeNode);
+      const tab = $assertNodeType(codeNode.getLastChild(), $isTabNode);
+      expect(tab.getFormat()).toBe(0);
+    });
   });
 
   it('should not escape code block on Enter when cursor is not at the end', () => {

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -11,7 +11,7 @@ import type {JSX} from 'react';
 import './index.css';
 
 import {useMergeRefs} from '@floating-ui/react';
-import {$isCodeHighlightNode} from '@lexical/code';
+import {$isCodeNode} from '@lexical/code';
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
@@ -410,7 +410,7 @@ function useFloatingTextFormatToolbar(
       }
 
       if (
-        !$isCodeHighlightNode(selection.anchor.getNode()) &&
+        !$isCodeNode(selection.anchor.getNode().getParent()) &&
         selection.getTextContent() !== ''
       ) {
         setIsText($isTextNode(node) || $isParagraphNode(node));


### PR DESCRIPTION
## Description

The floating text format toolbar shows when selecting a `TabNode` inside a code block, and formatting (bold, highlight, etc.) sticks. `CodeHighlightNode` already blocks this via a no-op `setFormat()`, but `TabNode` inherits from `TextNode` and has no such guard.

### Fix

`CodeExtension` now registers a `registerNodeTransform(TabNode, ...)` that strips format back to 0 when the parent is a `CodeNode`. A global `TabNode.setFormat()` override was not used because `TabNode` legitimately inherits format in normal paragraphs (the existing `INSERT_TAB_COMMAND` test verifies this).

The `FloatingTextFormatToolbarPlugin` guard is simplified from checking both `$isCodeHighlightNode(anchor)` and `$isCodeNode(anchor.getParent())` to just `$isCodeNode(anchor.getParent())` — the latter is a superset since `CodeHighlightNode` always has a `CodeNode` parent.

Closes #8749

## Test plan

- [x] `pnpm vitest run --project unit -t "CodeExtension"` — 5 pass (including new "should strip format from TabNode inside CodeNode").
- [x] `pnpm vitest run --project unit -t "TabNode"` — 23 pass, no regression.
- [x] `pnpm tsc --noEmit` clean.
- [x] Manual playground:
  - Tab inside code block → select → no floating toolbar.
  - Tab in normal paragraph → formatting still works as before.