### PR TITLE
[lexical] Bug Fix: Prevent text duplication on iOS Safari when formatting during composition

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -224,6 +224,7 @@ let isSelectionChangeFromMouseDown = false;
 let isInsertLineBreak = false;
 let isFirefoxEndingComposition = false;
 let isSafariEndingComposition = false;
+let hadOrphanedCompositionEvents = false;
 let safariEndCompositionEventData = '';
 let postDeleteSelectionToRestore: RangeSelection | null = null;
 let collapsedSelectionFormat: [number, string, number, NodeKey, number] = [
@@ -1029,9 +1030,12 @@ function $handleBeforeInput(event: InputEvent): boolean {
     }
 
     case 'insertFromComposition': {
-      // This is the end of composition
+      const skipRedundantInsert = hadOrphanedCompositionEvents;
+      hadOrphanedCompositionEvents = false;
       $setCompositionKey(null);
-      dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, event);
+      if (!skipRedundantInsert) {
+        dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, event);
+      }
       break;
     }
 
@@ -1194,7 +1198,23 @@ function $handleInput(event: InputEvent): boolean {
         ? getDOMSelectionPoints(domSelection, editor._rootElement)
         : null;
 
+    // formatText() (e.g. Bold during composition) clears compositionKey,
+    // but the browser still sends insertCompositionText with the
+    // committed text. The browser has already updated the DOM, so we
+    // must not re-insert via CONTROLLED_TEXT_INSERTION_COMMAND — let
+    // $updateSelectedTextFromDOM sync from the DOM instead. Not gated
+    // on IS_IOS because the formatText → $setCompositionKey(null) path
+    // is platform-independent.
+    const isOrphanedCompositionEnd =
+      event.inputType === 'insertCompositionText' &&
+      !isFirefoxEndingComposition &&
+      !editor.isComposing();
+    if (isOrphanedCompositionEnd) {
+      hadOrphanedCompositionEvents = true;
+    }
+
     if (
+      !isOrphanedCompositionEnd &&
       $shouldPreventDefaultAndInsertText(
         selection,
         targetRange,
@@ -1297,6 +1317,7 @@ function $handleCompositionStart(event: CompositionEvent): boolean {
   const selection = $getSelection();
 
   if ($isRangeSelection(selection) && !editor.isComposing()) {
+    hadOrphanedCompositionEvents = false;
     const anchor = selection.anchor;
     const node = selection.anchor.getNode();
     $setCompositionKey(anchor.key);


### PR DESCRIPTION
## Description

On iOS Safari, tapping Bold (or any format button) during an active IME composition duplicates the composed text. `formatText` calls `$setCompositionKey(null)`, which ends Lexical's composition tracking while the browser still considers composition active. The browser then fires `insertCompositionText` (committing the text to the DOM) followed by `insertFromComposition`, which Lexical dispatches as `CONTROLLED_TEXT_INSERTION_COMMAND` — reinserting text that's already in the DOM.

### Fix

A module-level flag `hadOrphanedCompositionEvents` tracks whether `insertCompositionText` arrived while `!editor.isComposing()` — a condition that only occurs when something external (like `formatText`) prematurely cleared the compositionKey. When the subsequent `insertFromComposition` fires, the flag causes Lexical to skip the redundant `CONTROLLED_TEXT_INSERTION_COMMAND` dispatch since the DOM already has the correct text.

The flag resets on `compositionStart` so it never leaks into a subsequent composition. The condition is not gated on `IS_IOS` because the `formatText → $setCompositionKey(null)` path is platform-independent.

Closes #5629

## Test plan

- [x] `pnpm vitest run --project unit` — 3338 pass, no regression.
- [x] `pnpm tsc --noEmit` clean.
- [x] Manual iOS Safari (Japanese IME):
  - Type text → tap Bold → tap confirm: no duplication.
  - Type text → tap keyboard suggestion: text replaces correctly (no disappearance).