### PR TITLE
[lexical][lexical-rich-text] Bug Fix: Place block cursor between decorators and shadow roots

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextBlockCursorShadowRoot.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextBlockCursorShadowRoot.test.ts
@@ -148,6 +148,58 @@ describe('$tryEnterFromBlockCursor — block cursor → enter shadow root (#8736
     });
   });
 
+  test('ArrowDown from block cursor before shadow root enters at selectStart', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        $getRoot().select(1, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND, makeArrowEvent('ArrowDown'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      const shadow = $getRoot().getChildAtIndex(1)!;
+      assert($isElementNode(shadow));
+      const paragraph = shadow.getFirstChild()!;
+      assert($isElementNode(paragraph));
+      const text = paragraph.getFirstChild()!;
+      expect(s.anchor.key).toBe(text.getKey());
+      expect(s.anchor.offset).toBe(0);
+    });
+  });
+
+  test('ArrowUp from block cursor after shadow root enters at selectEnd', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        $getRoot().select(2, 2);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_UP_COMMAND, makeArrowEvent('ArrowUp'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      const shadow = $getRoot().getChildAtIndex(1)!;
+      assert($isElementNode(shadow));
+      const paragraph = shadow.getFirstChild()!;
+      assert($isElementNode(paragraph));
+      const text = paragraph.getFirstChild()!;
+      expect(s.anchor.key).toBe(text.getKey());
+      expect(s.anchor.offset).toBe(6); // "inside".length
+    });
+  });
+
   test('ArrowLeft from block cursor after shadow root enters at selectEnd', () => {
     using editor = createDecoratorShadowRootEditor();
 
@@ -201,6 +253,60 @@ describe('$tryExitShadowRootToBlockCursor — shadow root → block cursor (#873
       expect(s.anchor.type).toBe('element');
       expect(s.anchor.key).toBe($getRoot().getKey());
       expect(s.anchor.offset).toBe(1);
+    });
+  });
+
+  test('ArrowUp at start of shadow root exits to block cursor before it', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        const shadow = $getRoot().getChildAtIndex(1)!;
+        assert($isElementNode(shadow));
+        const paragraph = shadow.getFirstChild()!;
+        assert($isElementNode(paragraph));
+        paragraph.select(0, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_UP_COMMAND, makeArrowEvent('ArrowUp'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(1);
+    });
+  });
+
+  test('ArrowDown at end of shadow root exits to block cursor after it', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        const shadow = $getRoot().getChildAtIndex(1)!;
+        assert($isElementNode(shadow));
+        const paragraph = shadow.getFirstChild()!;
+        assert($isElementNode(paragraph));
+        const text = paragraph.getFirstChild()!;
+        assert($isTextNode(text));
+        text.select(6, 6);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND, makeArrowEvent('ArrowDown'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(2);
     });
   });
 

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextBlockCursorShadowRoot.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextBlockCursorShadowRoot.test.ts
@@ -16,6 +16,7 @@ import {
   $getSelection,
   $isElementNode,
   $isRangeSelection,
+  $isTextNode,
   $setSelection,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
@@ -81,110 +82,38 @@ function createDecoratorShadowRootEditor() {
 }
 
 describe('$exitNodeSelectionToward — decorator → block cursor beside shadow root (#8736)', () => {
-  test('ArrowDown from decorator[0] lands at block cursor before shadow root', () => {
-    using editor = createDecoratorShadowRootEditor();
+  test.for([
+    {command: KEY_ARROW_DOWN_COMMAND, index: 0, key: 'ArrowDown', offset: 1},
+    {command: KEY_ARROW_RIGHT_COMMAND, index: 0, key: 'ArrowRight', offset: 1},
+    {command: KEY_ARROW_UP_COMMAND, index: 2, key: 'ArrowUp', offset: 2},
+    {command: KEY_ARROW_LEFT_COMMAND, index: 2, key: 'ArrowLeft', offset: 2},
+  ] as const)(
+    '$key from decorator[$index] lands at block cursor (offset $offset)',
+    ({key, command, index, offset}) => {
+      using editor = createDecoratorShadowRootEditor();
 
-    editor.update(
-      () => {
-        const decorator = $getRoot().getChildAtIndex(0)!;
-        const ns = $createNodeSelection();
-        ns.add(decorator.getKey());
-        $setSelection(ns);
-      },
-      {discrete: true},
-    );
+      editor.update(
+        () => {
+          const decorator = $getRoot().getChildAtIndex(index)!;
+          const ns = $createNodeSelection();
+          ns.add(decorator.getKey());
+          $setSelection(ns);
+        },
+        {discrete: true},
+      );
 
-    editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND, makeArrowEvent('ArrowDown'));
+      editor.dispatchCommand(command, makeArrowEvent(key));
 
-    editor.read(() => {
-      const s = $getSelection();
-      assert($isRangeSelection(s));
-      expect(s.isCollapsed()).toBe(true);
-      expect(s.anchor.type).toBe('element');
-      expect(s.anchor.key).toBe($getRoot().getKey());
-      // offset 1 = between decorator[0] and shadowRoot
-      expect(s.anchor.offset).toBe(1);
-    });
-  });
-
-  test('ArrowRight from decorator[0] lands at block cursor before shadow root', () => {
-    using editor = createDecoratorShadowRootEditor();
-
-    editor.update(
-      () => {
-        const decorator = $getRoot().getChildAtIndex(0)!;
-        const ns = $createNodeSelection();
-        ns.add(decorator.getKey());
-        $setSelection(ns);
-      },
-      {discrete: true},
-    );
-
-    editor.dispatchCommand(
-      KEY_ARROW_RIGHT_COMMAND,
-      makeArrowEvent('ArrowRight'),
-    );
-
-    editor.read(() => {
-      const s = $getSelection();
-      assert($isRangeSelection(s));
-      expect(s.isCollapsed()).toBe(true);
-      expect(s.anchor.type).toBe('element');
-      expect(s.anchor.key).toBe($getRoot().getKey());
-      expect(s.anchor.offset).toBe(1);
-    });
-  });
-
-  test('ArrowUp from decorator[2] lands at block cursor after shadow root', () => {
-    using editor = createDecoratorShadowRootEditor();
-
-    editor.update(
-      () => {
-        const decorator = $getRoot().getChildAtIndex(2)!;
-        const ns = $createNodeSelection();
-        ns.add(decorator.getKey());
-        $setSelection(ns);
-      },
-      {discrete: true},
-    );
-
-    editor.dispatchCommand(KEY_ARROW_UP_COMMAND, makeArrowEvent('ArrowUp'));
-
-    editor.read(() => {
-      const s = $getSelection();
-      assert($isRangeSelection(s));
-      expect(s.isCollapsed()).toBe(true);
-      expect(s.anchor.type).toBe('element');
-      expect(s.anchor.key).toBe($getRoot().getKey());
-      // offset 2 = between shadowRoot and decorator[2]
-      expect(s.anchor.offset).toBe(2);
-    });
-  });
-
-  test('ArrowLeft from decorator[2] lands at block cursor after shadow root', () => {
-    using editor = createDecoratorShadowRootEditor();
-
-    editor.update(
-      () => {
-        const decorator = $getRoot().getChildAtIndex(2)!;
-        const ns = $createNodeSelection();
-        ns.add(decorator.getKey());
-        $setSelection(ns);
-      },
-      {discrete: true},
-    );
-
-    editor.dispatchCommand(KEY_ARROW_LEFT_COMMAND, makeArrowEvent('ArrowLeft'));
-
-    editor.read(() => {
-      const s = $getSelection();
-      assert($isRangeSelection(s));
-      expect(s.isCollapsed()).toBe(true);
-      expect(s.anchor.type).toBe('element');
-      expect(s.anchor.key).toBe($getRoot().getKey());
-      expect(s.anchor.offset).toBe(2);
-    });
-  });
+      editor.read(() => {
+        const s = $getSelection();
+        assert($isRangeSelection(s));
+        expect(s.isCollapsed()).toBe(true);
+        expect(s.anchor.type).toBe('element');
+        expect(s.anchor.key).toBe($getRoot().getKey());
+        expect(s.anchor.offset).toBe(offset);
+      });
+    },
+  );
 });
 
 describe('$tryEnterFromBlockCursor — block cursor → enter shadow root (#8736)', () => {
@@ -285,7 +214,7 @@ describe('$tryExitShadowRootToBlockCursor — shadow root → block cursor (#873
         const paragraph = shadow.getFirstChild()!;
         assert($isElementNode(paragraph));
         const text = paragraph.getFirstChild()!;
-        // Place at end of text "inside"
+        assert($isTextNode(text));
         text.select(6, 6);
       },
       {discrete: true},
@@ -387,6 +316,7 @@ describe('nested shadow root exit (#8736)', () => {
         const paragraph = inner.getFirstChild()!;
         assert($isElementNode(paragraph));
         const text = paragraph.getFirstChild()!;
+        assert($isTextNode(text));
         text.select(6, 6);
       },
       {discrete: true},
@@ -512,6 +442,7 @@ describe('full round-trip: decorator → block cursor → shadow root → block 
         const paragraph = shadow.getFirstChild()!;
         assert($isElementNode(paragraph));
         const text = paragraph.getFirstChild()!;
+        assert($isTextNode(text));
         text.select(6, 6);
       },
       {discrete: true},

--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextBlockCursorShadowRoot.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextBlockCursorShadowRoot.test.ts
@@ -1,0 +1,532 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createNodeSelection,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $setSelection,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_LEFT_COMMAND,
+  KEY_ARROW_RIGHT_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  LexicalEditor,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  $createTestShadowRootNode,
+  TestDecoratorNode,
+  TestShadowRootNode,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
+
+function makeArrowEvent(key: string): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+}
+
+function sel(editor: LexicalEditor) {
+  return editor.read(() => {
+    const s = $getSelection();
+    if (!$isRangeSelection(s)) {
+      return null;
+    }
+    return {
+      anchorKey: s.anchor.key,
+      anchorOffset: s.anchor.offset,
+      anchorType: s.anchor.type,
+      focusKey: s.focus.key,
+      focusOffset: s.focus.offset,
+      focusType: s.focus.type,
+    };
+  });
+}
+
+// Structure used across tests:
+//   root
+//     decorator (block)       — index 0
+//     shadowRoot              — index 1
+//       paragraph > text
+//     decorator (block)       — index 2
+function createDecoratorShadowRootEditor() {
+  return buildEditorFromExtensions({
+    $initialEditorState: () => {
+      const decorator1 = $createTestDecoratorNode().setIsInline(false);
+      const shadow = $createTestShadowRootNode();
+      const paragraph = $createParagraphNode().append(
+        $createTextNode('inside'),
+      );
+      shadow.append(paragraph);
+      const decorator2 = $createTestDecoratorNode().setIsInline(false);
+      $getRoot().clear().append(decorator1, shadow, decorator2);
+    },
+    dependencies: [RichTextExtension],
+    name: 'test',
+    nodes: [TestDecoratorNode, TestShadowRootNode],
+  });
+}
+
+describe('$exitNodeSelectionToward — decorator → block cursor beside shadow root (#8736)', () => {
+  test('ArrowDown from decorator[0] lands at block cursor before shadow root', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        const decorator = $getRoot().getChildAtIndex(0)!;
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND, makeArrowEvent('ArrowDown'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      // offset 1 = between decorator[0] and shadowRoot
+      expect(s.anchor.offset).toBe(1);
+    });
+  });
+
+  test('ArrowRight from decorator[0] lands at block cursor before shadow root', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        const decorator = $getRoot().getChildAtIndex(0)!;
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      makeArrowEvent('ArrowRight'),
+    );
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(1);
+    });
+  });
+
+  test('ArrowUp from decorator[2] lands at block cursor after shadow root', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        const decorator = $getRoot().getChildAtIndex(2)!;
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_UP_COMMAND, makeArrowEvent('ArrowUp'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      // offset 2 = between shadowRoot and decorator[2]
+      expect(s.anchor.offset).toBe(2);
+    });
+  });
+
+  test('ArrowLeft from decorator[2] lands at block cursor after shadow root', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        const decorator = $getRoot().getChildAtIndex(2)!;
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_LEFT_COMMAND, makeArrowEvent('ArrowLeft'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(2);
+    });
+  });
+});
+
+describe('$tryEnterFromBlockCursor — block cursor → enter shadow root (#8736)', () => {
+  test('ArrowRight from block cursor before shadow root enters at selectStart', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    // Place selection at root offset 1 (block cursor between decorator[0] and shadow root)
+    editor.update(
+      () => {
+        $getRoot().select(1, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      makeArrowEvent('ArrowRight'),
+    );
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      // selectStart() resolves to the leaf text node
+      const shadow = $getRoot().getChildAtIndex(1)!;
+      assert($isElementNode(shadow));
+      const paragraph = shadow.getFirstChild()!;
+      assert($isElementNode(paragraph));
+      const text = paragraph.getFirstChild()!;
+      expect(s.anchor.key).toBe(text.getKey());
+      expect(s.anchor.offset).toBe(0);
+    });
+  });
+
+  test('ArrowLeft from block cursor after shadow root enters at selectEnd', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    // Place selection at root offset 2 (block cursor between shadow root and decorator[2])
+    editor.update(
+      () => {
+        $getRoot().select(2, 2);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_LEFT_COMMAND, makeArrowEvent('ArrowLeft'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      // selectEnd() resolves to the leaf text node at end offset
+      const shadow = $getRoot().getChildAtIndex(1)!;
+      assert($isElementNode(shadow));
+      const paragraph = shadow.getFirstChild()!;
+      assert($isElementNode(paragraph));
+      const text = paragraph.getFirstChild()!;
+      expect(s.anchor.key).toBe(text.getKey());
+      expect(s.anchor.offset).toBe(6); // "inside".length
+    });
+  });
+});
+
+describe('$tryExitShadowRootToBlockCursor — shadow root → block cursor (#8736)', () => {
+  test('ArrowLeft at start of shadow root exits to block cursor before it', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        const shadow = $getRoot().getChildAtIndex(1)!;
+        assert($isElementNode(shadow));
+        const paragraph = shadow.getFirstChild()!;
+        assert($isElementNode(paragraph));
+        paragraph.select(0, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_LEFT_COMMAND, makeArrowEvent('ArrowLeft'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(1);
+    });
+  });
+
+  test('ArrowRight at end of shadow root exits to block cursor after it', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    editor.update(
+      () => {
+        const shadow = $getRoot().getChildAtIndex(1)!;
+        assert($isElementNode(shadow));
+        const paragraph = shadow.getFirstChild()!;
+        assert($isElementNode(paragraph));
+        const text = paragraph.getFirstChild()!;
+        // Place at end of text "inside"
+        text.select(6, 6);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      makeArrowEvent('ArrowRight'),
+    );
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(2);
+    });
+  });
+});
+
+describe('nested shadow root exit (#8736)', () => {
+  // Structure:
+  //   root
+  //     decorator (block)
+  //     outerShadowRoot
+  //       innerShadowRoot
+  //         paragraph > text
+  //     decorator (block)
+  test('ArrowLeft at start of inner shadow root walks up and exits to block cursor', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator1 = $createTestDecoratorNode().setIsInline(false);
+        const outer = $createTestShadowRootNode();
+        const inner = $createTestShadowRootNode();
+        const paragraph = $createParagraphNode().append(
+          $createTextNode('nested'),
+        );
+        inner.append(paragraph);
+        outer.append(inner);
+        const decorator2 = $createTestDecoratorNode().setIsInline(false);
+        $getRoot().clear().append(decorator1, outer, decorator2);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode, TestShadowRootNode],
+    });
+
+    editor.update(
+      () => {
+        const outer = $getRoot().getChildAtIndex(1)!;
+        assert($isElementNode(outer));
+        const inner = outer.getFirstChild()!;
+        assert($isElementNode(inner));
+        const paragraph = inner.getFirstChild()!;
+        assert($isElementNode(paragraph));
+        paragraph.select(0, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_LEFT_COMMAND, makeArrowEvent('ArrowLeft'));
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(1);
+    });
+  });
+
+  test('ArrowRight at end of inner shadow root walks up and exits to block cursor', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const decorator1 = $createTestDecoratorNode().setIsInline(false);
+        const outer = $createTestShadowRootNode();
+        const inner = $createTestShadowRootNode();
+        const paragraph = $createParagraphNode().append(
+          $createTextNode('nested'),
+        );
+        inner.append(paragraph);
+        outer.append(inner);
+        const decorator2 = $createTestDecoratorNode().setIsInline(false);
+        $getRoot().clear().append(decorator1, outer, decorator2);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode, TestShadowRootNode],
+    });
+
+    editor.update(
+      () => {
+        const outer = $getRoot().getChildAtIndex(1)!;
+        assert($isElementNode(outer));
+        const inner = outer.getFirstChild()!;
+        assert($isElementNode(inner));
+        const paragraph = inner.getFirstChild()!;
+        assert($isElementNode(paragraph));
+        const text = paragraph.getFirstChild()!;
+        text.select(6, 6);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      makeArrowEvent('ArrowRight'),
+    );
+
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.isCollapsed()).toBe(true);
+      expect(s.anchor.type).toBe('element');
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(2);
+    });
+  });
+});
+
+describe('no block cursor between sibling shadow roots inside a shadow root parent (#8736)', () => {
+  // Structure (simulates layout-container > layout-items):
+  //   root
+  //     outerShadowRoot
+  //       shadowRoot1 (paragraph > text)
+  //       shadowRoot2 (paragraph > text)
+  // ArrowLeft at start of shadowRoot2 should NOT exit to a block cursor
+  // between the two shadow roots (their parent is also a shadow root).
+  test('ArrowLeft at start of sibling shadow root does not produce block cursor', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const outer = $createTestShadowRootNode();
+        const sr1 = $createTestShadowRootNode();
+        sr1.append($createParagraphNode().append($createTextNode('col1')));
+        const sr2 = $createTestShadowRootNode();
+        sr2.append($createParagraphNode().append($createTextNode('col2')));
+        outer.append(sr1, sr2);
+        $getRoot().clear().append(outer);
+      },
+      dependencies: [RichTextExtension],
+      name: 'test',
+      nodes: [TestDecoratorNode, TestShadowRootNode],
+    });
+
+    // Place cursor at start of sr2's paragraph
+    editor.update(
+      () => {
+        const outer = $getRoot().getFirstChild()!;
+        assert($isElementNode(outer));
+        const sr2 = outer.getChildAtIndex(1)!;
+        assert($isElementNode(sr2));
+        const paragraph = sr2.getFirstChild()!;
+        assert($isElementNode(paragraph));
+        paragraph.select(0, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.dispatchCommand(KEY_ARROW_LEFT_COMMAND, makeArrowEvent('ArrowLeft'));
+
+    // $tryExitShadowRootToBlockCursor should NOT place a block cursor
+    // on the outer shadow root (key = outer.getKey()). In jsdom, shadow
+    // root containment is not enforced so $moveCharacter may move the
+    // cursor elsewhere — the key assertion is that it doesn't land at
+    // a block cursor position on the outer shadow root.
+    const after = sel(editor);
+    const outerKey = editor.read(() => $getRoot().getFirstChild()!.getKey());
+    expect(after!.anchorKey).not.toBe(outerKey);
+  });
+});
+
+describe('full round-trip: decorator → block cursor → shadow root → block cursor → decorator (#8736)', () => {
+  test('ArrowRight traversal: decorator → enter shadow root → exit → reach next decorator', () => {
+    using editor = createDecoratorShadowRootEditor();
+
+    // Start: NodeSelection on decorator[0]
+    editor.update(
+      () => {
+        const decorator = $getRoot().getChildAtIndex(0)!;
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+      {discrete: true},
+    );
+
+    // Step 1: ArrowRight → block cursor at root:1
+    editor.dispatchCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      makeArrowEvent('ArrowRight'),
+    );
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(1);
+    });
+
+    // Step 2: ArrowRight → enter shadow root (selectStart → text:0)
+    editor.dispatchCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      makeArrowEvent('ArrowRight'),
+    );
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      const shadow = $getRoot().getChildAtIndex(1)!;
+      assert($isElementNode(shadow));
+      const paragraph = shadow.getFirstChild()!;
+      assert($isElementNode(paragraph));
+      const text = paragraph.getFirstChild()!;
+      expect(s.anchor.key).toBe(text.getKey());
+      expect(s.anchor.offset).toBe(0);
+    });
+
+    // Step 3: Place cursor at end of text (jsdom doesn't support
+    // selection.modify so we set it directly)
+    editor.update(
+      () => {
+        const shadow = $getRoot().getChildAtIndex(1)!;
+        assert($isElementNode(shadow));
+        const paragraph = shadow.getFirstChild()!;
+        assert($isElementNode(paragraph));
+        const text = paragraph.getFirstChild()!;
+        text.select(6, 6);
+      },
+      {discrete: true},
+    );
+
+    // Step 4: ArrowRight → exit shadow root → block cursor at root:2
+    editor.dispatchCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      makeArrowEvent('ArrowRight'),
+    );
+    editor.read(() => {
+      const s = $getSelection();
+      assert($isRangeSelection(s));
+      expect(s.anchor.key).toBe($getRoot().getKey());
+      expect(s.anchor.offset).toBe(2);
+    });
+  });
+});

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -641,6 +641,7 @@ const DEFAULT_ESCAPE_FORMAT_TRIGGERS: EscapeFormatTriggerConfig = {
   uppercase: {enter: true, space: true, tab: true},
 };
 
