### PR TITLE
[lexical] Bug Fix: Skip ZWSP insertion for format mismatch on Android Chrome

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1332,10 +1332,9 @@ function $handleCompositionStart(event: CompositionEvent): boolean {
       // need to invoke the empty space heuristic below.
       anchor.type === 'element' ||
       !selection.isCollapsed() ||
-      (!IS_ANDROID_CHROME && node.getFormat() !== selection.format) ||
       (!IS_ANDROID_CHROME &&
-        $isTextNode(node) &&
-        node.getStyle() !== selection.style)
+        (node.getFormat() !== selection.format ||
+          ($isTextNode(node) && node.getStyle() !== selection.style)))
     ) {
       // We insert a zero width character, ready for the composition
       // to get inserted into the new node we create. If

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1332,8 +1332,10 @@ function $handleCompositionStart(event: CompositionEvent): boolean {
       // need to invoke the empty space heuristic below.
       anchor.type === 'element' ||
       !selection.isCollapsed() ||
-      node.getFormat() !== selection.format ||
-      ($isTextNode(node) && node.getStyle() !== selection.style)
+      (!IS_ANDROID_CHROME && node.getFormat() !== selection.format) ||
+      (!IS_ANDROID_CHROME &&
+        $isTextNode(node) &&
+        node.getStyle() !== selection.style)
     ) {
       // We insert a zero width character, ready for the composition
       // to get inserted into the new node we create. If

--- a/packages/lexical/src/__tests__/unit/LexicalAndroidChromeComposition.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalAndroidChromeComposition.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * On Android Chrome, Samsung Keyboard (and similar non-Gboard keyboards)
+ * caches the composing region internally. When Lexical inserts a ZWSP during
+ * compositionStart to handle format/style mismatches, the resulting DOM
+ * mutation triggers Samsung's restartInput(), which restores the cached
+ * text and causes duplication.
+ *
+ * The fix: skip the ZWSP insertion for format/style mismatch on Android
+ * Chrome. The ZWSP is still inserted for other conditions (element anchor,
+ * non-collapsed selection, Android composition latency heuristic).
+ */
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  COMMAND_PRIORITY_CRITICAL,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
+  LexicalEditor,
+} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+vi.mock('lexical/src/environment', () => ({
+  CAN_USE_BEFORE_INPUT: true,
+  CAN_USE_DOM: true,
+  IS_ANDROID: true,
+  IS_ANDROID_CHROME: true,
+  IS_APPLE: false,
+  IS_APPLE_WEBKIT: false,
+  IS_CHROME: true,
+  IS_FIREFOX: false,
+  IS_IOS: false,
+  IS_SAFARI: false,
+}));
+
+describe('Android Chrome composition — format mismatch ZWSP skip', () => {
+  let container: HTMLDivElement;
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('data-lexical-editor', 'true');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    editor = createTestEditor();
+    editor.setRootElement(container);
+  });
+
+  afterEach(() => {
+    editor.setRootElement(null);
+    document.body.removeChild(container);
+  });
+
+  test('compositionStart with format mismatch skips CONTROLLED_TEXT_INSERTION', async () => {
+    editor.update(
+      () => {
+        const textNode = $createTextNode('hello');
+        const paragraph = $createParagraphNode().append(textNode);
+        $getRoot().clear().append(paragraph);
+        const selection = textNode.selectEnd();
+        selection.format = 1;
+      },
+      {discrete: true},
+    );
+
+    const insertionPayloads: string[] = [];
+    editor.registerCommand(
+      CONTROLLED_TEXT_INSERTION_COMMAND,
+      payload => {
+        insertionPayloads.push(typeof payload === 'string' ? payload : '');
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    container.dispatchEvent(
+      new CompositionEvent('compositionstart', {bubbles: true, data: ''}),
+    );
+
+    await Promise.resolve();
+
+    expect(insertionPayloads).toEqual([]);
+  });
+
+  test('compositionStart with element anchor still dispatches CONTROLLED_TEXT_INSERTION', async () => {
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().clear().append(paragraph);
+        paragraph.select();
+      },
+      {discrete: true},
+    );
+
+    const insertionPayloads: string[] = [];
+    editor.registerCommand(
+      CONTROLLED_TEXT_INSERTION_COMMAND,
+      payload => {
+        insertionPayloads.push(typeof payload === 'string' ? payload : '');
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    container.dispatchEvent(
+      new CompositionEvent('compositionstart', {bubbles: true, data: ''}),
+    );
+
+    await Promise.resolve();
+
+    expect(insertionPayloads.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

On Android Chrome, Samsung Keyboard and other non-Gboard keyboards (Yandex, FUTO) cache the composing region internally. When a user toggles bold/italic during composition, `$handleCompositionStart` detects a format mismatch between `selection.format` and `node.getFormat()` and inserts a ZWSP via `CONTROLLED_TEXT_INSERTION_COMMAND`. This DOM mutation triggers Samsung Keyboard's `restartInput()`, which restores the cached composing text and causes duplication.

The original issue (#7649) reports text duplication after toggling format on Samsung Keyboard. On our Android device the duplication didn't reproduce on the current main, but a related symptom did: typing Korean with bold enabled on Samsung Keyboard splits jamo (e.g. typing "한글" produces "ㅎㅏㄴㄱㅡㄹ" with each consonant/vowel separated). The root cause is the same — the ZWSP insertion disrupts Samsung's composing region tracking.

### Fix

Guard the format and style mismatch conditions with `!IS_ANDROID_CHROME` so the ZWSP insertion is skipped on Android Chrome. The other conditions that trigger ZWSP (element anchor, non-collapsed selection, `ANDROID_COMPOSITION_LATENCY` timing heuristic) remain unguarded since those handle structural cases unrelated to Samsung's caching behavior.

The trade-off: toggling format during an active composition on Android Chrome Samsung Keyboard won't show the format change visually until the composition ends. The format itself is preserved correctly — `selection.format` persists through the composition cycle and applies on the next `insertText`.

Closes #7649

## Test plan

- [x] `pnpm vitest run --project unit` — all pass, no regression.
- [x] `pnpm tsc --noEmit` clean.
- [x] New unit test `LexicalAndroidChromeComposition.test.ts`:
  - Format mismatch with `IS_ANDROID_CHROME: true` does not dispatch `CONTROLLED_TEXT_INSERTION_COMMAND`.
  - Element anchor still dispatches `CONTROLLED_TEXT_INSERTION_COMMAND` (guard doesn't leak to other conditions).
  - Test fails on main, passes with fix (verified by stashing the change and running against original code).
- [x] Manual Android Chrome (Samsung Keyboard):
  - Tap Bold → type Korean "한글": jamo compose correctly (no separation into "ㅎㅏㄴㄱㅡㄹ").
  - Type "hello" → tap Bold → type "world": no duplication, "world" appears once.
  - Gboard unaffected (Gboard handles `restartInput` gracefully).