### PR TITLE
[lexical] Bug Fix: deleteCharacter overwrites X11 PRIMARY selection via Selection.modify

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "attribution": {
+    "sessionUrl": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,10 @@ npm-debug.log*
 
 .idea
 
-.claude
+# Agent state and personal overrides are ignored, but the shared project
+# settings (e.g. attribution.sessionUrl) are tracked.
+.claude/*
+!.claude/settings.json
 # Lockfiles in standalone examples and integration test fixtures.
 # These directories are excluded from the pnpm workspace and have their own
 # dependency manifests. Tracking their lockfiles causes Dependabot to generate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,13 @@ When creating custom nodes:
 - Supports multiple build modes: development, production, www (Meta internal)
 - TypeScript source → compiled to CommonJS and ESM
 - Package manager logic in `scripts/shared/packagesManager.mjs`
+
+### Commit and PR Hygiene for Agents
+This is an open source project: never include agent-session URLs or other
+private/team-internal links (e.g. `https://claude.ai/code/session_...`) in
+commit messages, PR titles, or PR bodies. Those URLs are private to the
+person or team that ran the session and are meaningless or misleading to
+everyone else. Co-authorship attribution (e.g. `Co-Authored-By:`) is fine.
+For Claude Code this is enforced mechanically via `attribution.sessionUrl:
+false` in the checked-in `.claude/settings.json`; agents from other vendors
+should follow this rule as written.

--- a/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
@@ -301,11 +301,9 @@ test.describe('Keywords', () => {
 
     await page.keyboard.press('Space');
 
-    // Since deleteCharacter builds its selection in the model (#8766), the
-    // post-backspace selection state is engine-uniform, so the space
-    // insertion produces the same DOM in every browser; webkit previously
-    // diverged because the native selection extension left it in a
-    // different state.
+    // deleteCharacter builds its selection in the model (#8766), so the
+    // post-backspace state — and therefore the DOM produced by the space
+    // insertion — is the same in every browser.
     await assertHTML(
       page,
       html`

--- a/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
@@ -216,7 +216,6 @@ test.describe('Keywords', () => {
 
   test('Can type "congrats Bob!" where " Bob!" is bold', async ({
     page,
-    browserName,
     isCollab,
     isPlainText,
   }) => {
@@ -302,46 +301,30 @@ test.describe('Keywords', () => {
 
     await page.keyboard.press('Space');
 
-    if (browserName === 'webkit') {
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span
-              class="keyword"
-              style="cursor: default;"
-              data-lexical-text="true">
-              congrats
-            </span>
-            <strong
-              class="PlaygroundEditorTheme__textBold"
-              data-lexical-text="true">
-              Bob!
-            </strong>
-          </p>
-        `,
-      );
-    } else {
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span
-              class="keyword"
-              style="cursor: default;"
-              data-lexical-text="true">
-              congrats
-            </span>
-            <span data-lexical-text="true"></span>
-            <strong
-              class="PlaygroundEditorTheme__textBold"
-              data-lexical-text="true">
-              Bob!
-            </strong>
-          </p>
-        `,
-      );
-    }
+    // Since deleteCharacter builds its selection in the model (#8766), the
+    // post-backspace selection state is engine-uniform, so the space
+    // insertion produces the same DOM in every browser; webkit previously
+    // diverged because the native selection extension left it in a
+    // different state.
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span
+            class="keyword"
+            style="cursor: default;"
+            data-lexical-text="true">
+            congrats
+          </span>
+          <span data-lexical-text="true"></span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            Bob!
+          </strong>
+        </p>
+      `,
+    );
 
     await assertSelection(page, {
       anchorOffset: 1,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2462,21 +2462,21 @@ function moveNativeSelection(
 /**
  * Extend a collapsed selection by one unit (`character`, `word` or
  * `lineboundary`) in the deletion direction without ever creating a
- * non-collapsed DOM selection, as a PRIMARY-safe replacement for
- * `modify('extend', …)` in the delete* methods.
+ * non-collapsed DOM selection.
  *
  * On Linux/X11, browsers propagate any non-collapsed DOM selection made
  * during a user gesture to the PRIMARY selection (the middle-click paste
- * buffer), so the transient native `modify('extend')` overwrote PRIMARY on
- * every Backspace/Delete (https://github.com/facebook/lexical/issues/8766).
- * A collapsed caret never takes PRIMARY ownership, so the DOM caret is moved
- * with the native `modify('move')` to measure where the engine places the
- * unit boundary, and the `[original .. landed]` range a native extend would
- * have produced is reconstructed in the model. `applyDOMRange` only reads the
- * range's boundary points (it never touches the DOM selection), so the model
- * selection ends up identical to the `modify('extend')` path — same decorator
- * pre/post handling, point resolution, shadow-root shrink validation and
- * anchor/focus orientation — while the DOM selection was only ever collapsed.
+ * buffer), so a deletion must never pass through a transient non-collapsed
+ * DOM selection or every Backspace/Delete overwrites the user's paste
+ * buffer (https://github.com/facebook/lexical/issues/8766). A collapsed
+ * caret never takes PRIMARY ownership, so the DOM caret is moved with the
+ * native `modify('move')` to measure where the engine places the unit
+ * boundary, and the `[original .. landed]` range is constructed in the
+ * model only. `applyDOMRange` reads just the range's boundary points (it
+ * never touches the DOM selection), giving the same point resolution,
+ * decorator pre/post handling, shadow-root shrink validation and
+ * anchor/focus orientation as a native selection extension would, while
+ * the DOM selection is only ever collapsed.
  *
  * When the measurement is not possible — no DOM selection or no
  * `Selection.modify` (headless environments can polyfill it), or an
@@ -2573,14 +2573,13 @@ function $extendSelectionForDeletion(
   const landedContainer = landedRange.startContainer;
   const landedOffset = landedRange.startOffset;
   // In-node character deletion (the common case): keep the focus in the
-  // anchor's own text node so the resulting model selection matches
-  // modify('extend'), which keeps the extended focus in the node being
-  // extended. A native 'move' reports a caret that lands on a text-node
-  // boundary as a position in the *adjacent* node, and that representation
-  // changes how a later insertion (e.g. at a format boundary) resolves. When
-  // the move lands inside the anchor node its offset is used directly;
-  // landing on the node's edge is clamped to that edge. Word/line deletions
-  // legitimately span nodes, so they use the general path below.
+  // anchor's own text node. A native 'move' reports a caret that lands on a
+  // text-node boundary as a position in the *adjacent* node, and that
+  // representation changes how a later insertion (e.g. at a format or
+  // keyword boundary) resolves. When the move lands inside the anchor node
+  // its offset is used directly; landing on the node's edge is clamped to
+  // that edge. Word/line deletions legitimately span nodes, so they use the
+  // general path below.
   if (wasCollapsed && granularity === 'character' && anchor.type === 'text') {
     const anchorTextSize = anchorNode.getTextContentSize();
     let clampedOffset = -1;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2518,25 +2518,42 @@ function $extendSelectionForDeletion(
   ) {
     removeDOMBlockCursorElement(blockCursorElement, editor, rootElement);
   }
-  // Resolve the model anchor to a DOM position.
+  const $resolvePointDOM = (point: PointType): HTMLElement | Text | null => {
+    const pointNode = point.getNode();
+    const keyedDOM = editor.getElementByKey(point.key);
+    return keyedDOM !== null && point.type === 'text' && $isTextNode(pointNode)
+      ? $getDOMTextNode(pointNode, keyedDOM, editor)
+      : keyedDOM;
+  };
+  // Resolve the model anchor to a DOM position (one end of the final range).
   const anchorNode = anchor.getNode();
-  const anchorKeyedDOM = editor.getElementByKey(anchor.key);
-  const anchorDOM: HTMLElement | Text | null =
-    anchorKeyedDOM !== null && anchor.type === 'text' && $isTextNode(anchorNode)
-      ? $getDOMTextNode(anchorNode, anchorKeyedDOM, editor)
-      : anchorKeyedDOM;
+  const anchorDOM = $resolvePointDOM(anchor);
   if (anchorDOM === null) {
     return;
   }
   const anchorOffset = anchor.offset;
-  // Sync a COLLAPSED DOM caret at the anchor (base === extent), then move it
-  // by one unit to measure the engine's boundary. Neither touches PRIMARY.
+  // Measure from the FOCUS: the decorator/block pre-pass above may have
+  // hopped the model focus past an inline decorator and returned false — the
+  // shape where native caret movement is unreliable (it can refuse to move a
+  // caret adjacent to contenteditable=false content). modify() runs the
+  // native extend from the extent (the hopped focus); do the same here. For
+  // an untouched collapsed selection the focus is the anchor.
+  const wasCollapsed = selection.isCollapsed();
+  const focus = selection.focus;
+  const focusDOM = wasCollapsed ? anchorDOM : $resolvePointDOM(focus);
+  if (focusDOM === null) {
+    return;
+  }
+  const focusOffset = focus.offset;
+  // Sync a COLLAPSED DOM caret at the measurement origin (base === extent),
+  // then move it by one unit to measure the engine's boundary. Neither
+  // operation touches PRIMARY.
   setDOMSelectionBaseAndExtent(
     domSelection,
-    anchorDOM,
-    anchorOffset,
-    anchorDOM,
-    anchorOffset,
+    focusDOM,
+    focusOffset,
+    focusDOM,
+    focusOffset,
   );
   moveNativeSelection(
     domSelection,
@@ -2564,19 +2581,19 @@ function $extendSelectionForDeletion(
   // the move lands inside the anchor node its offset is used directly;
   // landing on the node's edge is clamped to that edge. Word/line deletions
   // legitimately span nodes, so they use the general path below.
-  if (granularity === 'character' && anchor.type === 'text') {
+  if (wasCollapsed && granularity === 'character' && anchor.type === 'text') {
     const anchorTextSize = anchorNode.getTextContentSize();
-    let focusOffset = -1;
+    let clampedOffset = -1;
     if (landedContainer === anchorDOM) {
-      focusOffset = landedOffset;
+      clampedOffset = landedOffset;
     } else if (isBackward && anchorOffset > 0) {
-      focusOffset = 0;
+      clampedOffset = 0;
     } else if (!isBackward && anchorOffset < anchorTextSize) {
-      focusOffset = anchorTextSize;
+      clampedOffset = anchorTextSize;
     }
-    if (focusOffset >= 0) {
-      if (focusOffset !== anchorOffset) {
-        selection.focus.set(anchor.key, focusOffset, 'text');
+    if (clampedOffset >= 0) {
+      if (clampedOffset !== anchorOffset) {
+        selection.focus.set(anchor.key, clampedOffset, 'text');
         selection.dirty = true;
       }
       return;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1770,37 +1770,7 @@ export class RangeSelection implements BaseSelection {
       this.applyDOMRange(range);
       this.dirty = true;
       if (!collapse) {
-        // Validate selection; make sure that the new extended selection respects shadow roots
-        const nodes = this.getNodes();
-        const validNodes = [];
-        let shrinkSelection = false;
-        for (let i = 0; i < nodes.length; i++) {
-          const nextNode = nodes[i];
-          if ($hasAncestor(nextNode, root)) {
-            validNodes.push(nextNode);
-          } else {
-            shrinkSelection = true;
-          }
-        }
-        if (shrinkSelection && validNodes.length > 0) {
-          // validNodes length check is a safeguard against an invalid selection; as getNodes()
-          // will return an empty array in this case
-          if (isBackward) {
-            const firstValidNode = validNodes[0];
-            if ($isElementNode(firstValidNode)) {
-              firstValidNode.selectStart();
-            } else {
-              firstValidNode.getParentOrThrow().selectStart();
-            }
-          } else {
-            const lastValidNode = validNodes[validNodes.length - 1];
-            if ($isElementNode(lastValidNode)) {
-              lastValidNode.selectEnd();
-            } else {
-              lastValidNode.getParentOrThrow().selectEnd();
-            }
-          }
-        }
+        $shrinkSelectionToRoot(this, isBackward, root);
 
         // Because a range works on start and end, we might need to flip
         // the anchor and focus points to match what the DOM has, not what
@@ -2460,6 +2430,38 @@ function moveNativeSelection(
 }
 
 /**
+ * Validate that the selection respects `root` (the nearest root or shadow
+ * root): if any selected node lies outside of it, shrink the selection to the
+ * valid edge in the given direction. The valid node check is a safeguard
+ * against an invalid selection, for which getNodes() returns an empty array.
+ *
+ * @returns true if the selection was shrunk
+ */
+function $shrinkSelectionToRoot(
+  selection: RangeSelection,
+  isBackward: boolean,
+  root: LexicalNode,
+): boolean {
+  const nodes = selection.getNodes();
+  const validNodes = nodes.filter(node => $hasAncestor(node, root));
+  if (validNodes.length === 0 || validNodes.length === nodes.length) {
+    return false;
+  }
+  const edgeNode = isBackward
+    ? validNodes[0]
+    : validNodes[validNodes.length - 1];
+  const edgeElement = $isElementNode(edgeNode)
+    ? edgeNode
+    : edgeNode.getParentOrThrow();
+  if (isBackward) {
+    edgeElement.selectStart();
+  } else {
+    edgeElement.selectEnd();
+  }
+  return true;
+}
+
+/**
  * Extend a collapsed selection by one unit (`character`, `word` or
  * `lineboundary`) in the deletion direction without ever creating a
  * non-collapsed DOM selection.
@@ -2581,15 +2583,14 @@ function $extendSelectionForDeletion(
   // that edge. Word/line deletions legitimately span nodes, so they use the
   // general path below.
   if (wasCollapsed && granularity === 'character' && anchor.type === 'text') {
-    const anchorTextSize = anchorNode.getTextContentSize();
-    let clampedOffset = -1;
-    if (landedContainer === anchorDOM) {
-      clampedOffset = landedOffset;
-    } else if (isBackward && anchorOffset > 0) {
-      clampedOffset = 0;
-    } else if (!isBackward && anchorOffset < anchorTextSize) {
-      clampedOffset = anchorTextSize;
-    }
+    // The deletion-side edge of the anchor's text.
+    const edgeOffset = isBackward ? 0 : anchorNode.getTextContentSize();
+    const clampedOffset =
+      landedContainer === anchorDOM
+        ? landedOffset
+        : anchorOffset !== edgeOffset
+          ? edgeOffset
+          : -1;
     if (clampedOffset >= 0) {
       if (clampedOffset !== anchorOffset) {
         selection.focus.set(anchor.key, clampedOffset, 'text');
@@ -2616,23 +2617,7 @@ function $extendSelectionForDeletion(
     startOffset,
   } as unknown as StaticRange);
   selection.dirty = true;
-  // Shrink the selection to the valid side of any crossed shadow-root
-  // boundary (mirrors modify()).
-  const allNodes = selection.getNodes();
-  const validNodes = allNodes.filter(n => $hasAncestor(n, root));
-  if (validNodes.length > 0 && validNodes.length < allNodes.length) {
-    const edgeNode = isBackward
-      ? validNodes[0]
-      : validNodes[validNodes.length - 1];
-    const edgeElement = $isElementNode(edgeNode)
-      ? edgeNode
-      : edgeNode.getParentOrThrow();
-    if (isBackward) {
-      edgeElement.selectStart();
-    } else {
-      edgeElement.selectEnd();
-    }
-  } else if (isBackward) {
+  if (!$shrinkSelectionToRoot(selection, isBackward, root) && isBackward) {
     // applyDOMRange set anchor = range start (the landed point); the deletion
     // anchor must stay at the original caret, so restore that orientation.
     $swapPoints(selection);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2022,11 +2022,11 @@ export class RangeSelection implements BaseSelection {
         // No text lies in the deletion direction and nothing in scope was
         // found to delete, so the caret sits at a slot edge. A slot value is
         // nested within its host's DOM, so the boundary lives only in the
-        // model: the native modify('extend') below would cross it and select
-        // into the host. Stop when that edge is a slot value — the slot link
-        // is a virtual shadow root, so this applies whether or not the value
-        // is itself a shadow root; an ordinary (non-slotted) shadow root
-        // keeps the native behavior.
+        // model: the native caret measurement below would cross it and
+        // select into the host. Stop when that edge is a slot value — the
+        // slot link is a virtual shadow root, so this applies whether or not
+        // the value is itself a shadow root; an ordinary (non-slotted)
+        // shadow root keeps the native behavior.
         for (let node: LexicalNode | null = anchor.getNode(); node !== null; ) {
           if ($getSlotHostKey(node) !== null) {
             return;
@@ -2040,7 +2040,10 @@ export class RangeSelection implements BaseSelection {
 
       // Handle the deletion around decorators.
       const focus = this.focus;
-      this.modify('extend', isBackward, 'character');
+      // Extend the selection in the model rather than with the native
+      // modify('extend'), which would clobber the X11 PRIMARY selection.
+      // See https://github.com/facebook/lexical/issues/8766
+      $extendSelectionForDeletion(this, isBackward, 'character');
 
       if (!this.isCollapsed()) {
         const focusNode = focus.type === 'text' ? focus.getNode() : null;
@@ -2126,7 +2129,7 @@ export class RangeSelection implements BaseSelection {
       return;
     }
     if (this.isCollapsed()) {
-      this.modify('extend', isBackward, 'lineboundary');
+      $extendSelectionForDeletion(this, isBackward, 'lineboundary');
     }
     if (this.isCollapsed()) {
       // If the selection was already collapsed at the lineboundary,
@@ -2164,7 +2167,7 @@ export class RangeSelection implements BaseSelection {
       if (this.forwardDeletion(anchor, anchorNode, isBackward)) {
         return;
       }
-      this.modify('extend', isBackward, 'word');
+      $extendSelectionForDeletion(this, isBackward, 'word');
     }
     if (this.isCollapsed()) {
       // If the selection was already collapsed at the lineboundary,
@@ -2457,9 +2460,182 @@ function moveNativeSelection(
 }
 
 /**
+ * Extend a collapsed selection by one unit (`character`, `word` or
+ * `lineboundary`) in the deletion direction without ever creating a
+ * non-collapsed DOM selection, as a PRIMARY-safe replacement for
+ * `modify('extend', …)` in the delete* methods.
+ *
+ * On Linux/X11, browsers propagate any non-collapsed DOM selection made
+ * during a user gesture to the PRIMARY selection (the middle-click paste
+ * buffer), so the transient native `modify('extend')` overwrote PRIMARY on
+ * every Backspace/Delete (https://github.com/facebook/lexical/issues/8766).
+ * A collapsed caret never takes PRIMARY ownership, so the DOM caret is moved
+ * with the native `modify('move')` to measure where the engine places the
+ * unit boundary, and the `[original .. landed]` range a native extend would
+ * have produced is reconstructed in the model. `applyDOMRange` only reads the
+ * range's boundary points (it never touches the DOM selection), so the model
+ * selection ends up identical to the `modify('extend')` path — same decorator
+ * pre/post handling, point resolution, shadow-root shrink validation and
+ * anchor/focus orientation — while the DOM selection was only ever collapsed.
+ *
+ * When the measurement is not possible — no DOM selection or no
+ * `Selection.modify` (headless environments can polyfill it), or an
+ * unresolvable anchor — the selection is left collapsed, so the deletion
+ * becomes a no-op for that keystroke.
+ */
+function $extendSelectionForDeletion(
+  selection: RangeSelection,
+  isBackward: boolean,
+  granularity: 'character' | 'word' | 'lineboundary',
+): void {
+  // Decorator/block handling, resolved in the model exactly as modify() does.
+  if (
+    $modifySelectionAroundDecoratorsAndBlocks(
+      selection,
+      'extend',
+      isBackward,
+      granularity,
+    )
+  ) {
+    return;
+  }
+  const editor = getActiveEditor();
+  const domSelection = getDOMSelection(getWindow(editor));
+  if (!domSelection || typeof domSelection.modify !== 'function') {
+    return;
+  }
+  const blockCursorElement = editor._blockCursorElement;
+  const rootElement = editor._rootElement;
+  const anchor = selection.anchor;
+  const focusNode = selection.focus.getNode();
+  // A block cursor element left in the DOM would corrupt element offsets.
+  if (
+    rootElement !== null &&
+    blockCursorElement !== null &&
+    $isElementNode(focusNode) &&
+    !focusNode.isInline() &&
+    !focusNode.canBeEmpty()
+  ) {
+    removeDOMBlockCursorElement(blockCursorElement, editor, rootElement);
+  }
+  // Resolve the model anchor to a DOM position.
+  const anchorNode = anchor.getNode();
+  const anchorKeyedDOM = editor.getElementByKey(anchor.key);
+  const anchorDOM: HTMLElement | Text | null =
+    anchorKeyedDOM !== null && anchor.type === 'text' && $isTextNode(anchorNode)
+      ? $getDOMTextNode(anchorNode, anchorKeyedDOM, editor)
+      : anchorKeyedDOM;
+  if (anchorDOM === null) {
+    return;
+  }
+  const anchorOffset = anchor.offset;
+  // Sync a COLLAPSED DOM caret at the anchor (base === extent), then move it
+  // by one unit to measure the engine's boundary. Neither touches PRIMARY.
+  setDOMSelectionBaseAndExtent(
+    domSelection,
+    anchorDOM,
+    anchorOffset,
+    anchorDOM,
+    anchorOffset,
+  );
+  moveNativeSelection(
+    domSelection,
+    'move',
+    isBackward ? 'backward' : 'forward',
+    granularity,
+  );
+  if (domSelection.rangeCount === 0) {
+    return;
+  }
+  // Inside a DOM shadow root getRangeAt(0) is retargeted to the host; read the
+  // composed StaticRange (real nodes) where available. After a 'move' the DOM
+  // selection is collapsed, so start === end === the landed caret.
+  const landedRange =
+    getComposedStaticRange(domSelection, rootElement) ||
+    domSelection.getRangeAt(0);
+  const landedContainer = landedRange.startContainer;
+  const landedOffset = landedRange.startOffset;
+  // In-node character deletion (the common case): keep the focus in the
+  // anchor's own text node so the resulting model selection matches
+  // modify('extend'), which keeps the extended focus in the node being
+  // extended. A native 'move' reports a caret that lands on a text-node
+  // boundary as a position in the *adjacent* node, and that representation
+  // changes how a later insertion (e.g. at a format boundary) resolves. When
+  // the move lands inside the anchor node its offset is used directly;
+  // landing on the node's edge is clamped to that edge. Word/line deletions
+  // legitimately span nodes, so they use the general path below.
+  if (granularity === 'character' && anchor.type === 'text') {
+    const anchorTextSize = anchorNode.getTextContentSize();
+    let focusOffset = -1;
+    if (landedContainer === anchorDOM) {
+      focusOffset = landedOffset;
+    } else if (isBackward && anchorOffset > 0) {
+      focusOffset = 0;
+    } else if (!isBackward && anchorOffset < anchorTextSize) {
+      focusOffset = anchorTextSize;
+    }
+    if (focusOffset >= 0) {
+      if (focusOffset !== anchorOffset) {
+        selection.focus.set(anchor.key, focusOffset, 'text');
+        selection.dirty = true;
+      }
+      return;
+    }
+  }
+  // General path: reconstruct, in document order, the [original .. landed]
+  // range a native extend would have produced. applyDOMRange only reads these
+  // four boundary properties into the model, so a plain StaticRange-shaped
+  // object is sufficient (and avoids a StaticRange constructor dependency).
+  const [startContainer, startOffset, endContainer, endOffset] = isBackward
+    ? [landedContainer, landedOffset, anchorDOM, anchorOffset]
+    : [anchorDOM, anchorOffset, landedContainer, landedOffset];
+  const root = $isRootNode(anchorNode)
+    ? anchorNode
+    : $getNearestRootOrShadowRoot(anchorNode);
+  selection.applyDOMRange({
+    collapsed: false,
+    endContainer,
+    endOffset,
+    startContainer,
+    startOffset,
+  } as unknown as StaticRange);
+  selection.dirty = true;
+  // Shrink the selection to the valid side of any crossed shadow-root
+  // boundary (mirrors modify()).
+  const allNodes = selection.getNodes();
+  const validNodes = allNodes.filter(n => $hasAncestor(n, root));
+  if (validNodes.length > 0 && validNodes.length < allNodes.length) {
+    const edgeNode = isBackward
+      ? validNodes[0]
+      : validNodes[validNodes.length - 1];
+    const edgeElement = $isElementNode(edgeNode)
+      ? edgeNode
+      : edgeNode.getParentOrThrow();
+    if (isBackward) {
+      edgeElement.selectStart();
+    } else {
+      edgeElement.selectEnd();
+    }
+  } else if (isBackward) {
+    // applyDOMRange set anchor = range start (the landed point); the deletion
+    // anchor must stay at the original caret, so restore that orientation.
+    $swapPoints(selection);
+  }
+  if (granularity === 'lineboundary') {
+    $modifySelectionAroundDecoratorsAndBlocks(
+      selection,
+      'extend',
+      isBackward,
+      granularity,
+      'decorators',
+    );
+  }
+}
+
+/**
  * Called by `RangeSelection.deleteCharacter` to determine if
- * `this.modify('extend', isBackward, 'character')` extended the selection
- * further than a user would expect for that operation.
+ * `$extendSelectionForDeletion` extended the selection further
+ * than a user would expect for that operation.
  *
  * A short(?) JavaScript string vs. Unicode primer:
  *
@@ -2493,7 +2669,7 @@ function moveNativeSelection(
  * essentially be arbitrarily long, as there are many ways to combine
  * them.
  *
- * The `this.modify(…)` call has already extended our selection by one
+ * The native caret measurement has already extended our selection by one
  * *grapheme* in the direction we want to delete. Sounds great, it's done
  * a lot of awfully tricky work for us because this functionality has only
  * recently become available in JavaScript via `Intl.Segmenter`. The

--- a/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalEditor,
+} from 'lexical';
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  type MockInstance,
+  onTestFinished,
+  test,
+  vi,
+} from 'vitest';
+
+// Regression tests for #8766.
+//
+// On Linux/X11, browsers propagate any non-collapsed DOM selection made
+// during a user gesture to the PRIMARY selection (the middle-click paste
+// buffer). `RangeSelection.deleteCharacter` used to extend the DOM selection
+// with the native `Selection.modify('extend', …, 'character')` before
+// removing text, overwriting PRIMARY on every Backspace/Delete. It now
+// measures a collapsed native caret move (which never takes PRIMARY
+// ownership) and builds the deletion range in the Lexical model only.
+//
+// These tests run in a real browser (see the `browser` project in
+// vitest.config.mts) because the contract under test is engine behavior:
+// the spies watch the engine's real Selection API to prove that character
+// deletion never creates a non-collapsed DOM selection — the invariant that
+// keeps PRIMARY intact — and the differential tests compare deletion
+// boundaries against the boundaries the engine itself produces.
+
+const ext = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '[8766-browser]',
+});
+
+function mountEditor(): LexicalEditor {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const contentEditable = document.createElement('div');
+  contentEditable.contentEditable = 'true';
+  container.appendChild(contentEditable);
+
+  const editor = buildEditorFromExtensions(ext);
+  editor.setRootElement(contentEditable);
+
+  onTestFinished(() => {
+    editor.setRootElement(null);
+    document.body.removeChild(container);
+  });
+
+  return editor;
+}
+
+function setup(
+  editor: LexicalEditor,
+  text: string,
+  offset: number,
+  mode?: 'token' | 'segmented',
+): void {
+  editor.update(
+    () => {
+      const paragraph = $createParagraphNode();
+      const textNode = $createTextNode(text);
+      if (mode) {
+        textNode.setMode(mode);
+      }
+      paragraph.append(textNode);
+      $getRoot().clear().append(paragraph);
+      textNode.select(offset, offset);
+    },
+    {discrete: true},
+  );
+}
+
+function deleteCharacter(editor: LexicalEditor, isBackward: boolean): void {
+  editor.update(
+    () => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection), 'Expected RangeSelection');
+      selection.deleteCharacter(isBackward);
+    },
+    {discrete: true},
+  );
+}
+
+function textContent(editor: LexicalEditor): string {
+  return editor.getEditorState().read(() => $getRoot().getTextContent());
+}
+
+/**
+ * Ask the engine itself where one native 'character' extension from `offset`
+ * lands, using a scratch contenteditable outside of Lexical. This is the
+ * operation the collapsed-move measurement replaces, so it defines the
+ * expected deletion boundary for whole-grapheme cases.
+ */
+function nativeCharacterExtension(
+  text: string,
+  offset: number,
+  isBackward: boolean,
+): number {
+  const div = document.createElement('div');
+  div.contentEditable = 'true';
+  document.body.appendChild(div);
+  try {
+    const textNode = document.createTextNode(text);
+    div.appendChild(textNode);
+    const domSelection = window.getSelection()!;
+    domSelection.setBaseAndExtent(textNode, offset, textNode, offset);
+    domSelection.modify(
+      'extend',
+      isBackward ? 'backward' : 'forward',
+      'character',
+    );
+    const boundary =
+      domSelection.focusNode === textNode
+        ? domSelection.focusOffset
+        : isBackward
+          ? 0
+          : text.length;
+    domSelection.removeAllRanges();
+    return boundary;
+  } finally {
+    document.body.removeChild(div);
+  }
+}
+
+describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', () => {
+  let modifySpy: MockInstance<Selection['modify']>;
+  let setBaseAndExtentSpy: MockInstance<Selection['setBaseAndExtent']>;
+  let extendSpy: MockInstance<Selection['extend']>;
+  let addRangeSpy: MockInstance<Selection['addRange']>;
+
+  beforeEach(() => {
+    // Wrap (not replace) the engine's real Selection API: calls delegate to
+    // the native implementations, and the spies record every way a
+    // non-collapsed DOM selection could be created.
+    modifySpy = vi.spyOn(Selection.prototype, 'modify');
+    setBaseAndExtentSpy = vi.spyOn(Selection.prototype, 'setBaseAndExtent');
+    extendSpy = vi.spyOn(Selection.prototype, 'extend');
+    addRangeSpy = vi.spyOn(Selection.prototype, 'addRange');
+  });
+
+  afterEach(() => {
+    modifySpy.mockRestore();
+    setBaseAndExtentSpy.mockRestore();
+    extendSpy.mockRestore();
+    addRangeSpy.mockRestore();
+  });
+
+  /**
+   * The PRIMARY-safety invariant: only non-collapsed DOM selections take
+   * PRIMARY ownership on X11, so deletion must never create one — no
+   * modify('extend'), no ranged setBaseAndExtent, no Selection.extend, no
+   * non-collapsed addRange.
+   */
+  function expectOnlyCollapsedDOMSelections() {
+    for (const [alter] of modifySpy.mock.calls) {
+      expect(alter).not.toBe('extend');
+    }
+    for (const [
+      anchorNode,
+      anchorOffset,
+      focusNode,
+      focusOffset,
+    ] of setBaseAndExtentSpy.mock.calls) {
+      expect(anchorNode).toBe(focusNode);
+      expect(anchorOffset).toBe(focusOffset);
+    }
+    expect(extendSpy).not.toHaveBeenCalled();
+    for (const [range] of addRangeSpy.mock.calls) {
+      expect(range.collapsed).toBe(true);
+    }
+  }
+
+  test('backspace removes one character with only collapsed DOM selections', () => {
+    const editor = mountEditor();
+    setup(editor, 'hello', 5);
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('hell');
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('hel');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('forward delete removes one character with only collapsed DOM selections', () => {
+    const editor = mountEditor();
+    setup(editor, 'hello', 0);
+    deleteCharacter(editor, false);
+    expect(textContent(editor)).toBe('ello');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('backspace deletes a combining mark one code unit at a time', () => {
+    // "n" + combining tilde (U+0303) in decomposed form (2 code units).
+    // Lexical does not normalize, so the combining mark is removed first,
+    // then the base letter.
+    const nTilde = 'n\u0303';
+    const editor = mountEditor();
+    setup(editor, nTilde, nTilde.length);
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('n');
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('backspace on RTL (Hebrew) text deletes logically, one letter at a time', () => {
+    // "שלום" (shin, lamed, vav, mem) — four single-code-unit RTL letters.
+    // Backspace removes the logically-last letter regardless of the RTL
+    // visual order.
+    const shalom = 'שלום';
+    const editor = mountEditor();
+    setup(editor, shalom, shalom.length);
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('שלו');
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('של');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('backspace on RTL (Arabic) text deletes a combining mark then the base', () => {
+    // Arabic lam (U+0644) + shadda combining mark (U+0651). The combining
+    // mark is a separate code point that is removed first.
+    const lamShadda = 'لّ';
+    const editor = mountEditor();
+    setup(editor, lamShadda, lamShadda.length);
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('ل');
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('backspace at the end of mixed bidi text deletes the logically-last character', () => {
+    // LTR "abc" followed by RTL "אבג" (alef, bet, gimel). The caret sits at
+    // the end (logical offset 6); Backspace deletes the logically-last
+    // character (gimel), not the visually-adjacent one.
+    const mixed = 'abcאבג';
+    const editor = mountEditor();
+    setup(editor, mixed, mixed.length);
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('abcאב');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('forward delete at the start of mixed bidi text deletes the logically-first character', () => {
+    // Caret at logical offset 0 of RTL "אבג" + LTR "abc"; Delete removes the
+    // logically-first character (alef).
+    const mixed = 'אבגabc';
+    const editor = mountEditor();
+    setup(editor, mixed, 0);
+    deleteCharacter(editor, false);
+    expect(textContent(editor)).toBe('בגabc');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('backspace removes a whole token node with only collapsed DOM selections', () => {
+    // Token nodes are atomic: a single Backspace removes the entire node.
+    const editor = mountEditor();
+    setup(editor, 'hello world', 11, 'token');
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('backspace on a segmented node removes the last segment with only collapsed DOM selections', () => {
+    // Segmented nodes delete a whole whitespace-delimited segment at a time.
+    const editor = mountEditor();
+    setup(editor, 'hello world', 11, 'segmented');
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('hello');
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('backspace after a linebreak deletes it with only collapsed DOM selections', () => {
+    // Caret at a text node boundary: the collapsed move lands past the
+    // linebreak and the measured range brackets it, so removeText deletes
+    // the LineBreakNode without any non-collapsed DOM selection. (This was
+    // previously a native modify('extend') fallback that clobbered PRIMARY.)
+    const editor = mountEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const before = $createTextNode('one');
+        const linebreak = $createLineBreakNode();
+        const after = $createTextNode('two');
+        paragraph.append(before, linebreak, after);
+        $getRoot().clear().append(paragraph);
+        after.select(0, 0);
+      },
+      {discrete: true},
+    );
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('onetwo');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  test('backspace across a format-run boundary deletes from the previous run', () => {
+    // Caret at the start of a bold run: the collapsed move lands inside the
+    // preceding plain run and the last character of that run is deleted.
+    // (Also previously a native modify('extend') fallback.)
+    const editor = mountEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const plain = $createTextNode('ab');
+        const bold = $createTextNode('cd');
+        bold.toggleFormat('bold');
+        paragraph.append(plain, bold);
+        $getRoot().clear().append(paragraph);
+        bold.select(0, 0);
+      },
+      {discrete: true},
+    );
+    deleteCharacter(editor, true);
+    expect(textContent(editor)).toBe('acd');
+    expectOnlyCollapsedDOMSelections();
+  });
+
+  describe('deletes the same whole grapheme the engine would select natively', () => {
+    // For emoji-class graphemes deleteCharacter removes the whole cluster,
+    // so the deleted span must match exactly what one native
+    // Selection.modify('extend', 'backward', 'character') selects in this
+    // engine. If the engine's move and extend boundaries ever disagree for
+    // these clusters, this fails here rather than in production.
+    [
+      {description: 'astral emoji (thumbs up)', text: 'a👍'},
+      {
+        description: 'ZWJ family emoji',
+        text: 'x👩‍👩‍👧‍👦',
+      },
+      {
+        description: 'emoji with skin-tone modifier',
+        text: 'x👏🏽',
+      },
+      {
+        description: 'BMP emoji with variation selector (heart)',
+        text: 'x❤️',
+      },
+      {description: 'keycap emoji', text: 'x#️⃣'},
+      {
+        description: 'flag emoji with ZWJ and variation selector',
+        text: 'x🏳️‍🌈',
+      },
+    ].forEach(({description, text}) => {
+      test(description, () => {
+        const nativeBoundary = nativeCharacterExtension(
+          text,
+          text.length,
+          true,
+        );
+        // Sanity: the engine treats the emoji as a single cluster.
+        expect(nativeBoundary).toBeGreaterThan(0);
+        expect(nativeBoundary).toBeLessThan(text.length);
+        // The scratch measurement above intentionally used modify('extend');
+        // reset the spies so the invariant below only sees the deletion.
+        modifySpy.mockClear();
+        setBaseAndExtentSpy.mockClear();
+        extendSpy.mockClear();
+        addRangeSpy.mockClear();
+
+        const editor = mountEditor();
+        setup(editor, text, text.length);
+        deleteCharacter(editor, true);
+        expect(textContent(editor)).toBe(text.slice(0, nativeBoundary));
+        expectOnlyCollapsedDOMSelections();
+      });
+    });
+  });
+});

--- a/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
@@ -78,20 +78,21 @@ function $createTestInlineDecoratorNode(): TestInlineDecoratorNode {
   return $create(TestInlineDecoratorNode);
 }
 
-const ext = defineExtension({
-  dependencies: [RichTextExtension],
-  name: '[8766-browser]',
-  nodes: [TestInlineDecoratorNode],
-});
-
-function mountEditor(): LexicalEditor {
+function mountEditor($initialEditorState: () => void): LexicalEditor {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const contentEditable = document.createElement('div');
   contentEditable.contentEditable = 'true';
   container.appendChild(contentEditable);
 
-  const editor = buildEditorFromExtensions(ext);
+  const editor = buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState,
+      dependencies: [RichTextExtension],
+      name: '[8766-browser]',
+      nodes: [TestInlineDecoratorNode],
+    }),
+  );
   editor.setRootElement(contentEditable);
 
   onTestFinished(() => {
@@ -102,25 +103,19 @@ function mountEditor(): LexicalEditor {
   return editor;
 }
 
-function setup(
-  editor: LexicalEditor,
+function $initWithText(
   text: string,
   offset: number,
   mode?: 'token' | 'segmented',
 ): void {
-  editor.update(
-    () => {
-      const paragraph = $createParagraphNode();
-      const textNode = $createTextNode(text);
-      if (mode) {
-        textNode.setMode(mode);
-      }
-      paragraph.append(textNode);
-      $getRoot().clear().append(paragraph);
-      textNode.select(offset, offset);
-    },
-    {discrete: true},
-  );
+  const paragraph = $createParagraphNode();
+  const textNode = $createTextNode(text);
+  if (mode) {
+    textNode.setMode(mode);
+  }
+  paragraph.append(textNode);
+  $getRoot().clear().append(paragraph);
+  textNode.select(offset, offset);
 }
 
 function deleteCharacter(editor: LexicalEditor, isBackward: boolean): void {
@@ -225,8 +220,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
   }
 
   test('backspace removes one character with only collapsed DOM selections', () => {
-    const editor = mountEditor();
-    setup(editor, 'hello', 5);
+    const editor = mountEditor(() => $initWithText('hello', 5));
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('hell');
     deleteCharacter(editor, true);
@@ -235,8 +229,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
   });
 
   test('forward delete removes one character with only collapsed DOM selections', () => {
-    const editor = mountEditor();
-    setup(editor, 'hello', 0);
+    const editor = mountEditor(() => $initWithText('hello', 0));
     deleteCharacter(editor, false);
     expect(textContent(editor)).toBe('ello');
     expectOnlyCollapsedDOMSelections();
@@ -247,8 +240,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // Lexical does not normalize, so the combining mark is removed first,
     // then the base letter.
     const nTilde = 'n\u0303';
-    const editor = mountEditor();
-    setup(editor, nTilde, nTilde.length);
+    const editor = mountEditor(() => $initWithText(nTilde, nTilde.length));
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('n');
     deleteCharacter(editor, true);
@@ -261,8 +253,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // Backspace removes the logically-last letter regardless of the RTL
     // visual order.
     const shalom = 'שלום';
-    const editor = mountEditor();
-    setup(editor, shalom, shalom.length);
+    const editor = mountEditor(() => $initWithText(shalom, shalom.length));
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('שלו');
     deleteCharacter(editor, true);
@@ -274,8 +265,9 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // Arabic lam (U+0644) + shadda combining mark (U+0651). The combining
     // mark is a separate code point that is removed first.
     const lamShadda = 'لّ';
-    const editor = mountEditor();
-    setup(editor, lamShadda, lamShadda.length);
+    const editor = mountEditor(() =>
+      $initWithText(lamShadda, lamShadda.length),
+    );
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('ل');
     deleteCharacter(editor, true);
@@ -288,8 +280,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // the end (logical offset 6); Backspace deletes the logically-last
     // character (gimel), not the visually-adjacent one.
     const mixed = 'abcאבג';
-    const editor = mountEditor();
-    setup(editor, mixed, mixed.length);
+    const editor = mountEditor(() => $initWithText(mixed, mixed.length));
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('abcאב');
     expectOnlyCollapsedDOMSelections();
@@ -299,8 +290,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // Caret at logical offset 0 of RTL "אבג" + LTR "abc"; Delete removes the
     // logically-first character (alef).
     const mixed = 'אבגabc';
-    const editor = mountEditor();
-    setup(editor, mixed, 0);
+    const editor = mountEditor(() => $initWithText(mixed, 0));
     deleteCharacter(editor, false);
     expect(textContent(editor)).toBe('בגabc');
     expectOnlyCollapsedDOMSelections();
@@ -308,8 +298,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
 
   test('backspace removes a whole token node with only collapsed DOM selections', () => {
     // Token nodes are atomic: a single Backspace removes the entire node.
-    const editor = mountEditor();
-    setup(editor, 'hello world', 11, 'token');
+    const editor = mountEditor(() => $initWithText('hello world', 11, 'token'));
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('');
     expectOnlyCollapsedDOMSelections();
@@ -317,8 +306,9 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
 
   test('backspace on a segmented node removes the last segment with only collapsed DOM selections', () => {
     // Segmented nodes delete a whole whitespace-delimited segment at a time.
-    const editor = mountEditor();
-    setup(editor, 'hello world', 11, 'segmented');
+    const editor = mountEditor(() =>
+      $initWithText('hello world', 11, 'segmented'),
+    );
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('hello');
     deleteCharacter(editor, true);
@@ -331,19 +321,15 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // linebreak and the measured range brackets it, so removeText deletes
     // the LineBreakNode without any non-collapsed DOM selection. (This was
     // previously a native modify('extend') fallback that clobbered PRIMARY.)
-    const editor = mountEditor();
-    editor.update(
-      () => {
-        const paragraph = $createParagraphNode();
-        const before = $createTextNode('one');
-        const linebreak = $createLineBreakNode();
-        const after = $createTextNode('two');
-        paragraph.append(before, linebreak, after);
-        $getRoot().clear().append(paragraph);
-        after.select(0, 0);
-      },
-      {discrete: true},
-    );
+    const editor = mountEditor(() => {
+      const paragraph = $createParagraphNode();
+      const before = $createTextNode('one');
+      const linebreak = $createLineBreakNode();
+      const after = $createTextNode('two');
+      paragraph.append(before, linebreak, after);
+      $getRoot().clear().append(paragraph);
+      after.select(0, 0);
+    });
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('onetwo');
     expectOnlyCollapsedDOMSelections();
@@ -353,19 +339,15 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // Caret at the start of a bold run: the collapsed move lands inside the
     // preceding plain run and the last character of that run is deleted.
     // (Also previously a native modify('extend') fallback.)
-    const editor = mountEditor();
-    editor.update(
-      () => {
-        const paragraph = $createParagraphNode();
-        const plain = $createTextNode('ab');
-        const bold = $createTextNode('cd');
-        bold.toggleFormat('bold');
-        paragraph.append(plain, bold);
-        $getRoot().clear().append(paragraph);
-        bold.select(0, 0);
-      },
-      {discrete: true},
-    );
+    const editor = mountEditor(() => {
+      const paragraph = $createParagraphNode();
+      const plain = $createTextNode('ab');
+      const bold = $createTextNode('cd');
+      bold.toggleFormat('bold');
+      paragraph.append(plain, bold);
+      $getRoot().clear().append(paragraph);
+      bold.select(0, 0);
+    });
     deleteCharacter(editor, true);
     expect(textContent(editor)).toBe('acd');
     expectOnlyCollapsedDOMSelections();
@@ -413,8 +395,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
         extendSpy.mockClear();
         addRangeSpy.mockClear();
 
-        const editor = mountEditor();
-        setup(editor, text, text.length);
+        const editor = mountEditor(() => $initWithText(text, text.length));
         deleteCharacter(editor, true);
         expect(textContent(editor)).toBe(text.slice(0, nativeBoundary));
         expectOnlyCollapsedDOMSelections();
@@ -429,25 +410,19 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // the inline decorator — exactly where native caret movement gets stuck —
     // and the native measurement must continue from that hopped focus, not
     // from the anchor.
-    function setupDecoratorLine(editor: LexicalEditor): void {
-      editor.update(
-        () => {
-          const p1 = $createParagraphNode();
-          p1.append($createTextNode('One'));
-          const p2 = $createParagraphNode();
-          p2.append($createTestInlineDecoratorNode(), $createTextNode('Two'));
-          const p3 = $createParagraphNode();
-          $getRoot().clear().append(p1, p2, p3);
-          // Caret before the decorator, as an element point on the paragraph.
-          p2.select(0, 0);
-        },
-        {discrete: true},
-      );
+    function $initDecoratorLine(): void {
+      const p1 = $createParagraphNode();
+      p1.append($createTextNode('One'));
+      const p2 = $createParagraphNode();
+      p2.append($createTestInlineDecoratorNode(), $createTextNode('Two'));
+      const p3 = $createParagraphNode();
+      $getRoot().clear().append(p1, p2, p3);
+      // Caret before the decorator, as an element point on the paragraph.
+      p2.select(0, 0);
     }
 
     test('forward deleteLine at a caret before an inline decorator deletes the rest of the line', () => {
-      const editor = mountEditor();
-      setupDecoratorLine(editor);
+      const editor = mountEditor($initDecoratorLine);
       editor.update(
         () => {
           const selection = $getSelection();
@@ -470,8 +445,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     });
 
     test('forward deleteWord at a caret before an inline decorator deletes it', () => {
-      const editor = mountEditor();
-      setupDecoratorLine(editor);
+      const editor = mountEditor($initDecoratorLine);
       editor.update(
         () => {
           const selection = $getSelection();

--- a/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
@@ -9,6 +9,7 @@
 import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
 import {
+  $create,
   $createLineBreakNode,
   $createParagraphNode,
   $createTextNode,
@@ -74,7 +75,7 @@ class TestInlineDecoratorNode extends DecoratorNode<null> {
 }
 
 function $createTestInlineDecoratorNode(): TestInlineDecoratorNode {
-  return new TestInlineDecoratorNode();
+  return $create(TestInlineDecoratorNode);
 }
 
 const ext = defineExtension({
@@ -151,27 +152,28 @@ function nativeCharacterExtension(
   const div = document.createElement('div');
   div.contentEditable = 'true';
   document.body.appendChild(div);
-  try {
-    const textNode = document.createTextNode(text);
-    div.appendChild(textNode);
-    const domSelection = window.getSelection()!;
-    domSelection.setBaseAndExtent(textNode, offset, textNode, offset);
-    domSelection.modify(
-      'extend',
-      isBackward ? 'backward' : 'forward',
-      'character',
-    );
-    const boundary =
-      domSelection.focusNode === textNode
-        ? domSelection.focusOffset
-        : isBackward
-          ? 0
-          : text.length;
-    domSelection.removeAllRanges();
-    return boundary;
-  } finally {
+  onTestFinished(() => {
     document.body.removeChild(div);
-  }
+  });
+  const textNode = document.createTextNode(text);
+  div.appendChild(textNode);
+  const domSelection = window.getSelection()!;
+  domSelection.setBaseAndExtent(textNode, offset, textNode, offset);
+  domSelection.modify(
+    'extend',
+    isBackward ? 'backward' : 'forward',
+    'character',
+  );
+  const boundary =
+    domSelection.focusNode === textNode
+      ? domSelection.focusOffset
+      : isBackward
+        ? 0
+        : text.length;
+  // Clear immediately (not at test end): a selection left in the scratch
+  // element would interfere with the editor deletion measured next.
+  domSelection.removeAllRanges();
+  return boundary;
 }
 
 describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', () => {

--- a/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
@@ -36,18 +36,16 @@ import {
 //
 // On Linux/X11, browsers propagate any non-collapsed DOM selection made
 // during a user gesture to the PRIMARY selection (the middle-click paste
-// buffer). `RangeSelection.deleteCharacter` used to extend the DOM selection
-// with the native `Selection.modify('extend', …, 'character')` before
-// removing text, overwriting PRIMARY on every Backspace/Delete. It now
-// measures a collapsed native caret move (which never takes PRIMARY
-// ownership) and builds the deletion range in the Lexical model only.
+// buffer), so deletion must never create one: `RangeSelection`'s delete
+// methods measure a collapsed native caret move (which never takes PRIMARY
+// ownership) and build the deletion range in the Lexical model only.
 //
 // These tests run in a real browser (see the `browser` project in
 // vitest.config.mts) because the contract under test is engine behavior:
-// the spies watch the engine's real Selection API to prove that character
-// deletion never creates a non-collapsed DOM selection — the invariant that
-// keeps PRIMARY intact — and the differential tests compare deletion
-// boundaries against the boundaries the engine itself produces.
+// the spies watch the engine's real Selection API to prove that deletion
+// never creates a non-collapsed DOM selection — the invariant that keeps
+// PRIMARY intact — and the differential tests compare deletion boundaries
+// against the boundaries the engine itself produces.
 
 // An inline, non-editable decorator with real layout, standing in for the
 // playground's inline ImageNode in the deleteLine/deleteWord scenarios.
@@ -135,9 +133,9 @@ function textContent(editor: LexicalEditor): string {
 
 /**
  * Ask the engine itself where one native 'character' extension from `offset`
- * lands, using a scratch contenteditable outside of Lexical. This is the
- * operation the collapsed-move measurement replaces, so it defines the
- * expected deletion boundary for whole-grapheme cases.
+ * lands, using a scratch contenteditable outside of Lexical. The engine's
+ * extension boundary defines the expected deletion span for whole-grapheme
+ * cases, so deleteCharacter's collapsed-move measurement must agree with it.
  */
 function nativeCharacterExtension(
   text: string,
@@ -319,8 +317,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
   test('backspace after a linebreak deletes it with only collapsed DOM selections', () => {
     // Caret at a text node boundary: the collapsed move lands past the
     // linebreak and the measured range brackets it, so removeText deletes
-    // the LineBreakNode without any non-collapsed DOM selection. (This was
-    // previously a native modify('extend') fallback that clobbered PRIMARY.)
+    // the LineBreakNode without any non-collapsed DOM selection.
     const editor = mountEditor(() => {
       const paragraph = $createParagraphNode();
       const before = $createTextNode('one');
@@ -338,7 +335,6 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
   test('backspace across a format-run boundary deletes from the previous run', () => {
     // Caret at the start of a bold run: the collapsed move lands inside the
     // preceding plain run and the last character of that run is deleted.
-    // (Also previously a native modify('extend') fallback.)
     const editor = mountEditor(() => {
       const paragraph = $createParagraphNode();
       const plain = $createTextNode('ab');

--- a/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
@@ -19,6 +19,7 @@ import {
   $isRangeSelection,
   DecoratorNode,
   type LexicalEditor,
+  type RangeSelection,
 } from 'lexical';
 import {
   afterEach,
@@ -116,15 +117,22 @@ function $initWithText(
   textNode.select(offset, offset);
 }
 
-function deleteCharacter(editor: LexicalEditor, isBackward: boolean): void {
+function runDelete(
+  editor: LexicalEditor,
+  $delete: (selection: RangeSelection) => void,
+): void {
   editor.update(
     () => {
       const selection = $getSelection();
       assert($isRangeSelection(selection), 'Expected RangeSelection');
-      selection.deleteCharacter(isBackward);
+      $delete(selection);
     },
     {discrete: true},
   );
+}
+
+function deleteCharacter(editor: LexicalEditor, isBackward: boolean): void {
+  runDelete(editor, selection => selection.deleteCharacter(isBackward));
 }
 
 function textContent(editor: LexicalEditor): string {
@@ -186,10 +194,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
   });
 
   afterEach(() => {
-    modifySpy.mockRestore();
-    setBaseAndExtentSpy.mockRestore();
-    extendSpy.mockRestore();
-    addRangeSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   /**
@@ -217,20 +222,33 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     }
   }
 
-  test('backspace removes one character with only collapsed DOM selections', () => {
-    const editor = mountEditor(() => $initWithText('hello', 5));
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('hell');
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('hel');
+  /**
+   * Mount an editor with `init`, run one deletion per entry of `expected`
+   * asserting the text content after each, then assert the PRIMARY-safety
+   * invariant.
+   */
+  function expectDeletionSequence(
+    init: () => void,
+    isBackward: boolean,
+    expected: string[],
+  ): void {
+    const editor = mountEditor(init);
+    for (const text of expected) {
+      deleteCharacter(editor, isBackward);
+      expect(textContent(editor)).toBe(text);
+    }
     expectOnlyCollapsedDOMSelections();
+  }
+
+  test('backspace removes one character with only collapsed DOM selections', () => {
+    expectDeletionSequence(() => $initWithText('hello', 5), true, [
+      'hell',
+      'hel',
+    ]);
   });
 
   test('forward delete removes one character with only collapsed DOM selections', () => {
-    const editor = mountEditor(() => $initWithText('hello', 0));
-    deleteCharacter(editor, false);
-    expect(textContent(editor)).toBe('ello');
-    expectOnlyCollapsedDOMSelections();
+    expectDeletionSequence(() => $initWithText('hello', 0), false, ['ello']);
   });
 
   test('backspace deletes a combining mark one code unit at a time', () => {
@@ -238,12 +256,10 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // Lexical does not normalize, so the combining mark is removed first,
     // then the base letter.
     const nTilde = 'n\u0303';
-    const editor = mountEditor(() => $initWithText(nTilde, nTilde.length));
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('n');
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('');
-    expectOnlyCollapsedDOMSelections();
+    expectDeletionSequence(() => $initWithText(nTilde, nTilde.length), true, [
+      'n',
+      '',
+    ]);
   });
 
   test('backspace on RTL (Hebrew) text deletes logically, one letter at a time', () => {
@@ -251,26 +267,21 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // Backspace removes the logically-last letter regardless of the RTL
     // visual order.
     const shalom = 'שלום';
-    const editor = mountEditor(() => $initWithText(shalom, shalom.length));
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('שלו');
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('של');
-    expectOnlyCollapsedDOMSelections();
+    expectDeletionSequence(() => $initWithText(shalom, shalom.length), true, [
+      'שלו',
+      'של',
+    ]);
   });
 
   test('backspace on RTL (Arabic) text deletes a combining mark then the base', () => {
     // Arabic lam (U+0644) + shadda combining mark (U+0651). The combining
     // mark is a separate code point that is removed first.
     const lamShadda = 'لّ';
-    const editor = mountEditor(() =>
-      $initWithText(lamShadda, lamShadda.length),
+    expectDeletionSequence(
+      () => $initWithText(lamShadda, lamShadda.length),
+      true,
+      ['ل', ''],
     );
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('ل');
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('');
-    expectOnlyCollapsedDOMSelections();
   });
 
   test('backspace at the end of mixed bidi text deletes the logically-last character', () => {
@@ -278,75 +289,68 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
     // the end (logical offset 6); Backspace deletes the logically-last
     // character (gimel), not the visually-adjacent one.
     const mixed = 'abcאבג';
-    const editor = mountEditor(() => $initWithText(mixed, mixed.length));
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('abcאב');
-    expectOnlyCollapsedDOMSelections();
+    expectDeletionSequence(() => $initWithText(mixed, mixed.length), true, [
+      'abcאב',
+    ]);
   });
 
   test('forward delete at the start of mixed bidi text deletes the logically-first character', () => {
     // Caret at logical offset 0 of RTL "אבג" + LTR "abc"; Delete removes the
     // logically-first character (alef).
     const mixed = 'אבגabc';
-    const editor = mountEditor(() => $initWithText(mixed, 0));
-    deleteCharacter(editor, false);
-    expect(textContent(editor)).toBe('בגabc');
-    expectOnlyCollapsedDOMSelections();
+    expectDeletionSequence(() => $initWithText(mixed, 0), false, ['בגabc']);
   });
 
   test('backspace removes a whole token node with only collapsed DOM selections', () => {
     // Token nodes are atomic: a single Backspace removes the entire node.
-    const editor = mountEditor(() => $initWithText('hello world', 11, 'token'));
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('');
-    expectOnlyCollapsedDOMSelections();
+    expectDeletionSequence(
+      () => $initWithText('hello world', 11, 'token'),
+      true,
+      [''],
+    );
   });
 
   test('backspace on a segmented node removes the last segment with only collapsed DOM selections', () => {
     // Segmented nodes delete a whole whitespace-delimited segment at a time.
-    const editor = mountEditor(() =>
-      $initWithText('hello world', 11, 'segmented'),
+    expectDeletionSequence(
+      () => $initWithText('hello world', 11, 'segmented'),
+      true,
+      ['hello', ''],
     );
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('hello');
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('');
-    expectOnlyCollapsedDOMSelections();
   });
 
   test('backspace after a linebreak deletes it with only collapsed DOM selections', () => {
     // Caret at a text node boundary: the collapsed move lands past the
     // linebreak and the measured range brackets it, so removeText deletes
     // the LineBreakNode without any non-collapsed DOM selection.
-    const editor = mountEditor(() => {
-      const paragraph = $createParagraphNode();
-      const before = $createTextNode('one');
-      const linebreak = $createLineBreakNode();
-      const after = $createTextNode('two');
-      paragraph.append(before, linebreak, after);
-      $getRoot().clear().append(paragraph);
-      after.select(0, 0);
-    });
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('onetwo');
-    expectOnlyCollapsedDOMSelections();
+    expectDeletionSequence(
+      () => {
+        const paragraph = $createParagraphNode();
+        const after = $createTextNode('two');
+        paragraph.append($createTextNode('one'), $createLineBreakNode(), after);
+        $getRoot().clear().append(paragraph);
+        after.select(0, 0);
+      },
+      true,
+      ['onetwo'],
+    );
   });
 
   test('backspace across a format-run boundary deletes from the previous run', () => {
     // Caret at the start of a bold run: the collapsed move lands inside the
     // preceding plain run and the last character of that run is deleted.
-    const editor = mountEditor(() => {
-      const paragraph = $createParagraphNode();
-      const plain = $createTextNode('ab');
-      const bold = $createTextNode('cd');
-      bold.toggleFormat('bold');
-      paragraph.append(plain, bold);
-      $getRoot().clear().append(paragraph);
-      bold.select(0, 0);
-    });
-    deleteCharacter(editor, true);
-    expect(textContent(editor)).toBe('acd');
-    expectOnlyCollapsedDOMSelections();
+    expectDeletionSequence(
+      () => {
+        const paragraph = $createParagraphNode();
+        const bold = $createTextNode('cd');
+        bold.toggleFormat('bold');
+        paragraph.append($createTextNode('ab'), bold);
+        $getRoot().clear().append(paragraph);
+        bold.select(0, 0);
+      },
+      true,
+      ['acd'],
+    );
   });
 
   describe('deletes the same whole grapheme the engine would select natively', () => {
@@ -386,15 +390,10 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
         expect(nativeBoundary).toBeLessThan(text.length);
         // The scratch measurement above intentionally used modify('extend');
         // reset the spies so the invariant below only sees the deletion.
-        modifySpy.mockClear();
-        setBaseAndExtentSpy.mockClear();
-        extendSpy.mockClear();
-        addRangeSpy.mockClear();
-
-        const editor = mountEditor(() => $initWithText(text, text.length));
-        deleteCharacter(editor, true);
-        expect(textContent(editor)).toBe(text.slice(0, nativeBoundary));
-        expectOnlyCollapsedDOMSelections();
+        vi.clearAllMocks();
+        expectDeletionSequence(() => $initWithText(text, text.length), true, [
+          text.slice(0, nativeBoundary),
+        ]);
       });
     });
   });
@@ -419,14 +418,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
 
     test('forward deleteLine at a caret before an inline decorator deletes the rest of the line', () => {
       const editor = mountEditor($initDecoratorLine);
-      editor.update(
-        () => {
-          const selection = $getSelection();
-          assert($isRangeSelection(selection), 'Expected RangeSelection');
-          selection.deleteLine(false);
-        },
-        {discrete: true},
-      );
+      runDelete(editor, selection => selection.deleteLine(false));
       editor.read(() => {
         const root = $getRoot();
         expect(root.getChildrenSize()).toBe(3);
@@ -442,14 +434,7 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
 
     test('forward deleteWord at a caret before an inline decorator deletes it', () => {
       const editor = mountEditor($initDecoratorLine);
-      editor.update(
-        () => {
-          const selection = $getSelection();
-          assert($isRangeSelection(selection), 'Expected RangeSelection');
-          selection.deleteWord(false);
-        },
-        {discrete: true},
-      );
+      runDelete(editor, selection => selection.deleteWord(false));
       editor.read(() => {
         const p2 = $getRoot().getChildAtIndex(1)!;
         assert($isElementNode(p2), 'Expected ElementNode');

--- a/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts
@@ -14,7 +14,9 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
+  DecoratorNode,
   type LexicalEditor,
 } from 'lexical';
 import {
@@ -46,9 +48,39 @@ import {
 // keeps PRIMARY intact — and the differential tests compare deletion
 // boundaries against the boundaries the engine itself produces.
 
+// An inline, non-editable decorator with real layout, standing in for the
+// playground's inline ImageNode in the deleteLine/deleteWord scenarios.
+class TestInlineDecoratorNode extends DecoratorNode<null> {
+  $config() {
+    return this.config('test_inline_decorator', {extends: DecoratorNode});
+  }
+  createDOM(): HTMLElement {
+    const span = document.createElement('span');
+    span.contentEditable = 'false';
+    span.style.display = 'inline-block';
+    span.style.width = '24px';
+    span.style.height = '24px';
+    return span;
+  }
+  updateDOM(): boolean {
+    return false;
+  }
+  isInline(): boolean {
+    return true;
+  }
+  decorate(): null {
+    return null;
+  }
+}
+
+function $createTestInlineDecoratorNode(): TestInlineDecoratorNode {
+  return new TestInlineDecoratorNode();
+}
+
 const ext = defineExtension({
   dependencies: [RichTextExtension],
   name: '[8766-browser]',
+  nodes: [TestInlineDecoratorNode],
 });
 
 function mountEditor(): LexicalEditor {
@@ -385,6 +417,75 @@ describe('deleteCharacter never creates a non-collapsed DOM selection (#8766)', 
         expect(textContent(editor)).toBe(text.slice(0, nativeBoundary));
         expectOnlyCollapsedDOMSelections();
       });
+    });
+  });
+
+  describe('deleteLine and deleteWord around inline decorators', () => {
+    // Mirrors the "can delete line which starts with element forwards"
+    // Selection e2e scenario (macOS-only binding in e2e, so covered here for
+    // all platforms). The decorator/block pre-pass hops the model focus past
+    // the inline decorator — exactly where native caret movement gets stuck —
+    // and the native measurement must continue from that hopped focus, not
+    // from the anchor.
+    function setupDecoratorLine(editor: LexicalEditor): void {
+      editor.update(
+        () => {
+          const p1 = $createParagraphNode();
+          p1.append($createTextNode('One'));
+          const p2 = $createParagraphNode();
+          p2.append($createTestInlineDecoratorNode(), $createTextNode('Two'));
+          const p3 = $createParagraphNode();
+          $getRoot().clear().append(p1, p2, p3);
+          // Caret before the decorator, as an element point on the paragraph.
+          p2.select(0, 0);
+        },
+        {discrete: true},
+      );
+    }
+
+    test('forward deleteLine at a caret before an inline decorator deletes the rest of the line', () => {
+      const editor = mountEditor();
+      setupDecoratorLine(editor);
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          assert($isRangeSelection(selection), 'Expected RangeSelection');
+          selection.deleteLine(false);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const root = $getRoot();
+        expect(root.getChildrenSize()).toBe(3);
+        expect(root.getChildAtIndex(0)!.getTextContent()).toBe('One');
+        const p2 = root.getChildAtIndex(1)!;
+        assert($isElementNode(p2), 'Expected ElementNode');
+        // The decorator and the trailing text are both deleted.
+        expect(p2.getChildrenSize()).toBe(0);
+        expect(root.getChildAtIndex(2)!.getTextContent()).toBe('');
+      });
+      expectOnlyCollapsedDOMSelections();
+    });
+
+    test('forward deleteWord at a caret before an inline decorator deletes it', () => {
+      const editor = mountEditor();
+      setupDecoratorLine(editor);
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          assert($isRangeSelection(selection), 'Expected RangeSelection');
+          selection.deleteWord(false);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const p2 = $getRoot().getChildAtIndex(1)!;
+        assert($isElementNode(p2), 'Expected ElementNode');
+        // The decorator is deleted as a unit; the text stays.
+        expect(p2.getChildrenSize()).toBe(1);
+        expect(p2.getTextContent()).toBe('Two');
+      });
+      expectOnlyCollapsedDOMSelections();
     });
   });
 });


### PR DESCRIPTION
## Description

On Linux/X11, browsers propagate any non-collapsed DOM selection made during
a user gesture to the PRIMARY selection (the middle-click paste buffer).
`RangeSelection.deleteCharacter`, `deleteWord`, and `deleteLine` extended the
DOM selection with the native `Selection.modify('extend', …)` before removing
text, so every Backspace/Delete/Ctrl+Backspace silently overwrote the user's
PRIMARY buffer with the deleted content.

Deletion no longer creates a non-collapsed DOM selection at all. A shared
`$extendSelectionForDeletion` helper replaces the three `modify('extend', …)`
calls:

- The DOM caret is synced collapsed from the model, then moved with the
  native `modify('move', …, granularity)` to measure the engine's
  character/word/line boundary — collapsed carets never take PRIMARY
  ownership.
- The `[original .. landed]` range a native extend would have produced is
  reconstructed and read into the Lexical model via `applyDOMRange`, which
  never touches the DOM selection. `modify()`'s decorator/block handling,
  shadow-root shrink validation, and anchor/focus orientation are preserved.
- For `character` granularity, a boundary landing is clamped into the
  anchor's own text node, since `'move'` reports boundary carets in the
  adjacent node while `'extend'` keeps the focus in the extended node — a
  difference that would otherwise change how a later insertion resolves at
  keyword/format boundaries.

Because the engine's own caret movement defines the boundary, grapheme
behavior is unchanged and no `Intl.Segmenter` is required. Without a DOM
selection or `Selection.modify` implementation the deletion is a no-op;
headless environments can polyfill `modify` (the shared test utils already
do, which is how the jsdom suites exercise this path).

Also included: `.claude/settings.json` (tracked via a `.gitignore` exception)
sets `attribution.sessionUrl: false`, and AGENTS.md documents the policy, so
coding agents don't embed private session URLs in commits or PRs.

Closes #8766

## Test plan

### Before

Reproduced in full Chromium under Xvfb driving the playground, with `xsel`
watching X11 PRIMARY: seed PRIMARY, click into the editor, type, press
Backspace → PRIMARY is overwritten with the deleted character (and on every
subsequent press; Ctrl+Backspace overwrites it with the deleted word). A
control harness isolated the mechanism: gesture-driven `modify('extend')`
clobbers PRIMARY; a collapsed `modify('move')` does not.

### After

Same real-X11 harness: PRIMARY is preserved for Backspace, forward Delete,
Backspace across a Shift+Enter linebreak, and Ctrl+Backspace — while
mouse-drag and Shift+Arrow selections still take PRIMARY ownership, the
expected platform behavior.

Backspace behavior is verified identical to a raw contenteditable with no JS
(11/11 cases, code point by code point, real keyboard events in Chromium):
combining marks (n+U+0303, Arabic shadda) and complex scripts (Hangul jamo,
Tamil, Devanagari) delete one code point per press; emoji clusters (astral,
ZWJ family, skin tone, variation selectors, keycap, flag) delete whole
clusters in one press.

New browser-mode tests
(`packages/lexical/src/__tests__/browser/Issue8766DeleteCharacter.test.ts`)
assert the invariant directly — deletion never calls `modify('extend')`,
never makes a ranged `setBaseAndExtent`, never uses `Selection.extend` or a
non-collapsed `addRange` — plus differential emoji-boundary checks against
the engine and coverage for RTL Hebrew/Arabic, mixed bidi, token, segmented,
linebreak, and format-run cases.

All suites passing: browser (60), unit (1086), e2e in real Chromium
(7163-graphemes, Keywords, Hashtags, Mentions, ShadowDOM, Emoticons,
AutoLinks, Selection), `tsc` and `eslint` clean. `deleteLine` has no
cross-platform e2e binding (macOS-only shortcut) but shares the same helper
and is covered by the unit suites.
