### PR TITLE
docs: fix duplicated words in comments and docs

### DIFF
--- a/packages/lexical-html/src/types.ts
+++ b/packages/lexical-html/src/types.ts
@@ -67,7 +67,7 @@ export type ContextConfigUpdater<Ctx extends AnyContextSymbol, V> = {
 /**
  * @experimental
  *
- * Set the the context at `cfg` to a specific value, constructed with {@link contextValue}
+ * Set the context at `cfg` to a specific value, constructed with {@link contextValue}
  */
 export type ContextConfigPair<Ctx extends AnyContextSymbol, V> = readonly [
   ContextConfig<Ctx, V>,

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -61,7 +61,7 @@ function $isSelectingEmptyListItem(
  * the root/shadow root, it will replace the ListItemNode with a ListNode and the old ListItemNode.
  * Otherwise it will replace its parent with a new ListNode and re-insert the ListItemNode and any previous children.
  * If the selection's anchor node is not an empty ListItemNode, it will add a new ListNode or merge an existing ListNode,
- * unless the the node is a leaf node, in which case it will attempt to find a ListNode up the branch and replace it with
+ * unless the node is a leaf node, in which case it will attempt to find a ListNode up the branch and replace it with
  * a new ListNode, or create a new ListNode at the nearest root/shadow root.
  * @param listType - The type of list, "number" | "bullet" | "check".
  */

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -2430,7 +2430,7 @@ describe('LexicalSelection tests', () => {
             offset: 0,
           };
         },
-        name: 'moves selection to to next text node if replacing with decorator',
+        name: 'moves selection to next text node if replacing with decorator',
       },
       {
         fn: () => {

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -223,7 +223,7 @@ export class TableSelection implements BaseSelection {
    * This will be true if any paragraph in table cells has the specified format.
    *
    * @param type the TextFormatType to check for.
-   * @returns true if the provided format is currently toggled on on the Selection, false otherwise.
+   * @returns true if the provided format is currently toggled on the Selection, false otherwise.
    */
   hasFormat(type: TextFormatType): boolean {
     let format = 0;

--- a/packages/lexical-website/docs/extensions/faq.mdx
+++ b/packages/lexical-website/docs/extensions/faq.mdx
@@ -68,7 +68,7 @@ decorate method could even be deprecated at some point!
 
 ## How will this interact with Lexical Dev Tools?
 
-All of the Builder metadata is present at runtime, and is is present
+All of the Builder metadata is present at runtime, and is present
 on the LexicalEditor instance with a well-known symbol so that the dev tools
 can access it. There are many things that could be done, here are
 a few examples:

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1189,7 +1189,7 @@ export class LexicalEditor {
     return registerListener(this._listeners.update, listener);
   }
   /**
-   * Registers a listener for for when the editor changes between editable and non-editable states.
+   * Registers a listener for when the editor changes between editable and non-editable states.
    * Will trigger the provided callback each time the editor transitions between these states until the
    * teardown function is called.
    *

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1159,7 +1159,7 @@ function $handleBeforeInput(event: InputEvent): boolean {
 
 function onInput(event: InputEvent, editor: LexicalEditor): void {
   // Note that the MutationObserver may or may not have already fired,
-  // but the the DOM and selection may have already changed.
+  // but the DOM and selection may have already changed.
   // See also:
   // - https://github.com/facebook/lexical/issues/7028
   // - https://github.com/facebook/lexical/pull/794

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -825,7 +825,7 @@ export class RangeSelection implements BaseSelection {
    * has the specified format.
    *
    * @param type the TextFormatType to check for.
-   * @returns true if the provided format is currently toggled on on the Selection, false otherwise.
+   * @returns true if the provided format is currently toggled on the Selection, false otherwise.
    */
   hasFormat(type: TextFormatType): boolean {
     const formatFlag = TEXT_TYPE_TO_FORMAT[type];

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -56,7 +56,7 @@ const config = defineConfig({
   use: {
     actionTimeout: 10000, // Max time to wait for actions
     navigationTimeout: 30000,
-    // this causes issues in the CI on on current version.
+    // this causes issues in the CI on current version.
     //trace: 'retain-on-failure',
     video: 'on-first-retry',
   },


### PR DESCRIPTION
## Description

Fixes accidental duplicated words ("the the", "for for", "on on", "to to", "is is") found across source comments, JSDoc, a test case name, the extensions FAQ doc, and the Playwright config. These are comment/documentation-only changes with no behavioral impact.

### Before → After

| File | Before | After |
| --- | --- | --- |
| `packages/lexical/src/LexicalEditor.ts` | Registers a listener **for for** when… | Registers a listener **for** when… |
| `packages/lexical/src/LexicalEvents.ts` | but **the the** DOM and selection… | but **the** DOM and selection… |
| `packages/lexical/src/LexicalSelection.ts` | currently toggled **on on** the Selection | currently toggled **on** the Selection |
| `packages/lexical-table/src/LexicalTableSelection.ts` | currently toggled **on on** the Selection | currently toggled **on** the Selection |
| `packages/lexical-list/src/formatList.ts` | unless **the the** node is a leaf node | unless **the** node is a leaf node |
| `packages/lexical-html/src/types.ts` | Set **the the** context at `cfg`… | Set **the** context at `cfg`… |
| `packages/lexical-website/docs/extensions/faq.mdx` | at runtime, and **is is** present | at runtime, and **is** present |
| `packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx` | moves selection **to to** next text node… | moves selection **to** next text node… |
| `playwright.config.mjs` | issues in the CI **on on** current version | issues in the CI **on** current version |

## Test plan

Documentation/comment-only edits; no runtime logic changed. The single test-file edit only touches a descriptive test case `name` string, not any assertion. Pre-commit prettier/eslint hooks passed.
