### PR TITLE
[lexical][*] Feature: registerEventListener / registerEventListeners DOM helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,30 @@ For E2E testing workflow:
 - `pnpm run tsc` - Run TypeScript compiler
 - `pnpm run ci-check` - Run all checks (TypeScript, Flow, Prettier, ESLint)
 
+### Searching and refactoring
+
+Prefer **ast-grep** over line-oriented regex (`grep`/`sed`) for anything
+structural — matching or rewriting imports, call sites, JSX, type
+annotations, etc. Regexes miss multi-line forms (a symbol on its own line
+inside a multi-line `import { ... }` block) and produce false positives
+(`IS_APPLE` matching inside `IS_APPLE_WEBKIT`); ast-grep matches the syntax
+tree, so it does neither.
+
+It isn't a dependency, so run it via npx (the CLI binary is `ast-grep`, not
+the shadow-utils `sg` that may be on `PATH`):
+
+```sh
+# Find every import of something from '@lexical/utils' (ts and tsx are
+# separate grammars, so pass -l for each; add --json=compact to post-process)
+npx --package @ast-grep/cli ast-grep run \
+  -p "import { \$\$\$NAMES } from '@lexical/utils'" -l ts packages
+```
+
+Metavariables (`$NAME`, `$$$LIST`) capture nodes for reporting or rewriting
+with `--rewrite`. Reach for it whenever a change spans many files and must be
+precise — e.g. moving symbols that `@lexical/utils` merely re-exports back to
+a direct `lexical` import.
+
 ### Tree-shaking annotations
 
 Module-scope calls to the side-effect-free factories (`defineExtension`,

--- a/packages/lexical-a11y/src/index.ts
+++ b/packages/lexical-a11y/src/index.ts
@@ -26,6 +26,7 @@ import {
   type LexicalEditor,
   REDO_COMMAND,
   type RefCountedRegistry,
+  registerEventListener,
   safeCast,
   UNDO_COMMAND,
 } from 'lexical';
@@ -205,20 +206,22 @@ function registerFocusTrap(
     }
   };
 
-  container.addEventListener('keydown', keydownHandler);
-  doc.addEventListener('focusin', focusinHandler);
-
-  return () => {
-    container.removeEventListener('keydown', keydownHandler);
-    doc.removeEventListener('focusin', focusinHandler);
-    if (
-      previouslyFocused !== null &&
-      typeof previouslyFocused.focus === 'function' &&
-      containsComposed(doc, previouslyFocused)
-    ) {
-      previouslyFocused.focus();
-    }
-  };
+  return mergeRegister(
+    // Placed first so mergeRegister's reverse (LIFO) teardown runs it last,
+    // after the focusin listener is removed — otherwise restoring focus to an
+    // element outside the container would re-trigger the trap.
+    () => {
+      if (
+        previouslyFocused !== null &&
+        typeof previouslyFocused.focus === 'function' &&
+        containsComposed(doc, previouslyFocused)
+      ) {
+        previouslyFocused.focus();
+      }
+    },
+    registerEventListener(container, 'keydown', keydownHandler),
+    registerEventListener(doc, 'focusin', focusinHandler),
+  );
 }
 
 export type RovingOrientation = 'horizontal' | 'vertical' | 'both';
@@ -352,14 +355,15 @@ function registerRovingTabIndex(
     items[nextIdx].focus();
   };
 
-  container.addEventListener('keydown', handler);
-  return () => {
-    container.removeEventListener('keydown', handler);
-    const items = getItems();
-    items.forEach(item => {
-      item.tabIndex = 0;
-    });
-  };
+  return mergeRegister(
+    registerEventListener(container, 'keydown', handler),
+    () => {
+      const items = getItems();
+      items.forEach(item => {
+        item.tabIndex = 0;
+      });
+    },
+  );
 }
 
 const DEFAULT_TOOLBAR_FOCUSABLE_SELECTOR =
@@ -426,8 +430,6 @@ function registerFocusManager(
     editor.focus();
     rootElement.focus();
   };
-  toolbar.addEventListener('keydown', handler);
-
   return mergeRegister(
     editor.registerCommand(
       KEY_DOWN_COMMAND,
@@ -447,9 +449,7 @@ function registerFocusManager(
       },
       COMMAND_PRIORITY_LOW,
     ),
-    () => {
-      toolbar.removeEventListener('keydown', handler);
-    },
+    registerEventListener(toolbar, 'keydown', handler),
   );
 }
 

--- a/packages/lexical-a11y/src/index.ts
+++ b/packages/lexical-a11y/src/index.ts
@@ -13,7 +13,6 @@ import {
   RootElementExtension,
   signal,
 } from '@lexical/extension';
-import {mergeRegister} from '@lexical/utils';
 import {
   COMMAND_PRIORITY_LOW,
   createRefCountedRegistry,
@@ -24,6 +23,7 @@ import {
   isHTMLElement,
   KEY_DOWN_COMMAND,
   type LexicalEditor,
+  mergeRegister,
   REDO_COMMAND,
   type RefCountedRegistry,
   registerEventListener,

--- a/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
+++ b/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
@@ -14,6 +14,8 @@ import {
   defineExtension,
   LexicalEditor,
   LexicalNode,
+  mergeRegister,
+  registerEventListener,
   safeCast,
   stopLexicalPropagation,
 } from 'lexical';
@@ -213,12 +215,10 @@ export const ClickAfterLastBlockExtension = /* @__PURE__ */ defineExtension({
         // Capture phase so the mousedown preventDefault runs before any
         // bubble-phase handler can react, and so the click flag is set
         // before lexical core's bubble-phase onClick reads it.
-        rootElement.addEventListener('mousedown', onMouseDown, true);
-        rootElement.addEventListener('click', onClick, true);
-        return () => {
-          rootElement.removeEventListener('mousedown', onMouseDown, true);
-          rootElement.removeEventListener('click', onClick, true);
-        };
+        return mergeRegister(
+          registerEventListener(rootElement, 'mousedown', onMouseDown, true),
+          registerEventListener(rootElement, 'click', onClick, true),
+        );
       });
     }),
 });

--- a/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
+++ b/packages/lexical-extension/src/ClickAfterLastBlockExtension.ts
@@ -14,8 +14,7 @@ import {
   defineExtension,
   LexicalEditor,
   LexicalNode,
-  mergeRegister,
-  registerEventListener,
+  registerEventListeners,
   safeCast,
   stopLexicalPropagation,
 } from 'lexical';
@@ -215,9 +214,10 @@ export const ClickAfterLastBlockExtension = /* @__PURE__ */ defineExtension({
         // Capture phase so the mousedown preventDefault runs before any
         // bubble-phase handler can react, and so the click flag is set
         // before lexical core's bubble-phase onClick reads it.
-        return mergeRegister(
-          registerEventListener(rootElement, 'mousedown', onMouseDown, true),
-          registerEventListener(rootElement, 'click', onClick, true),
+        return registerEventListeners(
+          rootElement,
+          {click: onClick, mousedown: onMouseDown},
+          true,
         );
       });
     }),

--- a/packages/lexical-extension/src/IMEExtension.ts
+++ b/packages/lexical-extension/src/IMEExtension.ts
@@ -18,6 +18,7 @@ import {
   type LexicalEditor,
   mergeRegister,
   type NodeKey,
+  registerEventListener,
   type TextNode,
 } from 'lexical';
 
@@ -126,10 +127,11 @@ export const IMEExtension = /* @__PURE__ */ defineExtension({
       const onCompositionEnd = () => {
         compositionKey.value = null;
       };
-      rootElem.addEventListener('compositionend', onCompositionEnd);
-      return () => {
-        rootElem.removeEventListener('compositionend', onCompositionEnd);
-      };
+      return registerEventListener(
+        rootElem,
+        'compositionend',
+        onCompositionEnd,
+      );
     });
 
     return mergeRegister(

--- a/packages/lexical-extension/src/NormalizeTripleClickSelectionExtension.ts
+++ b/packages/lexical-extension/src/NormalizeTripleClickSelectionExtension.ts
@@ -29,6 +29,7 @@ import {
   defineExtension,
   getDOMSelection,
   mergeRegister,
+  registerEventListener,
   safeCast,
   SELECTION_CHANGE_COMMAND,
   SKIP_SCROLL_INTO_VIEW_TAG,
@@ -195,16 +196,9 @@ export const NormalizeTripleClickSelectionExtension =
               },
               COMMAND_PRIORITY_BEFORE_CRITICAL,
             ),
-            (() => {
-              const events = ['mouseup', 'mousedown'] as const;
-              events.forEach(v =>
-                rootElement.addEventListener(v, refreshTripleClick, true),
-              );
-              return () =>
-                events.forEach(v =>
-                  rootElement.removeEventListener(v, refreshTripleClick, true),
-                );
-            })(),
+            ...(['mouseup', 'mousedown'] as const).map(v =>
+              registerEventListener(rootElement, v, refreshTripleClick, true),
+            ),
           );
         });
       }),

--- a/packages/lexical-extension/src/NormalizeTripleClickSelectionExtension.ts
+++ b/packages/lexical-extension/src/NormalizeTripleClickSelectionExtension.ts
@@ -29,7 +29,7 @@ import {
   defineExtension,
   getDOMSelection,
   mergeRegister,
-  registerEventListener,
+  registerEventListeners,
   safeCast,
   SELECTION_CHANGE_COMMAND,
   SKIP_SCROLL_INTO_VIEW_TAG,
@@ -196,8 +196,10 @@ export const NormalizeTripleClickSelectionExtension =
               },
               COMMAND_PRIORITY_BEFORE_CRITICAL,
             ),
-            ...(['mouseup', 'mousedown'] as const).map(v =>
-              registerEventListener(rootElement, v, refreshTripleClick, true),
+            registerEventListeners(
+              rootElement,
+              {mousedown: refreshTripleClick, mouseup: refreshTripleClick},
+              true,
             ),
           );
         });

--- a/packages/lexical-extension/src/PreventSelectAllExtension.ts
+++ b/packages/lexical-extension/src/PreventSelectAllExtension.ts
@@ -11,6 +11,7 @@ import {
   defineExtension,
   isExactShortcutMatch,
   isHTMLElement,
+  registerEventListener,
   safeCast,
   stopLexicalPropagation,
 } from 'lexical';
