### PR TITLE
[ci] Add internal-registry dependency availability check

### DIFF
--- a/.github/actions/internal-registry/dependency-check/action.yml
+++ b/.github/actions/internal-registry/dependency-check/action.yml
@@ -1,13 +1,10 @@
 name: Internal registry dependency check
 description: >-
-  Assert every third-party version pinned in the lockfile is currently served by
-  Meta's internal npm registry (registry.facebook.net), so a frozen install
-  inside Meta won't fail on a withheld/unavailable version. Authenticates with a
-  short-lived token minted from the job's GitHub OIDC identity (no static
-  secret). The calling job must grant `permissions: id-token: write` and have
-  checked out the repo being checked. Works in trusted contexts (push,
-  workflow_dispatch, merge_group, same-repo PRs); fork PRs can't mint OIDC, so
-  they pass with a notice and should be enforced via a required merge_group run.
+  Checks that every dependency version pinned in the lockfile is available from
+  the configured registry. Authenticates with a short-lived token minted from
+  the job's GitHub OIDC identity. The calling job must grant
+  `permissions: id-token: write` and check out the repo. Fork PRs can't mint
+  OIDC and are skipped with a notice; enforce via a required merge_group run.
 
 inputs:
   lockfile:
@@ -17,9 +14,9 @@ inputs:
     required: false
     default: pnpm-lock.yaml
   registry-url:
-    description: Internal npm registry base URL.
+    description: Registry base URL.
     required: false
-    default: https://registry.facebook.net
+    default: https://registry.x2p.facebook.net
   node-version:
     description: Node version used to run the check.
     required: false
@@ -31,7 +28,7 @@ runs:
     - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-    - name: Check dependencies are available in the internal npm registry
+    - name: Check dependencies are available in the registry
       shell: bash
       env:
         REGISTRY_URL: ${{ inputs.registry-url }}
@@ -53,9 +50,7 @@ runs:
           "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=meta_jwt_access_token" \
           | python3 -c "import sys,json;print(json.load(sys.stdin)['value'])")
 