+// Keep in sync with needsBlockCursor in LexicalUtils.ts
 function $needsBlockCursorBeside(node: LexicalNode): boolean {
   if (node.isInline()) {
     return false;
@@ -672,7 +673,7 @@ function $tryEnterFromBlockCursor(
     : offset > 0
       ? parent.getChildAtIndex(offset - 1)
       : null;
-  if ($isElementNode(child) && child.isShadowRoot() && !child.isInline()) {
+  if ($isElementNode(child) && !child.isInline() && child.isShadowRoot()) {
     if (isForward) {
       child.selectStart();
     } else {
@@ -681,6 +682,16 @@ function $tryEnterFromBlockCursor(
     return true;
   }
   return false;
+}
+
+function $tryBlockCursorShadowRootNavigation(
+  selection: RangeSelection,
+  isBackward: boolean,
+): boolean {
+  return (
+    $tryExitShadowRootToBlockCursor(selection, isBackward) ||
+    $tryEnterFromBlockCursor(selection, !isBackward)
+  );
 }
 
 function $tryExitShadowRootToBlockCursor(
@@ -777,8 +788,8 @@ function $exitNodeSelectionToward(node: LexicalNode, isForward: boolean): void {
   const sibling = isForward ? node.getNextSibling() : node.getPreviousSibling();
   if (
     $isElementNode(sibling) &&
-    sibling.isShadowRoot() &&
-    !sibling.isInline()
+    !sibling.isInline() &&
+    sibling.isShadowRoot()
   ) {
     const parent = node.getParentOrThrow();
     const offset = isForward
@@ -1067,6 +1078,13 @@ export function registerRichText(
             return true;
           }
         } else if ($isRangeSelection(selection)) {
+          if (
+            !event.shiftKey &&
+            $tryBlockCursorShadowRootNavigation(selection, true)
+          ) {
+            event.preventDefault();
+            return true;
+          }
           const possibleNode = $getAdjacentNode(selection.focus, true);
           if (
             !event.shiftKey &&
@@ -1098,6 +1116,13 @@ export function registerRichText(
           }
         } else if ($isRangeSelection(selection)) {
           if ($isSelectionAtEndOfRoot(selection)) {
+            event.preventDefault();
+            return true;
+          }
+          if (
+            !event.shiftKey &&
+            $tryBlockCursorShadowRootNavigation(selection, false)
+          ) {
             event.preventDefault();
             return true;
           }
@@ -1136,14 +1161,10 @@ export function registerRichText(
         }
         if (
           !event.shiftKey &&
-          ($tryExitShadowRootToBlockCursor(
+          $tryBlockCursorShadowRootNavigation(
             selection,
             !$isParentRTL(selection.anchor.getNode()),
-          ) ||
-            $tryEnterFromBlockCursor(
-              selection,
-              $isParentRTL(selection.anchor.getNode()),
-            ))
+          )
         ) {
           event.preventDefault();
           return true;
@@ -1185,14 +1206,10 @@ export function registerRichText(
         }
         if (
           !event.shiftKey &&
-          ($tryExitShadowRootToBlockCursor(
+          $tryBlockCursorShadowRootNavigation(
             selection,
             $isParentRTL(selection.anchor.getNode()),
-          ) ||
-            $tryEnterFromBlockCursor(
-              selection,
-              !$isParentRTL(selection.anchor.getNode()),
-            ))
+          )
         ) {
           event.preventDefault();
           return true;

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -55,10 +55,12 @@ import {
   $createParagraphNode,
   $createRangeSelection,
   $createTabNode,
+  $extendCaretToRange,
   $findMatchingParent,
   $getAdjacentNode,
+  $getCaretRange,
   $getChildCaret,
-  $getChildCaretAtIndex,
+  $getCollapsedCaretRange,
   $getNearestNodeFromDOMNode,
   $getRoot,
   $getSelection,
@@ -71,13 +73,17 @@ import {
   $isRangeSelection,
   $isRootNode,
   $isSelectionCapturedInDecoratorInput,
+  $isShadowRootNode,
+  $isSiblingCaret,
   $isTextNode,
+  $needsBlockCursorBeside,
+  $normalizeCaret,
   $normalizeSelection__EXPERIMENTAL,
   $selectAll,
   $setDirectionFromDOM,
   $setFormatFromDOM,
-  $setPointFromCaret,
   $setSelection,
+  $setSelectionFromCaretRange,
   addClassNamesToElement,
   CAN_USE_BEFORE_INPUT,
   CLICK_COMMAND,
@@ -646,24 +652,6 @@ const DEFAULT_ESCAPE_FORMAT_TRIGGERS: EscapeFormatTriggerConfig = {
   uppercase: {enter: true, space: true, tab: true},
 };
 
-// Keep in sync with needsBlockCursor in LexicalUtils.ts
-function $needsBlockCursorBeside(node: LexicalNode): boolean {
-  if (node.isInline()) {
-    return false;
-  }
-  if ($isDecoratorNode(node)) {
-    return true;
-  }
-  if ($isElementNode(node)) {
-    if (node.isShadowRoot()) {
-      const parent = node.getParent();
-      return !($isElementNode(parent) && parent.isShadowRoot());
-    }
-    return !node.canBeEmpty();
-  }
-  return false;
-}
-
 function $tryEnterFromBlockCursor(
   selection: RangeSelection,
   direction: CaretDirection,
@@ -671,19 +659,14 @@ function $tryEnterFromBlockCursor(
   if (!selection.isCollapsed() || selection.anchor.type !== 'element') {
     return false;
   }
-  const parent = selection.anchor.getNode();
-  const caret = $getChildCaretAtIndex(
-    parent,
-    selection.anchor.offset,
-    direction,
-  );
+  const caret = $caretFromPoint(selection.anchor, direction);
   const child = caret.getNodeAtCaret();
-  if ($isElementNode(child) && !child.isInline() && child.isShadowRoot()) {
-    if (direction === 'next') {
-      child.selectStart();
-    } else {
-      child.selectEnd();
-    }
+  if ($isShadowRootNode(child) && !child.isInline()) {
+    $setSelectionFromCaretRange(
+      $getCollapsedCaretRange(
+        $normalizeCaret($getChildCaret(child, direction)),
+      ),
+    );
     return true;
   }
   return false;
@@ -708,88 +691,63 @@ function $tryExitShadowRootToBlockCursor(
   }
   const focusCaret = $caretFromPoint(selection.focus, direction);
   // Walk up from focus to find the nearest shadow root ancestor.
-  // Start from the focus node itself (caret.origin) since it may be a
+  // Start from the focus node itself since it may be a
   // shadow root (e.g. LayoutItem with element-type selection).
-  const caret = focusCaret.getSiblingCaret();
-  let shadowRoot: ElementNode | null = null;
-  for (
-    let walk = caret as typeof caret | null;
-    walk !== null;
-    walk = walk.getParentCaret()
-  ) {
-    if ($isElementNode(walk.origin) && walk.origin.isShadowRoot()) {
-      shadowRoot = walk.origin;
-      break;
-    }
-  }
-  if (shadowRoot === null) {
+  const shadowRoot = $findMatchingParent(focusCaret.origin, $isShadowRootNode);
+  if (!shadowRoot) {
     return false;
   }
   // Check that the focus is at the edge of the shadow root in the given
   // direction. If focus is the shadow root itself, check the offset directly.
   // Otherwise walk toward the deepest first/last descendant.
-  let atEdge = false;
-  if (selection.focus.key === shadowRoot.__key) {
-    atEdge =
-      selection.focus.offset ===
-      (direction === 'next' ? shadowRoot.getChildrenSize() : 0);
-  } else {
-    let edgeCaret = $getChildCaret(shadowRoot, direction);
-    while (true) {
-      const adj = edgeCaret.getAdjacentCaret();
-      if (adj === null) {
-        atEdge = selection.focus.key === edgeCaret.origin.__key;
-        break;
-      }
-      if (adj.origin.__key === selection.focus.key) {
-        if ($isTextNode(adj.origin)) {
-          const edgeOffset =
-            direction === 'next' ? adj.origin.getTextContentSize() : 0;
-          atEdge = selection.focus.offset === edgeOffset;
-        } else {
-          atEdge =
-            selection.focus.offset ===
-            (direction === 'next'
-              ? $isElementNode(adj.origin)
-                ? adj.origin.getChildrenSize()
-                : 0
-              : 0);
-        }
-        break;
-      }
-      const childCaret = adj.getChildCaret();
-      if (childCaret === null) {
-        break;
-      }
-      edgeCaret = childCaret;
-    }
-  }
-  if (!atEdge) {
+  const textRange = $getCaretRange(
+    focusCaret,
+    $getSiblingCaret(shadowRoot, direction),
+  );
+  // If there's text we're not at the edge
+  if (
+    textRange
+      .getTextSlices()
+      .some(slice => slice && slice.getTextContentSize() > 0)
+  ) {
     return false;
+  }
+  // Normalize the anchor in case it started with a ChildCaret
+  const range = $getCaretRange(
+    textRange.anchor.getSiblingCaret(),
+    textRange.focus,
+  );
+  // When traversing from the edge to the root we expect to see only parent nodes
+  // as sibling carets
+  let prevOrigin = range.anchor.origin;
+  for (const caret of range) {
+    if (!($isSiblingCaret(caret) && caret.origin.is(prevOrigin.getParent()))) {
+      return false;
+    }
+    prevOrigin = caret.origin;
   }
   // Walk outward from the shadow root through nested shadow roots until
   // we find a sibling that needs a block cursor beside it.
-  let sr = $getSiblingCaret(shadowRoot, direction);
-  while (sr !== null) {
-    const sibling = sr.getAdjacentCaret();
-    if (sibling !== null) {
-      if (!$needsBlockCursorBeside(sibling.origin)) {
-        return false;
+  let prevShadow = shadowRoot;
+  for (const caret of $extendCaretToRange(
+    $getSiblingCaret(shadowRoot, direction),
+  )) {
+    // A caret whose origin is the parent of the current level is the "leave"
+    // step walking outward; only keep going while those parents are shadow
+    // roots. Any other origin is the adjacent sibling at this level.
+    if (caret.origin.is(prevShadow.getParent())) {
+      if (!$isShadowRootNode(caret.origin)) {
+        break;
       }
-      $setPointFromCaret(selection.anchor, sr);
-      $setPointFromCaret(selection.focus, sr);
-      return true;
-    }
-    const parentCaret = sr.getParentCaret();
-    if (
-      parentCaret !== null &&
-      $isElementNode(parentCaret.origin) &&
-      parentCaret.origin.isShadowRoot()
-    ) {
-      sr = parentCaret;
+      prevShadow = caret.origin;
       continue;
     }
-    return false;
+    if ($needsBlockCursorBeside(caret.origin)) {
+      const sr = $getSiblingCaret(prevShadow, direction);
+      $setSelectionFromCaretRange($getCaretRange(sr, sr));
+      return true;
+    }
+    break;
   }
   return false;
 }
@@ -806,12 +764,7 @@ function $exitNodeSelectionToward(
     !sibling.origin.isInline() &&
     sibling.origin.isShadowRoot()
   ) {
-    const parent = node.getParentOrThrow();
-    const offset =
-      direction === 'next'
-        ? sibling.origin.getIndexWithinParent()
-        : node.getIndexWithinParent();
-    parent.select(offset, offset);
+    $setSelectionFromCaretRange($getCollapsedCaretRange(caret));
   } else if (direction === 'next') {
     node.selectNext(0, 0);
   } else {

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -641,6 +641,157 @@ const DEFAULT_ESCAPE_FORMAT_TRIGGERS: EscapeFormatTriggerConfig = {
   uppercase: {enter: true, space: true, tab: true},
 };
 
+function $needsBlockCursorBeside(node: LexicalNode): boolean {
+  if (node.isInline()) {
+    return false;
+  }
+  if ($isDecoratorNode(node)) {
+    return true;
+  }
+  if ($isElementNode(node)) {
+    if (node.isShadowRoot()) {
+      const parent = node.getParent();
+      return !($isElementNode(parent) && parent.isShadowRoot());
+    }
+    return !node.canBeEmpty();
+  }
+  return false;
+}
+
+function $tryEnterFromBlockCursor(
+  selection: RangeSelection,
+  isForward: boolean,
+): boolean {
+  if (!selection.isCollapsed() || selection.anchor.type !== 'element') {
+    return false;
+  }
+  const parent = selection.anchor.getNode();
+  const offset = selection.anchor.offset;
+  const child = isForward
+    ? parent.getChildAtIndex(offset)
+    : offset > 0
+      ? parent.getChildAtIndex(offset - 1)
+      : null;
+  if ($isElementNode(child) && child.isShadowRoot() && !child.isInline()) {
+    if (isForward) {
+      child.selectStart();
+    } else {
+      child.selectEnd();
+    }
+    return true;
+  }
+  return false;
+}
+
+function $tryExitShadowRootToBlockCursor(
+  selection: RangeSelection,
+  isBackward: boolean,
+): boolean {
+  if (!selection.isCollapsed()) {
+    return false;
+  }
+  const focus = selection.focus;
+  const focusNode = focus.getNode();
+  let shadowRoot: ElementNode | null = null;
+  let current: LexicalNode | null = $isElementNode(focusNode)
+    ? focusNode
+    : focusNode.getParent();
+  while (current !== null) {
+    if ($isElementNode(current) && current.isShadowRoot()) {
+      shadowRoot = current;
+      break;
+    }
+    current = current.getParent();
+  }
+  if (shadowRoot === null) {
+    return false;
+  }
+  if (isBackward) {
+    if (focus.offset !== 0) {
+      return false;
+    }
+    let walk: LexicalNode | null = shadowRoot;
+    let atEdge = false;
+    while (walk !== null) {
+      if (focus.key === walk.__key) {
+        atEdge = true;
+        break;
+      }
+      walk = $isElementNode(walk) ? walk.getFirstChild() : null;
+    }
+    if (!atEdge) {
+      return false;
+    }
+  } else {
+    let walk: LexicalNode | null = shadowRoot;
+    let atEdge = false;
+    while (walk !== null) {
+      if (focus.key === walk.__key) {
+        if ($isTextNode(walk)) {
+          atEdge = focus.offset === walk.getTextContentSize();
+        } else if ($isElementNode(walk)) {
+          atEdge = focus.offset === walk.getChildrenSize();
+        }
+        break;
+      }
+      walk = $isElementNode(walk) ? walk.getLastChild() : null;
+    }
+    if (!atEdge) {
+      return false;
+    }
+  }
+  let sr: ElementNode | null = shadowRoot;
+  while (sr !== null) {
+    const sibling = isBackward ? sr.getPreviousSibling() : sr.getNextSibling();
+    if (sibling !== null) {
+      if (!$needsBlockCursorBeside(sibling)) {
+        return false;
+      }
+      const parent = sr.getParentOrThrow();
+      const offset = isBackward
+        ? sr.getIndexWithinParent()
+        : sr.getIndexWithinParent() + 1;
+      parent.select(offset, offset);
+      return true;
+    }
+    const parentNode: ElementNode | null = sr.getParent();
+    if (
+      parentNode !== null &&
+      $isElementNode(parentNode) &&
+      parentNode.isShadowRoot()
+    ) {
+      const atEdge = isBackward
+        ? parentNode.getFirstChild() === sr
+        : parentNode.getLastChild() === sr;
+      if (atEdge) {
+        sr = parentNode;
+        continue;
+      }
+    }
+    return false;
+  }
+  return false;
+}
+
+function $exitNodeSelectionToward(node: LexicalNode, isForward: boolean): void {
+  const sibling = isForward ? node.getNextSibling() : node.getPreviousSibling();
+  if (
+    $isElementNode(sibling) &&
+    sibling.isShadowRoot() &&
+    !sibling.isInline()
+  ) {
+    const parent = node.getParentOrThrow();
+    const offset = isForward
+      ? sibling.getIndexWithinParent()
+      : node.getIndexWithinParent();
+    parent.select(offset, offset);
+  } else if (isForward) {
+    node.selectNext(0, 0);
+  } else {
+    node.selectPrevious();
+  }
+}
+
 /**
  * Collapse a NodeSelection to a caret at the surrounding block's edge for
  * MOVE_TO_START / MOVE_TO_END. Picks the document-order first node for
@@ -912,7 +1063,7 @@ export function registerRichText(
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            nodes[0].selectPrevious();
+            $exitNodeSelectionToward(nodes[0], false);
             return true;
           }
         } else if ($isRangeSelection(selection)) {
@@ -942,7 +1093,7 @@ export function registerRichText(
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            nodes[0].selectNext(0, 0);
+            $exitNodeSelectionToward(nodes[0], true);
             return true;
           }
         } else if ($isRangeSelection(selection)) {
@@ -976,16 +1127,26 @@ export function registerRichText(
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            if ($isParentRTL(nodes[0])) {
-              nodes[0].selectNext(0, 0);
-            } else {
-              nodes[0].selectPrevious();
-            }
+            $exitNodeSelectionToward(nodes[0], $isParentRTL(nodes[0]));
             return true;
           }
         }
         if (!$isRangeSelection(selection)) {
           return false;
+        }
+        if (
+          !event.shiftKey &&
+          ($tryExitShadowRootToBlockCursor(
+            selection,
+            !$isParentRTL(selection.anchor.getNode()),
+          ) ||
+            $tryEnterFromBlockCursor(
+              selection,
+              $isParentRTL(selection.anchor.getNode()),
+            ))
+        ) {
+          event.preventDefault();
+          return true;
         }
         if (!event.shiftKey) {
           $escapeFormatsForTrigger(
@@ -1015,16 +1176,26 @@ export function registerRichText(
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            if ($isParentRTL(nodes[0])) {
-              nodes[0].selectPrevious();
-            } else {
-              nodes[0].selectNext(0, 0);
-            }
+            $exitNodeSelectionToward(nodes[0], !$isParentRTL(nodes[0]));
             return true;
           }
         }
         if (!$isRangeSelection(selection)) {
           return false;
+        }
+        if (
+          !event.shiftKey &&
+          ($tryExitShadowRootToBlockCursor(
+            selection,
+            $isParentRTL(selection.anchor.getNode()),
+          ) ||
+            $tryEnterFromBlockCursor(
+              selection,
+              !$isParentRTL(selection.anchor.getNode()),
+            ))
+        ) {
+          event.preventDefault();
+          return true;
         }
         if (!event.shiftKey) {
           $escapeFormatsForTrigger(

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  CaretDirection,
   CommandPayloadType,
   DOMConversionMap,
   DOMConversionOutput,
@@ -49,12 +50,15 @@ import {
 } from '@lexical/utils';
 import {
   $applyNodeReplacement,
+  $caretFromPoint,
   $comparePointCaretNext,
   $createParagraphNode,
   $createRangeSelection,
   $createTabNode,
   $findMatchingParent,
   $getAdjacentNode,
+  $getChildCaret,
+  $getChildCaretAtIndex,
   $getNearestNodeFromDOMNode,
   $getRoot,
   $getSelection,
@@ -72,6 +76,7 @@ import {
   $selectAll,
   $setDirectionFromDOM,
   $setFormatFromDOM,
+  $setPointFromCaret,
   $setSelection,
   addClassNamesToElement,
   CAN_USE_BEFORE_INPUT,
@@ -661,20 +666,20 @@ function $needsBlockCursorBeside(node: LexicalNode): boolean {
 
 function $tryEnterFromBlockCursor(
   selection: RangeSelection,
-  isForward: boolean,
+  direction: CaretDirection,
 ): boolean {
   if (!selection.isCollapsed() || selection.anchor.type !== 'element') {
     return false;
   }
   const parent = selection.anchor.getNode();
-  const offset = selection.anchor.offset;
-  const child = isForward
-    ? parent.getChildAtIndex(offset)
-    : offset > 0
-      ? parent.getChildAtIndex(offset - 1)
-      : null;
+  const caret = $getChildCaretAtIndex(
+    parent,
+    selection.anchor.offset,
+    direction,
+  );
+  const child = caret.getNodeAtCaret();
   if ($isElementNode(child) && !child.isInline() && child.isShadowRoot()) {
-    if (isForward) {
+    if (direction === 'next') {
       child.selectStart();
     } else {
       child.selectEnd();
@@ -686,117 +691,122 @@ function $tryEnterFromBlockCursor(
 
 function $tryBlockCursorShadowRootNavigation(
   selection: RangeSelection,
-  isBackward: boolean,
+  direction: CaretDirection,
 ): boolean {
   return (
-    $tryExitShadowRootToBlockCursor(selection, isBackward) ||
-    $tryEnterFromBlockCursor(selection, !isBackward)
+    $tryExitShadowRootToBlockCursor(selection, direction) ||
+    $tryEnterFromBlockCursor(selection, direction)
   );
 }
 
 function $tryExitShadowRootToBlockCursor(
   selection: RangeSelection,
-  isBackward: boolean,
+  direction: CaretDirection,
 ): boolean {
   if (!selection.isCollapsed()) {
     return false;
   }
-  const focus = selection.focus;
-  const focusNode = focus.getNode();
+  const focusCaret = $caretFromPoint(selection.focus, direction);
+  // Walk up from focus to find the nearest shadow root ancestor.
+  const caret = focusCaret.getSiblingCaret();
   let shadowRoot: ElementNode | null = null;
-  let current: LexicalNode | null = $isElementNode(focusNode)
-    ? focusNode
-    : focusNode.getParent();
-  while (current !== null) {
-    if ($isElementNode(current) && current.isShadowRoot()) {
-      shadowRoot = current;
+  for (
+    let parent = caret.getParentCaret();
+    parent !== null;
+    parent = parent.getParentCaret()
+  ) {
+    const parentNode = parent.origin;
+    if ($isElementNode(parentNode) && parentNode.isShadowRoot()) {
+      shadowRoot = parentNode;
       break;
     }
-    current = current.getParent();
   }
   if (shadowRoot === null) {
     return false;
   }
-  if (isBackward) {
-    if (focus.offset !== 0) {
-      return false;
+  // Check that the focus is at the edge of the shadow root in the given
+  // direction. Walk from the shadow root's child-caret toward the deepest
+  // first/last descendant and verify the focus sits there.
+  let edgeCaret = $getChildCaret(shadowRoot, direction);
+  let atEdge = false;
+  while (true) {
+    const adj = edgeCaret.getAdjacentCaret();
+    if (adj === null) {
+      // Empty element — focus must be this element at offset 0 / childrenSize
+      atEdge = selection.focus.key === edgeCaret.origin.__key;
+      break;
     }
-    let walk: LexicalNode | null = shadowRoot;
-    let atEdge = false;
-    while (walk !== null) {
-      if (focus.key === walk.__key) {
-        atEdge = true;
-        break;
+    if (adj.origin.__key === selection.focus.key) {
+      if ($isTextNode(adj.origin)) {
+        const edgeOffset =
+          direction === 'next' ? adj.origin.getTextContentSize() : 0;
+        atEdge = selection.focus.offset === edgeOffset;
+      } else {
+        atEdge =
+          selection.focus.offset ===
+          (direction === 'next'
+            ? $isElementNode(adj.origin)
+              ? adj.origin.getChildrenSize()
+              : 0
+            : 0);
       }
-      walk = $isElementNode(walk) ? walk.getFirstChild() : null;
+      break;
     }
-    if (!atEdge) {
-      return false;
+    const childCaret = adj.getChildCaret();
+    if (childCaret === null) {
+      break;
     }
-  } else {
-    let walk: LexicalNode | null = shadowRoot;
-    let atEdge = false;
-    while (walk !== null) {
-      if (focus.key === walk.__key) {
-        if ($isTextNode(walk)) {
-          atEdge = focus.offset === walk.getTextContentSize();
-        } else if ($isElementNode(walk)) {
-          atEdge = focus.offset === walk.getChildrenSize();
-        }
-        break;
-      }
-      walk = $isElementNode(walk) ? walk.getLastChild() : null;
-    }
-    if (!atEdge) {
-      return false;
-    }
+    edgeCaret = childCaret;
   }
-  let sr: ElementNode | null = shadowRoot;
+  if (!atEdge) {
+    return false;
+  }
+  // Walk outward from the shadow root through nested shadow roots until
+  // we find a sibling that needs a block cursor beside it.
+  let sr = $getSiblingCaret(shadowRoot, direction);
   while (sr !== null) {
-    const sibling = isBackward ? sr.getPreviousSibling() : sr.getNextSibling();
+    const sibling = sr.getAdjacentCaret();
     if (sibling !== null) {
-      if (!$needsBlockCursorBeside(sibling)) {
+      if (!$needsBlockCursorBeside(sibling.origin)) {
         return false;
       }
-      const parent = sr.getParentOrThrow();
-      const offset = isBackward
-        ? sr.getIndexWithinParent()
-        : sr.getIndexWithinParent() + 1;
-      parent.select(offset, offset);
+      $setPointFromCaret(selection.anchor, sr);
+      $setPointFromCaret(selection.focus, sr);
       return true;
     }
-    const parentNode: ElementNode | null = sr.getParent();
+    const parentCaret = sr.getParentCaret();
     if (
-      parentNode !== null &&
-      $isElementNode(parentNode) &&
-      parentNode.isShadowRoot()
+      parentCaret !== null &&
+      $isElementNode(parentCaret.origin) &&
+      parentCaret.origin.isShadowRoot()
     ) {
-      const atEdge = isBackward
-        ? parentNode.getFirstChild() === sr
-        : parentNode.getLastChild() === sr;
-      if (atEdge) {
-        sr = parentNode;
-        continue;
-      }
+      sr = parentCaret;
+      continue;
     }
     return false;
   }
   return false;
 }
 
-function $exitNodeSelectionToward(node: LexicalNode, isForward: boolean): void {
-  const sibling = isForward ? node.getNextSibling() : node.getPreviousSibling();
+function $exitNodeSelectionToward(
+  node: LexicalNode,
+  direction: CaretDirection,
+): void {
+  const caret = $getSiblingCaret(node, direction);
+  const sibling = caret.getAdjacentCaret();
   if (
-    $isElementNode(sibling) &&
-    !sibling.isInline() &&
-    sibling.isShadowRoot()
+    sibling !== null &&
+    $isElementNode(sibling.origin) &&
+    !sibling.origin.isInline() &&
+    sibling.origin.isShadowRoot()
   ) {
     const parent = node.getParentOrThrow();
-    const offset = isForward
-      ? sibling.getIndexWithinParent()
-      : node.getIndexWithinParent();
+    const offset =
+      direction === 'next'
+        ? sibling.origin.getIndexWithinParent()
+        : node.getIndexWithinParent();
     parent.select(offset, offset);
-  } else if (isForward) {
+  } else if (direction === 'next') {
     node.selectNext(0, 0);
   } else {
     node.selectPrevious();
@@ -1074,13 +1084,13 @@ export function registerRichText(
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            $exitNodeSelectionToward(nodes[0], false);
+            $exitNodeSelectionToward(nodes[0], 'previous');
             return true;
           }
         } else if ($isRangeSelection(selection)) {
           if (
             !event.shiftKey &&
-            $tryBlockCursorShadowRootNavigation(selection, true)
+            $tryBlockCursorShadowRootNavigation(selection, 'previous')
           ) {
             event.preventDefault();
             return true;
@@ -1111,7 +1121,7 @@ export function registerRichText(
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            $exitNodeSelectionToward(nodes[0], true);
+            $exitNodeSelectionToward(nodes[0], 'next');
             return true;
           }
         } else if ($isRangeSelection(selection)) {
@@ -1121,7 +1131,7 @@ export function registerRichText(
           }
           if (
             !event.shiftKey &&
-            $tryBlockCursorShadowRootNavigation(selection, false)
+            $tryBlockCursorShadowRootNavigation(selection, 'next')
           ) {
             event.preventDefault();
             return true;
@@ -1152,7 +1162,10 @@ export function registerRichText(
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            $exitNodeSelectionToward(nodes[0], $isParentRTL(nodes[0]));
+            $exitNodeSelectionToward(
+              nodes[0],
+              $isParentRTL(nodes[0]) ? 'next' : 'previous',
+            );
             return true;
           }
         }
@@ -1163,7 +1176,7 @@ export function registerRichText(
           !event.shiftKey &&
           $tryBlockCursorShadowRootNavigation(
             selection,
-            !$isParentRTL(selection.anchor.getNode()),
+            $isParentRTL(selection.anchor.getNode()) ? 'next' : 'previous',
           )
         ) {
           event.preventDefault();
@@ -1197,7 +1210,10 @@ export function registerRichText(
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            $exitNodeSelectionToward(nodes[0], !$isParentRTL(nodes[0]));
+            $exitNodeSelectionToward(
+              nodes[0],
+              $isParentRTL(nodes[0]) ? 'previous' : 'next',
+            );
             return true;
           }
         }
@@ -1208,7 +1224,7 @@ export function registerRichText(
           !event.shiftKey &&
           $tryBlockCursorShadowRootNavigation(
             selection,
-            $isParentRTL(selection.anchor.getNode()),
+            $isParentRTL(selection.anchor.getNode()) ? 'previous' : 'next',
           )
         ) {
           event.preventDefault();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -708,16 +708,17 @@ function $tryExitShadowRootToBlockCursor(
   }
   const focusCaret = $caretFromPoint(selection.focus, direction);
   // Walk up from focus to find the nearest shadow root ancestor.
+  // Start from the focus node itself (caret.origin) since it may be a
+  // shadow root (e.g. LayoutItem with element-type selection).
   const caret = focusCaret.getSiblingCaret();
   let shadowRoot: ElementNode | null = null;
   for (
-    let parent = caret.getParentCaret();
-    parent !== null;
-    parent = parent.getParentCaret()
+    let walk = caret as typeof caret | null;
+    walk !== null;
+    walk = walk.getParentCaret()
   ) {
-    const parentNode = parent.origin;
-    if ($isElementNode(parentNode) && parentNode.isShadowRoot()) {
-      shadowRoot = parentNode;
+    if ($isElementNode(walk.origin) && walk.origin.isShadowRoot()) {
+      shadowRoot = walk.origin;
       break;
     }
   }
@@ -725,38 +726,43 @@ function $tryExitShadowRootToBlockCursor(
     return false;
   }
   // Check that the focus is at the edge of the shadow root in the given
-  // direction. Walk from the shadow root's child-caret toward the deepest
-  // first/last descendant and verify the focus sits there.
-  let edgeCaret = $getChildCaret(shadowRoot, direction);
+  // direction. If focus is the shadow root itself, check the offset directly.
+  // Otherwise walk toward the deepest first/last descendant.
   let atEdge = false;
-  while (true) {
-    const adj = edgeCaret.getAdjacentCaret();
-    if (adj === null) {
-      // Empty element — focus must be this element at offset 0 / childrenSize
-      atEdge = selection.focus.key === edgeCaret.origin.__key;
-      break;
-    }
-    if (adj.origin.__key === selection.focus.key) {
-      if ($isTextNode(adj.origin)) {
-        const edgeOffset =
-          direction === 'next' ? adj.origin.getTextContentSize() : 0;
-        atEdge = selection.focus.offset === edgeOffset;
-      } else {
-        atEdge =
-          selection.focus.offset ===
-          (direction === 'next'
-            ? $isElementNode(adj.origin)
-              ? adj.origin.getChildrenSize()
-              : 0
-            : 0);
+  if (selection.focus.key === shadowRoot.__key) {
+    atEdge =
+      selection.focus.offset ===
+      (direction === 'next' ? shadowRoot.getChildrenSize() : 0);
+  } else {
+    let edgeCaret = $getChildCaret(shadowRoot, direction);
+    while (true) {
+      const adj = edgeCaret.getAdjacentCaret();
+      if (adj === null) {
+        atEdge = selection.focus.key === edgeCaret.origin.__key;
+        break;
       }
-      break;
+      if (adj.origin.__key === selection.focus.key) {
+        if ($isTextNode(adj.origin)) {
+          const edgeOffset =
+            direction === 'next' ? adj.origin.getTextContentSize() : 0;
+          atEdge = selection.focus.offset === edgeOffset;
+        } else {
+          atEdge =
+            selection.focus.offset ===
+            (direction === 'next'
+              ? $isElementNode(adj.origin)
+                ? adj.origin.getChildrenSize()
+                : 0
+              : 0);
+        }
+        break;
+      }
+      const childCaret = adj.getChildCaret();
+      if (childCaret === null) {
+        break;
+      }
+      edgeCaret = childCaret;
     }
-    const childCaret = adj.getChildCaret();
-    if (childCaret === null) {
-      break;
-    }
-    edgeCaret = childCaret;
   }
   if (!atEdge) {
     return false;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1170,6 +1170,9 @@ declare export function $isShadowRootNode(
 declare export function $isRootOrShadowRoot(
   node: ?LexicalNode,
 ): node is RootNode | ShadowRootNode;
+declare export function $needsBlockCursorBeside(
+  node: null | LexicalNode,
+): boolean;
 declare export function $hasAncestor(
   child: LexicalNode,
   targetNode: LexicalNode,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1158,12 +1158,18 @@ declare export function generateRandomKey(): string;
 declare export function $isInlineElementOrDecoratorNode<T = unknown>(
   node: LexicalNode,
 ): node is ElementNode|  DecoratorNode<T>;
+export interface ShadowRootNode extends ElementNode {
+  isShadowRoot(): true;
+}
 declare export function $getNearestRootOrShadowRoot(
   node: LexicalNode,
 ): RootNode | ElementNode;
+declare export function $isShadowRootNode(
+  node: ?LexicalNode,
+): node is ShadowRootNode;
 declare export function $isRootOrShadowRoot(
   node: ?LexicalNode,
-): node is RootNode | ElementNode;
+): node is RootNode | ShadowRootNode;
 declare export function $hasAncestor(
   child: LexicalNode,
   targetNode: LexicalNode,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1897,9 +1897,15 @@ function createBlockCursorElement(editorConfig: EditorConfig): HTMLDivElement {
   return element;
 }
 
-// Keep in sync with $needsBlockCursorBeside in @lexical/rich-text
-function needsBlockCursor(node: null | LexicalNode): boolean {
-  if (node === null || node.isInline()) {
+/**
+ * Returns true if the given node needs a block cursor given an adjacent selection,
+ * the node must be non-inline and one of:
+ * - DecoratorNode
+ * - ShadowRootNode with a parent that is not also a ShadowRootNode
+ * - An ElementNode that can't be empty
+ */
+export function $needsBlockCursorBeside(node: null | LexicalNode): boolean {
+  if (!node || node.isInline()) {
     return false;
   }
   if ($isDecoratorNode(node)) {
@@ -1952,14 +1958,14 @@ export function $updateDOMBlockCursorElement(
 
     if (offset === elementNodeSize) {
       const child = elementNode.getChildAtIndex(offset - 1);
-      if (needsBlockCursor(child)) {
+      if ($needsBlockCursorBeside(child)) {
         isBlockCursor = true;
       }
     } else {
       const child = elementNode.getChildAtIndex(offset);
-      if (child !== null && needsBlockCursor(child)) {
+      if (child !== null && $needsBlockCursorBeside(child)) {
         const sibling = child.getPreviousSibling();
-        if (sibling === null || needsBlockCursor(sibling)) {
+        if (sibling === null || $needsBlockCursorBeside(sibling)) {
           isBlockCursor = true;
           insertBeforeElement = editor.getElementByKey(child.__key);
         }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -19,7 +19,6 @@ import type {
   NodeMutation,
   RegisteredNode,
   RegisteredNodes,
-  Spread,
 } from './LexicalEditor';
 import type {EditorState} from './LexicalEditorState';
 import type {
@@ -1748,14 +1747,21 @@ export function $getNearestRootOrShadowRoot(
 const ShadowRootNodeBrand: unique symbol = Symbol.for(
   '@lexical/ShadowRootNodeBrand',
 );
-type ShadowRootNode = Spread<
-  {isShadowRoot(): true; [ShadowRootNodeBrand]: never},
-  ElementNode
->;
+export interface ShadowRootNode extends ElementNode {
+  [ShadowRootNodeBrand]: never;
+  isShadowRoot(): true;
+}
+
+export function $isShadowRootNode(
+  node: null | LexicalNode,
+): node is ShadowRootNode {
+  return $isElementNode(node) && node.isShadowRoot();
+}
+
 export function $isRootOrShadowRoot(
   node: null | LexicalNode,
 ): node is RootNode | ShadowRootNode {
-  return $isRootNode(node) || ($isElementNode(node) && node.isShadowRoot());
+  return $isRootNode(node) || $isShadowRootNode(node);
 }
 
 /**

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1892,10 +1892,20 @@ function createBlockCursorElement(editorConfig: EditorConfig): HTMLDivElement {
 }
 
 function needsBlockCursor(node: null | LexicalNode): boolean {
-  return (
-    ($isDecoratorNode(node) || ($isElementNode(node) && !node.canBeEmpty())) &&
-    !node.isInline()
-  );
+  if (node === null || node.isInline()) {
+    return false;
+  }
+  if ($isDecoratorNode(node)) {
+    return true;
+  }
+  if ($isElementNode(node)) {
+    if (node.isShadowRoot()) {
+      const parent = node.getParent();
+      return !($isElementNode(parent) && parent.isShadowRoot());
+    }
+    return !node.canBeEmpty();
+  }
+  return false;
 }
 
 export function removeDOMBlockCursorElement(

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1891,6 +1891,7 @@ function createBlockCursorElement(editorConfig: EditorConfig): HTMLDivElement {
   return element;
 }
 
+// Keep in sync with $needsBlockCursorBeside in @lexical/rich-text
 function needsBlockCursor(node: null | LexicalNode): boolean {
   if (node === null || node.isInline()) {
     return false;

--- a/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
@@ -719,7 +719,7 @@ describe('ElementDOMSlot block cursor handling', () => {
     editor.update(
       () => {
         const wrap = $createInnerWrapNode();
-        // setIsInline(false) makes this a block decorator (needsBlockCursor).
+        // setIsInline(false) makes this a block decorator ($needsBlockCursorBeside).
         wrap.append($createTestDecoratorNode().setIsInline(false));
         $getRoot().clear().append(wrap);
         wrap.select(0, 0);

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -310,6 +310,7 @@ export {
   $isLeafNode,
   $isRootOrShadowRoot,
   $isSelectionCapturedInDecoratorInput,
+  $isShadowRootNode,
   $isTokenOrSegmented,
   $isTokenOrTab,
   $markSlotEditable,
@@ -372,6 +373,7 @@ export {
   setDOMUnmanaged,
   type SetDOMUnmanagedOptions,
   setNodeIndentFromDOM,
+  type ShadowRootNode,
   toggleTextFormatType,
   unmountSlotContainer,
 } from './LexicalUtils';

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -314,6 +314,7 @@ export {
   $isTokenOrSegmented,
   $isTokenOrTab,
   $markSlotEditable,
+  $needsBlockCursorBeside,
   $nodesOfType,
   $onUpdate,
   $removeFromParent,


### PR DESCRIPTION
## Description

`needsBlockCursor` only considered `DecoratorNode` and non-empty `ElementNode`, so the block cursor never rendered beside a shadow root. Arrow-key navigation jumped straight into or over shadow roots with no way to place the caret in between.

### Fix

`needsBlockCursor` (rendering, in LexicalUtils.ts) and its navigation mirror `$needsBlockCursorBeside` (in lexical-rich-text) now return `true` for shadow roots whose parent is not itself a shadow root. The parent check avoids rendering block cursors between sibling shadow roots inside a shadow root parent (e.g. layout-items inside a layout-container, where CSS grid/flex would break).

Four navigation helpers handle the arrow-key transitions:

- `$tryBlockCursorShadowRootNavigation` — combines exit and enter into one call, used by all four arrow handlers.
- `$tryExitShadowRootToBlockCursor` — when the caret is at the edge of a shadow root and the adjacent sibling needs a block cursor, moves to the block cursor position. Walks up through nested shadow roots.
- `$tryEnterFromBlockCursor` — from a block cursor position, enters the adjacent shadow root via `selectStart()`/`selectEnd()`.
- `$exitNodeSelectionToward` — from a `NodeSelection` on a decorator, stops at the block cursor beside an adjacent shadow root instead of jumping in.

Closes #8736

## Test plan

- [x] `pnpm vitest run --project unit` — 3354 pass, no regression.
- [x] `pnpm tsc --noEmit` clean.
- [x] Manual playground (Chrome, Firefox, Safari) with layout-container (shadow root) between two horizontal rules (decorators):
  - ArrowDown from decorator → block cursor renders between decorator and layout → ArrowDown enters layout.
  - ArrowRight through layout text → exits to block cursor after layout → ArrowRight reaches next decorator.
  - ArrowLeft/ArrowUp reverse path works symmetrically.
  - Sibling layout-items inside layout-container: no spurious block cursor between columns.