### PR TITLE
[lexical-rich-text] Bug Fix: Stop ArrowUp/Down from skipping block decorators

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -22,6 +22,7 @@ import {
   getPageOrFrame,
   html,
   initialize,
+  insertCollapsible,
   pasteFromClipboard,
   selectFromInsertDropdown,
   test,
@@ -746,6 +747,86 @@ test.describe('HorizontalRule', () => {
     expect(inList).toBe(true);
 
     // ArrowDown from last list item should select the HR
+    await page.keyboard.press('ArrowDown');
+
+    const isNodeSel = await getPageOrFrame(page).evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
+    });
+    expect(isNodeSel).toBe(true);
+  });
+
+  test('ArrowDown from block cursor between shadow root and decorator selects the decorator', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+
+    await page.keyboard.type('Top');
+    await page.keyboard.press('Enter');
+
+    // Insert a collapsible (shadow root) — cursor lands in the title
+    await insertCollapsible(page);
+    await page.keyboard.type('Title');
+
+    // Navigate out of the collapsible: right from title end → content,
+    // then right again → trailing paragraph after the collapsible.
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+
+    // Insert an HR (decorator) right after the collapsible
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+    await waitForSelector(page, 'hr');
+
+    // Remove the empty paragraph between collapsible and HR, then set
+    // selection to a block cursor just before the HR so the two nodes
+    // are directly adjacent (the tree shape that triggers the bug).
+    await getPageOrFrame(page).evaluate(() => {
+      const editor = window.lexicalEditor;
+      editor.update(
+        () => {
+          const root = editor.getEditorState()._nodeMap.get('root');
+          const children = root.getChildren();
+          for (let i = 0; i < children.length; i++) {
+            const child = children[i];
+            if (
+              child.getType() === 'paragraph' &&
+              child.getTextContentSize() === 0 &&
+              i > 0 &&
+              children[i - 1].getType() === 'collapsible-container'
+            ) {
+              child.remove();
+              break;
+            }
+          }
+          // Set block cursor between collapsible and HR
+          const updated = root.getChildren();
+          for (let i = 0; i < updated.length; i++) {
+            if (updated[i].getType() === 'horizontalrule') {
+              root.select(i, i);
+              break;
+            }
+          }
+        },
+        {discrete: true},
+      );
+    });
+
+    // Verify we're at a block cursor on root
+    const blockCursorState = await getPageOrFrame(page).evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      return (
+        sel !== null &&
+        'anchor' in sel &&
+        sel.anchor.type === 'element' &&
+        sel.anchor.key === 'root'
+      );
+    });
+    expect(blockCursorState).toBe(true);
+
+    // ArrowDown from this block cursor should select the HR
     await page.keyboard.press('ArrowDown');
 
     const isNodeSel = await getPageOrFrame(page).evaluate(() => {

--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -19,6 +19,7 @@ import {
   copyToClipboard,
   expect,
   focusEditor,
+  getPageOrFrame,
   html,
   initialize,
   pasteFromClipboard,
@@ -75,7 +76,7 @@ test.describe('HorizontalRule', () => {
 
     // NodeSelection DOM representation varies across browsers
     // (Chromium auto-restores it), so assert Lexical internal state.
-    const nodeSelAfterUp = await page.evaluate(() => {
+    const nodeSelAfterUp = await getPageOrFrame(page).evaluate(() => {
       const sel = window.lexicalEditor.getEditorState()._selection;
       return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
     });
@@ -631,7 +632,7 @@ test.describe('HorizontalRule', () => {
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('ArrowUp');
-    const inParagraph = await page.evaluate(() => {
+    const inParagraph = await getPageOrFrame(page).evaluate(() => {
       const sel = window.lexicalEditor.getEditorState()._selection;
       return sel !== null && 'anchor' in sel;
     });
@@ -641,7 +642,7 @@ test.describe('HorizontalRule', () => {
     await page.keyboard.press('ArrowDown');
 
     // Should still be a RangeSelection (not NodeSelection on the HR)
-    const stillRange = await page.evaluate(() => {
+    const stillRange = await getPageOrFrame(page).evaluate(() => {
       const sel = window.lexicalEditor.getEditorState()._selection;
       return sel !== null && 'anchor' in sel && !('_nodes' in sel);
     });
@@ -664,12 +665,12 @@ test.describe('HorizontalRule', () => {
     await page.keyboard.type('Bottom');
 
     const isNodeSel = () =>
-      page.evaluate(() => {
+      getPageOrFrame(page).evaluate(() => {
         const sel = window.lexicalEditor.getEditorState()._selection;
         return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
       });
     const isRangeSel = () =>
-      page.evaluate(() => {
+      getPageOrFrame(page).evaluate(() => {
         const sel = window.lexicalEditor.getEditorState()._selection;
         return sel !== null && 'anchor' in sel && !('_nodes' in sel);
       });
@@ -708,7 +709,7 @@ test.describe('HorizontalRule', () => {
     // ArrowDown from this single-line paragraph should select the HR
     await page.keyboard.press('ArrowDown');
 
-    const isNodeSel = await page.evaluate(() => {
+    const isNodeSel = await getPageOrFrame(page).evaluate(() => {
       const sel = window.lexicalEditor.getEditorState()._selection;
       return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
     });
@@ -738,7 +739,7 @@ test.describe('HorizontalRule', () => {
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('ArrowUp');
 
-    const inList = await page.evaluate(() => {
+    const inList = await getPageOrFrame(page).evaluate(() => {
       const sel = window.lexicalEditor.getEditorState()._selection;
       return sel !== null && 'anchor' in sel;
     });
@@ -747,7 +748,7 @@ test.describe('HorizontalRule', () => {
     // ArrowDown from last list item should select the HR
     await page.keyboard.press('ArrowDown');
 
-    const isNodeSel = await page.evaluate(() => {
+    const isNodeSel = await getPageOrFrame(page).evaluate(() => {
       const sel = window.lexicalEditor.getEditorState()._selection;
       return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
     });

--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -17,6 +17,7 @@ import {
   assertSelection,
   click,
   copyToClipboard,
+  expect,
   focusEditor,
   html,
   initialize,
@@ -72,12 +73,13 @@ test.describe('HorizontalRule', () => {
 
     await page.keyboard.press('ArrowUp');
 
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0],
-      focusOffset: 0,
-      focusPath: [0],
+    // NodeSelection DOM representation varies across browsers
+    // (Chromium auto-restores it), so assert Lexical internal state.
+    const nodeSelAfterUp = await page.evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
     });
+    expect(nodeSelAfterUp).toBe(true);
 
     await page.keyboard.press('ArrowRight');
     await page.keyboard.press('ArrowRight');
@@ -471,6 +473,9 @@ test.describe('HorizontalRule', () => {
       });
 
       await page.keyboard.press('ArrowUp');
+      // ArrowUp from empty paragraph now stops at the decorator
+      // (NodeSelection); press again to exit past it.
+      await page.keyboard.press('ArrowUp');
       await page.keyboard.press('Backspace');
 
       await pasteFromClipboard(page, clipboard);
@@ -596,5 +601,156 @@ test.describe('HorizontalRule', () => {
       focusOffset: 0,
       focusPath: [],
     });
+  });
+
+  test('ArrowDown from middle of multi-line paragraph does not jump to adjacent decorator', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+
+    // Soft line breaks (Shift+Enter) guarantee multiple visual lines
+    // regardless of viewport width.
+    await page.keyboard.type('Line one');
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Enter');
+    await page.keyboard.up('Shift');
+    await page.keyboard.type('Line two');
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Enter');
+    await page.keyboard.up('Shift');
+    await page.keyboard.type('Line three');
+    await page.keyboard.press('Enter');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+    await waitForSelector(page, 'hr');
+
+    // Move cursor to the first line of the paragraph
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    const inParagraph = await page.evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      return sel !== null && 'anchor' in sel;
+    });
+    expect(inParagraph).toBe(true);
+
+    // ArrowDown from line one should move to line two, NOT to the decorator.
+    await page.keyboard.press('ArrowDown');
+
+    // Should still be a RangeSelection (not NodeSelection on the HR)
+    const stillRange = await page.evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      return sel !== null && 'anchor' in sel && !('_nodes' in sel);
+    });
+    expect(stillRange).toBe(true);
+  });
+
+  test('ArrowUp navigates through consecutive decorators', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+
+    await page.keyboard.type('Top');
+    await page.keyboard.press('Enter');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+    await waitForSelector(page, 'hr');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+    await page.keyboard.type('Bottom');
+
+    const isNodeSel = () =>
+      page.evaluate(() => {
+        const sel = window.lexicalEditor.getEditorState()._selection;
+        return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
+      });
+    const isRangeSel = () =>
+      page.evaluate(() => {
+        const sel = window.lexicalEditor.getEditorState()._selection;
+        return sel !== null && 'anchor' in sel && !('_nodes' in sel);
+      });
+
+    // ArrowUp from "Bottom" → should select second HR
+    await page.keyboard.press('ArrowUp');
+    expect(await isNodeSel()).toBe(true);
+
+    // ArrowUp → exit NodeSelection, then ArrowUp → first HR
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    expect(await isNodeSel()).toBe(true);
+
+    // ArrowUp → should exit to "Top" paragraph
+    await page.keyboard.press('ArrowUp');
+    expect(await isRangeSel()).toBe(true);
+  });
+
+  test('ArrowDown from last line of paragraph stops at adjacent decorator', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+
+    await page.keyboard.type('Some text');
+    await page.keyboard.press('Enter');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+    await waitForSelector(page, 'hr');
+
+    // Go back to "Some text" paragraph
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+
+    // ArrowDown from this single-line paragraph should select the HR
+    await page.keyboard.press('ArrowDown');
+
+    const isNodeSel = await page.evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
+    });
+    expect(isNodeSel).toBe(true);
+  });
+
+  test('ArrowDown from last list item selects adjacent decorator', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+
+    // Create a bullet list then insert HR after it
+    await page.keyboard.type('Item one');
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .icon.bullet-list');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Item two');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+    await waitForSelector(page, 'hr');
+
+    // Move cursor back to the last list item
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+
+    const inList = await page.evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      return sel !== null && 'anchor' in sel;
+    });
+    expect(inList).toBe(true);
+
+    // ArrowDown from last list item should select the HR
+    await page.keyboard.press('ArrowDown');
+
+    const isNodeSel = await page.evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      return sel !== null && '_nodes' in sel && sel._nodes.size === 1;
+    });
+    expect(isNodeSel).toBe(true);
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -68,6 +68,7 @@ import {
   $getSelection,
   $getSiblingCaret,
   $getSlotFrame,
+  $hasAncestor,
   $insertNodes,
   $isDecoratorNode,
   $isElementNode,
@@ -698,6 +699,16 @@ function $tryExitShadowRootToBlockCursor(
   // shadow root (e.g. LayoutItem with element-type selection).
   const shadowRoot = $findMatchingParent(focusCaret.origin, $isShadowRootNode);
   if (!shadowRoot) {
+    return false;
+  }
+  // When focus is an element-type point, $caretFromPoint returns a caret
+  // whose origin is a child of the focus node. If that child happens to be
+  // (or sit inside) a shadow root, $findMatchingParent matches it even
+  // though the selection is at the parent level, not inside the shadow root.
+  // Skip the exit logic when the focus node is not actually inside the
+  // found shadow root.
+  const focusNode = selection.focus.getNode();
+  if (!shadowRoot.is(focusNode) && !$hasAncestor(focusNode, shadowRoot)) {
     return false;
   }
   // Check that the focus is at the edge of the shadow root in the given

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -75,6 +75,7 @@ import {
   $isNodeSelection,
   $isRangeSelection,
   $isRootNode,
+  $isRootOrShadowRoot,
   $isSelectionCapturedInDecoratorInput,
   $isShadowRootNode,
   $isSiblingCaret,
@@ -792,18 +793,15 @@ function $tryDecoratorLineNavigation(
   }
   const focus = selection.focus;
   const focusNode = focus.getNode();
+  const direction = isBackward ? 'previous' : 'next';
+  const focusCaret = $caretFromPoint(focus, direction);
 
   if (
     focus.type === 'element' &&
     $isElementNode(focusNode) &&
     ($isRootNode(focusNode) || $isShadowRootNode(focusNode))
   ) {
-    const offset = focus.offset;
-    const adjacentChild = isBackward
-      ? offset > 0
-        ? focusNode.getChildAtIndex(offset - 1)
-        : null
-      : focusNode.getChildAtIndex(offset);
+    const adjacentChild = focusCaret.getNodeAtCaret();
     if (adjacentChild !== null && $isSelectableBlockDecorator(adjacentChild)) {
       $selectNode(adjacentChild.__key);
       return true;
@@ -814,16 +812,15 @@ function $tryDecoratorLineNavigation(
   const topBlock = $findMatchingParent(
     $isElementNode(focusNode) ? focusNode : focusNode.getParentOrThrow(),
     (n): n is ElementNode =>
-      $isElementNode(n) &&
-      !n.isInline() &&
-      ($isRootNode(n.getParent()) || $isShadowRootNode(n.getParent())),
+      $isElementNode(n) && !n.isInline() && $isRootOrShadowRoot(n.getParent()),
   );
   if (topBlock === null) {
     return false;
   }
-  const adjacentSibling = isBackward
-    ? topBlock.getPreviousSibling()
-    : topBlock.getNextSibling();
+  const adjacentSibling = $getSiblingCaret(
+    topBlock,
+    direction,
+  ).getNodeAtCaret();
   if (
     adjacentSibling === null ||
     !$isSelectableBlockDecorator(adjacentSibling)
@@ -880,8 +877,7 @@ function $tryDecoratorLineNavigation(
     return true;
   }
   const stillInSameBlock =
-    movedNode.is(topBlock) ||
-    $findMatchingParent(movedNode, n => n.is(topBlock)) !== null;
+    movedNode.is(topBlock) || $hasAncestor(movedNode, topBlock);
   if (stillInSameBlock) {
     return false;
   }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -52,16 +52,17 @@ import {
   $applyNodeReplacement,
   $caretFromPoint,
   $comparePointCaretNext,
+  $createNodeSelection,
   $createParagraphNode,
   $createRangeSelection,
   $createTabNode,
   $extendCaretToRange,
   $findMatchingParent,
   $formatText,
-  $getAdjacentNode,
   $getCaretRange,
   $getChildCaret,
   $getCollapsedCaretRange,
+  $getEditor,
   $getNearestNodeFromDOMNode,
   $getRoot,
   $getSelection,
@@ -103,6 +104,7 @@ import {
   ElementNode,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
+  getDOMSelection,
   INDENT_CONTENT_COMMAND,
   INSERT_LINE_BREAK_COMMAND,
   INSERT_PARAGRAPH_COMMAND,
@@ -753,6 +755,146 @@ function $tryExitShadowRootToBlockCursor(
   return false;
 }
 
+function $isSelectableBlockDecorator(
+  node: LexicalNode | null | undefined,
+): boolean {
+  return (
+    $isDecoratorNode(node) &&
+    !node.isInline() &&
+    !node.isIsolated() &&
+    node.isKeyboardSelectable()
+  );
+}
+
+function $selectNode(key: NodeKey): void {
+  const nodeSelection = $createNodeSelection();
+  nodeSelection.add(key);
+  $setSelection(nodeSelection);
+}
+
+function $tryDecoratorLineNavigation(
+  selection: RangeSelection,
+  isBackward: boolean,
+): boolean {
+  if (!selection.isCollapsed()) {
+    return false;
+  }
+  const focus = selection.focus;
+  const focusNode = focus.getNode();
+
+  if (
+    focus.type === 'element' &&
+    $isElementNode(focusNode) &&
+    ($isRootNode(focusNode) || $isShadowRootNode(focusNode))
+  ) {
+    const offset = focus.offset;
+    const adjacentChild = isBackward
+      ? offset > 0
+        ? focusNode.getChildAtIndex(offset - 1)
+        : null
+      : focusNode.getChildAtIndex(offset);
+    if (adjacentChild !== null && $isSelectableBlockDecorator(adjacentChild)) {
+      $selectNode(adjacentChild.__key);
+      return true;
+    }
+    return false;
+  }
+
+  const topBlock = $findMatchingParent(
+    $isElementNode(focusNode) ? focusNode : focusNode.getParentOrThrow(),
+    (n): n is ElementNode =>
+      $isElementNode(n) &&
+      !n.isInline() &&
+      ($isRootNode(n.getParent()) || $isShadowRootNode(n.getParent())),
+  );
+  if (topBlock === null) {
+    return false;
+  }
+  const adjacentSibling = isBackward
+    ? topBlock.getPreviousSibling()
+    : topBlock.getNextSibling();
+  if (
+    adjacentSibling === null ||
+    !$isSelectableBlockDecorator(adjacentSibling)
+  ) {
+    return false;
+  }
+  // Empty blocks always escape on line-move, so skip the DOM probe.
+  if (topBlock.getTextContentSize() === 0) {
+    $selectNode(adjacentSibling.__key);
+    return true;
+  }
+  const rootElement = $getEditor().getRootElement();
+  if (rootElement === null) {
+    return false;
+  }
+  const domSelection = getDOMSelection(rootElement.ownerDocument.defaultView);
+  if (domSelection === null || domSelection.rangeCount === 0) {
+    return false;
+  }
+  const savedAnchorNode = domSelection.anchorNode;
+  const savedAnchorOffset = domSelection.anchorOffset;
+  const savedFocusNode = domSelection.focusNode;
+  const savedFocusOffset = domSelection.focusOffset;
+  domSelection.modify('move', isBackward ? 'backward' : 'forward', 'line');
+  const newAnchorNode = domSelection.anchorNode;
+  const newAnchorOffset = domSelection.anchorOffset;
+  if (newAnchorNode === null) {
+    restoreDOMSelection(
+      domSelection,
+      savedAnchorNode,
+      savedAnchorOffset,
+      savedFocusNode,
+      savedFocusOffset,
+    );
+    return false;
+  }
+  const movedNode = $getNearestNodeFromDOMNode(newAnchorNode);
+  restoreDOMSelection(
+    domSelection,
+    savedAnchorNode,
+    savedAnchorOffset,
+    savedFocusNode,
+    savedFocusOffset,
+  );
+  if (movedNode === null) {
+    return false;
+  }
+  // Firefox stays in place when modify('move', 'backward', 'line') hits
+  // the top of a block — treat no movement as reaching the block edge.
+  const didNotMove =
+    newAnchorNode === savedAnchorNode && newAnchorOffset === savedAnchorOffset;
+  if (didNotMove) {
+    $selectNode(adjacentSibling.__key);
+    return true;
+  }
+  const stillInSameBlock =
+    movedNode.is(topBlock) ||
+    $findMatchingParent(movedNode, n => n.is(topBlock)) !== null;
+  if (stillInSameBlock) {
+    return false;
+  }
+  $selectNode(adjacentSibling.__key);
+  return true;
+}
+
+function restoreDOMSelection(
+  domSelection: Selection,
+  anchorNode: Node | null,
+  anchorOffset: number,
+  focusNode: Node | null,
+  focusOffset: number,
+): void {
+  if (anchorNode !== null && focusNode !== null) {
+    domSelection.setBaseAndExtent(
+      anchorNode,
+      anchorOffset,
+      focusNode,
+      focusOffset,
+    );
+  }
+}
+
 function $exitNodeSelectionToward(
   node: LexicalNode,
   direction: CaretDirection,
@@ -1055,14 +1197,7 @@ export function registerRichText(
             event.preventDefault();
             return true;
           }
-          const possibleNode = $getAdjacentNode(selection.focus, true);
-          if (
-            !event.shiftKey &&
-            $isDecoratorNode(possibleNode) &&
-            !possibleNode.isIsolated() &&
-            !possibleNode.isInline()
-          ) {
-            possibleNode.selectPrevious();
+          if (!event.shiftKey && $tryDecoratorLineNavigation(selection, true)) {
             event.preventDefault();
             return true;
           }
@@ -1096,14 +1231,10 @@ export function registerRichText(
             event.preventDefault();
             return true;
           }
-          const possibleNode = $getAdjacentNode(selection.focus, false);
           if (
             !event.shiftKey &&
-            $isDecoratorNode(possibleNode) &&
-            !possibleNode.isIsolated() &&
-            !possibleNode.isInline()
+            $tryDecoratorLineNavigation(selection, false)
           ) {
-            possibleNode.selectNext();
             event.preventDefault();
             return true;
           }

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -66,6 +66,7 @@ import {
   $cloneWithProperties,
   $getCompositionKey,
   $getNodeByKey,
+  $hasAncestor,
   $isRootOrShadowRoot,
   $maybeMoveChildrenSelectionToParent,
   $removeFromParent,
@@ -1291,8 +1292,7 @@ export class LexicalNode {
    * @param targetNode - the would-be child node.
    */
   isParentOf(targetNode: LexicalNode): boolean {
-    const result = $getCommonAncestor(this, targetNode);
-    return result !== null && result.type === 'ancestor';
+    return $hasAncestor(targetNode, this);
   }
 
   // TO-DO: this function can be simplified a lot


### PR DESCRIPTION
## Description

ArrowUp/Down skip over block decorators (HorizontalRule, PageBreak, etc.) instead of stopping at them. The old code used `$getAdjacentNode` to check whether the focus point's immediate neighbor in the Lexical tree was a decorator, but that only works when the cursor is already at the edge of its block. From the middle of a paragraph, the adjacent Lexical node is a text node, not the decorator — so the arrow key handler never fires and the browser's native line movement jumps straight past the decorator.

### Fix

Replace `$getAdjacentNode` + `selectPrevious()`/`selectNext()` with a new `$tryDecoratorLineNavigation` function that uses `domSelection.modify('move', direction, 'line')` as a DOM-level probe. The probe moves the DOM caret one visual line, checks whether it left the current top-level block, and restores the original position. If the caret would escape and the adjacent root-level sibling is a selectable block decorator, the function creates a `NodeSelection` on that decorator.

Three fast paths avoid the DOM probe when the answer is already known:
- **Element-type selection at root/shadow root** (block cursor): the adjacent child is looked up directly by offset.
- **Empty blocks**: always escape on a line move, so the decorator is selected immediately.
- **Firefox no-movement**: Firefox's `modify('move', 'backward', 'line')` stays in place at the top of a block instead of crossing to the previous block. Treated as reaching the block edge.

This is the first use of `domSelection.modify` with `'line'` granularity in the codebase — existing callers only use `'character'`, `'word'`, and `'lineboundary'`.

Closes #7966

## Test plan

- [x] `pnpm vitest run --project unit` — 3485 pass.
- [x] `npx playwright test HorizontalRule.spec.mjs` — 33 pass (11 tests × Chromium/Firefox/WebKit).
  - Existing tests adjusted for NodeSelection stop.
  - New: "ArrowDown from middle of multi-line paragraph does not jump to adjacent decorator" (false positive guard, uses Shift+Enter for viewport-independent line breaks).
  - New: "ArrowUp navigates through consecutive decorators" (text → NodeSelection → block cursor → NodeSelection → text round-trip).
  - New: "ArrowDown from last line of paragraph stops at adjacent decorator".
  - New: "ArrowDown from last list item selects adjacent decorator" (list as top-level block).
- [x] Table (253), list (105), code block (48) E2E suites — no regression.
- [x] Manual playground (Chrome, Firefox, Safari):
  - Single paragraph + HR: ArrowDown stops at HR, ArrowUp returns to paragraph.
  - Consecutive HRs: ArrowUp walks through each decorator via NodeSelection → block cursor cycle.
  - Multi-line paragraph + HR: ArrowDown from non-last line stays in paragraph.
- [x] tsc / prettier / eslint clean.