-        # 2) Exchange it for a short-lived registry bearer token. "metaccio" is
-        #    the registry's service audience — the value the exchange mints the
-        #    JWT for and the registry validates as the token's `aud`.
+        # 2) Exchange it for a short-lived registry token.
         TOKEN=$(curl -sS --max-time 25 -H "Accept: application/jwt" \
           --data-urlencode "id_token=$ID" \
           --data-urlencode "peer=metaccio" \

--- a/.github/actions/internal-registry/dependency-check/action.yml
+++ b/.github/actions/internal-registry/dependency-check/action.yml
@@ -1,0 +1,67 @@
+name: Internal registry dependency check
+description: >-
+  Assert every third-party version pinned in the lockfile is currently served by
+  Meta's internal npm registry (registry.facebook.net), so a frozen install
+  inside Meta won't fail on a withheld/unavailable version. Authenticates with a
+  short-lived token minted from the job's GitHub OIDC identity (no static
+  secret). The calling job must grant `permissions: id-token: write` and have
+  checked out the repo being checked. Works in trusted contexts (push,
+  workflow_dispatch, merge_group, same-repo PRs); fork PRs can't mint OIDC, so
+  they pass with a notice and should be enforced via a required merge_group run.
+
+inputs:
+  lockfile:
+    description: >-
+      Path to the lockfile to check. Format is auto-detected by filename:
+      pnpm-lock.yaml, package-lock.json, or yarn.lock.
+    required: false
+    default: pnpm-lock.yaml
+  registry-url:
+    description: Internal npm registry base URL.
+    required: false
+    default: https://registry.facebook.net
+  node-version:
+    description: Node version used to run the check.
+    required: false
+    default: '24'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Check dependencies are available in the internal npm registry
+      shell: bash
+      env:
+        REGISTRY_URL: ${{ inputs.registry-url }}
+        LOCKFILE: ${{ inputs.lockfile }}
+      run: |
+        set -euo pipefail
+
+        # Fork PRs get a read-only token with no OIDC, so they can't
+        # authenticate. Pass with a notice (the required merge-queue run gates
+        # them) so this check always reports a conclusion and is never stuck.
+        if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+          echo "::notice::No OIDC identity available (likely a fork PR) — deferring to the required merge-queue run."
+          exit 0
+        fi
+
+        # 1) Mint this job's GitHub OIDC token.
+        ID=$(curl -sS --max-time 20 \
+          -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=meta_jwt_access_token" \
+          | python3 -c "import sys,json;print(json.load(sys.stdin)['value'])")
+
+        # 2) Exchange it for a short-lived registry bearer token. "metaccio" is
+        #    the registry's service audience — the value the exchange mints the
+        #    JWT for and the registry validates as the token's `aud`.
+        TOKEN=$(curl -sS --max-time 25 -H "Accept: application/jwt" \
+          --data-urlencode "id_token=$ID" \
+          --data-urlencode "peer=metaccio" \
+          --data-urlencode "audience=metaccio" \
+          https://www.internalfb.com/intern/crypto_jwt/access_token_exchange/)
+        [ "$(printf '%s' "$TOKEN" | tr -cd '.' | wc -c)" -eq 2 ] || { echo "::error::OIDC token exchange failed"; exit 1; }
+
+        # 3) Assert every pinned dependency version is served by the registry.
+        REGISTRY_TOKEN="$TOKEN" node "${{ github.action_path }}/check.mjs"

--- a/.github/actions/internal-registry/dependency-check/action.yml
+++ b/.github/actions/internal-registry/dependency-check/action.yml
@@ -16,7 +16,7 @@ inputs:
   registry-url:
     description: Registry base URL.
     required: false
-    default: https://registry.x2p.facebook.net
+    default: https://registry.facebook.net
   node-version:
     description: Node version used to run the check.
     required: false

--- a/.github/actions/internal-registry/dependency-check/check.mjs
+++ b/.github/actions/internal-registry/dependency-check/check.mjs
@@ -15,7 +15,7 @@
 import {readFile} from 'node:fs/promises';
 
 const REGISTRY = (
-  process.env.REGISTRY_URL ?? 'https://registry.x2p.facebook.net'
+  process.env.REGISTRY_URL ?? 'https://registry.facebook.net'
 ).replace(/\/$/, '');
 const LOCKFILE = process.env.LOCKFILE ?? 'pnpm-lock.yaml';
 const CONCURRENCY = Number(process.env.CHECK_CONCURRENCY ?? 20);

--- a/.github/actions/internal-registry/dependency-check/check.mjs
+++ b/.github/actions/internal-registry/dependency-check/check.mjs
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// Internal npm registry availability gate.
+//
+// Every third-party (name, version) pinned in the lockfile must be fetchable
+// from Meta's internal npm registry (registry.facebook.net) *right now*. The
+// internal registry withholds newly published third-party versions for a short
+// window, so a freshly published version is absent from the metadata it serves
+// even though it exists on public npm. A frozen install inside Meta would then
+// fail on that version, even though it installs fine in public GitHub CI. This
+// catches that gap before code lands.
+//
+// It checks metadata membership (is the version listed?), not tarball
+// reachability: the withholding happens at the metadata layer, and third-party
+// tarballs are not gated, so a tarball probe would give a false green. It is
+// also window-agnostic — it just asks "is this version served?", so it needs no
+// knowledge of the withholding window's length.
+//
+// Lockfiles: pnpm, npm, and yarn are supported, auto-detected by filename. An
+// unrecognized format (or one that parses to zero packages) fails loudly rather
+// than silently passing — a format mismatch must never look like "all clear".
+//
+// Auth: a short-lived bearer token in $REGISTRY_TOKEN (minted from this CI job's
+// GitHub OIDC identity by the surrounding action). We talk to the registry over
+// fetch() with an explicit Authorization header and deliberately do NOT write
+// .npmrc.
+
+import {readFile} from 'node:fs/promises';
+
+const REGISTRY = (
+  process.env.REGISTRY_URL ?? 'https://registry.facebook.net'
+).replace(/\/$/, '');
+const LOCKFILE = process.env.LOCKFILE ?? 'pnpm-lock.yaml';
+const CONCURRENCY = Number(process.env.CHECK_CONCURRENCY ?? 20);
+const TOKEN = process.env.REGISTRY_TOKEN;
+
+if (!TOKEN) {
+  console.error(
+    '::error::REGISTRY_TOKEN is not set — the OIDC token-exchange step must run first.',
+  );
+  process.exit(1);
+}
+
+function add(byName, name, version) {
+  if (!name || !version) {
+    return;
+  }
+  if (!byName.has(name)) {
+    byName.set(name, new Set());
+  }
+  byName.get(name).add(version);
+}
+
+// Dispatch on the lockfile name. Deliberately bounded to the three mainstream
+// ecosystems; anything else throws (handled below as a hard failure).
+function parsePinned(lockfilePath, text) {
+  const base = lockfilePath.split('/').pop();
+  if (base === 'pnpm-lock.yaml') {
+    return parsePnpm(text);
+  }
+  if (base === 'package-lock.json') {
+    return parseNpm(text);
+  }
+  if (base === 'yarn.lock') {
+    return parseYarn(text);
+  }
+  throw new Error(
+    `Unsupported lockfile "${base}". Supported: pnpm-lock.yaml, package-lock.json, yarn.lock.`,
+  );
+}
+
+// pnpm v9: `packages:` section, keys are bare `name@version` (peer-dep suffixes
+// live in `snapshots:`). Workspace packages link locally and don't appear here.
+function parsePnpm(text) {
+  const lines = text.split('\n');
+  const start = lines.indexOf('packages:');
+  const byName = new Map();
+  if (start === -1) {
+    return byName;
+  }
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === '') {
+      continue;
+    }
+    if (!/^\s/.test(line)) {
+      break;
+    }
+    const m = line.match(/^  (?:'([^']+)'|([^'\s][^:]*?)):\s*$/);
+    if (!m) {
+      continue;
+    }
+    const key = m[1] ?? m[2];
+    const at = key.lastIndexOf('@');
+    if (at <= 0) {
+      continue;
+    }
+    add(byName, key.slice(0, at), key.slice(at + 1));
+  }
+  return byName;
+}
+
+// npm v2/v3: `packages` map keyed by node_modules paths, each with `version`.
+// Falls back to the v1 nested `dependencies` tree. Only registry-resolved
+// entries are checked (skip workspace links and git/file/tarball specs).
+function parseNpm(text) {
+  const json = JSON.parse(text);
+  const byName = new Map();
+  if (json.packages) {
+    for (const [path, info] of Object.entries(json.packages)) {
+      if (!path || info.link || !info.version) {
+        continue;
+      }
+      if (info.resolved && !/^https?:/.test(info.resolved)) {
+        continue;
+      }
+      const i = path.lastIndexOf('node_modules/');
+      const name = i === -1 ? path : path.slice(i + 'node_modules/'.length);
+      add(byName, name, info.version);
+    }
+  } else if (json.dependencies) {
+    const walk = deps => {
+      for (const [name, info] of Object.entries(deps)) {
+        if (
+          info.version &&
+          (!info.resolved || /^https?:/.test(info.resolved))
+        ) {
+          add(byName, name, info.version);
+        }
+        if (info.dependencies) {
+          walk(info.dependencies);
+        }
+      }
+    };
+    walk(json.dependencies);
+  }
+  return byName;
+}
+
+// yarn classic + berry: a descriptor line lists comma-separated specifiers, then
+// an indented `version "x"` (classic) or `version: x` (berry). The resolved
+// version is that field; the name is the specifier minus its range.
+function parseYarn(text) {
+  const byName = new Map();
+  let pending = null;
+  for (const line of text.split('\n')) {
+    if (/^[^\s#]/.test(line)) {
+      pending = line
+        .replace(/:\s*$/, '')
+        .split(',')
+        .map(s => s.trim().replace(/^"|"$/g, ''))
+        .map(s => {
+          const at = s.lastIndexOf('@');
+          return at <= 0 ? s : s.slice(0, at);
+        })
+        .filter(n => n && n !== '__metadata');
+    } else if (pending && /^\s+version[:\s]/.test(line)) {
+      const m = line.match(/version[:\s]+"?([^"\s]+)"?/);
+      if (m) {
+        for (const n of pending) {
+          add(byName, n, m[1]);
+        }
+      }
+      pending = null;
+    }
+  }
+  return byName;
+}
+
+async function fetchPackument(name, attempt = 0) {
+  const url = `${REGISTRY}/${name.replace('/', '%2F')}`;
+  try {
+    const res = await fetch(url, {
+      headers: {Authorization: `Bearer ${TOKEN}`, Accept: 'application/json'},
+    });
+    if (res.status >= 500 && attempt < 1) {
+      return fetchPackument(name, attempt + 1);
+    }
+    return res;
+  } catch (e) {
+    if (attempt < 1) {
+      return fetchPackument(name, attempt + 1);
+    }
+    throw e;
+  }
+}
+
+const text = await readFile(LOCKFILE, 'utf8');
+let byName;
+try {
+  byName = parsePinned(LOCKFILE, text);
+} catch (e) {
+  console.error(`::error::${e.message}`);
+  process.exit(4);
+}
+const names = [...byName.keys()];
+
+// Fail closed: a recognized lockfile with real content must yield packages. Zero
+// means the format/version drifted from what we parse — never treat that as OK.
+if (names.length === 0) {
+  console.error(
+    `::error::Parsed 0 packages from ${LOCKFILE} — unrecognized or unexpected lockfile format/version. Refusing to pass.`,
+  );
+  process.exit(4);
+}
+
+const totalVersions = names.reduce((n, k) => n + byName.get(k).size, 0);
+console.log(
+  `Checking ${totalVersions} pinned version(s) across ${names.length} package(s) from ${LOCKFILE} against ${REGISTRY} …`,
+);
+
+const missing = []; // {name, version, reason}
+const authErrors = [];
+const otherErrors = [];
+
+let idx = 0;
+async function worker() {
+  while (idx < names.length) {
+    if (authErrors.length) {
+      return; // someone already hit an auth wall; stop early
+    }
+    const name = names[idx++];
+    try {
+      const res = await fetchPackument(name);
+      if (res.status === 401 || res.status === 403) {
+        authErrors.push({name, status: res.status});
+        return;
+      }
+      if (res.status === 404) {
+        for (const v of byName.get(name)) {
+          missing.push({
+            name,
+            version: v,
+            reason: 'package not found on the registry',
+          });
+        }
+        continue;
+      }
+      if (!res.ok) {
+        otherErrors.push({name, detail: `HTTP ${res.status}`});
+        continue;
+      }
+      const served = (await res.json()).versions ?? {};
+      for (const v of byName.get(name)) {
+        if (!(v in served)) {
+          missing.push({
+            name,
+            version: v,
+            reason: 'absent from registry metadata (withheld/unavailable)',
+          });
+        }
+      }
+    } catch (e) {
+      otherErrors.push({name, detail: String(e)});
+    }
+  }
+}
+
+await Promise.all(
+  Array.from({length: Math.min(CONCURRENCY, names.length)}, worker),
+);
+
+// Auth failure is a misconfiguration, not a dependency problem — say so.
+if (authErrors.length) {
+  console.error(
+    `::error::The registry returned ${authErrors[0].status} for ${authErrors[0].name} — this CI identity is not authorized to read. ` +
+      `Confirm the registry read-auth onboarding for this repo (D109850078) is deployed. This is NOT a dependency problem.`,
+  );
+  process.exit(2);
+}
+
+// Network/5xx errors are a gate, so fail closed rather than pass silently.
+if (otherErrors.length) {
+  console.error(
+    `::error::Could not verify ${otherErrors.length} package(s) against the registry (failing closed):`,
+  );
+  for (const e of otherErrors.slice(0, 30)) {
+    console.error(`  - ${e.name}: ${e.detail}`);
+  }
+  process.exit(3);
+}
+
+if (missing.length) {
+  console.error(
+    `::error::${missing.length} pinned version(s) are not served by the internal registry (${REGISTRY}). A frozen install inside Meta would fail on these:`,
+  );
+  for (const m of missing.slice(0, 100)) {
+    console.error(`  - ${m.name}@${m.version}  — ${m.reason}`);
+  }
+  if (missing.length > 100) {
+    console.error(`  … and ${missing.length - 100} more`);
+  }
+  console.error(
+    'A recently-published third-party version is most likely being withheld for the usual window and becomes available once it ages out; ' +
+      'an older missing version may be unavailable/blocked. Options: wait out the window, pin an available version, or request an allowlist entry.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `OK — all ${totalVersions} pinned version(s) are served by the internal registry.`,
+);

--- a/.github/actions/internal-registry/dependency-check/check.mjs
+++ b/.github/actions/internal-registry/dependency-check/check.mjs
@@ -6,44 +6,23 @@
  *
  */
 
-// Internal npm registry availability gate.
-//
-// Every third-party (name, version) pinned in the lockfile must be fetchable
-// from Meta's internal npm registry (registry.facebook.net) *right now*. The
-// internal registry withholds newly published third-party versions for a short
-// window, so a freshly published version is absent from the metadata it serves
-// even though it exists on public npm. A frozen install inside Meta would then
-// fail on that version, even though it installs fine in public GitHub CI. This
-// catches that gap before code lands.
-//
-// It checks metadata membership (is the version listed?), not tarball
-// reachability: the withholding happens at the metadata layer, and third-party
-// tarballs are not gated, so a tarball probe would give a false green. It is
-// also window-agnostic — it just asks "is this version served?", so it needs no
-// knowledge of the withholding window's length.
-//
-// Lockfiles: pnpm, npm, and yarn are supported, auto-detected by filename. An
-// unrecognized format (or one that parses to zero packages) fails loudly rather
-// than silently passing — a format mismatch must never look like "all clear".
-//
-// Auth: a short-lived bearer token in $REGISTRY_TOKEN (minted from this CI job's
-// GitHub OIDC identity by the surrounding action). We talk to the registry over
-// fetch() with an explicit Authorization header and deliberately do NOT write
-// .npmrc.
+// Checks that every dependency version pinned in the lockfile is available from
+// the configured registry, and fails if any pinned version is not served.
+// Supports pnpm, npm and yarn lockfiles (auto-detected by filename); an
+// unrecognized lockfile fails rather than passing silently. Auth is a
+// short-lived token in $REGISTRY_TOKEN.
 
 import {readFile} from 'node:fs/promises';
 
 const REGISTRY = (
-  process.env.REGISTRY_URL ?? 'https://registry.facebook.net'
+  process.env.REGISTRY_URL ?? 'https://registry.x2p.facebook.net'
 ).replace(/\/$/, '');
 const LOCKFILE = process.env.LOCKFILE ?? 'pnpm-lock.yaml';
 const CONCURRENCY = Number(process.env.CHECK_CONCURRENCY ?? 20);
 const TOKEN = process.env.REGISTRY_TOKEN;
 
 if (!TOKEN) {
-  console.error(
-    '::error::REGISTRY_TOKEN is not set — the OIDC token-exchange step must run first.',
-  );
+  console.error('::error::REGISTRY_TOKEN is not set.');
   process.exit(1);
 }
 
@@ -57,8 +36,6 @@ function add(byName, name, version) {
   byName.get(name).add(version);
 }
 
-// Dispatch on the lockfile name. Deliberately bounded to the three mainstream
-// ecosystems; anything else throws (handled below as a hard failure).
 function parsePinned(lockfilePath, text) {
   const base = lockfilePath.split('/').pop();
   if (base === 'pnpm-lock.yaml') {
@@ -75,8 +52,8 @@ function parsePinned(lockfilePath, text) {
   );
 }
 
-// pnpm v9: `packages:` section, keys are bare `name@version` (peer-dep suffixes
-// live in `snapshots:`). Workspace packages link locally and don't appear here.
+// pnpm v9: `packages:` keys are bare `name@version` (peer suffixes live in
+// `snapshots:`). Workspace packages link locally and don't appear here.
 function parsePnpm(text) {
   const lines = text.split('\n');
   const start = lines.indexOf('packages:');
@@ -92,7 +69,7 @@ function parsePnpm(text) {
     if (!/^\s/.test(line)) {
       break;
     }
-    const m = line.match(/^  (?:'([^']+)'|([^'\s][^:]*?)):\s*$/);
+    const m = line.match(/^ {2}(?:'([^']+)'|([^'\s][^:]*?)):\s*$/);
     if (!m) {
       continue;
     }