@@ -54,9 +55,12 @@ export const PreventSelectAllExtension = /* @__PURE__ */ defineExtension({
       if (!stores.disabled.value) {
         return editor.registerRootListener(rootElement => {
           if (rootElement) {
-            rootElement.addEventListener('keydown', captureKeydown, true);
-            return () =>
-              rootElement.removeEventListener('keydown', captureKeydown, true);
+            return registerEventListener(
+              rootElement,
+              'keydown',
+              captureKeydown,
+              true,
+            );
           }
         });
       }

--- a/packages/lexical-extension/src/PreventSelectAllExtension.ts
+++ b/packages/lexical-extension/src/PreventSelectAllExtension.ts
@@ -6,9 +6,9 @@
  *
  */
 
-import {IS_APPLE} from '@lexical/utils';
 import {
   defineExtension,
+  IS_APPLE,
   isExactShortcutMatch,
   isHTMLElement,
   registerEventListener,

--- a/packages/lexical-link/src/ClickableLinkExtension.ts
+++ b/packages/lexical-link/src/ClickableLinkExtension.ts
@@ -18,6 +18,8 @@ import {
   isDOMNode,
   isHTMLAnchorElement,
   LexicalEditor,
+  mergeRegister,
+  registerEventListener,
   safeCast,
 } from 'lexical';
 
@@ -115,12 +117,10 @@ export function registerClickableLink(
 
   return editor.registerRootListener(rootElement => {
     if (rootElement) {
-      rootElement.addEventListener('click', onClick, eventOptions);
-      rootElement.addEventListener('mouseup', onMouseUp, eventOptions);
-      return () => {
-        rootElement.removeEventListener('click', onClick);
-        rootElement.removeEventListener('mouseup', onMouseUp);
-      };
+      return mergeRegister(
+        registerEventListener(rootElement, 'click', onClick, eventOptions),
+        registerEventListener(rootElement, 'mouseup', onMouseUp, eventOptions),
+      );
     }
   });
 }

--- a/packages/lexical-link/src/ClickableLinkExtension.ts
+++ b/packages/lexical-link/src/ClickableLinkExtension.ts
@@ -18,8 +18,7 @@ import {
   isDOMNode,
   isHTMLAnchorElement,
   LexicalEditor,
-  mergeRegister,
-  registerEventListener,
+  registerEventListeners,
   safeCast,
 } from 'lexical';
 
@@ -117,9 +116,10 @@ export function registerClickableLink(
 
   return editor.registerRootListener(rootElement => {
     if (rootElement) {
-      return mergeRegister(
-        registerEventListener(rootElement, 'click', onClick, eventOptions),
-        registerEventListener(rootElement, 'mouseup', onMouseUp, eventOptions),
+      return registerEventListeners(
+        rootElement,
+        {click: onClick, mouseup: onMouseUp},
+        eventOptions,
       );
     }
   });

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -29,6 +29,7 @@ import {
   KEY_ESCAPE_COMMAND,
   KEY_SPACE_COMMAND,
   mergeRegister,
+  registerEventListener,
   SKIP_DOM_SELECTION_TAG,
   SKIP_SELECTION_FOCUS_TAG,
 } from 'lexical';
@@ -221,51 +222,43 @@ export function registerCheckList(
 
     editor.registerRootListener(rootElement => {
       if (rootElement !== null) {
-        rootElement.addEventListener('click', configHandleClick);
-        rootElement.addEventListener('pointerup', configHandlePointerUp);
-        // Use capture so we run before other listeners that might move focus.
-        rootElement.addEventListener(
-          'pointerdown',
-          configHandleSelectDefaults,
-          {
-            capture: true,
-          },
-        );
-        // Some browsers / integrations still generate mousedown events; handle them too.
-        rootElement.addEventListener('mousedown', configHandleSelectDefaults, {
-          capture: true,
-        });
-        // Intercept touchstart to stop the mobile browser from placing the caret
-        // and opening the keyboard when tapping the checklist marker.
-        rootElement.addEventListener('touchstart', configHandleSelectDefaults, {
-          capture: true,
-          passive: false,
-        });
-        return () => {
-          rootElement.removeEventListener('click', configHandleClick);
-          rootElement.removeEventListener('pointerup', configHandlePointerUp);
-          rootElement.removeEventListener(
+        return mergeRegister(
+          registerEventListener(rootElement, 'click', configHandleClick),
+          registerEventListener(
+            rootElement,
+            'pointerup',
+            configHandlePointerUp,
+          ),
+          // Use capture so we run before other listeners that might move focus.
+          registerEventListener(
+            rootElement,
             'pointerdown',
             configHandleSelectDefaults,
             {
               capture: true,
             },
-          );
-          rootElement.removeEventListener(
+          ),
+          // Some browsers / integrations still generate mousedown events; handle them too.
+          registerEventListener(
+            rootElement,
             'mousedown',
             configHandleSelectDefaults,
             {
               capture: true,
             },
-          );
-          rootElement.removeEventListener(
+          ),
+          // Intercept touchstart to stop the mobile browser from placing the caret
+          // and opening the keyboard when tapping the checklist marker.
+          registerEventListener(
+            rootElement,
             'touchstart',
             configHandleSelectDefaults,
             {
               capture: true,
+              passive: false,
             },
-          );
-        };
+          ),
+        );
       }
     }),
   );

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -30,6 +30,7 @@ import {
   KEY_SPACE_COMMAND,
   mergeRegister,
   registerEventListener,
+  registerEventListeners,
   SKIP_DOM_SELECTION_TAG,
   SKIP_SELECTION_FOCUS_TAG,
 } from 'lexical';
@@ -223,32 +224,25 @@ export function registerCheckList(
     editor.registerRootListener(rootElement => {
       if (rootElement !== null) {
         return mergeRegister(
-          registerEventListener(rootElement, 'click', configHandleClick),
-          registerEventListener(
-            rootElement,
-            'pointerup',
-            configHandlePointerUp,
-          ),
+          registerEventListeners(rootElement, {
+            click: configHandleClick,
+            pointerup: configHandlePointerUp,
+          }),
           // Use capture so we run before other listeners that might move focus.
-          registerEventListener(
+          // Some browsers / integrations still generate mousedown events as well
+          // as pointerdown, so handle both.
+          registerEventListeners(
             rootElement,
-            'pointerdown',
-            configHandleSelectDefaults,
             {
-              capture: true,
+              mousedown: configHandleSelectDefaults,
+              pointerdown: configHandleSelectDefaults,
             },
+            {capture: true},
           ),
-          // Some browsers / integrations still generate mousedown events; handle them too.
-          registerEventListener(
-            rootElement,
-            'mousedown',
-            configHandleSelectDefaults,
-            {
-              capture: true,
-            },
-          ),
-          // Intercept touchstart to stop the mobile browser from placing the caret
-          // and opening the keyboard when tapping the checklist marker.
+          // Intercept touchstart to stop the mobile browser from placing the
+          // caret and opening the keyboard when tapping the checklist marker.
+          // passive:false lets the handler call preventDefault, so it needs its
+          // own options and can't share the capture-only group above.
           registerEventListener(
             rootElement,
             'touchstart',

--- a/packages/lexical-playground/esm/index.mjs
+++ b/packages/lexical-playground/esm/index.mjs
@@ -9,8 +9,7 @@
 import {registerDragonSupport} from '@lexical/dragon';
 import {createEmptyHistoryState, registerHistory} from '@lexical/history';
 import {HeadingNode, QuoteNode, registerRichText} from '@lexical/rich-text';
-import {mergeRegister} from '@lexical/utils';
-import {createEditor, HISTORY_MERGE_TAG} from 'lexical';
+import {createEditor, HISTORY_MERGE_TAG, mergeRegister} from 'lexical';
 
 import prepopulatedRichText from './prepopulatedRichText.mjs';
 

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -12,6 +12,7 @@ import {CharacterLimitPlugin} from '@lexical/react/LexicalCharacterLimitPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TabIndentationPlugin} from '@lexical/react/LexicalTabIndentationPlugin';
 import {CAN_USE_DOM} from '@lexical/utils';
+import {registerEventListener} from 'lexical';
 import {useEffect, useState} from 'react';
 
 import {createWebsocketProvider} from './collaboration';
@@ -89,11 +90,7 @@ export default function Editor(): JSX.Element {
       }
     };
     updateViewPortWidth();
-    window.addEventListener('resize', updateViewPortWidth);
-
-    return () => {
-      window.removeEventListener('resize', updateViewPortWidth);
-    };
+    return registerEventListener(window, 'resize', updateViewPortWidth);
   }, [isSmallWidthViewport]);
 
   return (

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -10,8 +10,7 @@ import type {JSX} from 'react';
 
 import {CharacterLimitPlugin} from '@lexical/react/LexicalCharacterLimitPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {CAN_USE_DOM} from '@lexical/utils';
-import {registerEventListener} from 'lexical';
+import {CAN_USE_DOM, registerEventListener} from 'lexical';
 import {useEffect, useState} from 'react';
 
 import {createWebsocketProvider} from './collaboration';

--- a/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeComponent.tsx
+++ b/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeComponent.tsx
@@ -35,6 +35,7 @@ import {
   IS_STRIKETHROUGH,
   IS_UNDERLINE,
   NodeKey,
+  registerEventListener,
 } from 'lexical';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
@@ -120,14 +121,12 @@ export default function DateTimeComponent({
       setIsOpen(true);
     }
 
-    if (dateTimePillRef) {
-      dateTimePillRef.addEventListener('click', onClick);
-    }
+    const unregisterClick = dateTimePillRef
+      ? registerEventListener(dateTimePillRef, 'click', onClick)
+      : null;
 
     return () => {
-      if (dateTimePillRef) {
-        dateTimePillRef.removeEventListener('click', onClick);
-      }
+      unregisterClick?.();
     };
   }, [refs, editor]);
 

--- a/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeComponent.tsx
+++ b/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeComponent.tsx
@@ -121,13 +121,9 @@ export default function DateTimeComponent({
       setIsOpen(true);
     }
 
-    const unregisterClick = dateTimePillRef
+    return dateTimePillRef
       ? registerEventListener(dateTimePillRef, 'click', onClick)
-      : null;
-
-    return () => {
-      unregisterClick?.();
-    };
+      : () => {};
   }, [refs, editor]);
 
   const withDateTimeNode = (

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -39,6 +39,7 @@ import {
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
   mergeRegister,
+  registerEventListener,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -412,9 +413,11 @@ export default function ImageComponent({
       ),
       editor.registerRootListener(rootElement => {
         if (rootElement) {
-          rootElement.addEventListener('contextmenu', onRightClick);
-          return () =>
-            rootElement.removeEventListener('contextmenu', onRightClick);
+          return registerEventListener(
+            rootElement,
+            'contextmenu',
+            onRightClick,
+          );
         }
       }),
     );

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -16,7 +16,7 @@ import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {LexicalExtensionEditorComposer} from '@lexical/react/LexicalExtensionEditorComposer';
 import {calculateZoomLevel} from '@lexical/utils';
-import {$getNodeByKey} from 'lexical';
+import {$getNodeByKey, registerEventListener} from 'lexical';
 import * as React from 'react';
 import {useEffect, useLayoutEffect, useRef} from 'react';
 
@@ -110,10 +110,14 @@ export default function StickyComponent({
       }
     };
 
-    window.addEventListener('resize', handleWindowResize);
+    const removeWindowResize = registerEventListener(
+      window,
+      'resize',
+      handleWindowResize,
+    );
 
     return () => {
-      window.removeEventListener('resize', handleWindowResize);
+      removeWindowResize();
       removeRootListener();
     };
   }, [editor]);

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -16,7 +16,7 @@ import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {LexicalExtensionEditorComposer} from '@lexical/react/LexicalExtensionEditorComposer';
 import {calculateZoomLevel} from '@lexical/utils';
-import {$getNodeByKey, registerEventListener} from 'lexical';
+import {$getNodeByKey, mergeRegister, registerEventListener} from 'lexical';
 import * as React from 'react';
 import {useEffect, useLayoutEffect, useRef} from 'react';
 
@@ -94,13 +94,6 @@ export default function StickyComponent({
       }
     });
 
-    const removeRootListener = editor.registerRootListener(nextRootElem => {
-      if (nextRootElem !== null) {
-        resizeObserver.observe(nextRootElem);
-        return () => resizeObserver.unobserve(nextRootElem);
-      }
-    });
-
     const handleWindowResize = () => {
       const rootElement = editor.getRootElement();
       const stickyContainer = stickyContainerRef.current;
@@ -110,16 +103,15 @@ export default function StickyComponent({
       }
     };
 
-    const removeWindowResize = registerEventListener(
-      window,
-      'resize',
-      handleWindowResize,
+    return mergeRegister(
+      editor.registerRootListener(nextRootElem => {
+        if (nextRootElem !== null) {
+          resizeObserver.observe(nextRootElem);
+          return () => resizeObserver.unobserve(nextRootElem);
+        }
+      }),
+      registerEventListener(window, 'resize', handleWindowResize),
     );
-
-    return () => {
-      removeWindowResize();
-      removeRootListener();
-    };
   }, [editor]);
 
   useEffect(() => {

--- a/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
@@ -733,17 +733,13 @@ export const AutocompleteExtension = /* @__PURE__ */ defineExtension({
       for (const loader of Object.values(output.dictionaries.value)) {
         loadDictionary(loader);
       }
-      const removeCompositionUpdateListener = registerEventListener(
-        rootElem,
-        'compositionupdate',
-        onCompositionUpdateDOM,
-      );
-      const removeCompositionEndListener = registerEventListener(
-        rootElem,
-        'compositionend',
-        onCompositionEndDOM,
-      );
       return mergeRegister(
+        registerEventListener(
+          rootElem,
+          'compositionupdate',
+          onCompositionUpdateDOM,
+        ),
+        registerEventListener(rootElem, 'compositionend', onCompositionEndDOM),
         editor.registerUpdateListener(handleUpdate),
         // Drop the ghost as soon as the editor loses focus, rather than
         // waiting for the next update.
@@ -778,11 +774,7 @@ export const AutocompleteExtension = /* @__PURE__ */ defineExtension({
           COMMAND_PRIORITY_LOW,
         ),
         addSwipeRightListener(rootElem, handleSwipeRight),
-        () => {
-          clearPendingCompositionTimer();
-          removeCompositionUpdateListener();
-          removeCompositionEndListener();
-        },
+        clearPendingCompositionTimer,
         // Tear down on dispose: clear any ghost still attached so a fresh
         // build doesn't see leftover decoration.
         dismiss,

--- a/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
@@ -35,6 +35,7 @@ import {
   type LexicalEditor,
   mergeRegister,
   type NodeKey,
+  registerEventListener,
   safeCast,
   setDOMUnmanaged,
 } from 'lexical';
@@ -732,8 +733,16 @@ export const AutocompleteExtension = /* @__PURE__ */ defineExtension({
       for (const loader of Object.values(output.dictionaries.value)) {
         loadDictionary(loader);
       }
-      rootElem.addEventListener('compositionupdate', onCompositionUpdateDOM);
-      rootElem.addEventListener('compositionend', onCompositionEndDOM);
+      const removeCompositionUpdateListener = registerEventListener(
+        rootElem,
+        'compositionupdate',
+        onCompositionUpdateDOM,
+      );
+      const removeCompositionEndListener = registerEventListener(
+        rootElem,
+        'compositionend',
+        onCompositionEndDOM,
+      );
       return mergeRegister(
         editor.registerUpdateListener(handleUpdate),
         // Drop the ghost as soon as the editor loses focus, rather than
@@ -771,11 +780,8 @@ export const AutocompleteExtension = /* @__PURE__ */ defineExtension({
         addSwipeRightListener(rootElem, handleSwipeRight),
         () => {
           clearPendingCompositionTimer();
-          rootElem.removeEventListener(
-            'compositionupdate',
-            onCompositionUpdateDOM,
-          );
-          rootElem.removeEventListener('compositionend', onCompositionEndDOM);
+          removeCompositionUpdateListener();
+          removeCompositionEndListener();
         },
         // Tear down on dispose: clear any ghost still attached so a fresh
         // build doesn't see leftover decoration.

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
@@ -21,6 +21,7 @@ import {
   $getNearestNodeFromDOMNode,
   getComposedEventTarget,
   isHTMLElement,
+  registerEventListener,
 } from 'lexical';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
@@ -107,12 +108,16 @@ function CodeActionMenuContainer({
       return;
     }
 
-    document.addEventListener('mousemove', debouncedOnMouseMove);
+    const removeMouseMoveListener = registerEventListener(
+      document,
+      'mousemove',
+      debouncedOnMouseMove,
+    );
 
     return () => {
       setShown(false);
       debouncedOnMouseMove.cancel();
-      document.removeEventListener('mousemove', debouncedOnMouseMove);
+      removeMouseMoveListener();
     };
   }, [shouldListenMouseMove, debouncedOnMouseMove]);
 

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
@@ -21,6 +21,7 @@ import {
   $getNearestNodeFromDOMNode,
   getComposedEventTarget,
   isHTMLElement,
+  mergeRegister,
   registerEventListener,
 } from 'lexical';
 import * as React from 'react';
@@ -108,17 +109,13 @@ function CodeActionMenuContainer({
       return;
     }
 
-    const removeMouseMoveListener = registerEventListener(
-      document,
-      'mousemove',
-      debouncedOnMouseMove,
+    return mergeRegister(
+      registerEventListener(document, 'mousemove', debouncedOnMouseMove),
+      () => {
+        setShown(false);
+        debouncedOnMouseMove.cancel();
+      },
     );
-
-    return () => {
-      setShown(false);
-      debouncedOnMouseMove.cancel();
-      removeMouseMoveListener();
-    };
   }, [shouldListenMouseMove, debouncedOnMouseMove]);
 
   useEffect(() => {

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import {IS_CHROME, IS_FIREFOX} from '@lexical/utils';
 import {
   $getSiblingCaret,
   $isElementNode,
@@ -14,6 +13,8 @@ import {
   DOMExportOutput,
   EditorConfig,
   ElementNode,
+  IS_CHROME,
+  IS_FIREFOX,
   isHTMLElement,
   LexicalEditor,
   LexicalNode,

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContentNode.ts
@@ -6,11 +6,12 @@
  *
  */
 
-import {IS_CHROME, IS_FIREFOX} from '@lexical/utils';
 import {
   DOMExportOutput,
   EditorConfig,
   ElementNode,
+  IS_CHROME,
+  IS_FIREFOX,
   LexicalEditor,
   LexicalNode,
 } from 'lexical';

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleTitleNode.ts
@@ -6,12 +6,13 @@
  *
  */
 
-import {IS_CHROME, IS_FIREFOX} from '@lexical/utils';
 import {
   $createParagraphNode,
   $isElementNode,
   EditorConfig,
   ElementNode,
+  IS_CHROME,
+  IS_FIREFOX,
   LexicalEditor,
   LexicalNode,
   RangeSelection,

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -55,6 +55,7 @@ import {
   getRootOwnerDocument,
   KEY_ESCAPE_COMMAND,
   mergeRegister,
+  registerEventListener,
 } from 'lexical';
 import * as React from 'react';
 import {
@@ -109,11 +110,7 @@ function AddCommentBox({
   }, [anchorKey, editor]);
 
   useEffect(() => {
-    window.addEventListener('resize', updatePosition);
-
-    return () => {
-      window.removeEventListener('resize', updatePosition);
-    };
+    return registerEventListener(window, 'resize', updatePosition);
   }, [editor, updatePosition]);
 
   useLayoutEffect(() => {
@@ -316,11 +313,7 @@ function CommentInputBox({
   }, [selectionState.container, updateLocation]);
 
   useEffect(() => {
-    window.addEventListener('resize', updateLocation);
-
-    return () => {
-      window.removeEventListener('resize', updateLocation);
-    };
+    return registerEventListener(window, 'resize', updateLocation);
   }, [updateLocation]);
 
   const onEscape = (event: KeyboardEvent): boolean => {

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -20,6 +20,7 @@ import {
   $isParagraphNode,
   $isTextNode,
   getComposedEventTarget,
+  registerEventListener,
 } from 'lexical';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as ReactDOM from 'react-dom';
@@ -115,10 +116,7 @@ export default function DraggableBlockPlugin({
       setIsPickerOpen(false);
       setPickerState(null);
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
+    return registerEventListener(document, 'mousedown', handleClickOutside);
   }, [isPickerOpen]);
 
   const selectOption = useCallback(
@@ -189,10 +187,7 @@ export default function DraggableBlockPlugin({
         setPickerState(null);
       }
     };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
+    return registerEventListener(window, 'keydown', handleKeyDown);
   }, [highlightedIndex, isPickerOpen, options, selectOption]);
 
   function openComponentPicker(e: React.MouseEvent) {

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -47,6 +47,7 @@ import {
   LexicalEditor,
   mergeRegister,
   RangeSelection,
+  registerEventListener,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -287,10 +288,7 @@ function FloatingLinkEditor({
         setIsLinkEditMode(false);
       }
     };
-    editorElement.addEventListener('focusout', handleBlur);
-    return () => {
-      editorElement.removeEventListener('focusout', handleBlur);
-    };
+    return registerEventListener(editorElement, 'focusout', handleBlur);
   }, [editorRef, setIsLink, setIsLinkEditMode, isLink]);
 
   const monitorInputInteraction = (

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -181,21 +181,12 @@ function TextFormatFloatingToolbar({
       });
     };
 
-    const removeResizeListener = registerEventListener(
-      window,
-      'resize',
-      update,
+    return mergeRegister(
+      registerEventListener(window, 'resize', update),
+      scrollerElem
+        ? registerEventListener(scrollerElem, 'scroll', update)
+        : () => {},
     );
-    const removeScrollListener = scrollerElem
-      ? registerEventListener(scrollerElem, 'scroll', update)
-      : null;
-
-    return () => {
-      removeResizeListener();
-      if (removeScrollListener) {
-        removeScrollListener();
-      }
-    };
   }, [editor, $updateTextFormatFloatingToolbar, anchorElem]);
 
   useEffect(() => {

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -29,6 +29,7 @@ import {
   LexicalEditor,
   mergeRegister,
   registerEventListener,
+  registerEventListeners,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -123,10 +124,10 @@ function TextFormatFloatingToolbar({
 
   useEffect(() => {
     if (popupCharStylesEditorRef?.current) {
-      return mergeRegister(
-        registerEventListener(document, 'mousemove', mouseMoveListener),
-        registerEventListener(document, 'mouseup', mouseUpListener),
-      );
+      return registerEventListeners(document, {
+        mousemove: mouseMoveListener,
+        mouseup: mouseUpListener,
+      });
     }
   }, [popupCharStylesEditorRef]);
 
@@ -448,10 +449,10 @@ function useFloatingTextFormatToolbar(
         ref.current.style.display = 'block';
       }
     };
-    return mergeRegister(
-      registerEventListener(document, 'dragstart', onDragStart, true),
-      registerEventListener(document, 'dragend', onDragEnd, true),
-      registerEventListener(document, 'drop', onDragEnd, true),
+    return registerEventListeners(
+      document,
+      {dragend: onDragEnd, dragstart: onDragStart, drop: onDragEnd},
+      true,
     );
   }, []);
 

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -28,6 +28,7 @@ import {
   isDOMShadowRoot,
   LexicalEditor,
   mergeRegister,
+  registerEventListener,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -122,13 +123,10 @@ function TextFormatFloatingToolbar({
 
   useEffect(() => {
     if (popupCharStylesEditorRef?.current) {
-      document.addEventListener('mousemove', mouseMoveListener);
-      document.addEventListener('mouseup', mouseUpListener);
-
-      return () => {
-        document.removeEventListener('mousemove', mouseMoveListener);
-        document.removeEventListener('mouseup', mouseUpListener);
-      };
+      return mergeRegister(
+        registerEventListener(document, 'mousemove', mouseMoveListener),
+        registerEventListener(document, 'mouseup', mouseUpListener),
+      );
     }
   }, [popupCharStylesEditorRef]);
 
@@ -182,15 +180,19 @@ function TextFormatFloatingToolbar({
       });
     };
 
-    window.addEventListener('resize', update);
-    if (scrollerElem) {
-      scrollerElem.addEventListener('scroll', update);
-    }
+    const removeResizeListener = registerEventListener(
+      window,
+      'resize',
+      update,
+    );
+    const removeScrollListener = scrollerElem
+      ? registerEventListener(scrollerElem, 'scroll', update)
+      : null;
 
     return () => {
-      window.removeEventListener('resize', update);
-      if (scrollerElem) {
-        scrollerElem.removeEventListener('scroll', update);
+      removeResizeListener();
+      if (removeScrollListener) {
+        removeScrollListener();
       }
     };
   }, [editor, $updateTextFormatFloatingToolbar, anchorElem]);
@@ -427,10 +429,7 @@ function useFloatingTextFormatToolbar(
   }, [editor]);
 
   useEffect(() => {
-    document.addEventListener('selectionchange', updatePopup);
-    return () => {
-      document.removeEventListener('selectionchange', updatePopup);
-    };
+    return registerEventListener(document, 'selectionchange', updatePopup);
   }, [updatePopup]);
 
   // Hide the popup while a drag is in progress. Otherwise it sits on top of
@@ -449,14 +448,11 @@ function useFloatingTextFormatToolbar(
         ref.current.style.display = 'block';
       }
     };
-    document.addEventListener('dragstart', onDragStart, true);
-    document.addEventListener('dragend', onDragEnd, true);
-    document.addEventListener('drop', onDragEnd, true);
-    return () => {
-      document.removeEventListener('dragstart', onDragStart, true);
-      document.removeEventListener('dragend', onDragEnd, true);
-      document.removeEventListener('drop', onDragEnd, true);
-    };
+    return mergeRegister(
+      registerEventListener(document, 'dragstart', onDragStart, true),
+      registerEventListener(document, 'dragend', onDragEnd, true),
+      registerEventListener(document, 'drop', onDragEnd, true),
+    );
   }, []);
 
   useEffect(() => {

--- a/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
@@ -46,6 +46,7 @@ import {
   LexicalCommand,
   LexicalEditor,
   mergeRegister,
+  registerEventListener,
   SKIP_DOM_SELECTION_TAG,
 } from 'lexical';
 import {useEffect, useRef, useState} from 'react';
@@ -246,10 +247,7 @@ export function InsertImageDialog({
     const handler = (e: KeyboardEvent) => {
       hasModifier.current = e.altKey;
     };
-    document.addEventListener('keydown', handler);
-    return () => {
-      document.removeEventListener('keydown', handler);
-    };
+    return registerEventListener(document, 'keydown', handler);
   }, [activeEditor]);
 
   const onClick = (payload: InsertImagePayload) => {

--- a/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
@@ -24,7 +24,7 @@ import {
   HISTORY_MERGE_TAG,
   mergeRegister,
   NodeKey,
-  registerEventListener,
+  registerEventListeners,
   RootNode,
   safeCast,
   SELECTION_CHANGE_COMMAND,
@@ -764,8 +764,10 @@ export const PagesExtension = /* @__PURE__ */ defineExtension({
             removeRootTransform,
             removePageContentTransform,
             removeMutationListeners,
-            registerEventListener(window, 'beforeprint', handleBeforePrint),
-            registerEventListener(window, 'afterprint', handleAfterPrint),
+            registerEventListeners(window, {
+              afterprint: handleAfterPrint,
+              beforeprint: handleBeforePrint,
+            }),
           );
         });
       });

--- a/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
@@ -744,35 +744,31 @@ export const PagesExtension = /* @__PURE__ */ defineExtension({
             }
           };
 
-          const removeBeforePrintListener = registerEventListener(
-            window,
-            'beforeprint',
-            handleBeforePrint,
+          return mergeRegister(
+            // Placed first so mergeRegister's reverse (LIFO) teardown runs it
+            // last, only after every observer, listener, and transform below
+            // has been torn down.
+            () => {
+              if (output.disabled.peek()) {
+                destroyPageStructure();
+              }
+            },
+            () => rootObserver.disconnect(),
+            () => pageObserver.disconnect(),
+            () => {
+              if (rafId !== null) {
+                cancelAnimationFrame(rafId);
+              }
+            },
+            clearMeasurementFlags,
+            removeCommandListeners,
+            removePageTransform,
+            removeRootTransform,
+            removePageContentTransform,
+            removeMutationListeners,
+            registerEventListener(window, 'beforeprint', handleBeforePrint),
+            registerEventListener(window, 'afterprint', handleAfterPrint),
           );
-          const removeAfterPrintListener = registerEventListener(
-            window,
-            'afterprint',
-            handleAfterPrint,
-          );
-
-          return () => {
-            rootObserver.disconnect();
-            pageObserver.disconnect();
-            if (rafId !== null) {
-              cancelAnimationFrame(rafId);
-            }
-            clearMeasurementFlags();
-            removeCommandListeners();
-            removePageTransform();
-            removeRootTransform();
-            removePageContentTransform();
-            removeMutationListeners();
-            removeBeforePrintListener();
-            removeAfterPrintListener();
-            if (output.disabled.peek()) {
-              destroyPageStructure();
-            }
-          };
         });
       });
     }),

--- a/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
@@ -746,18 +746,16 @@ export const PagesExtension = /* @__PURE__ */ defineExtension({
 
           return mergeRegister(
             // Placed first so mergeRegister's reverse (LIFO) teardown runs it
-            // last, only after every observer, listener, and transform below
-            // has been torn down.
-            () => {
-              if (output.disabled.peek()) {
-                destroyPageStructure();
-              }
-            },
-            () => rootObserver.disconnect(),
-            () => pageObserver.disconnect(),
+            // last, only after every listener and transform below has been
+            // torn down.
             () => {
               if (rafId !== null) {
                 cancelAnimationFrame(rafId);
+              }
+              pageObserver.disconnect();
+              rootObserver.disconnect();
+              if (output.disabled.peek()) {
+                destroyPageStructure();
               }
             },
             clearMeasurementFlags,

--- a/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PagesExtension.ts
@@ -24,6 +24,7 @@ import {
   HISTORY_MERGE_TAG,
   mergeRegister,
   NodeKey,
+  registerEventListener,
   RootNode,
   safeCast,
   SELECTION_CHANGE_COMMAND,
@@ -743,8 +744,16 @@ export const PagesExtension = /* @__PURE__ */ defineExtension({
             }
           };
 
-          window.addEventListener('beforeprint', handleBeforePrint);
-          window.addEventListener('afterprint', handleAfterPrint);
+          const removeBeforePrintListener = registerEventListener(
+            window,
+            'beforeprint',
+            handleBeforePrint,
+          );
+          const removeAfterPrintListener = registerEventListener(
+            window,
+            'afterprint',
+            handleAfterPrint,
+          );
 
           return () => {
             rootObserver.disconnect();
@@ -758,8 +767,8 @@ export const PagesExtension = /* @__PURE__ */ defineExtension({
             removeRootTransform();
             removePageContentTransform();
             removeMutationListeners();
-            window.removeEventListener('beforeprint', handleBeforePrint);
-            window.removeEventListener('afterprint', handleAfterPrint);
+            removeBeforePrintListener();
+            removeAfterPrintListener();
             if (output.disabled.peek()) {
               destroyPageStructure();
             }

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -7,8 +7,7 @@
  */
 
 import {HeadingTagType} from '@lexical/rich-text';
-import {IS_APPLE} from '@lexical/utils';
-import {isExactShortcutMatch} from 'lexical';
+import {IS_APPLE, isExactShortcutMatch} from 'lexical';
 
 //disable eslint sorting rule for quick reference to shortcuts
 /* eslint-disable sort-keys-fix/sort-keys-fix */

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -46,6 +46,7 @@ import {
   getRootOwnerDocument,
   isDOMNode,
   mergeRegister,
+  registerEventListener,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -222,9 +223,7 @@ function TableActionMenu({
       }
     }
 
-    window.addEventListener('click', handleClickOutside);
-
-    return () => window.removeEventListener('click', handleClickOutside);
+    return registerEventListener(window, 'click', handleClickOutside);
   }, [setIsMenuOpen, contextRef]);
 
   const clearTableSelection = useCallback(() => {
@@ -880,10 +879,13 @@ function TableCellActionMenuContainer({
       ),
       editor.registerRootListener((rootElement, prevRootElement) => {
         if (rootElement) {
-          rootElement.addEventListener('pointerup', delayedCallback);
+          const removePointerUpListener = registerEventListener(
+            rootElement,
+            'pointerup',
+            delayedCallback,
+          );
           delayedCallback();
-          return () =>
-            rootElement.removeEventListener('pointerup', delayedCallback);
+          return removePointerUpListener;
         }
       }),
       () => clearTimeout(timeoutId),

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -879,13 +879,12 @@ function TableCellActionMenuContainer({
       ),
       editor.registerRootListener((rootElement, prevRootElement) => {
         if (rootElement) {
-          const removePointerUpListener = registerEventListener(
+          delayedCallback();
+          return registerEventListener(
             rootElement,
             'pointerup',
             delayedCallback,
           );
-          delayedCallback();
-          return removePointerUpListener;
         }
       }),
       () => clearTimeout(timeoutId),

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -172,27 +172,26 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
     };
 
     const resizerContainer = resizerRef.current;
-    const removeResizerContainerListener = resizerContainer
-      ? registerEventListener(resizerContainer, 'pointermove', onPointerMove, {
-          capture: true,
-        })
-      : null;
-
-    const removeRootListener = editor.registerRootListener(rootElement => {
-      if (rootElement) {
-        return registerEventListeners(rootElement, {
-          pointerdown: onPointerDown,
-          pointermove: onPointerMove,
-        });
-      }
-    });
-
-    return () => {
-      removeRootListener();
-      if (removeResizerContainerListener) {
-        removeResizerContainerListener();
-      }
-    };
+    return mergeRegister(
+      editor.registerRootListener(rootElement => {
+        if (rootElement) {
+          return registerEventListeners(rootElement, {
+            pointerdown: onPointerDown,
+            pointermove: onPointerMove,
+          });
+        }
+      }),
+      resizerContainer
+        ? registerEventListener(
+            resizerContainer,
+            'pointermove',
+            onPointerMove,
+            {
+              capture: true,
+            },
+          )
+        : () => {},
+    );
   }, [activeCell, draggingDirection, editor, resetState, hasTable]);
 
   const isHeightChanging = (direction: PointerDraggingDirection) => {

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -171,9 +171,11 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
     };
 
     const resizerContainer = resizerRef.current;
-    resizerContainer?.addEventListener('pointermove', onPointerMove, {
-      capture: true,
-    });
+    const removeResizerContainerListener = resizerContainer
+      ? registerEventListener(resizerContainer, 'pointermove', onPointerMove, {
+          capture: true,
+        })
+      : null;
 
     const removeRootListener = editor.registerRootListener(rootElement => {
       if (rootElement) {
@@ -186,7 +188,9 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
 
     return () => {
       removeRootListener();
-      resizerContainer?.removeEventListener('pointermove', onPointerMove);
+      if (removeResizerContainerListener) {
+        removeResizerContainerListener();
+      }
     };
   }, [activeCell, draggingDirection, editor, resetState, hasTable]);
 

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -29,6 +29,7 @@ import {
   isHTMLElement,
   mergeRegister,
   registerEventListener,
+  registerEventListeners,
   SKIP_SCROLL_INTO_VIEW_TAG,
 } from 'lexical';
 import * as React from 'react';
@@ -179,10 +180,10 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
 
     const removeRootListener = editor.registerRootListener(rootElement => {
       if (rootElement) {
-        return mergeRegister(
-          registerEventListener(rootElement, 'pointermove', onPointerMove),
-          registerEventListener(rootElement, 'pointerdown', onPointerDown),
-        );
+        return registerEventListeners(rootElement, {
+          pointerdown: onPointerDown,
+          pointermove: onPointerMove,
+        });
       }
     });
 

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -28,6 +28,7 @@ import {
   $getNearestNodeFromDOMNode,
   isHTMLElement,
   mergeRegister,
+  registerEventListener,
   SKIP_SCROLL_INTO_VIEW_TAG,
 } from 'lexical';
 import * as React from 'react';
@@ -176,12 +177,10 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
 
     const removeRootListener = editor.registerRootListener(rootElement => {
       if (rootElement) {
-        rootElement.addEventListener('pointermove', onPointerMove);
-        rootElement.addEventListener('pointerdown', onPointerDown);
-        return () => {
-          rootElement.removeEventListener('pointermove', onPointerMove);
-          rootElement.removeEventListener('pointerdown', onPointerDown);
-        };
+        return mergeRegister(
+          registerEventListener(rootElement, 'pointermove', onPointerMove),
+          registerEventListener(rootElement, 'pointerdown', onPointerDown),
+        );
       }
     });
 

--- a/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
@@ -42,6 +42,7 @@ import {
   getComposedEventTarget,
   isDOMNode,
   isHTMLElement,
+  registerEventListener,
 } from 'lexical';
 import {useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
@@ -337,10 +338,14 @@ function TableHoverActionsV2({
       }
     };
 
-    document.addEventListener('mousemove', handleMouseMove);
+    const removeMouseMoveListener = registerEventListener(
+      document,
+      'mousemove',
+      handleMouseMove,
+    );
 
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
+      removeMouseMoveListener();
       setIsVisible(false);
       setIsLeftVisible(false);
     };
@@ -378,9 +383,11 @@ function TableHoverActionsV2({
 
     return editor.registerRootListener(rootElement => {
       if (rootElement) {
-        rootElement.addEventListener('mouseleave', handleMouseLeave);
-        return () =>
-          rootElement.removeEventListener('mouseleave', handleMouseLeave);
+        return registerEventListener(
+          rootElement,
+          'mouseleave',
+          handleMouseLeave,
+        );
       }
     });
   }, [editor]);

--- a/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsV2Plugin/index.tsx
@@ -42,6 +42,7 @@ import {
   getComposedEventTarget,
   isDOMNode,
   isHTMLElement,
+  mergeRegister,
   registerEventListener,
 } from 'lexical';
 import {useEffect, useRef, useState} from 'react';
@@ -338,17 +339,13 @@ function TableHoverActionsV2({
       }
     };
 
-    const removeMouseMoveListener = registerEventListener(
-      document,
-      'mousemove',
-      handleMouseMove,
+    return mergeRegister(
+      registerEventListener(document, 'mousemove', handleMouseMove),
+      () => {
+        setIsVisible(false);
+        setIsLeftVisible(false);
+      },
     );
-
-    return () => {
-      removeMouseMoveListener();
-      setIsVisible(false);
-      setIsLeftVisible(false);
-    };
   }, [
     editor,
     anchorElem,

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -14,6 +14,7 @@ import './index.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TableOfContentsPlugin as LexicalTableOfContentsPlugin} from '@lexical/react/LexicalTableOfContentsPlugin';
+import {registerEventListener} from 'lexical';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 
@@ -133,8 +134,7 @@ function TableOfContentsList({
       debounceFunction(scrollCallback, 10);
     }
 
-    document.addEventListener('scroll', onScroll);
-    return () => document.removeEventListener('scroll', onScroll);
+    return registerEventListener(document, 'scroll', onScroll);
   }, [tableOfContents, editor]);
 
   return (

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
@@ -17,8 +17,7 @@ import {
   $getRoot,
   getDOMSelection,
   getDOMSelectionPoints,
-  mergeRegister,
-  registerEventListener,
+  registerEventListeners,
 } from 'lexical';
 import * as React from 'react';
 import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
@@ -292,10 +291,10 @@ ${steps.map(formatStep).join(`\n`)}
 
     return editor.registerRootListener(rootElement => {
       if (rootElement) {
-        return mergeRegister(
-          registerEventListener(rootElement, 'keydown', onKeyDown),
-          registerEventListener(rootElement, 'keyup', onKeyUp),
-        );
+        return registerEventListeners(rootElement, {
+          keydown: onKeyDown,
+          keyup: onKeyUp,
+        });
       }
     });
   }, [editor, isRecording, pushStep]);

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
@@ -17,6 +17,8 @@ import {
   $getRoot,
   getDOMSelection,
   getDOMSelectionPoints,
+  mergeRegister,
+  registerEventListener,
 } from 'lexical';
 import * as React from 'react';
 import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
@@ -290,12 +292,10 @@ ${steps.map(formatStep).join(`\n`)}
 
     return editor.registerRootListener(rootElement => {
       if (rootElement) {
-        rootElement.addEventListener('keydown', onKeyDown);
-        rootElement.addEventListener('keyup', onKeyUp);
-        return () => {
-          rootElement.removeEventListener('keydown', onKeyDown);
-          rootElement.removeEventListener('keyup', onKeyUp);
-        };
+        return mergeRegister(
+          registerEventListener(rootElement, 'keydown', onKeyDown),
+          registerEventListener(rootElement, 'keyup', onKeyUp),
+        );
       }
     });
   }, [editor, isRecording, pushStep]);

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
@@ -10,13 +10,13 @@ import type {BaseSelection, LexicalEditor} from 'lexical';
 import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {IS_APPLE} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
   getDOMSelection,
   getDOMSelectionPoints,
+  IS_APPLE,
   registerEventListeners,
 } from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -33,11 +33,7 @@ import {
   $patchStyleText,
 } from '@lexical/selection';
 import {$isTableNode, $isTableSelection} from '@lexical/table';
-import {
-  $getNearestNodeOfType,
-  $isEditorIsNestedEditor,
-  IS_APPLE,
-} from '@lexical/utils';
+import {$getNearestNodeOfType, $isEditorIsNestedEditor} from '@lexical/utils';
 import {
   $addUpdateTag,
   $findMatchingParent,
@@ -57,6 +53,7 @@ import {
   FORMAT_TEXT_COMMAND,
   HISTORIC_TAG,
   INDENT_CONTENT_COMMAND,
+  IS_APPLE,
   LexicalCommand,
   LexicalEditor,
   LexicalNode,

--- a/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
@@ -8,7 +8,7 @@
 
 import type {JSX} from 'react';
 
-import {mergeRegister, registerEventListener} from 'lexical';
+import {registerEventListeners} from 'lexical';
 import {useEffect} from 'react';
 
 import useReport from '../../hooks/useReport';
@@ -101,12 +101,16 @@ export default function TypingPerfPlugin(): JSX.Element | null {
       invalidatingEvent = true;
     };
 
-    return mergeRegister(
-      registerEventListener(window, 'keydown', keyDownHandler, true),
-      registerEventListener(window, 'selectionchange', measureEventEnd, true),
-      registerEventListener(window, 'beforeinput', beforeInputHandler, true),
-      registerEventListener(window, 'paste', pasteHandler, true),
-      registerEventListener(window, 'cut', cutHandler, true),
+    return registerEventListeners(
+      window,
+      {
+        beforeinput: beforeInputHandler,
+        cut: cutHandler,
+        keydown: keyDownHandler,
+        paste: pasteHandler,
+        selectionchange: measureEventEnd,
+      },
+      true,
     );
   }, [report]);
 

--- a/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
@@ -8,6 +8,7 @@
 
 import type {JSX} from 'react';
 
+import {mergeRegister, registerEventListener} from 'lexical';
 import {useEffect} from 'react';
 
 import useReport from '../../hooks/useReport';
@@ -100,19 +101,13 @@ export default function TypingPerfPlugin(): JSX.Element | null {
       invalidatingEvent = true;
     };
 
-    window.addEventListener('keydown', keyDownHandler, true);
-    window.addEventListener('selectionchange', measureEventEnd, true);
-    window.addEventListener('beforeinput', beforeInputHandler, true);
-    window.addEventListener('paste', pasteHandler, true);
-    window.addEventListener('cut', cutHandler, true);
-
-    return () => {
-      window.removeEventListener('keydown', keyDownHandler, true);
-      window.removeEventListener('selectionchange', measureEventEnd, true);
-      window.removeEventListener('beforeinput', beforeInputHandler, true);
-      window.removeEventListener('paste', pasteHandler, true);
-      window.removeEventListener('cut', cutHandler, true);
-    };
+    return mergeRegister(
+      registerEventListener(window, 'keydown', keyDownHandler, true),
+      registerEventListener(window, 'selectionchange', measureEventEnd, true),
+      registerEventListener(window, 'beforeinput', beforeInputHandler, true),
+      registerEventListener(window, 'paste', pasteHandler, true),
+      registerEventListener(window, 'cut', cutHandler, true),
+    );
   }, [report]);
 
   return null;

--- a/packages/lexical-playground/src/ui/DropDown.tsx
+++ b/packages/lexical-playground/src/ui/DropDown.tsx
@@ -9,7 +9,11 @@
 import type {JSX} from 'react';
 
 import {calculateZoomLevel} from '@lexical/utils';
-import {getComposedEventTarget, isDOMNode} from 'lexical';
+import {
+  getComposedEventTarget,
+  isDOMNode,
+  registerEventListener,
+} from 'lexical';
 import * as React from 'react';
 import {
   ReactNode,
@@ -230,11 +234,7 @@ export default function DropDown({
           }
         }
       };
-      document.addEventListener('click', handle);
-
-      return () => {
-        document.removeEventListener('click', handle);
-      };
+      return registerEventListener(document, 'click', handle);
     }
   }, [dropDownRef, buttonRef, showDropDown, stopCloseOnClickSelf]);
 
@@ -253,11 +253,11 @@ export default function DropDown({
       }
     };
 
-    document.addEventListener('scroll', handleButtonPositionUpdate);
-
-    return () => {
-      document.removeEventListener('scroll', handleButtonPositionUpdate);
-    };
+    return registerEventListener(
+      document,
+      'scroll',
+      handleButtonPositionUpdate,
+    );
   }, [buttonRef, dropDownRef, showDropDown]);
 
   const handleOnClick = (e: React.MouseEvent) => {

--- a/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
@@ -17,7 +17,7 @@ import type {JSX} from 'react';
 import './ExcalidrawModal.css';
 
 import {Excalidraw} from '@excalidraw/excalidraw';
-import {isDOMNode} from 'lexical';
+import {isDOMNode, registerEventListener} from 'lexical';
 import * as React from 'react';
 import {ReactPortal, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
@@ -91,7 +91,7 @@ export default function ExcalidrawModal({
   }, []);
 
   useEffect(() => {
-    let modalOverlayElement: HTMLElement | null = null;
+    let unregisterClickOutside: (() => void) | null = null;
 
     const clickOutsideHandler = (event: MouseEvent) => {
       const target = event.target;
@@ -106,12 +106,18 @@ export default function ExcalidrawModal({
     };
 
     if (excaliDrawModelRef.current !== null) {
-      modalOverlayElement = excaliDrawModelRef.current?.parentElement;
-      modalOverlayElement?.addEventListener('click', clickOutsideHandler);
+      const modalOverlayElement = excaliDrawModelRef.current?.parentElement;
+      if (modalOverlayElement) {
+        unregisterClickOutside = registerEventListener(
+          modalOverlayElement,
+          'click',
+          clickOutsideHandler,
+        );
+      }
     }
 
     return () => {
-      modalOverlayElement?.removeEventListener('click', clickOutsideHandler);
+      unregisterClickOutside?.();
     };
   }, [closeOnClickOutside, onDelete]);
 
@@ -124,10 +130,12 @@ export default function ExcalidrawModal({
       }
     };
 
-    currentModalRef?.addEventListener('keydown', onKeyDown);
+    const unregisterKeyDown = currentModalRef
+      ? registerEventListener(currentModalRef, 'keydown', onKeyDown)
+      : null;
 
     return () => {
-      currentModalRef?.removeEventListener('keydown', onKeyDown);
+      unregisterKeyDown?.();
     };
   }, [elements, files, onDelete]);
 

--- a/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
@@ -91,8 +91,6 @@ export default function ExcalidrawModal({
   }, []);
 
   useEffect(() => {
-    let unregisterClickOutside: (() => void) | null = null;
-
     const clickOutsideHandler = (event: MouseEvent) => {
       const target = event.target;
       if (
@@ -105,20 +103,10 @@ export default function ExcalidrawModal({
       }
     };
 
-    if (excaliDrawModelRef.current !== null) {
-      const modalOverlayElement = excaliDrawModelRef.current?.parentElement;
-      if (modalOverlayElement) {
-        unregisterClickOutside = registerEventListener(
-          modalOverlayElement,
-          'click',
-          clickOutsideHandler,
-        );
-      }
-    }
-
-    return () => {
-      unregisterClickOutside?.();
-    };
+    const modalOverlayElement = excaliDrawModelRef.current?.parentElement;
+    return modalOverlayElement
+      ? registerEventListener(modalOverlayElement, 'click', clickOutsideHandler)
+      : () => {};
   }, [closeOnClickOutside, onDelete]);
 
   useLayoutEffect(() => {
@@ -130,13 +118,9 @@ export default function ExcalidrawModal({
       }
     };
 
-    const unregisterKeyDown = currentModalRef
+    return currentModalRef
       ? registerEventListener(currentModalRef, 'keydown', onKeyDown)
-      : null;
-
-    return () => {
-      unregisterKeyDown?.();
-    };
+      : () => {};
   }, [elements, files, onDelete]);
 
   const save = () => {

--- a/packages/lexical-playground/src/ui/Modal.tsx
+++ b/packages/lexical-playground/src/ui/Modal.tsx
@@ -10,7 +10,7 @@ import type {JSX} from 'react';
 
 import './Modal.css';
 
-import {isDOMNode, registerEventListener} from 'lexical';
+import {isDOMNode, mergeRegister, registerEventListener} from 'lexical';
 import * as React from 'react';
 import {ReactNode, useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
@@ -35,7 +35,6 @@ function PortalImpl({
   }, []);
 
   useEffect(() => {
-    let unregisterClickOutside: (() => void) | null = null;
     const handler = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose();
@@ -52,26 +51,17 @@ function PortalImpl({
         onClose();
       }
     };
-    const modelElement = modalRef.current;
-    if (modelElement !== null) {
-      const modalOverlayElement = modelElement.parentElement;
-      if (modalOverlayElement !== null) {
-        unregisterClickOutside = registerEventListener(
-          modalOverlayElement,
-          'click',
-          clickOutsideHandler,
-        );
-      }
-    }
-
-    const unregisterKeydown = registerEventListener(window, 'keydown', handler);
-
-    return () => {
-      unregisterKeydown();
-      if (unregisterClickOutside !== null) {
-        unregisterClickOutside();
-      }
-    };
+    const modalOverlayElement = modalRef.current?.parentElement ?? null;
+    return mergeRegister(
+      registerEventListener(window, 'keydown', handler),
+      modalOverlayElement
+        ? registerEventListener(
+            modalOverlayElement,
+            'click',
+            clickOutsideHandler,
+          )
+        : () => {},
+    );
   }, [closeOnClickOutside, onClose]);
 
   return (

--- a/packages/lexical-playground/src/ui/Modal.tsx
+++ b/packages/lexical-playground/src/ui/Modal.tsx
@@ -10,7 +10,7 @@ import type {JSX} from 'react';
 
 import './Modal.css';
 
-import {isDOMNode} from 'lexical';
+import {isDOMNode, registerEventListener} from 'lexical';
 import * as React from 'react';
 import {ReactNode, useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
@@ -35,7 +35,7 @@ function PortalImpl({
   }, []);
 
   useEffect(() => {
-    let modalOverlayElement: HTMLElement | null = null;
+    let unregisterClickOutside: (() => void) | null = null;
     const handler = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose();
@@ -54,18 +54,22 @@ function PortalImpl({
     };
     const modelElement = modalRef.current;
     if (modelElement !== null) {
-      modalOverlayElement = modelElement.parentElement;
+      const modalOverlayElement = modelElement.parentElement;
       if (modalOverlayElement !== null) {
-        modalOverlayElement.addEventListener('click', clickOutsideHandler);
+        unregisterClickOutside = registerEventListener(
+          modalOverlayElement,
+          'click',
+          clickOutsideHandler,
+        );
       }
     }
 
-    window.addEventListener('keydown', handler);
+    const unregisterKeydown = registerEventListener(window, 'keydown', handler);
 
     return () => {
-      window.removeEventListener('keydown', handler);
-      if (modalOverlayElement !== null) {
-        modalOverlayElement?.removeEventListener('click', clickOutsideHandler);
+      unregisterKeydown();
+      if (unregisterClickOutside !== null) {
+        unregisterClickOutside();
       }
     };
   }, [closeOnClickOutside, onClose]);

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -32,6 +32,7 @@ import {
   LexicalEditor,
   mergeRegister,
   registerEventListener,
+  registerEventListeners,
 } from 'lexical';
 import {
   DragEvent as ReactDragEvent,
@@ -328,10 +329,10 @@ function useDraggableBlockMenu(
     }
 
     if (scrollerElem != null) {
-      return mergeRegister(
-        registerEventListener(scrollerElem, 'mousemove', onMouseMove),
-        registerEventListener(scrollerElem, 'mouseleave', onMouseLeave),
-      );
+      return registerEventListeners(scrollerElem, {
+        mouseleave: onMouseLeave,
+        mousemove: onMouseMove,
+      });
     }
   }, [scrollerElem, anchorElem, editor, isOnMenu, setDraggableBlockElem]);
 

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -31,6 +31,7 @@ import {
   isHTMLElement,
   LexicalEditor,
   mergeRegister,
+  registerEventListener,
 } from 'lexical';
 import {
   DragEvent as ReactDragEvent,
@@ -488,8 +489,7 @@ function useDraggableBlockMenu(
         }
 
         if (rootElement) {
-          rootElement.addEventListener('blur', onBlur, true);
-          return () => rootElement.removeEventListener('blur', onBlur, true);
+          return registerEventListener(rootElement, 'blur', onBlur, true);
         }
       }),
       // Intercept BLUR_COMMAND if focus is on the menu (fallback in case event propagation wasn't stopped)

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -328,16 +328,11 @@ function useDraggableBlockMenu(
     }
 
     if (scrollerElem != null) {
-      scrollerElem.addEventListener('mousemove', onMouseMove);
-      scrollerElem.addEventListener('mouseleave', onMouseLeave);
+      return mergeRegister(
+        registerEventListener(scrollerElem, 'mousemove', onMouseMove),
+        registerEventListener(scrollerElem, 'mouseleave', onMouseLeave),
+      );
     }
-
-    return () => {
-      if (scrollerElem != null) {
-        scrollerElem.removeEventListener('mousemove', onMouseMove);
-        scrollerElem.removeEventListener('mouseleave', onMouseLeave);
-      }
-    };
   }, [scrollerElem, anchorElem, editor, isOnMenu, setDraggableBlockElem]);
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -22,7 +22,12 @@ import {
   useTypeahead,
 } from '@floating-ui/react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getNearestNodeFromDOMNode, $getRoot, LexicalNode} from 'lexical';
+import {
+  $getNearestNodeFromDOMNode,
+  $getRoot,
+  LexicalNode,
+  registerEventListener,
+} from 'lexical';
 import {forwardRef, JSX, RefObject, useEffect, useRef, useState} from 'react';
 
 class MenuOption {
@@ -272,9 +277,7 @@ const NodeContextMenuPlugin = forwardRef<
 
     return editor.registerRootListener(rootElement => {
       if (rootElement !== null) {
-        rootElement.addEventListener('contextmenu', onContextMenu);
-        return () =>
-          rootElement.removeEventListener('contextmenu', onContextMenu);
+        return registerEventListener(rootElement, 'contextmenu', onContextMenu);
       }
     });
   }, [items, itemClassName, separatorClassName, refs, editor]);

--- a/packages/lexical-react/src/LexicalNodeEventPlugin.ts
+++ b/packages/lexical-react/src/LexicalNodeEventPlugin.ts
@@ -9,7 +9,11 @@
 import type {Klass, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$findMatchingParent, $getNearestNodeFromDOMNode} from 'lexical';
+import {
+  $findMatchingParent,
+  $getNearestNodeFromDOMNode,
+  registerEventListener,
+} from 'lexical';
 import {useEffect, useRef} from 'react';
 
 const capturedEvents = new Set<string>(['mouseenter', 'mouseleave']);
@@ -65,9 +69,12 @@ export function NodeEventPlugin({
 
     return editor.registerRootListener(rootElement => {
       if (rootElement) {
-        rootElement.addEventListener(eventType, onEvent, isCaptured);
-        return () =>
-          rootElement.removeEventListener(eventType, onEvent, isCaptured);
+        return registerEventListener(
+          rootElement,
+          eventType,
+          onEvent,
+          isCaptured,
+        );
       }
     });
     // We intentionally don't respect changes to eventType.

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -248,45 +248,32 @@ export function useDynamicPositioning(
         }
       };
       const resizeObserver = new ResizeObserver(onReposition);
-      const removeResizeListener = registerEventListener(
-        window,
-        'resize',
-        onReposition,
-      );
-      const removeScrollListener = registerEventListener(
-        document,
-        'scroll',
-        handleScroll,
-        {
-          capture: true,
-          passive: true,
-        },
-      );
       // Scroll events are non-composed and do not cross shadow boundaries,
-      // so the document-level listener above never sees scrolls inside an
+      // so the document-level listener below never sees scrolls inside an
       // enclosing shadow tree. Key off the editor root rather than the
       // target — the target may be portaled into the light DOM while the
       // editor (and its scroll container) live inside a shadow tree, and
       // getDOMShadowRoots(target) would then return an empty list. Walk
       // out of the editor's enclosing shadow roots instead so internal
       // scrolls at any depth reposition the floating menu.
-      const shadowRootSource = rootElement ?? targetElement;
-      const enclosingShadowRoots = getDOMShadowRoots(shadowRootSource);
-      const removeShadowRootListeners = enclosingShadowRoots.map(root =>
-        registerEventListener(root, 'scroll', handleScroll, {
+      const enclosingShadowRoots = getDOMShadowRoots(
+        rootElement ?? targetElement,
+      );
+      resizeObserver.observe(targetElement);
+      return mergeRegister(
+        registerEventListener(window, 'resize', onReposition),
+        registerEventListener(document, 'scroll', handleScroll, {
           capture: true,
           passive: true,
         }),
+        ...enclosingShadowRoots.map(root =>
+          registerEventListener(root, 'scroll', handleScroll, {
+            capture: true,
+            passive: true,
+          }),
+        ),
+        () => resizeObserver.unobserve(targetElement),
       );
-      resizeObserver.observe(targetElement);
-      return () => {
-        resizeObserver.unobserve(targetElement);
-        removeResizeListener();
-        removeScrollListener();
-        for (const removeShadowRootListener of removeShadowRootListeners) {
-          removeShadowRootListener();
-        }
-      };
     }
   }, [targetElement, editor, onVisibilityChange, onReposition, resolution]);
 }

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -27,6 +27,7 @@ import {
   LexicalCommand,
   LexicalEditor,
   mergeRegister,
+  registerEventListener,
   TextNode,
 } from 'lexical';
 import {
@@ -247,11 +248,20 @@ export function useDynamicPositioning(
         }
       };
       const resizeObserver = new ResizeObserver(onReposition);
-      window.addEventListener('resize', onReposition);
-      document.addEventListener('scroll', handleScroll, {
-        capture: true,
-        passive: true,
-      });
+      const removeResizeListener = registerEventListener(
+        window,
+        'resize',
+        onReposition,
+      );
+      const removeScrollListener = registerEventListener(
+        document,
+        'scroll',
+        handleScroll,
+        {
+          capture: true,
+          passive: true,
+        },
+      );
       // Scroll events are non-composed and do not cross shadow boundaries,
       // so the document-level listener above never sees scrolls inside an
       // enclosing shadow tree. Key off the editor root rather than the
@@ -262,19 +272,19 @@ export function useDynamicPositioning(
       // scrolls at any depth reposition the floating menu.
       const shadowRootSource = rootElement ?? targetElement;
       const enclosingShadowRoots = getDOMShadowRoots(shadowRootSource);
-      for (const root of enclosingShadowRoots) {
-        root.addEventListener('scroll', handleScroll, {
+      const removeShadowRootListeners = enclosingShadowRoots.map(root =>
+        registerEventListener(root, 'scroll', handleScroll, {
           capture: true,
           passive: true,
-        });
-      }
+        }),
+      );
       resizeObserver.observe(targetElement);
       return () => {
         resizeObserver.unobserve(targetElement);
-        window.removeEventListener('resize', onReposition);
-        document.removeEventListener('scroll', handleScroll, true);
-        for (const root of enclosingShadowRoots) {
-          root.removeEventListener('scroll', handleScroll, true);
+        removeResizeListener();
+        removeScrollListener();
+        for (const removeShadowRootListener of removeShadowRootListeners) {
+          removeShadowRootListener();
         }
       };
     }

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -48,7 +48,7 @@ import {
   HISTORY_MERGE_TAG,
   mergeRegister,
   REDO_COMMAND,
-  registerEventListener,
+  registerEventListeners,
   SKIP_COLLAB_TAG,
   UNDO_COMMAND,
 } from 'lexical';
@@ -458,10 +458,10 @@ function useProvider(
     // Use both beforeunload and pagehide for maximum browser compatibility
     // beforeunload: fires before page unloads (may be cancelable)
     // pagehide: fires when page is being unloaded (more reliable, especially on mobile)
-    return mergeRegister(
-      registerEventListener(window, 'beforeunload', clearAwarenessState),
-      registerEventListener(window, 'pagehide', clearAwarenessState),
-    );
+    return registerEventListeners(window, {
+      beforeunload: clearAwarenessState,
+      pagehide: clearAwarenessState,
+    });
   }, [provider]);
 }
 

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -48,6 +48,7 @@ import {
   HISTORY_MERGE_TAG,
   mergeRegister,
   REDO_COMMAND,
+  registerEventListener,
   SKIP_COLLAB_TAG,
   UNDO_COMMAND,
 } from 'lexical';
@@ -457,13 +458,10 @@ function useProvider(
     // Use both beforeunload and pagehide for maximum browser compatibility
     // beforeunload: fires before page unloads (may be cancelable)
     // pagehide: fires when page is being unloaded (more reliable, especially on mobile)
-    window.addEventListener('beforeunload', clearAwarenessState);
-    window.addEventListener('pagehide', clearAwarenessState);
-
-    return () => {
-      window.removeEventListener('beforeunload', clearAwarenessState);
-      window.removeEventListener('pagehide', clearAwarenessState);
-    };
+    return mergeRegister(
+      registerEventListener(window, 'beforeunload', clearAwarenessState),
+      registerEventListener(window, 'pagehide', clearAwarenessState),
+    );
   }, [provider]);
 }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -91,6 +91,7 @@ import {
   KEY_DELETE_COMMAND,
   KEY_ESCAPE_COMMAND,
   KEY_TAB_COMMAND,
+  registerEventListener,
   removeClassNamesFromElement,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
@@ -242,10 +243,11 @@ export function registerTableWindowHandlers(
       });
     };
 
-    editorWindow.addEventListener('pointerdown', pointerDownCallback);
-    return () => {
-      editorWindow.removeEventListener('pointerdown', pointerDownCallback);
-    };
+    return registerEventListener(
+      editorWindow,
+      'pointerdown',
+      pointerDownCallback,
+    );
   });
 }
 
@@ -425,14 +427,14 @@ export function applyTableHandlers(
       }
     }
   };
-  tableElement.addEventListener(
-    'mousedown',
-    onTripleClick,
-    tableObserver.listenerOptions,
+  tableObserver.listenersToRemove.add(
+    registerEventListener(
+      tableElement,
+      'mousedown',
+      onTripleClick,
+      tableObserver.listenerOptions,
+    ),
   );
-  tableObserver.listenersToRemove.add(() => {
-    tableElement.removeEventListener('mousedown', onTripleClick);
-  });
 
   for (const [command, direction] of ARROW_KEY_COMMANDS_WITH_DIRECTION) {
     tableObserver.listenersToRemove.add(

--- a/packages/lexical-utils/src/selectionAlwaysOnDisplay.ts
+++ b/packages/lexical-utils/src/selectionAlwaysOnDisplay.ts
@@ -9,6 +9,7 @@
 import {
   getDOMSelectionPoints,
   LexicalEditor,
+  mergeRegister,
   registerEventListener,
 } from 'lexical';
 
@@ -59,18 +60,16 @@ export default function selectionAlwaysOnDisplay(
   return editor.registerRootListener(rootElement => {
     if (rootElement) {
       const document = rootElement.ownerDocument;
-      const removeSelectionChange = registerEventListener(
-        document,
-        'selectionchange',
-        onSelectionChange,
+      const cleanup = mergeRegister(
+        registerEventListener(document, 'selectionchange', onSelectionChange),
+        () => {
+          if (removeSelectionMark !== null) {
+            removeSelectionMark();
+          }
+        },
       );
       onSelectionChange();
-      return () => {
-        if (removeSelectionMark !== null) {
-          removeSelectionMark();
-        }
-        removeSelectionChange();
-      };
+      return cleanup;
     }
   });
 }

--- a/packages/lexical-utils/src/selectionAlwaysOnDisplay.ts
+++ b/packages/lexical-utils/src/selectionAlwaysOnDisplay.ts
@@ -6,7 +6,11 @@
  *
  */
 
-import {getDOMSelectionPoints, LexicalEditor} from 'lexical';
+import {
+  getDOMSelectionPoints,
+  LexicalEditor,
+  registerEventListener,
+} from 'lexical';
 
 import markSelection from './markSelection';
 
@@ -55,13 +59,17 @@ export default function selectionAlwaysOnDisplay(
   return editor.registerRootListener(rootElement => {
     if (rootElement) {
       const document = rootElement.ownerDocument;
-      document.addEventListener('selectionchange', onSelectionChange);
+      const removeSelectionChange = registerEventListener(
+        document,
+        'selectionchange',
+        onSelectionChange,
+      );
       onSelectionChange();
       return () => {
         if (removeSelectionMark !== null) {
           removeSelectionMark();
         }
-        document.removeEventListener('selectionchange', onSelectionChange);
+        removeSelectionChange();
       };
     }
   });

--- a/packages/lexical-website/docs/concepts/dom-events.md
+++ b/packages/lexical-website/docs/concepts/dom-events.md
@@ -42,6 +42,23 @@ const removeRootListener = editor.registerRootListener((rootElement) => {
 
 It mirrors the `addEventListener` overloads (so the event type is strongly typed) and composes well with `mergeRegister` when you need to register several listeners at once.
 
+To attach several listeners to the same target, `registerEventListeners(target, listeners, options?)` takes a `{type: listener}` map and returns a single dispose function that removes all of them. Each listener's event argument is still strongly typed per event type, and the optional `options` argument is shared across every listener:
+
+```js
+import {registerEventListeners} from 'lexical';
+
+const removeListeners = registerEventListeners(
+  rootElement,
+  {
+    click: onClick,
+    keydown: onKeyDown, // receives a KeyboardEvent
+  },
+  {capture: true}, // shared by both listeners
+);
+```
+
+Because `options` is shared, register a group that needs different options (such as a different `capture` flag) with a separate `registerEventListeners` call and combine the results with `mergeRegister`.
+
 ## 2. Directly Attach Handlers
 
 In some cases, it may be better to attach an event handler directly to the underlying DOM node of each specific node. With this approach, you generally don't need to filter the event target in the handler, which can make it a bit simpler. It will also guarantee that your handler isn't running for events that you don't care about. This approach is implemented via a [Mutation Listener](listeners.md).

--- a/packages/lexical-website/docs/concepts/dom-events.md
+++ b/packages/lexical-website/docs/concepts/dom-events.md
@@ -28,6 +28,20 @@ removeRootListener();
 ```
 This can be a simple, efficient way to handle some use cases, since it's not necessary to attach a listener to each DOM node individually.
 
+The `addEventListener`/`removeEventListener` pairing above is common enough that the core `lexical` package exports a `registerEventListener(target, type, listener, options?)` helper. It attaches the listener and returns a dispose function that removes it, so the example above becomes:
+
+```js
+import {registerEventListener} from 'lexical';
+
+const removeRootListener = editor.registerRootListener((rootElement) => {
+    // registerEventListener returns the matching removeEventListener cleanup,
+    // so there's no need to write the teardown by hand.
+    return registerEventListener(rootElement, 'click', myListener);
+});
+```
+
+It mirrors the `addEventListener` overloads (so the event type is strongly typed) and composes well with `mergeRegister` when you need to register several listeners at once.
+
 ## 2. Directly Attach Handlers
 
 In some cases, it may be better to attach an event handler directly to the underlying DOM node of each specific node. With this approach, you generally don't need to filter the event target in the handler, which can make it a bit simpler. It will also guarantee that your handler isn't running for events that you don't care about. This approach is implemented via a [Mutation Listener](listeners.md).

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -2074,10 +2074,10 @@ declare export function registerEventListener(
   listener: EventListener,
   options?: EventListenerOptionsOrUseCapture,
 ): () => void;
-export type EventListenerMap<T> = {+[type: string]: EventListener};
+export type EventListenerMap<T> = {readonly [type: string]: EventListener};
 declare export function registerEventListeners(
   target: EventTarget,
-  listeners: {+[type: string]: EventListener},
+  listeners: {readonly [type: string]: EventListener},
   options?: EventListenerOptionsOrUseCapture,
 ): () => void;
 declare export function normalizeClassNames(...classNames: (typeof undefined | boolean | null | string)[]): string[];

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -2074,6 +2074,12 @@ declare export function registerEventListener(
   listener: EventListener,
   options?: EventListenerOptionsOrUseCapture,
 ): () => void;
+export type EventListenerMap<T> = {+[type: string]: EventListener};
+declare export function registerEventListeners(
+  target: EventTarget,
+  listeners: {+[type: string]: EventListener},
+  options?: EventListenerOptionsOrUseCapture,
+): () => void;
 declare export function normalizeClassNames(...classNames: (typeof undefined | boolean | null | string)[]): string[];
 declare export function getStyleObjectFromCSS(css: string): {
   [string]: string,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -2075,9 +2075,9 @@ declare export function registerEventListener(
   options?: EventListenerOptionsOrUseCapture,
 ): () => void;
 export type EventListenerMap<T> = {readonly [type: string]: EventListener};
-declare export function registerEventListeners(
-  target: EventTarget,
-  listeners: {readonly [type: string]: EventListener},
+declare export function registerEventListeners<T: EventTarget>(
+  target: T,
+  listeners: EventListenerMap<T>,
   options?: EventListenerOptionsOrUseCapture,
 ): () => void;
 declare export function normalizeClassNames(...classNames: (typeof undefined | boolean | null | string)[]): string[];

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -2068,6 +2068,12 @@ declare export function removeClassNamesFromElement(
   ...classNames: (typeof undefined | boolean | null | string)[]
 ): void;
 declare export function mergeRegister(...func: (() => void)[]): () => void;
+declare export function registerEventListener(
+  target: EventTarget,
+  type: string,
+  listener: EventListener,
+  options?: EventListenerOptionsOrUseCapture,
+): () => void;
 declare export function normalizeClassNames(...classNames: (typeof undefined | boolean | null | string)[]): string[];
 declare export function getStyleObjectFromCSS(css: string): {
   [string]: string,

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -158,6 +158,7 @@ import {
   isUnderline,
   isUndo,
 } from './LexicalUtils';
+import {registerEventListener} from './utils/registerEventListener';
 
 type RootElementRemoveHandles = (() => void)[];
 type RootElementEvents = [
@@ -1875,10 +1876,9 @@ export function addRootElementEvents(
                 );
             }
           };
-    rootElement.addEventListener(eventName, eventHandler);
-    removeHandles.push(() => {
-      rootElement.removeEventListener(eventName, eventHandler);
-    });
+    removeHandles.push(
+      registerEventListener(rootElement, eventName, eventHandler),
+    );
   }
 }
 

--- a/packages/lexical/src/__tests__/unit/registerEventListener.test.ts
+++ b/packages/lexical/src/__tests__/unit/registerEventListener.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {registerEventListener} from 'lexical';
+import {describe, expect, it, vi} from 'vitest';
+
+describe('registerEventListener', () => {
+  it('adds the listener and dispatches events to it', () => {
+    const target = document.createElement('div');
+    const listener = vi.fn();
+    registerEventListener(target, 'click', listener);
+    target.dispatchEvent(new Event('click'));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a dispose function that removes the listener', () => {
+    const target = document.createElement('div');
+    const listener = vi.fn();
+    const dispose = registerEventListener(target, 'click', listener);
+    dispose();
+    target.dispatchEvent(new Event('click'));
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('forwards the capture option to addEventListener and removeEventListener', () => {
+    const target = document.createElement('div');
+    const addSpy = vi.spyOn(target, 'addEventListener');
+    const removeSpy = vi.spyOn(target, 'removeEventListener');
+    const listener = vi.fn();
+    const options = {capture: true};
+    const dispose = registerEventListener(target, 'click', listener, options);
+    expect(addSpy).toHaveBeenCalledWith('click', listener, options);
+    dispose();
+    expect(removeSpy).toHaveBeenCalledWith('click', listener, options);
+  });
+});

--- a/packages/lexical/src/__tests__/unit/registerEventListeners.test.ts
+++ b/packages/lexical/src/__tests__/unit/registerEventListeners.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {registerEventListeners} from 'lexical';
+import {describe, expect, it, vi} from 'vitest';
+
+describe('registerEventListeners', () => {
+  it('registers every listener in the map', () => {
+    const target = document.createElement('div');
+    const onClick = vi.fn();
+    const onKeyDown = vi.fn();
+    registerEventListeners(target, {click: onClick, keydown: onKeyDown});
+    target.dispatchEvent(new Event('click'));
+    target.dispatchEvent(new Event('keydown'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a dispose function that removes every listener', () => {
+    const target = document.createElement('div');
+    const onClick = vi.fn();
+    const onKeyDown = vi.fn();
+    const dispose = registerEventListeners(target, {
+      click: onClick,
+      keydown: onKeyDown,
+    });
+    dispose();
+    target.dispatchEvent(new Event('click'));
+    target.dispatchEvent(new Event('keydown'));
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('forwards the shared options to add and removeEventListener', () => {
+    const target = document.createElement('div');
+    const addSpy = vi.spyOn(target, 'addEventListener');
+    const removeSpy = vi.spyOn(target, 'removeEventListener');
+    const onClick = vi.fn();
+    const onKeyDown = vi.fn();
+    const options = {capture: true};
+    const dispose = registerEventListeners(
+      target,
+      {click: onClick, keydown: onKeyDown},
+      options,
+    );
+    expect(addSpy).toHaveBeenCalledWith('click', onClick, options);
+    expect(addSpy).toHaveBeenCalledWith('keydown', onKeyDown, options);
+    dispose();
+    expect(removeSpy).toHaveBeenCalledWith('click', onClick, options);
+    expect(removeSpy).toHaveBeenCalledWith('keydown', onKeyDown, options);
+  });
+});

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -485,6 +485,7 @@ export {
   removeClassNamesFromElement,
 } from './utils/classNames';
 export {mergeRegister} from './utils/mergeRegister';
+export {registerEventListener} from './utils/registerEventListener';
 export {
   getStyleObjectFromCSS,
   setDOMStyleFromCSS,

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -486,6 +486,8 @@ export {
 } from './utils/classNames';
 export {mergeRegister} from './utils/mergeRegister';
 export {registerEventListener} from './utils/registerEventListener';
+export type {EventListenerMap} from './utils/registerEventListeners';
+export {registerEventListeners} from './utils/registerEventListeners';
 export {
   getStyleObjectFromCSS,
   setDOMStyleFromCSS,

--- a/packages/lexical/src/utils/registerEventListener.ts
+++ b/packages/lexical/src/utils/registerEventListener.ts
@@ -7,6 +7,19 @@
  */
 
 /**
+ * The typed event map for a given {@link EventTarget}, falling back to a
+ * permissive record so custom targets and events still type-check. Shared by
+ * {@link registerEventListener} and `registerEventListeners`.
+ */
+export type EventMapOf<T extends EventTarget> = T extends Window
+  ? WindowEventMap
+  : T extends Document
+    ? DocumentEventMap
+    : T extends HTMLElement
+      ? HTMLElementEventMap
+      : Record<string, Event>;
+
+/**
  * Add an event listener to `target` and return a function that removes it.
  *
  * This is a thin, strongly typed wrapper around
@@ -43,24 +56,17 @@
  * @param options - Options forwarded to `add`/`removeEventListener`
  * @returns A function that removes the listener when called
  */
-export function registerEventListener<K extends keyof WindowEventMap>(
-  target: Window,
+export function registerEventListener<
+  T extends EventTarget,
+  K extends keyof EventMapOf<T> & string,
+>(
+  target: T,
   type: K,
-  listener: (this: Window, ev: WindowEventMap[K]) => unknown,
+  listener: (this: T, ev: EventMapOf<T>[K]) => unknown,
   options?: boolean | AddEventListenerOptions,
 ): () => void;
-export function registerEventListener<K extends keyof DocumentEventMap>(
-  target: Document,
-  type: K,
-  listener: (this: Document, ev: DocumentEventMap[K]) => unknown,
-  options?: boolean | AddEventListenerOptions,
-): () => void;
-export function registerEventListener<K extends keyof HTMLElementEventMap>(
-  target: HTMLElement,
-  type: K,
-  listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => unknown,
-  options?: boolean | AddEventListenerOptions,
-): () => void;
+// Fallback for non-standard event names (e.g. the legacy `textInput`) and
+// targets without a typed event map.
 export function registerEventListener(
   target: EventTarget,
   type: string,

--- a/packages/lexical/src/utils/registerEventListener.ts
+++ b/packages/lexical/src/utils/registerEventListener.ts
@@ -7,9 +7,12 @@
  */
 
 /**
- * The typed event map for a given {@link EventTarget}, falling back to a
- * permissive record so custom targets and events still type-check. Shared by
- * {@link registerEventListener} and `registerEventListeners`.
+ * The typed event map for a given {@link EventTarget}. Falls back to the global
+ * handlers map (rather than a permissive `Record<string, Event>`) so unknown
+ * event names are rejected as typos. Shared by {@link registerEventListener}
+ * and `registerEventListeners`; the former additionally has a `string` overload
+ * as an escape hatch for non-standard names (e.g. the legacy `textInput`),
+ * which the object form intentionally does not.
  */
 export type EventMapOf<T extends EventTarget> = T extends Window
   ? WindowEventMap
@@ -17,7 +20,7 @@ export type EventMapOf<T extends EventTarget> = T extends Window
     ? DocumentEventMap
     : T extends HTMLElement
       ? HTMLElementEventMap
-      : Record<string, Event>;
+      : GlobalEventHandlersEventMap;
 
 /**
  * Add an event listener to `target` and return a function that removes it.

--- a/packages/lexical/src/utils/registerEventListener.ts
+++ b/packages/lexical/src/utils/registerEventListener.ts
@@ -74,7 +74,7 @@ export function registerEventListener(
   options?: boolean | AddEventListenerOptions,
 ): () => void {
   target.addEventListener(type, listener, options);
-  return () => {
-    target.removeEventListener(type, listener, options);
-  };
+  // Return a bound `removeEventListener` rather than an arrow so the dispose
+  // function doesn't allocate an extra closure over the arguments.
+  return target.removeEventListener.bind(target, type, listener, options);
 }

--- a/packages/lexical/src/utils/registerEventListener.ts
+++ b/packages/lexical/src/utils/registerEventListener.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Add an event listener to `target` and return a function that removes it.
+ *
+ * This is a thin, strongly typed wrapper around
+ * {@link EventTarget.addEventListener} that mirrors its overloads but returns a
+ * dispose function instead of `void`. It removes the
+ * `addEventListener`/`removeEventListener` boilerplate that every DOM
+ * subscription would otherwise duplicate, and composes cleanly with
+ * {@link mergeRegister} or as the return value of an effect.
+ *
+ * The same `options` value is forwarded to both `addEventListener` and
+ * `removeEventListener` so that the `capture` flag always matches, which is
+ * required for the listener to be removed correctly.
+ *
+ * @example
+ * ```ts
+ * // Returned directly from a React effect
+ * useEffect(
+ *   () => registerEventListener(container, 'keydown', handler),
+ *   [container],
+ * );
+ * ```
+ * @example
+ * ```ts
+ * // Composed with other teardown via mergeRegister
+ * return mergeRegister(
+ *   registerEventListener(window, 'resize', onResize),
+ *   registerEventListener(document, 'selectionchange', onSelectionChange),
+ * );
+ * ```
+ *
+ * @param target - The {@link EventTarget} to subscribe to
+ * @param type - The event type to listen for (e.g. `'keydown'`)
+ * @param listener - The listener invoked when a matching event is dispatched
+ * @param options - Options forwarded to `add`/`removeEventListener`
+ * @returns A function that removes the listener when called
+ */
+export function registerEventListener<K extends keyof WindowEventMap>(
+  target: Window,
+  type: K,
+  listener: (this: Window, ev: WindowEventMap[K]) => unknown,
+  options?: boolean | AddEventListenerOptions,
+): () => void;
+export function registerEventListener<K extends keyof DocumentEventMap>(
+  target: Document,
+  type: K,
+  listener: (this: Document, ev: DocumentEventMap[K]) => unknown,
+  options?: boolean | AddEventListenerOptions,
+): () => void;
+export function registerEventListener<K extends keyof HTMLElementEventMap>(
+  target: HTMLElement,
+  type: K,
+  listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => unknown,
+  options?: boolean | AddEventListenerOptions,
+): () => void;
+export function registerEventListener(
+  target: EventTarget,
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options?: boolean | AddEventListenerOptions,
+): () => void;
+export function registerEventListener(
+  target: EventTarget,
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options?: boolean | AddEventListenerOptions,
+): () => void {
+  target.addEventListener(type, listener, options);
+  return () => {
+    target.removeEventListener(type, listener, options);
+  };
+}

--- a/packages/lexical/src/utils/registerEventListeners.ts
+++ b/packages/lexical/src/utils/registerEventListeners.ts
@@ -6,21 +6,10 @@
  *
  */
 
+import type {EventMapOf} from './registerEventListener';
+
 import {mergeRegister} from './mergeRegister';
 import {registerEventListener} from './registerEventListener';
-
-/**
- * The typed event map for a given {@link EventTarget}, falling back to a
- * permissive record so custom targets and events still type-check. The typed
- * cases mirror the overloads of {@link registerEventListener}.
- */
-type EventMapOf<T extends EventTarget> = T extends Window
-  ? WindowEventMap
-  : T extends Document
-    ? DocumentEventMap
-    : T extends HTMLElement
-      ? HTMLElementEventMap
-      : Record<string, Event>;
 
 /**
  * A map of event type to listener for a given {@link EventTarget}. Each

--- a/packages/lexical/src/utils/registerEventListeners.ts
+++ b/packages/lexical/src/utils/registerEventListeners.ts
@@ -71,21 +71,13 @@ export function registerEventListeners<T extends EventTarget>(
   listeners: EventListenerMap<T>,
   options?: boolean | AddEventListenerOptions,
 ): () => void {
-  const disposers: (() => void)[] = [];
-  for (const type in listeners) {
-    if (Object.prototype.hasOwnProperty.call(listeners, type)) {
-      const listener = listeners[type as keyof EventListenerMap<T>];
-      if (listener) {
-        disposers.push(
-          registerEventListener(
-            target,
-            type,
-            listener as EventListener,
-            options,
-          ),
-        );
-      }
-    }
-  }
-  return mergeRegister(...disposers);
+  // Erase the per-event-type listener signatures to the loose
+  // `addEventListener` form at the single boundary where the typed map is
+  // turned into untyped registrations.
+  const entries = Object.entries(listeners) as [string, EventListener][];
+  return mergeRegister(
+    ...entries.map(([type, listener]) =>
+      registerEventListener(target, type, listener, options),
+    ),
+  );
 }

--- a/packages/lexical/src/utils/registerEventListeners.ts
+++ b/packages/lexical/src/utils/registerEventListeners.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {mergeRegister} from './mergeRegister';
+import {registerEventListener} from './registerEventListener';
+
+/**
+ * The typed event map for a given {@link EventTarget}, falling back to a
+ * permissive record so custom targets and events still type-check. The typed
+ * cases mirror the overloads of {@link registerEventListener}.
+ */
+type EventMapOf<T extends EventTarget> = T extends Window
+  ? WindowEventMap
+  : T extends Document
+    ? DocumentEventMap
+    : T extends HTMLElement
+      ? HTMLElementEventMap
+      : Record<string, Event>;
+
+/**
+ * A map of event type to listener for a given {@link EventTarget}. Each
+ * listener's event argument is inferred from the event type, e.g. for an
+ * `HTMLElement` the `'keydown'` listener receives a `KeyboardEvent`.
+ */
+export type EventListenerMap<T extends EventTarget> = {
+  [K in keyof EventMapOf<T>]?: (this: T, ev: EventMapOf<T>[K]) => unknown;
+};
+
+/**
+ * Add several event listeners to a single `target` and return one function
+ * that removes all of them.
+ *
+ * This is the batch form of {@link registerEventListener}: it takes a
+ * `{type: listener}` object (strongly typed per event type) and shares one
+ * `options` value across every listener. The returned dispose function removes
+ * the listeners in reverse registration order (via {@link mergeRegister}).
+ *
+ * Because `options` is shared, register listeners that need a different
+ * `options` value (e.g. a different `capture` flag) with a separate call and
+ * combine the results with `mergeRegister`.
+ *
+ * @example
+ * ```ts
+ * // All five listeners share {capture: true}
+ * return registerEventListeners(
+ *   window,
+ *   {
+ *     beforeinput: report,
+ *     cut: report,
+ *     keydown: report,
+ *     paste: report,
+ *     selectionchange: report,
+ *   },
+ *   {capture: true},
+ * );
+ * ```
+ *
+ * @param target - The {@link EventTarget} to subscribe to
+ * @param listeners - A map of event type to listener
+ * @param options - Options forwarded to `add`/`removeEventListener` for every
+ *   listener
+ * @returns A function that removes every listener when called
+ */
+export function registerEventListeners<T extends EventTarget>(
+  target: T,
+  listeners: EventListenerMap<T>,
+  options?: boolean | AddEventListenerOptions,
+): () => void {
+  const disposers: (() => void)[] = [];
+  for (const type in listeners) {
+    if (Object.prototype.hasOwnProperty.call(listeners, type)) {
+      const listener = listeners[type as keyof EventListenerMap<T>];
+      if (listener) {
+        disposers.push(
+          registerEventListener(
+            target,
+            type,
+            listener as EventListener,
+            options,
+          ),
+        );
+      }
+    }
+  }
+  return mergeRegister(...disposers);
+}


### PR DESCRIPTION
## Description

Adding/removing a DOM event listener and returning a matching teardown is a pattern repeated all over the codebase:

```ts
// Before
container.addEventListener('keydown', handler);
return () => container.removeEventListener('keydown', handler);
```

```ts
// Before
rootElement.addEventListener('mousedown', onMouseDown, true);
rootElement.addEventListener('click', onClick, true);
return () => {
  rootElement.removeEventListener('mousedown', onMouseDown, true);
  rootElement.removeEventListener('click', onClick, true);
};
```

**New API**

- `registerEventListener(target, type, listener, options?)` — wraps `addEventListener` and returns a dispose function that calls the matching `removeEventListener`. It mirrors the `addEventListener` overloads (event type is strongly typed per target via a shared `EventMapOf<T>` conditional, with a `string` fallback for non-standard names like the legacy `textInput`), and forwards the same `options` to both add and remove so the `capture` flag always matches. The dispose function is a bound `removeEventListener` to avoid an extra closure.
- `registerEventListeners(target, listeners, options?)` — the batch form. Takes a `{type: listener}` object (each listener's event argument inferred per key), shares one `options` across all listeners, and returns a single dispose function (built on `registerEventListener` + `mergeRegister`). Unlike the singular helper it has no `string` escape hatch, so unknown event names are rejected as typos. Use a separate call for a group that needs different options.

Both are exported from `lexical`, declared in the Flow types, and documented in `docs/concepts/dom-events.md`.

```ts
// After
return registerEventListener(container, 'keydown', handler);
```

```ts
// After
return registerEventListeners(
  rootElement,
  {click: onClick, mousedown: onMouseDown},
  true,
);
```

**Adoption**

The `addEventListener`/`removeEventListener` boilerplate is replaced with these helpers throughout `lexical`, `@lexical/react`, `@lexical/list`, `@lexical/link`, `@lexical/table`, `@lexical/extension`, `@lexical/utils`, and the playground. Multi-listener sites with uniform options use the object form; mixed-option groups stay as separate calls combined with `mergeRegister`. Stored disposers that were only invoked in a trailing cleanup are returned directly (or folded into a `mergeRegister`), removing the intermediate variables.

Sites that intentionally keep raw `addEventListener` are listeners that are fire-and-forget (never removed), ref-counted/shared, or whose add/remove are split across separate handler bodies — the dispose-function model doesn't fit those.

**Bug fix (included)**

`TableCellResizer` added a `pointermove` listener with `{capture: true}` but removed it without the capture flag, so `removeEventListener` never matched and capture-phase listeners accumulated on every effect re-run. Routing it through the helper (which forwards identical options to both sides) fixes the leak by construction.

Closes #8120

## Test plan

### Before

No dedicated coverage — the add/remove boilerplate was duplicated per call site, and the `TableCellResizer` capture-flag mismatch leaked listeners.

### After

- New unit tests for both helpers (`registerEventListener.test.ts`, `registerEventListeners.test.ts`) covering registration, disposal, and that `options`/`capture` are forwarded to both add and remove.
- All existing unit tests pass (behavior-preserving adoption).
- `pnpm run ci-check` green: TypeScript, Flow (incl. `lint-flow` export consistency), Prettier, and ESLint.

No user-visible behavior change apart from the `TableCellResizer` leak fix.
