### PR TITLE
[lexical-website] Bug Fix: Remove horizontal scroll on homepage hero

### DIFF
--- a/packages/lexical-website/src/pages/index.tsx
+++ b/packages/lexical-website/src/pages/index.tsx
@@ -19,7 +19,7 @@ import Layout from '@theme/Layout';
 
 function LandingHero() {
   return (
-    <div className="flex w-screen flex-col items-center justify-start gap-10 p-10 lg:h-[75vh] lg:flex-row lg:justify-around">
+    <div className="flex w-full flex-col items-center justify-start gap-10 p-10 lg:h-[75vh] lg:flex-row lg:justify-around">
       <div className="w-full space-y-6 lg:max-w-[40rem] lg:min-w-[20rem]">
         <p className="text-4xl font-extrabold lg:text-6xl">
           A text editor framework that does things{' '}


### PR DESCRIPTION
## Description

The homepage has a persistent horizontal scrollbar (~15px) on the landing page.

The landing hero container in `packages/lexical-website/src/pages/index.tsx` uses Tailwind's `w-screen` (`width: 100vw`). `100vw` includes the width of the vertical scrollbar, so whenever the page has vertical scroll the hero is wider than the available content area, overflowing horizontally and forcing a horizontal scrollbar across the whole homepage.

This changes `w-screen` to `w-full` (`width: 100%`), which respects the scrollbar gutter and eliminates the overflow. The inner column already uses `w-full`, so the visual layout is unchanged.

The `w-screen` class was introduced in #8216.

## Test plan

Ran the website locally (`pnpm run start:website`) and measured `document.documentElement.scrollWidth - clientWidth` at multiple viewport widths.

### Before

At a 1280px viewport: `scrollWidth` 1280 vs `clientWidth` 1265 → **15px horizontal overflow** (horizontal scrollbar present). The single offending element was the hero `<div className="flex w-screen ...">`.

### After

| Viewport | Horizontal overflow |
|---|---|
| 1280px | 0 |
| 768 / 1024 / 1440 / 1920px | 0 |
| mobile | 0 |

No horizontal scroll at any width; homepage layout is visually unchanged.