### PR TITLE
[lexical-selection] Bug Fix: re-resolve detached firstBlock in insert…

### DIFF
--- a/packages/lexical-playground/__tests__/unit/ToolbarPluginFormatCode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/ToolbarPluginFormatCode.test.ts
@@ -100,6 +100,14 @@ describe('formatCode (Toolbar) — selection-aware code block conversion', () =>
       text: 'Heading',
     },
     {
+      end: 'Head'.length,
+      expected: 'code:Head|paragraph:ing',
+      headingTag: 'h1' as const,
+      name: 'partial from offset 0 (regression for detached firstBlock)',
+      start: 0,
+      text: 'Heading',
+    },
+    {
       end: 'Section title'.length,
       expected: 'heading:Section |code:title',
       headingTag: 'h2' as const,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1502,8 +1502,8 @@ export class RangeSelection implements BaseSelection {
     }
 
     const firstPoint = this.isBackward() ? this.focus : this.anchor;
-    const firstNode = firstPoint.getNode();
-    const firstBlock = $findMatchingParent(firstNode, INTERNAL_$isBlock);
+    let firstNode = firstPoint.getNode();
+    let firstBlock = $findMatchingParent(firstNode, INTERNAL_$isBlock);
 
     const last = nodes[nodes.length - 1]!;
 
@@ -1621,6 +1621,10 @@ export class RangeSelection implements BaseSelection {
 
     const shouldInsert = !$isElementNode(firstBlock) || !firstBlock.isEmpty();
     const insertedParagraph = shouldInsert ? this.insertParagraph() : null;
+    if (insertedParagraph && !firstBlock.isAttached()) {
+      firstNode = this.anchor.getNode();
+      firstBlock = $findMatchingParent(firstNode, INTERNAL_$isBlock);
+    }
     const lastToInsert: LexicalNode | undefined = blocks[blocks.length - 1];
     let firstToInsert: LexicalNode | undefined = blocks[0];
     if (isMergeable(firstToInsert)) {


### PR DESCRIPTION
## Description
Fixes a crash in `RangeSelection.insertNodes` that occurs when the insertion target is a `HeadingNode` (or any block whose `insertNewAfter` replaces itself) and the selection starts at offset `0` with a non-empty block.

### Current behavior
When `insertNodes` is called with a selection at offset `0` inside a non-empty `HeadingNode`, `insertParagraph()` invokes `HeadingNode.insertNewAfter`, which replaces the heading with a paragraph. The `firstBlock` variable captured *before* `insertParagraph()` becomes a detached node. The subsequent call to `insertRangeAfter(firstBlock, ...)` then calls `getParentOrThrow()` on this detached node, throwing "Expected node x to have a parent.".

### Changes
After calling `insertParagraph()`, if the cached `firstBlock` is no longer attached to the document tree, `firstNode` and `firstBlock` are re-resolved from the current anchor selection so that `insertRangeAfter` operates on a valid, attached block.

## Test plan

A test case has been added (`heading partial from offset 0`) for `formatCode (Toolbar) — selection-aware code block conversion`

### Before

https://github.com/user-attachments/assets/f5a9244c-2684-4f19-9719-37183f37140d

### After

https://github.com/user-attachments/assets/40a9ef7d-aedb-4780-bfde-f7b81520b879