@@ -106,9 +83,8 @@ function parsePnpm(text) {
   return byName;
 }
 
-// npm v2/v3: `packages` map keyed by node_modules paths, each with `version`.
-// Falls back to the v1 nested `dependencies` tree. Only registry-resolved
-// entries are checked (skip workspace links and git/file/tarball specs).
+// npm v2/v3: `packages` map keyed by node_modules paths; falls back to the v1
+// nested `dependencies` tree. Only registry-resolved entries are checked.
 function parseNpm(text) {
   const json = JSON.parse(text);
   const byName = new Map();
@@ -144,8 +120,7 @@ function parseNpm(text) {
 }
 
 // yarn classic + berry: a descriptor line lists comma-separated specifiers, then
-// an indented `version "x"` (classic) or `version: x` (berry). The resolved
-// version is that field; the name is the specifier minus its range.
+// an indented `version "x"` / `version: x`. Name is the specifier minus range.
 function parseYarn(text) {
   const byName = new Map();
   let pending = null;
@@ -177,7 +152,7 @@ async function fetchPackument(name, attempt = 0) {
   const url = `${REGISTRY}/${name.replace('/', '%2F')}`;
   try {
     const res = await fetch(url, {
-      headers: {Authorization: `Bearer ${TOKEN}`, Accept: 'application/json'},
+      headers: {Accept: 'application/json', Authorization: `Bearer ${TOKEN}`},
     });
     if (res.status >= 500 && attempt < 1) {
       return fetchPackument(name, attempt + 1);
@@ -201,21 +176,19 @@ try {
 }
 const names = [...byName.keys()];
 
-// Fail closed: a recognized lockfile with real content must yield packages. Zero
-// means the format/version drifted from what we parse — never treat that as OK.
+// A recognized lockfile with content must yield packages; zero means the format
+// drifted from what we parse, so fail rather than pass silently.
 if (names.length === 0) {
-  console.error(
-    `::error::Parsed 0 packages from ${LOCKFILE} — unrecognized or unexpected lockfile format/version. Refusing to pass.`,
-  );
+  console.error(`::error::Parsed 0 packages from ${LOCKFILE}.`);
   process.exit(4);
 }
 
 const totalVersions = names.reduce((n, k) => n + byName.get(k).size, 0);
-console.log(
-  `Checking ${totalVersions} pinned version(s) across ${names.length} package(s) from ${LOCKFILE} against ${REGISTRY} …`,
+console.warn(
+  `Checking ${totalVersions} version(s) across ${names.length} package(s) against ${REGISTRY} …`,
 );
 
-const missing = []; // {name, version, reason}
+const missing = [];
 const authErrors = [];
 const otherErrors = [];
 
@@ -223,7 +196,7 @@ let idx = 0;
 async function worker() {
   while (idx < names.length) {
     if (authErrors.length) {
-      return; // someone already hit an auth wall; stop early
+      return;
     }
     const name = names[idx++];
     try {
@@ -234,30 +207,22 @@ async function worker() {
       }
       if (res.status === 404) {
         for (const v of byName.get(name)) {
-          missing.push({
-            name,
-            version: v,
-            reason: 'package not found on the registry',
-          });
+          missing.push({name, version: v});
         }
         continue;
       }
       if (!res.ok) {
-        otherErrors.push({name, detail: `HTTP ${res.status}`});
+        otherErrors.push({detail: `HTTP ${res.status}`, name});
         continue;
       }
       const served = (await res.json()).versions ?? {};
       for (const v of byName.get(name)) {
         if (!(v in served)) {
-          missing.push({
-            name,
-            version: v,
-            reason: 'absent from registry metadata (withheld/unavailable)',
-          });
+          missing.push({name, version: v});
         }
       }
     } catch (e) {
-      otherErrors.push({name, detail: String(e)});
+      otherErrors.push({detail: String(e), name});
     }
   }
 }
@@ -266,19 +231,18 @@ await Promise.all(
   Array.from({length: Math.min(CONCURRENCY, names.length)}, worker),
 );
 
-// Auth failure is a misconfiguration, not a dependency problem — say so.
+// Auth failure is a setup problem, not a dependency problem.
 if (authErrors.length) {
   console.error(
-    `::error::The registry returned ${authErrors[0].status} for ${authErrors[0].name} — this CI identity is not authorized to read. ` +
-      `Confirm the registry read-auth onboarding for this repo (D109850078) is deployed. This is NOT a dependency problem.`,
+    `::error::Registry returned ${authErrors[0].status} (not authorized) — check the CI registry credentials.`,
   );
   process.exit(2);
 }
 
-// Network/5xx errors are a gate, so fail closed rather than pass silently.
+// Network errors fail closed rather than passing silently.
 if (otherErrors.length) {
   console.error(
-    `::error::Could not verify ${otherErrors.length} package(s) against the registry (failing closed):`,
+    `::error::Could not reach the registry for ${otherErrors.length} package(s):`,
   );
   for (const e of otherErrors.slice(0, 30)) {
     console.error(`  - ${e.name}: ${e.detail}`);
@@ -288,21 +252,15 @@ if (otherErrors.length) {
 
 if (missing.length) {
   console.error(
-    `::error::${missing.length} pinned version(s) are not served by the internal registry (${REGISTRY}). A frozen install inside Meta would fail on these:`,
+    `::error::${missing.length} pinned version(s) are not available from the registry:`,
   );
   for (const m of missing.slice(0, 100)) {
-    console.error(`  - ${m.name}@${m.version}  — ${m.reason}`);
+    console.error(`  - ${m.name}@${m.version}`);
   }
   if (missing.length > 100) {
     console.error(`  … and ${missing.length - 100} more`);
   }
-  console.error(
-    'A recently-published third-party version is most likely being withheld for the usual window and becomes available once it ages out; ' +
-      'an older missing version may be unavailable/blocked. Options: wait out the window, pin an available version, or request an allowlist entry.',
-  );
   process.exit(1);
 }
 
-console.log(
-  `OK — all ${totalVersions} pinned version(s) are served by the internal registry.`,
-);
+console.warn(`OK — all ${totalVersions} pinned version(s) are available.`);

--- a/.github/actions/internal-registry/dependency-check/check.mjs
+++ b/.github/actions/internal-registry/dependency-check/check.mjs
@@ -149,7 +149,7 @@ function parseYarn(text) {
 }
 
 async function fetchPackument(name, attempt = 0) {
-  const url = `${REGISTRY}/${name.replace('/', '%2F')}`;
+  const url = `${REGISTRY}/${name.replace(/\//g, '%2F')}`;
   try {
     const res = await fetch(url, {
       headers: {Accept: 'application/json', Authorization: `Bearer ${TOKEN}`},

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    cooldown:
+      default-days: 7
     groups:
       docusaurus-and-typedoc:
         patterns:

--- a/.github/workflows/internal-registry.yml
+++ b/.github/workflows/internal-registry.yml
@@ -1,0 +1,22 @@
+name: Internal Registry
+
+# Verifies every pinned dependency is available from the registry before it can
+# break a build. Mark the merge_group run ("Internal Registry / dependency-check")
+# as a REQUIRED status check to gate landing; fork PRs are skipped and enforced
+# by that required merge_group run.
+
+on:
+  pull_request:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/internal-registry/dependency-check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,19 @@ jobs:
   e2e-tests:
     if: github.repository_owner == 'facebook'
     uses: ./.github/workflows/call-e2e-canary-tests.yml
+
+  # Assert every third-party dependency pinned in pnpm-lock.yaml is fetchable
+  # from Meta's internal npm registry. Newly published versions are withheld
+  # there for a short window, so a frozen install inside Meta can fail on a
+  # just-published version even though it installs fine from public npm. Mark
+  # this job's merge_group run REQUIRED so it blocks landing; fork PRs can't mint
+  # the registry identity and pass with a notice (the required merge-queue run
+  # enforces them).
+  dependency-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/internal-registry/dependency-check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,12 +28,9 @@ jobs:
     if: github.repository_owner == 'facebook'
     uses: ./.github/workflows/call-e2e-canary-tests.yml
 
-  # Assert every third-party dependency pinned in pnpm-lock.yaml is fetchable
-  # from Meta's internal npm registry. Newly published versions are withheld
-  # there for a short window, so a frozen install inside Meta can fail on a
-  # just-published version even though it installs fine from public npm. Mark
-  # this job's merge_group run REQUIRED so it blocks landing; fork PRs can't mint
-  # the registry identity and pass with a notice (the required merge-queue run
+  # Checks that every dependency pinned in pnpm-lock.yaml is available from the
+  # registry before it can break a build. Mark this job's merge_group run
+  # REQUIRED to gate landing; fork PRs are skipped (the required merge_group run
   # enforces them).
   dependency-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,16 +27,3 @@ jobs:
   e2e-tests:
     if: github.repository_owner == 'facebook'
     uses: ./.github/workflows/call-e2e-canary-tests.yml
-
-  # Checks that every dependency pinned in pnpm-lock.yaml is available from the
-  # registry before it can break a build. Mark this job's merge_group run
-  # REQUIRED to gate landing; fork PRs are skipped (the required merge_group run
-  # enforces them).
-  dependency-check:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/internal-registry/dependency-check


### PR DESCRIPTION
## What

Adds a CI check that verifies every third-party version pinned in `pnpm-lock.yaml` is currently served by Meta's internal npm registry (`registry.facebook.net`).

## Why

The internal registry withholds newly published third-party versions for a short window. A lockfile pinning a just-published version installs fine from public npm (and in this GitHub CI) but a frozen install **inside Meta** fails, because that version isn't served yet. This catches the gap before it lands.

## How

- Composite action: `.github/actions/internal-registry/dependency-check`
  - Parses the lockfile (pnpm / npm / yarn, auto-detected by filename; **fails closed** on anything else).
  - Checks packument membership, not tarball reachability (withholding is metadata-only, so a tarball probe would false-green).
  - Authenticates with a short-lived token minted from the job's GitHub OIDC identity — **no static secret**.
- Dogfooded via a new `dependency-check` job in `tests.yml`.
- Coverage: runs on PRs (early feedback) and `merge_group`. Fork PRs can't mint OIDC, so they pass with a notice and are enforced by the **required** `merge_group` run.

## Reuse

The action carries its own script, so other `facebook` repos can consume it cross-repo:

```yaml
- uses: actions/checkout@v6
- uses: facebook/lexical/.github/actions/internal-registry/dependency-check@<tag>
```

## Activation

- [ ] Registry read-auth onboarding for `repo:facebook/` deployed.
- [ ] Mark the `dependency-check` `merge_group` run as a required status check.

> Until onboarding is fully deployed the check exits with an auth error by design (a misconfig reads as a misconfig, not as broken deps).
