### PR TITLE
[lexical-playground] Bug Fix: Deduplicate speech-to-text insertion on Android Chrome

### DIFF
--- a/packages/lexical-playground/src/plugins/SpeechToTextPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/SpeechToTextPlugin/index.ts
@@ -51,10 +51,12 @@ function SpeechToTextPlugin(): null {
     // @ts-expect-error missing type
     window.SpeechRecognition || window.webkitSpeechRecognition;
   const recognition = useRef<typeof SpeechRecognition | null>(null);
+  const lastInsertedText = useRef('');
   const report = useReport();
 
   useEffect(() => {
     if (isEnabled && recognition.current === null) {
+      lastInsertedText.current = '';
       recognition.current = new SpeechRecognition();
       recognition.current.continuous = true;
       recognition.current.interimResults = true;
@@ -65,25 +67,39 @@ function SpeechToTextPlugin(): null {
           const {transcript} = resultItem.item(0);
           report(transcript);
 
-          if (!resultItem.isFinal) {
+          if (!resultItem.isFinal || transcript.length === 0) {
             return;
           }
+
+          const prev = lastInsertedText.current;
+          // Skip shrunk reinterpretations from the speech engine
+          if (transcript === prev || prev.startsWith(transcript)) {
+            return;
+          }
+
+          let textToInsert: string;
+          if (transcript.startsWith(prev)) {
+            textToInsert = transcript.slice(prev.length);
+          } else {
+            textToInsert = transcript;
+          }
+          lastInsertedText.current = transcript;
 
           editor.update(() => {
             const selection = $getSelection();
 
             if ($isRangeSelection(selection)) {
-              const command = VOICE_COMMANDS[transcript.toLowerCase().trim()];
+              const command = VOICE_COMMANDS[textToInsert.toLowerCase().trim()];
 
               if (command) {
                 command({
                   editor,
                   selection,
                 });
-              } else if (transcript.match(/\s*\n\s*/)) {
+              } else if (textToInsert.match(/\s*\n\s*/)) {
                 selection.insertParagraph();
               } else {
-                selection.insertText(transcript);
+                selection.insertText(textToInsert);
               }
             }
           });
@@ -102,6 +118,7 @@ function SpeechToTextPlugin(): null {
     return () => {
       if (recognition.current !== null) {
         recognition.current.stop();
+        recognition.current = null;
       }
     };
   }, [SpeechRecognition, editor, isEnabled, report]);


### PR DESCRIPTION
## Description

Android Chrome's Web Speech API fires every recognition result with `isFinal: true` and a unique sequential index. Desktop browsers fire interim results that share the same index, with only the final one marked `isFinal: true`. The SpeechToTextPlugin inserted the full transcript for every final result, so on Android the same words got inserted repeatedly.

### Why transcript-based deduplication

Tracking processed result indices doesn't work — Android gives every result a unique index, so they all look "new." The only reliable signal for deduplication is the transcript text itself: same words at different indices get caught by an equality check, and cumulative growth (`"testing"` → `"testing 1 2"`) gets caught by a prefix check that extracts just the suffix.

### Fix

Track the last inserted transcript in a ref. When a new result extends the previous text, only the suffix is inserted. Duplicate and shrunk reinterpretations are skipped. Voice commands (`"undo"`, `"redo"`) still work because `.trim()` strips the leading space from the sliced delta.

Also nulls out `recognition.current` in the effect cleanup so React StrictMode's unmount/remount creates a fresh instance instead of calling `start()` on a stopped one.

Closes #7247

## Test plan

- [x] Manual Android Chrome (HTTPS, Korean speech): say "테스팅 테스팅 원 투" — editor shows it once, no duplication.
- [x] Toggle microphone off/on, speak again — fresh insertion, no carryover from previous session.
- [x] Desktop Chrome speech-to-text unchanged (single final result per utterance, delta logic is a no-op).
- [x] tsc / prettier / eslint clean.