### PR TITLE
fix(lexical): use `extends` for type parameter bound in registerEventListeners flow type

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -2083,7 +2083,7 @@ declare export function registerEventListener(
   options?: EventListenerOptionsOrUseCapture,
 ): () => void;
 export type EventListenerMap<T> = {readonly [type: string]: EventListener};
-declare export function registerEventListeners<T: EventTarget>(
+declare export function registerEventListeners<T extends EventTarget>(
   target: T,
   listeners: EventListenerMap<T>,
   options?: EventListenerOptionsOrUseCapture,


### PR DESCRIPTION
## Description

The `registerEventListeners` declaration in the Lexical flow stub (`packages/lexical/flow/Lexical.js.flow`) uses the deprecated `<T: EventTarget>` syntax for its type parameter bound:

```js
declare export function registerEventListeners<T: EventTarget>(
```

Newer Flow versions reject `:` for type parameter bounds with an `unsupported-syntax` error and require `extends`:

> Using `:` for type parameter bounds is deprecated. Use `extends` instead (e.g., `<T extends Bound>`).

This declaration was introduced in #8767 (registerEventListener / registerEventListeners DOM helpers). The TypeScript source already uses the modern form —

```ts
export function registerEventListeners<T extends EventTarget>(
```

(`packages/lexical/src/utils/registerEventListeners.ts`) — and every other generic in this `.flow` file already uses `extends`. This one declaration was the lone holdout.

## Fix

Change `<T: EventTarget>` → `<T extends EventTarget>` so the flow stub matches the TS source and passes stricter Flow parsers.

## Test Plan

- `prettier --check` passes on the file.
- Verified the identical change resolves the `unsupported-syntax` Flow error where this stub is consumed with a strict Flow toolchain.
- No behavioral change — type-only edit to a `.flow` declaration.
