### PR TITLE
[lexical-playground] Bug Fix: Restore floating toolbar comment icon after mask-image conversion

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -500,6 +500,11 @@ i.link {
   mask-image: url(images/icons/link.svg);
 }
 
+i.add-comment {
+  -webkit-mask-image: url(images/icons/chat-left-text.svg);
+  mask-image: url(images/icons/chat-left-text.svg);
+}
+
 i.horizontal-rule {
   -webkit-mask-image: url(images/icons/horizontal-rule.svg);
   mask-image: url(images/icons/horizontal-rule.svg);


### PR DESCRIPTION
## Description

PR #8591 converted the shared icon glyph classes (`i.bold`, `i.italic`, etc.) from `background-image` to `mask-image` for forced-colors support. The floating toolbar's `i.format` fill was restored in 3bcb93ce8, but `i.add-comment` didn't have a corresponding `mask-image` rule in `index.css`, so it rendered as a solid rectangle.

This adds the missing `mask-image` rule for `i.add-comment`, matching the pattern used by every other icon glyph.

## Test plan

### Before

The "Insert comment" button (rightmost in the floating toolbar) shows as a black square.

### After

The button shows the `chat-left-text.svg` speech bubble icon.

- [x] Manual playground: select text, floating toolbar appears, comment icon renders correctly
- [x] prettier clean