### PR TITLE
Add missing copyright headers to 4 source files

### DIFF
--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.css
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 .code-action-menu-container .prettier-wrapper {
   position: relative;
 }

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 .draggable-block-menu {
   border-radius: 4px;
   padding: 2px 1px;

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 .link-editor {
   display: flex;
   z-index: 10;

--- a/stubs/empty/index.d.ts
+++ b/stubs/empty/index.d.ts
@@ -1,1 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 export {};


### PR DESCRIPTION
These files were missing the standard Meta copyright header. CSS files and .d.ts stubs are not covered by the eslint header rule, so they slipped through.

Files updated:
- packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.css
- packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
- packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
- stubs/empty/index.d.ts

Header matches scripts/www/headerTemplate.js exactly.