### PR TITLE
[lexical] Modernize InlineFormattableNode Flow stub syntax rejected by fb-www flow strict

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -811,11 +811,11 @@ declare export class TextNode extends LexicalNode {
   exportJSON(): SerializedTextNode;
 }
 export interface InlineFormattableNode {
-  +__isInlineFormattable: true;
+  readonly __isInlineFormattable: true;
   getFormatFlags(type: TextFormatType, alignWithFormat: null | number): number;
   hasFormat(type: TextFormatType): boolean;
-  setFormat(format: number): mixed;
-  toggleFormat(type: TextFormatType): mixed;
+  setFormat(format: number): unknown;
+  toggleFormat(type: TextFormatType): unknown;
 }
 declare export function $isInlineFormattable(
   node: ?LexicalNode,


### PR DESCRIPTION
## Description

The hand-maintained `InlineFormattableNode` Flow stub in `packages/lexical/flow/Lexical.js.flow` uses legacy Flow syntax that Meta's internal **fb-www flow strict** mode rejects, breaking the www Lexical sync:

- `+__isInlineFormattable: true;` — covariant-property shorthand → `readonly __isInlineFormattable: true;`
- `setFormat(format: number): mixed;` → `setFormat(format: number): unknown;`
- `toggleFormat(type: TextFormatType): mixed;` → `toggleFormat(type: TextFormatType): unknown;`

This is the same class of fix as #8742 ("Modernize Flow type-stub syntax rejected by fb-www flow strict"). The `InlineFormattableNode` interface was added in #8737 after #8742 landed, so it reintroduced the old syntax.

The TypeScript source already uses the modern forms — `packages/lexical/src/nodes/LexicalTextNode.ts`:

```ts
export interface InlineFormattableNode {
  /** @internal */
  readonly __isInlineFormattable: true;
  getFormatFlags(type: TextFormatType, alignWithFormat: null | number): number;
  hasFormat(type: TextFormatType): boolean;
  setFormat(format: number): unknown;
  toggleFormat(type: TextFormatType): unknown;
}
```

So this change only aligns the Flow stub with the existing `.d.ts`/TS definition — no semantic change to exports or signatures.

## Test plan

- `readonly` and `unknown` are the same types the TS source declares, so flow/d.ts export consistency is preserved.
- Verified there are no other `+`-covariant or `mixed` usages remaining in any `packages/**/*.js.flow` stub.
- Validated against fb-www flow strict via the internal Lexical sync.
