### PR TITLE
[lexical-playground] Feature: Find and Replace

### DIFF
--- a/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
+++ b/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
@@ -31,6 +31,7 @@ import {
   $replaceAllMatches,
   $replaceMatch,
   $resolveMatchToPoints,
+  expandReplacement,
   findMatches,
 } from '../../src/plugins/FindReplaceExtension';
 
@@ -48,44 +49,44 @@ describe('findMatches', () => {
     expect(findMatches('', 'hello', false, false)).toEqual([]);
   });
 
-  test('finds single match', () => {
+  test('finds single match with matchText', () => {
     expect(findMatches('hello world', 'world', false, false)).toEqual([
-      {end: 11, start: 6},
+      {end: 11, matchText: 'world', start: 6},
     ]);
   });
 
   test('finds multiple non-overlapping matches', () => {
     expect(findMatches('foo bar foo baz foo', 'foo', false, false)).toEqual([
-      {end: 3, start: 0},
-      {end: 11, start: 8},
-      {end: 19, start: 16},
+      {end: 3, matchText: 'foo', start: 0},
+      {end: 11, matchText: 'foo', start: 8},
+      {end: 19, matchText: 'foo', start: 16},
     ]);
   });
 
-  test('case-insensitive search by default', () => {
+  test('case-insensitive search preserves original case in matchText', () => {
     expect(findMatches('Hello HELLO hello', 'hello', false, false)).toEqual([
-      {end: 5, start: 0},
-      {end: 11, start: 6},
-      {end: 17, start: 12},
+      {end: 5, matchText: 'Hello', start: 0},
+      {end: 11, matchText: 'HELLO', start: 6},
+      {end: 17, matchText: 'hello', start: 12},
     ]);
   });
 
   test('case-sensitive search', () => {
     expect(findMatches('Hello HELLO hello', 'hello', true, false)).toEqual([
-      {end: 17, start: 12},
+      {end: 17, matchText: 'hello', start: 12},
     ]);
   });
 
   test('regex search: basic pattern', () => {
     expect(findMatches('foo123bar456', '\\d+', false, true)).toEqual([
-      {end: 6, start: 3},
-      {end: 12, start: 9},
+      {end: 6, matchText: '123', start: 3},
+      {end: 12, matchText: '456', start: 9},
     ]);
   });
 
   test('regex search: with groups uses full match range', () => {
     expect(findMatches('2026-07-03', '(\\d{4})-(\\d{2})', false, true)).toEqual(
-      [{end: 7, start: 0}],
+      [{end: 7, matchText: '2026-07', start: 0}],
     );
   });
 
@@ -95,19 +96,19 @@ describe('findMatches', () => {
 
   test('non-regex mode escapes special characters', () => {
     expect(findMatches('price is $10.00', '$10.00', false, false)).toEqual([
-      {end: 15, start: 9},
+      {end: 15, matchText: '$10.00', start: 9},
     ]);
   });
 
   test('matches at string boundaries', () => {
     expect(findMatches('abc', 'abc', false, false)).toEqual([
-      {end: 3, start: 0},
+      {end: 3, matchText: 'abc', start: 0},
     ]);
   });
 
   test('matches at start of string', () => {
     expect(findMatches('hello world', 'hello', false, false)).toEqual([
-      {end: 5, start: 0},
+      {end: 5, matchText: 'hello', start: 0},
     ]);
   });
 
@@ -117,6 +118,38 @@ describe('findMatches', () => {
 
   test('skips zero-length regex matches', () => {
     expect(findMatches('abc', '(?=a)', false, true)).toEqual([]);
+  });
+});
+
+describe('expandReplacement', () => {
+  test('returns template as-is when no regex', () => {
+    expect(expandReplacement('$1', 'foo', null)).toBe('$1');
+  });
+
+  test('expands $1/$2 capture groups', () => {
+    expect(expandReplacement('$1-$2', '2026-07', /(\d{4})-(\d{2})/)).toBe(
+      '2026-07',
+    );
+  });
+
+  test('expands named capture groups with different template', () => {
+    expect(expandReplacement('year=$1', '2026-07', /(\d{4})-(\d{2})/)).toBe(
+      'year=2026',
+    );
+  });
+
+  test('expands $& for full match', () => {
+    expect(expandReplacement('[$&]', 'foo', /foo/)).toBe('[foo]');
+  });
+
+  test('swaps groups', () => {
+    expect(expandReplacement('$2/$1', 'user@host', /(\w+)@(\w+)/)).toBe(
+      'host/user',
+    );
+  });
+
+  test('literal $1 with no groups in regex', () => {
+    expect(expandReplacement('$1', 'hello', /hello/)).toBe('$1');
   });
 });
 
@@ -173,7 +206,6 @@ describe('$buildOffsetMap', () => {
     const map = editor.read(() => $buildOffsetMap());
     expect(map).toHaveLength(2);
     expect(map[0]).toMatchObject({globalEnd: 3, globalStart: 0});
-    // "abc" + "\n\n" + "def" → p2 starts at 5
     expect(map[1]).toMatchObject({globalEnd: 8, globalStart: 5});
   });
 
@@ -252,7 +284,6 @@ describe('$buildOffsetMap', () => {
       const text = $getRoot().getTextContent();
       return {map, text};
     });
-    // "before\n\naaa\n\nbbb"
     expect(result.text).toBe('before\n\naaa\n\nbbb');
     expect(result.map).toHaveLength(3);
     expect(result.map[0]).toMatchObject({globalEnd: 6, globalStart: 0});
@@ -276,7 +307,7 @@ describe('$resolveMatchToPoints', () => {
     );
     const result = editor.read(() => {
       const map = $buildOffsetMap();
-      return $resolveMatchToPoints({end: 5, start: 0}, map);
+      return $resolveMatchToPoints({end: 5, matchText: 'hello', start: 0}, map);
     });
     invariant(result !== null, 'expected non-null match points');
     expect(result.anchorKey).toBe(result.focusKey);
@@ -300,13 +331,12 @@ describe('$resolveMatchToPoints', () => {
     );
     const result = editor.read(() => {
       const map = $buildOffsetMap();
-      // "hello" spans hel(0-3) + lo(3-5)
-      return $resolveMatchToPoints({end: 5, start: 0}, map);
+      return $resolveMatchToPoints({end: 5, matchText: 'hello', start: 0}, map);
     });
     invariant(result !== null, 'expected non-null match points');
     expect(result.anchorKey).not.toBe(result.focusKey);
     expect(result.anchorOffset).toBe(0);
-    expect(result.focusOffset).toBe(2); // offset 5 - globalStart 3 = 2
+    expect(result.focusOffset).toBe(2);
     expect(result.format).toBe(0);
   });
 
@@ -324,8 +354,10 @@ describe('$resolveMatchToPoints', () => {
     );
     const result = editor.read(() => {
       const map = $buildOffsetMap();
-      // "abc\n\ndef" — offsets 3-4 are the \n\n gap, no TextNode covers them
-      return $resolveMatchToPoints({end: 5, start: 3}, map);
+      return $resolveMatchToPoints(
+        {end: 5, matchText: 'c\n\nd', start: 3},
+        map,
+      );
     });
     expect(result).toBeNull();
   });
@@ -347,7 +379,10 @@ describe('$replaceMatch', () => {
     editor.update(
       () => {
         const map = $buildOffsetMap();
-        const points = $resolveMatchToPoints({end: 5, start: 0}, map);
+        const points = $resolveMatchToPoints(
+          {end: 5, matchText: 'hello', start: 0},
+          map,
+        );
         invariant(points !== null, 'expected non-null match points');
         $replaceMatch(points, 'goodbye');
       },
@@ -380,7 +415,10 @@ describe('$replaceMatch', () => {
     editor.update(
       () => {
         const map = $buildOffsetMap();
-        const points = $resolveMatchToPoints({end: 5, start: 0}, map);
+        const points = $resolveMatchToPoints(
+          {end: 5, matchText: 'hello', start: 0},
+          map,
+        );
         invariant(points !== null, 'expected non-null match points');
         $replaceMatch(points, 'hi');
       },
@@ -404,7 +442,10 @@ describe('$replaceMatch', () => {
     editor.update(
       () => {
         const map = $buildOffsetMap();
-        const points = $resolveMatchToPoints({end: 6, start: 0}, map);
+        const points = $resolveMatchToPoints(
+          {end: 6, matchText: 'hello ', start: 0},
+          map,
+        );
         invariant(points !== null, 'expected non-null match points');
         $replaceMatch(points, '');
       },
@@ -412,6 +453,56 @@ describe('$replaceMatch', () => {
     );
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('world');
+    });
+  });
+
+  test('regex capture group replacement with $1/$2', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('user@host'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const map = $buildOffsetMap();
+        const match = {end: 9, matchText: 'user@host', start: 0};
+        const points = $resolveMatchToPoints(match, map);
+        invariant(points !== null, 'expected non-null match points');
+        $replaceMatch(points, '$2/$1', match, /(\w+)@(\w+)/);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('host/user');
+    });
+  });
+
+  test('non-regex mode ignores $1 in replacement', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('hello world'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const map = $buildOffsetMap();
+        const match = {end: 5, matchText: 'hello', start: 0};
+        const points = $resolveMatchToPoints(match, map);
+        invariant(points !== null, 'expected non-null match points');
+        $replaceMatch(points, '$1');
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('$1 world');
     });
   });
 });
@@ -488,6 +579,32 @@ describe('$replaceAllMatches', () => {
     );
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('quxxx bar quxxx');
+    });
+  });
+
+  test('replaces all with regex capture groups', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('a@b and c@d'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const text = $getRoot().getTextContent();
+        const map = $buildOffsetMap();
+        const matches = findMatches(text, '(\\w+)@(\\w+)', false, true);
+        const regex = /(\w+)@(\w+)/;
+        const count = $replaceAllMatches(matches, map, '$2/$1', regex);
+        expect(count).toBe(2);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('b/a and d/c');
     });
   });
 });

--- a/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
+++ b/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import invariant from '@lexical/internal/invariant';
+import {
+  $createListItemNode,
+  $createListNode,
+  ListExtension,
+} from '@lexical/list';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  $isTextNode,
+  defineExtension,
+  IS_BOLD,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+import {
+  $buildOffsetMap,
+  $replaceAllMatches,
+  $replaceMatch,
+  $resolveMatchToPoints,
+  findMatches,
+} from '../../src/plugins/FindReplaceExtension';
+
+const TestExtension = defineExtension({
+  dependencies: [RichTextExtension, ListExtension],
+  name: '[test-find-replace]',
+});
+
+describe('findMatches', () => {
+  test('returns empty array for empty search term', () => {
+    expect(findMatches('hello world', '', false, false)).toEqual([]);
+  });
+
+  test('returns empty array for empty text', () => {
+    expect(findMatches('', 'hello', false, false)).toEqual([]);
+  });
+
+  test('finds single match', () => {
+    expect(findMatches('hello world', 'world', false, false)).toEqual([
+      {end: 11, start: 6},
+    ]);
+  });
+
+  test('finds multiple non-overlapping matches', () => {
+    expect(findMatches('foo bar foo baz foo', 'foo', false, false)).toEqual([
+      {end: 3, start: 0},
+      {end: 11, start: 8},
+      {end: 19, start: 16},
+    ]);
+  });
+
+  test('case-insensitive search by default', () => {
+    expect(findMatches('Hello HELLO hello', 'hello', false, false)).toEqual([
+      {end: 5, start: 0},
+      {end: 11, start: 6},
+      {end: 17, start: 12},
+    ]);
+  });
+
+  test('case-sensitive search', () => {
+    expect(findMatches('Hello HELLO hello', 'hello', true, false)).toEqual([
+      {end: 17, start: 12},
+    ]);
+  });
+
+  test('regex search: basic pattern', () => {
+    expect(findMatches('foo123bar456', '\\d+', false, true)).toEqual([
+      {end: 6, start: 3},
+      {end: 12, start: 9},
+    ]);
+  });
+
+  test('regex search: with groups uses full match range', () => {
+    expect(findMatches('2026-07-03', '(\\d{4})-(\\d{2})', false, true)).toEqual(
+      [{end: 7, start: 0}],
+    );
+  });
+
+  test('regex search: invalid regex returns empty array', () => {
+    expect(findMatches('hello', '[invalid', false, true)).toEqual([]);
+  });
+
+  test('non-regex mode escapes special characters', () => {
+    expect(findMatches('price is $10.00', '$10.00', false, false)).toEqual([
+      {end: 15, start: 9},
+    ]);
+  });
+
+  test('matches at string boundaries', () => {
+    expect(findMatches('abc', 'abc', false, false)).toEqual([
+      {end: 3, start: 0},
+    ]);
+  });
+
+  test('matches at start of string', () => {
+    expect(findMatches('hello world', 'hello', false, false)).toEqual([
+      {end: 5, start: 0},
+    ]);
+  });
+
+  test('no match returns empty array', () => {
+    expect(findMatches('hello world', 'xyz', false, false)).toEqual([]);
+  });
+
+  test('skips zero-length regex matches', () => {
+    expect(findMatches('abc', '(?=a)', false, true)).toEqual([]);
+  });
+});
+
+describe('$buildOffsetMap', () => {
+  test('maps single paragraph with one TextNode', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('hello'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    const map = editor.read(() => $buildOffsetMap());
+    expect(map).toHaveLength(1);
+    expect(map[0].globalStart).toBe(0);
+    expect(map[0].globalEnd).toBe(5);
+  });
+
+  test('maps paragraph with multiple TextNodes (bold boundary)', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        const plain = $createTextNode('hel');
+        const bold = $createTextNode('lo');
+        bold.setFormat(IS_BOLD);
+        p.append(plain, bold);
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    const map = editor.read(() => $buildOffsetMap());
+    expect(map).toHaveLength(2);
+    expect(map[0].globalStart).toBe(0);
+    expect(map[0].globalEnd).toBe(3);
+    expect(map[1].globalStart).toBe(3);
+    expect(map[1].globalEnd).toBe(5);
+  });
+
+  test('maps across multiple paragraphs with double line break offset', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p1 = $createParagraphNode();
+        p1.append($createTextNode('abc'));
+        const p2 = $createParagraphNode();
+        p2.append($createTextNode('def'));
+        $getRoot().clear().append(p1, p2);
+      },
+      {discrete: true},
+    );
+    const map = editor.read(() => $buildOffsetMap());
+    expect(map).toHaveLength(2);
+    expect(map[0]).toMatchObject({globalEnd: 3, globalStart: 0});
+    // "abc" + "\n\n" + "def" → p2 starts at 5
+    expect(map[1]).toMatchObject({globalEnd: 8, globalStart: 5});
+  });
+
+  test('handles empty editor', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    const map = editor.read(() => $buildOffsetMap());
+    expect(map).toEqual([]);
+  });
+
+  test('accounts for LineBreakNode in offset calculation', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append(
+          $createTextNode('hello'),
+          $createLineBreakNode(),
+          $createTextNode('world'),
+        );
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    const result = editor.read(() => {
+      const map = $buildOffsetMap();
+      const text = $getRoot().getTextContent();
+      return {map, text};
+    });
+    expect(result.text).toBe('hello\nworld');
+    expect(result.map).toHaveLength(2);
+    expect(result.map[0]).toMatchObject({globalEnd: 5, globalStart: 0});
+    expect(result.map[1]).toMatchObject({globalEnd: 11, globalStart: 6});
+  });
+
+  test('handles empty paragraph between text paragraphs', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p1 = $createParagraphNode();
+        p1.append($createTextNode('abc'));
+        const p2 = $createParagraphNode();
+        const p3 = $createParagraphNode();
+        p3.append($createTextNode('def'));
+        $getRoot().clear().append(p1, p2, p3);
+      },
+      {discrete: true},
+    );
+    const result = editor.read(() => {
+      const map = $buildOffsetMap();
+      const text = $getRoot().getTextContent();
+      return {map, text};
+    });
+    expect(result.text).toBe('abc\n\n\n\ndef');
+    expect(result.map).toHaveLength(2);
+    expect(result.map[0]).toMatchObject({globalEnd: 3, globalStart: 0});
+    expect(result.map[1]).toMatchObject({globalEnd: 10, globalStart: 7});
+  });
+
+  test('maps list items without extra offset for parent→child', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('before'));
+        const list = $createListNode('bullet');
+        list.append(
+          $createListItemNode().append($createTextNode('aaa')),
+          $createListItemNode().append($createTextNode('bbb')),
+        );
+        $getRoot().clear().append(p, list);
+      },
+      {discrete: true},
+    );
+    const result = editor.read(() => {
+      const map = $buildOffsetMap();
+      const text = $getRoot().getTextContent();
+      return {map, text};
+    });
+    // "before\n\naaa\n\nbbb"
+    expect(result.text).toBe('before\n\naaa\n\nbbb');
+    expect(result.map).toHaveLength(3);
+    expect(result.map[0]).toMatchObject({globalEnd: 6, globalStart: 0});
+    expect(result.map[1]).toMatchObject({globalEnd: 11, globalStart: 8});
+    expect(result.map[2]).toMatchObject({globalEnd: 16, globalStart: 13});
+  });
+});
+
+describe('$resolveMatchToPoints', () => {
+  test('single-node match returns correct points with format', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        const text = $createTextNode('hello world');
+        text.setFormat(IS_BOLD);
+        p.append(text);
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    const result = editor.read(() => {
+      const map = $buildOffsetMap();
+      return $resolveMatchToPoints({end: 5, start: 0}, map);
+    });
+    invariant(result !== null, 'expected non-null match points');
+    expect(result.anchorKey).toBe(result.focusKey);
+    expect(result.anchorOffset).toBe(0);
+    expect(result.focusOffset).toBe(5);
+    expect(result.format).toBe(IS_BOLD);
+  });
+
+  test('cross-node match returns different keys with format 0', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        const plain = $createTextNode('hel');
+        const bold = $createTextNode('lo');
+        bold.setFormat(IS_BOLD);
+        p.append(plain, bold);
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    const result = editor.read(() => {
+      const map = $buildOffsetMap();
+      // "hello" spans hel(0-3) + lo(3-5)
+      return $resolveMatchToPoints({end: 5, start: 0}, map);
+    });
+    invariant(result !== null, 'expected non-null match points');
+    expect(result.anchorKey).not.toBe(result.focusKey);
+    expect(result.anchorOffset).toBe(0);
+    expect(result.focusOffset).toBe(2); // offset 5 - globalStart 3 = 2
+    expect(result.format).toBe(0);
+  });
+
+  test('match falling in paragraph boundary gap returns null', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p1 = $createParagraphNode();
+        p1.append($createTextNode('abc'));
+        const p2 = $createParagraphNode();
+        p2.append($createTextNode('def'));
+        $getRoot().clear().append(p1, p2);
+      },
+      {discrete: true},
+    );
+    const result = editor.read(() => {
+      const map = $buildOffsetMap();
+      // "abc\n\ndef" — offsets 3-4 are the \n\n gap, no TextNode covers them
+      return $resolveMatchToPoints({end: 5, start: 3}, map);
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('$replaceMatch', () => {
+  test('single-node replace preserves text format', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        const text = $createTextNode('hello world');
+        text.setFormat(IS_BOLD);
+        p.append(text);
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const map = $buildOffsetMap();
+        const points = $resolveMatchToPoints({end: 5, start: 0}, map);
+        invariant(points !== null, 'expected non-null match points');
+        $replaceMatch(points, 'goodbye');
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const text = $getRoot().getTextContent();
+      expect(text).toBe('goodbye world');
+      const p = $getRoot().getFirstChild();
+      invariant($isElementNode(p), 'expected ElementNode');
+      const firstChild = p.getFirstChild();
+      invariant($isTextNode(firstChild), 'expected TextNode');
+      expect(firstChild.getFormat()).toBe(IS_BOLD);
+    });
+  });
+
+  test('multi-node replace produces plain text', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        const plain = $createTextNode('hel');
+        const bold = $createTextNode('lo');
+        bold.setFormat(IS_BOLD);
+        p.append(plain, bold);
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const map = $buildOffsetMap();
+        const points = $resolveMatchToPoints({end: 5, start: 0}, map);
+        invariant(points !== null, 'expected non-null match points');
+        $replaceMatch(points, 'hi');
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('hi');
+    });
+  });
+
+  test('replace with empty string deletes match', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('hello world'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const map = $buildOffsetMap();
+        const points = $resolveMatchToPoints({end: 6, start: 0}, map);
+        invariant(points !== null, 'expected non-null match points');
+        $replaceMatch(points, '');
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('world');
+    });
+  });
+});
+
+describe('$replaceAllMatches', () => {
+  test('replaces all matches in reverse order', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('foo bar foo'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const map = $buildOffsetMap();
+        const matches = findMatches('foo bar foo', 'foo', false, false);
+        const count = $replaceAllMatches(matches, map, 'baz');
+        expect(count).toBe(2);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('baz bar baz');
+    });
+  });
+
+  test('replaces all with shorter replacement', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('foo bar foo'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const text = $getRoot().getTextContent();
+        const map = $buildOffsetMap();
+        const matches = findMatches(text, 'foo', false, false);
+        const count = $replaceAllMatches(matches, map, 'x');
+        expect(count).toBe(2);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('x bar x');
+    });
+  });
+
+  test('replaces all with longer replacement', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('foo bar foo'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const text = $getRoot().getTextContent();
+        const map = $buildOffsetMap();
+        const matches = findMatches(text, 'foo', false, false);
+        const count = $replaceAllMatches(matches, map, 'quxxx');
+        expect(count).toBe(2);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('quxxx bar quxxx');
+    });
+  });
+});

--- a/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
+++ b/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
@@ -636,7 +636,7 @@ describe('$replaceMatch', () => {
       invariant($isElementNode(p), 'expected ElementNode');
       const children = p.getChildren();
       expect(children).toHaveLength(3);
-      expect($isLinkNode(children[1])).toBe(true);
+      invariant($isLinkNode(children[1]), 'expected LinkNode');
       expect(children[1].getTextContent()).toBe('repo');
     });
   });

--- a/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
+++ b/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
@@ -40,7 +40,12 @@ import {
   FIND_PREV_COMMAND,
   findMatches,
   FindReplaceExtension,
+  REPLACE_ALL_COMMAND,
+  REPLACE_CURRENT_COMMAND,
+  SET_SEARCH_TERM_COMMAND,
+  TOGGLE_CASE_SENSITIVE_COMMAND,
   TOGGLE_FIND_REPLACE_COMMAND,
+  TOGGLE_REGEX_COMMAND,
 } from '../../src/plugins/FindReplaceExtension';
 
 const TestExtension = defineExtension({
@@ -49,115 +54,209 @@ const TestExtension = defineExtension({
 });
 
 describe('findMatches', () => {
-  test('returns empty array for empty search term', () => {
-    expect(findMatches('hello world', '', false, false)).toEqual([]);
+  test.for([
+    {
+      caseSensitive: false,
+      expected: [],
+      isRegex: false,
+      label: 'empty search term',
+      term: '',
+      text: 'hello world',
+    },
+    {
+      caseSensitive: false,
+      expected: [],
+      isRegex: false,
+      label: 'empty text',
+      term: 'hello',
+      text: '',
+    },
+    {
+      caseSensitive: false,
+      expected: [{end: 11, matchText: 'world', start: 6}],
+      isRegex: false,
+      label: 'single match with matchText',
+      term: 'world',
+      text: 'hello world',
+    },
+    {
+      caseSensitive: false,
+      expected: [
+        {end: 3, matchText: 'foo', start: 0},
+        {end: 11, matchText: 'foo', start: 8},
+        {end: 19, matchText: 'foo', start: 16},
+      ],
+      isRegex: false,
+      label: 'multiple non-overlapping matches',
+      term: 'foo',
+      text: 'foo bar foo baz foo',
+    },
+    {
+      caseSensitive: false,
+      expected: [
+        {end: 5, matchText: 'Hello', start: 0},
+        {end: 11, matchText: 'HELLO', start: 6},
+        {end: 17, matchText: 'hello', start: 12},
+      ],
+      isRegex: false,
+      label: 'case-insensitive preserves original case in matchText',
+      term: 'hello',
+      text: 'Hello HELLO hello',
+    },
+    {
+      caseSensitive: true,
+      expected: [{end: 17, matchText: 'hello', start: 12}],
+      isRegex: false,
+      label: 'case-sensitive search',
+      term: 'hello',
+      text: 'Hello HELLO hello',
+    },
+    {
+      caseSensitive: false,
+      expected: [
+        {end: 6, matchText: '123', start: 3},
+        {end: 12, matchText: '456', start: 9},
+      ],
+      isRegex: true,
+      label: 'regex: basic pattern',
+      term: '\\d+',
+      text: 'foo123bar456',
+    },
+    {
+      caseSensitive: false,
+      expected: [{end: 7, matchText: '2026-07', start: 0}],
+      isRegex: true,
+      label: 'regex: with groups uses full match range',
+      term: '(\\d{4})-(\\d{2})',
+      text: '2026-07-03',
+    },
+    {
+      caseSensitive: false,
+      expected: [],
+      isRegex: true,
+      label: 'regex: invalid regex returns empty',
+      term: '[invalid',
+      text: 'hello',
+    },
+    {
+      caseSensitive: false,
+      expected: [{end: 15, matchText: '$10.00', start: 9}],
+      isRegex: false,
+      label: 'non-regex escapes special characters',
+      term: '$10.00',
+      text: 'price is $10.00',
+    },
+    {
+      caseSensitive: false,
+      expected: [{end: 3, matchText: 'abc', start: 0}],
+      isRegex: false,
+      label: 'matches at string boundaries',
+      term: 'abc',
+      text: 'abc',
+    },
+    {
+      caseSensitive: false,
+      expected: [{end: 5, matchText: 'hello', start: 0}],
+      isRegex: false,
+      label: 'matches at start of string',
+      term: 'hello',
+      text: 'hello world',
+    },
+    {
+      caseSensitive: false,
+      expected: [],
+      isRegex: false,
+      label: 'no match returns empty',
+      term: 'xyz',
+      text: 'hello world',
+    },
+    {
+      caseSensitive: false,
+      expected: [],
+      isRegex: true,
+      label: 'skips zero-length regex matches',
+      term: '(?=a)',
+      text: 'abc',
+    },
+  ])('$label', ({text, term, caseSensitive, isRegex, expected}) => {
+    expect(findMatches(text, term, caseSensitive, isRegex)).toEqual(expected);
   });
+});
 
-  test('returns empty array for empty text', () => {
-    expect(findMatches('', 'hello', false, false)).toEqual([]);
-  });
-
-  test('finds single match with matchText', () => {
-    expect(findMatches('hello world', 'world', false, false)).toEqual([
-      {end: 11, matchText: 'world', start: 6},
-    ]);
-  });
-
-  test('finds multiple non-overlapping matches', () => {
-    expect(findMatches('foo bar foo baz foo', 'foo', false, false)).toEqual([
-      {end: 3, matchText: 'foo', start: 0},
-      {end: 11, matchText: 'foo', start: 8},
-      {end: 19, matchText: 'foo', start: 16},
-    ]);
-  });
-
-  test('case-insensitive search preserves original case in matchText', () => {
-    expect(findMatches('Hello HELLO hello', 'hello', false, false)).toEqual([
-      {end: 5, matchText: 'Hello', start: 0},
-      {end: 11, matchText: 'HELLO', start: 6},
-      {end: 17, matchText: 'hello', start: 12},
-    ]);
-  });
-
-  test('case-sensitive search', () => {
-    expect(findMatches('Hello HELLO hello', 'hello', true, false)).toEqual([
-      {end: 17, matchText: 'hello', start: 12},
-    ]);
-  });
-
-  test('regex search: basic pattern', () => {
-    expect(findMatches('foo123bar456', '\\d+', false, true)).toEqual([
-      {end: 6, matchText: '123', start: 3},
-      {end: 12, matchText: '456', start: 9},
-    ]);
-  });
-
-  test('regex search: with groups uses full match range', () => {
-    expect(findMatches('2026-07-03', '(\\d{4})-(\\d{2})', false, true)).toEqual(
-      [{end: 7, matchText: '2026-07', start: 0}],
-    );
-  });
-
-  test('regex search: invalid regex returns empty array', () => {
-    expect(findMatches('hello', '[invalid', false, true)).toEqual([]);
-  });
-
-  test('non-regex mode escapes special characters', () => {
-    expect(findMatches('price is $10.00', '$10.00', false, false)).toEqual([
-      {end: 15, matchText: '$10.00', start: 9},
-    ]);
-  });
-
-  test('matches at string boundaries', () => {
-    expect(findMatches('abc', 'abc', false, false)).toEqual([
-      {end: 3, matchText: 'abc', start: 0},
-    ]);
-  });
-
-  test('matches at start of string', () => {
-    expect(findMatches('hello world', 'hello', false, false)).toEqual([
-      {end: 5, matchText: 'hello', start: 0},
-    ]);
-  });
-
-  test('no match returns empty array', () => {
-    expect(findMatches('hello world', 'xyz', false, false)).toEqual([]);
-  });
-
-  test('skips zero-length regex matches', () => {
-    expect(findMatches('abc', '(?=a)', false, true)).toEqual([]);
+describe('findMatches — zero-length regex edge cases', () => {
+  test.for([
+    {
+      expected: [{end: 3, matchText: 'abc', start: 0}],
+      label: '.* matches entire text as single match',
+      term: '.*',
+      text: 'abc',
+    },
+    {
+      expected: [
+        {end: 2, matchText: 'aa', start: 0},
+        {end: 5, matchText: 'aa', start: 3},
+      ],
+      label: 'a* matches non-empty runs only',
+      term: 'a*',
+      text: 'aabaa',
+    },
+    {
+      expected: [],
+      label: 'x? on text without x returns no matches',
+      term: 'x?',
+      text: 'abc',
+    },
+  ])('$label', ({text, term, expected}) => {
+    expect(findMatches(text, term, false, true)).toEqual(expected);
   });
 });
 
 describe('expandReplacement', () => {
-  test('returns template as-is when no regex', () => {
-    expect(expandReplacement('$1', 'foo', null)).toBe('$1');
-  });
-
-  test('expands $1/$2 capture groups', () => {
-    expect(expandReplacement('$1-$2', '2026-07', /(\d{4})-(\d{2})/)).toBe(
-      '2026-07',
-    );
-  });
-
-  test('expands named capture groups with different template', () => {
-    expect(expandReplacement('year=$1', '2026-07', /(\d{4})-(\d{2})/)).toBe(
-      'year=2026',
-    );
-  });
-
-  test('expands $& for full match', () => {
-    expect(expandReplacement('[$&]', 'foo', /foo/)).toBe('[foo]');
-  });
-
-  test('swaps groups', () => {
-    expect(expandReplacement('$2/$1', 'user@host', /(\w+)@(\w+)/)).toBe(
-      'host/user',
-    );
-  });
-
-  test('literal $1 with no groups in regex', () => {
-    expect(expandReplacement('$1', 'hello', /hello/)).toBe('$1');
+  test.for([
+    {
+      expected: '$1',
+      label: 'returns template as-is when no regex',
+      matchText: 'foo',
+      regex: null,
+      template: '$1',
+    },
+    {
+      expected: '2026-07',
+      label: 'expands $1/$2 capture groups',
+      matchText: '2026-07',
+      regex: /(\d{4})-(\d{2})/,
+      template: '$1-$2',
+    },
+    {
+      expected: 'year=2026',
+      label: 'expands named capture groups with different template',
+      matchText: '2026-07',
+      regex: /(\d{4})-(\d{2})/,
+      template: 'year=$1',
+    },
+    {
+      expected: '[foo]',
+      label: 'expands $& for full match',
+      matchText: 'foo',
+      regex: /foo/,
+      template: '[$&]',
+    },
+    {
+      expected: 'host/user',
+      label: 'swaps groups',
+      matchText: 'user@host',
+      regex: /(\w+)@(\w+)/,
+      template: '$2/$1',
+    },
+    {
+      expected: '$1',
+      label: 'literal $1 with no groups in regex',
+      matchText: 'hello',
+      regex: /hello/,
+      template: '$1',
+    },
+  ])('$label', ({template, matchText, regex, expected}) => {
+    expect(expandReplacement(template, matchText, regex)).toBe(expected);
   });
 });
 
@@ -387,12 +486,10 @@ describe('$replaceMatch', () => {
     editor.update(
       () => {
         const map = $buildOffsetMap();
-        const points = $resolveMatchToPoints(
-          {end: 5, matchText: 'hello', start: 0},
-          map,
-        );
+        const match = {end: 5, matchText: 'hello', start: 0};
+        const points = $resolveMatchToPoints(match, map);
         invariant(points !== null, 'expected non-null match points');
-        $replaceMatch(points, 'goodbye');
+        $replaceMatch(points, 'goodbye', match, null);
       },
       {discrete: true},
     );
@@ -423,12 +520,10 @@ describe('$replaceMatch', () => {
     editor.update(
       () => {
         const map = $buildOffsetMap();
-        const points = $resolveMatchToPoints(
-          {end: 5, matchText: 'hello', start: 0},
-          map,
-        );
+        const match = {end: 5, matchText: 'hello', start: 0};
+        const points = $resolveMatchToPoints(match, map);
         invariant(points !== null, 'expected non-null match points');
-        $replaceMatch(points, 'hi');
+        $replaceMatch(points, 'hi', match, null);
       },
       {discrete: true},
     );
@@ -450,12 +545,10 @@ describe('$replaceMatch', () => {
     editor.update(
       () => {
         const map = $buildOffsetMap();
-        const points = $resolveMatchToPoints(
-          {end: 6, matchText: 'hello ', start: 0},
-          map,
-        );
+        const match = {end: 6, matchText: 'hello ', start: 0};
+        const points = $resolveMatchToPoints(match, map);
         invariant(points !== null, 'expected non-null match points');
-        $replaceMatch(points, '');
+        $replaceMatch(points, '', match, null);
       },
       {discrete: true},
     );
@@ -505,7 +598,7 @@ describe('$replaceMatch', () => {
         const match = {end: 5, matchText: 'hello', start: 0};
         const points = $resolveMatchToPoints(match, map);
         invariant(points !== null, 'expected non-null match points');
-        $replaceMatch(points, '$1');
+        $replaceMatch(points, '$1', match, null);
       },
       {discrete: true},
     );
@@ -530,7 +623,7 @@ describe('$replaceAllMatches', () => {
       () => {
         const map = $buildOffsetMap();
         const matches = findMatches('foo bar foo', 'foo', false, false);
-        const count = $replaceAllMatches(matches, map, 'baz');
+        const count = $replaceAllMatches(matches, map, 'baz', null);
         expect(count).toBe(2);
       },
       {discrete: true},
@@ -555,7 +648,7 @@ describe('$replaceAllMatches', () => {
         const text = $getRoot().getTextContent();
         const map = $buildOffsetMap();
         const matches = findMatches(text, 'foo', false, false);
-        const count = $replaceAllMatches(matches, map, 'x');
+        const count = $replaceAllMatches(matches, map, 'x', null);
         expect(count).toBe(2);
       },
       {discrete: true},
@@ -580,7 +673,7 @@ describe('$replaceAllMatches', () => {
         const text = $getRoot().getTextContent();
         const map = $buildOffsetMap();
         const matches = findMatches(text, 'foo', false, false);
-        const count = $replaceAllMatches(matches, map, 'quxxx');
+        const count = $replaceAllMatches(matches, map, 'quxxx', null);
         expect(count).toBe(2);
       },
       {discrete: true},
@@ -614,25 +707,6 @@ describe('$replaceAllMatches', () => {
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('b/a and d/c');
     });
-  });
-});
-
-describe('findMatches — zero-length regex edge cases', () => {
-  test('.* matches entire text as single match', () => {
-    expect(findMatches('abc', '.*', false, true)).toEqual([
-      {end: 3, matchText: 'abc', start: 0},
-    ]);
-  });
-
-  test('a* matches non-empty runs only', () => {
-    expect(findMatches('aabaa', 'a*', false, true)).toEqual([
-      {end: 2, matchText: 'aa', start: 0},
-      {end: 5, matchText: 'aa', start: 3},
-    ]);
-  });
-
-  test('x? on text without x returns no matches', () => {
-    expect(findMatches('abc', 'x?', false, true)).toEqual([]);
   });
 });
 
@@ -707,5 +781,161 @@ describe('FindReplaceExtension — command dispatch integration', () => {
     // backward wrap
     editor.dispatchCommand(FIND_PREV_COMMAND, undefined);
     expect(dep.output.currentIndex.peek()).toBe(2);
+  });
+
+  test('FIND_NEXT_COMMAND with zero matches is a no-op', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.searchTerm.value = 'nonexistent';
+    expect(dep.output.matches.peek()).toHaveLength(0);
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(0);
+    editor.dispatchCommand(FIND_PREV_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(0);
+  });
+
+  test('matches returns empty when isOpen is false', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('hello')));
+      },
+      {discrete: true},
+    );
+    dep.output.searchTerm.value = 'hello';
+    expect(dep.output.isOpen.peek()).toBe(false);
+    expect(dep.output.matches.peek()).toEqual([]);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    expect(dep.output.matches.peek()).toHaveLength(1);
+  });
+
+  test('effectiveIndex clamps when match count decreases', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('a b a b a')));
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.searchTerm.value = 'a';
+    expect(dep.output.matches.peek()).toHaveLength(3);
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(2);
+    dep.output.searchTerm.value = 'a b';
+    expect(dep.output.matches.peek()).toHaveLength(2);
+    expect(dep.output.effectiveIndex.peek()).toBe(1);
+  });
+
+  test('regexError computed returns true for invalid regex', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.isRegex.value = true;
+    dep.output.searchTerm.value = '[invalid';
+    expect(dep.output.regexError.peek()).toBe(true);
+    dep.output.searchTerm.value = '\\d+';
+    expect(dep.output.regexError.peek()).toBe(false);
+  });
+
+  test('SET_SEARCH_TERM_COMMAND resets currentIndex to 0', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('a b a b a')));
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.searchTerm.value = 'a';
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(2);
+    editor.dispatchCommand(SET_SEARCH_TERM_COMMAND, 'b');
+    expect(dep.output.currentIndex.peek()).toBe(0);
+    expect(dep.output.searchTerm.peek()).toBe('b');
+  });
+
+  test('TOGGLE_CASE_SENSITIVE / TOGGLE_REGEX reset currentIndex to 0', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('a b a b a')));
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.searchTerm.value = 'a';
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(1);
+    editor.dispatchCommand(TOGGLE_CASE_SENSITIVE_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(0);
+    expect(dep.output.caseSensitive.peek()).toBe(true);
+
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(1);
+    editor.dispatchCommand(TOGGLE_REGEX_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(0);
+    expect(dep.output.isRegex.peek()).toBe(true);
+  });
+
+  test('REPLACE_CURRENT_COMMAND replaces the current match', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append($createTextNode('foo bar foo')),
+          );
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.searchTerm.value = 'foo';
+    dep.output.replaceTerm.value = 'baz';
+    expect(dep.output.matches.peek()).toHaveLength(2);
+    editor.dispatchCommand(REPLACE_CURRENT_COMMAND, undefined);
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('baz bar foo');
+    });
+  });
+
+  test('REPLACE_ALL_COMMAND replaces all matches', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append($createTextNode('foo bar foo')),
+          );
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.searchTerm.value = 'foo';
+    dep.output.replaceTerm.value = 'qux';
+    expect(dep.output.matches.peek()).toHaveLength(2);
+    editor.dispatchCommand(REPLACE_ALL_COMMAND, undefined);
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('qux bar qux');
+    });
   });
 });

--- a/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
+++ b/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
@@ -6,7 +6,10 @@
  *
  */
 
-import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  buildEditorFromExtensions,
+  getExtensionDependencyFromEditor,
+} from '@lexical/extension';
 import invariant from '@lexical/internal/invariant';
 import {
   $createListItemNode,
@@ -31,8 +34,13 @@ import {
   $replaceAllMatches,
   $replaceMatch,
   $resolveMatchToPoints,
+  CLOSE_FIND_REPLACE_COMMAND,
   expandReplacement,
+  FIND_NEXT_COMMAND,
+  FIND_PREV_COMMAND,
   findMatches,
+  FindReplaceExtension,
+  TOGGLE_FIND_REPLACE_COMMAND,
 } from '../../src/plugins/FindReplaceExtension';
 
 const TestExtension = defineExtension({
@@ -606,5 +614,98 @@ describe('$replaceAllMatches', () => {
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('b/a and d/c');
     });
+  });
+});
+
+describe('findMatches — zero-length regex edge cases', () => {
+  test('.* matches entire text as single match', () => {
+    expect(findMatches('abc', '.*', false, true)).toEqual([
+      {end: 3, matchText: 'abc', start: 0},
+    ]);
+  });
+
+  test('a* matches non-empty runs only', () => {
+    expect(findMatches('aabaa', 'a*', false, true)).toEqual([
+      {end: 2, matchText: 'aa', start: 0},
+      {end: 5, matchText: 'aa', start: 3},
+    ]);
+  });
+
+  test('x? on text without x returns no matches', () => {
+    expect(findMatches('abc', 'x?', false, true)).toEqual([]);
+  });
+});
+
+describe('FindReplaceExtension — command dispatch integration', () => {
+  test('TOGGLE_FIND_REPLACE_COMMAND toggles isOpen signal', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    expect(dep.output.isOpen.peek()).toBe(false);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    expect(dep.output.isOpen.peek()).toBe(true);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    expect(dep.output.isOpen.peek()).toBe(false);
+  });
+
+  test('CLOSE_FIND_REPLACE_COMMAND sets isOpen to false', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    expect(dep.output.isOpen.peek()).toBe(true);
+    editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
+    expect(dep.output.isOpen.peek()).toBe(false);
+  });
+
+  test('matches computed signal updates when searchTerm and text change', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append($createTextNode('hello world hello')),
+          );
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.searchTerm.value = 'hello';
+    expect(dep.output.matches.peek()).toHaveLength(2);
+    expect(dep.output.matches.peek()[0]).toMatchObject({
+      matchText: 'hello',
+      start: 0,
+    });
+  });
+
+  test('FIND_NEXT_COMMAND / FIND_PREV_COMMAND cycle currentIndex', () => {
+    using editor = buildEditorFromExtensions(FindReplaceExtension);
+    const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('a b a b a')));
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    dep.output.searchTerm.value = 'a';
+    expect(dep.output.matches.peek()).toHaveLength(3);
+    expect(dep.output.currentIndex.peek()).toBe(0);
+
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(1);
+
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(2);
+
+    // wrap around
+    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(0);
+
+    // backward wrap
+    editor.dispatchCommand(FIND_PREV_COMMAND, undefined);
+    expect(dep.output.currentIndex.peek()).toBe(2);
   });
 });

--- a/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
+++ b/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
@@ -11,6 +11,7 @@ import {
   getExtensionDependencyFromEditor,
 } from '@lexical/extension';
 import invariant from '@lexical/internal/invariant';
+import {$createLinkNode, $isLinkNode, LinkExtension} from '@lexical/link';
 import {
   $createListItemNode,
   $createListNode,
@@ -49,7 +50,7 @@ import {
 } from '../../src/plugins/FindReplaceExtension';
 
 const TestExtension = defineExtension({
-  dependencies: [RichTextExtension, ListExtension],
+  dependencies: [RichTextExtension, ListExtension, LinkExtension],
   name: '[test-find-replace]',
 });
 
@@ -604,6 +605,39 @@ describe('$replaceMatch', () => {
     );
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('$1 world');
+    });
+  });
+
+  test('single-node replace inside LinkNode preserves link', () => {
+    using editor = buildEditorFromExtensions(TestExtension);
+    editor.update(
+      () => {
+        const p = $createParagraphNode();
+        const link = $createLinkNode('https://example.com');
+        link.append($createTextNode('repository'));
+        p.append($createTextNode('visit '), link, $createTextNode(' now'));
+        $getRoot().clear().append(p);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const map = $buildOffsetMap();
+        const match = {end: 16, matchText: 'repository', start: 6};
+        const points = $resolveMatchToPoints(match, map);
+        invariant(points !== null, 'expected non-null match points');
+        $replaceMatch(points, 'repo', match, null);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getRoot().getTextContent()).toBe('visit repo now');
+      const p = $getRoot().getFirstChild();
+      invariant($isElementNode(p), 'expected ElementNode');
+      const children = p.getChildren();
+      expect(children).toHaveLength(3);
+      expect($isLinkNode(children[1])).toBe(true);
+      expect(children[1].getTextContent()).toBe('repo');
     });
   });
 });

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -88,6 +88,7 @@ import {EmojisExtension} from './plugins/EmojisExtension';
 import {EquationsExtension} from './plugins/EquationsExtension';
 import {ExcalidrawExtension} from './plugins/ExcalidrawExtension';
 import {FigmaExtension} from './plugins/FigmaExtension';
+import {ReactFindReplaceExtension} from './plugins/FindReplaceExtension';
 import {ImagesExtension} from './plugins/ImagesExtension';
 import {LayoutExtension} from './plugins/LayoutExtension/LayoutExtension';
 import {PlaygroundMarkdownShortcutsExtension} from './plugins/MarkdownShortcutsExtension';
@@ -240,6 +241,7 @@ const PlaygroundRichTextExtension = /* @__PURE__ */ defineExtension({
     ExcalidrawExtension,
     CardExtension,
     ReactReviewExtension,
+    ReactFindReplaceExtension,
     PullQuoteExtension,
     /* @__PURE__ */ configExtension(TabIndentationExtension, {maxIndent: 7}),
   ],

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/FindReplace.css
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/FindReplace.css
@@ -62,7 +62,7 @@
 .find-replace-count {
   font-size: 11px;
   color: #777;
-  min-width: 50px;
+  min-width: 70px;
   text-align: center;
   white-space: nowrap;
   user-select: none;

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/FindReplace.css
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/FindReplace.css
@@ -11,9 +11,12 @@
   right: max(8px, calc(50% - 564px));
   top: 92px;
   z-index: 100;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: 1fr repeat(8, auto);
+  grid-template-rows: auto auto;
+  align-items: center;
+  column-gap: 4px;
+  row-gap: 6px;
   padding: 8px 10px;
   background-color: #fff;
   border-radius: 8px;
@@ -31,7 +34,9 @@
   color: #050505;
 }
 
-.find-replace-row {
+.find-replace-row2-actions {
+  grid-row: 2;
+  grid-column: 2 / -1;
   display: flex;
   align-items: center;
   gap: 4px;

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/FindReplace.css
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/FindReplace.css
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+.find-replace-panel {
+  position: fixed;
+  right: max(8px, calc(50% - 564px));
+  top: 92px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow:
+    0 12px 28px 0 rgba(0, 0, 0, 0.2),
+    0 2px 4px 0 rgba(0, 0, 0, 0.1),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    '.SFNSText-Regular',
+    sans-serif;
+  font-size: 13px;
+  color: #050505;
+}
+
+.find-replace-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.find-replace-input {
+  flex: 1;
+  min-width: 180px;
+  padding: 5px 8px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #050505;
+  background: #f9f9fb;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.find-replace-input:focus {
+  border-color: rgb(60, 132, 244);
+  background: #fff;
+}
+
+.find-replace-input::placeholder {
+  color: #999;
+}
+
+.find-replace-count {
+  font-size: 11px;
+  color: #777;
+  min-width: 50px;
+  text-align: center;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.find-replace-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: none;
+  color: #555;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background-color 0.1s,
+    color 0.1s;
+}
+
+.find-replace-btn:hover {
+  background-color: #eee;
+  color: #050505;
+}
+
+.find-replace-btn:focus-visible {
+  outline: 2px solid rgb(60, 132, 244);
+  outline-offset: -2px;
+}
+
+.find-replace-btn:disabled {
+  color: #ccc;
+  cursor: not-allowed;
+}
+
+.find-replace-btn:disabled:hover {
+  background: none;
+}
+
+.find-replace-btn svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+.find-replace-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: none;
+  color: #777;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  flex-shrink: 0;
+  transition:
+    background-color 0.1s,
+    border-color 0.1s,
+    color 0.1s;
+}
+
+.find-replace-toggle:hover {
+  background-color: #eee;
+  color: #050505;
+}
+
+.find-replace-toggle:focus-visible {
+  outline: 2px solid rgb(60, 132, 244);
+  outline-offset: -2px;
+}
+
+.find-replace-toggle[aria-pressed='true'] {
+  background-color: rgba(60, 132, 244, 0.1);
+  border-color: rgba(60, 132, 244, 0.4);
+  color: rgb(60, 132, 244);
+}
+
+.find-replace-action {
+  height: 28px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 6px;
+  background: none;
+  color: #555;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  transition:
+    background-color 0.1s,
+    color 0.1s;
+}
+
+.find-replace-action:hover {
+  background-color: #eee;
+  color: #050505;
+}
+
+.find-replace-action:focus-visible {
+  outline: 2px solid rgb(60, 132, 244);
+  outline-offset: -2px;
+}
+
+.find-replace-action:disabled {
+  color: #ccc;
+  cursor: not-allowed;
+}
+
+.find-replace-action:disabled:hover {
+  background: none;
+}
+
+.find-replace-separator {
+  width: 1px;
+  height: 18px;
+  background: #e0e0e0;
+  flex-shrink: 0;
+}
+
+@media screen and (max-width: 640px) {
+  .find-replace-panel {
+    right: 4px;
+    left: 4px;
+    top: 8px;
+    border-radius: 10px;
+  }
+
+  .find-replace-input {
+    min-width: 0;
+  }
+}

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/FindReplace.css
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/FindReplace.css
@@ -188,6 +188,42 @@
   flex-shrink: 0;
 }
 
+@media (forced-colors: active) {
+  .find-replace-panel {
+    border: 1px solid CanvasText;
+    background-color: Canvas;
+    color: CanvasText;
+    box-shadow: none;
+    forced-color-adjust: none;
+  }
+
+  .find-replace-input {
+    border-color: CanvasText;
+    background: Canvas;
+    color: CanvasText;
+  }
+
+  .find-replace-input:focus {
+    border-color: Highlight;
+  }
+
+  .find-replace-toggle[aria-pressed='true'] {
+    background-color: Highlight;
+    color: HighlightText;
+    border-color: Highlight;
+  }
+
+  .find-replace-separator {
+    background-color: CanvasText;
+  }
+
+  .find-replace-btn:focus-visible,
+  .find-replace-toggle:focus-visible,
+  .find-replace-action:focus-visible {
+    outline: 2px solid Highlight;
+  }
+}
+
 @media screen and (max-width: 640px) {
   .find-replace-panel {
     right: 4px;

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -38,7 +38,7 @@ import {
   mergeRegister,
   type NodeKey,
 } from 'lexical';
-import {useCallback, useEffect, useRef} from 'react';
+import {useRef} from 'react';
 import {createPortal} from 'react-dom';
 
 // ---------------------------------------------------------------------------
@@ -816,53 +816,42 @@ function FindReplacePanel({
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (isOpen && searchInputRef.current) {
-      searchInputRef.current.focus();
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
+      editor.focus();
+      return;
     }
-  }, [isOpen]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
-        editor.focus();
-        return;
-      }
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        editor.dispatchCommand(
-          e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
-          undefined,
-        );
-        return;
-      }
-      const isMod = IS_APPLE
-        ? e.metaKey && !e.ctrlKey
-        : e.ctrlKey && !e.metaKey;
-      if (e.code === 'KeyG' && isMod && !e.altKey) {
-        e.preventDefault();
-        editor.dispatchCommand(
-          e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
-          undefined,
-        );
-      } else if (
-        (e.code === 'KeyF' && isMod && !e.altKey && !e.shiftKey) ||
-        (!IS_APPLE &&
-          e.code === 'KeyH' &&
-          e.ctrlKey &&
-          !e.metaKey &&
-          !e.altKey &&
-          !e.shiftKey) ||
-        (IS_APPLE && e.code === 'KeyF' && e.metaKey && e.altKey && !e.ctrlKey)
-      ) {
-        e.preventDefault();
-        searchInputRef.current?.focus();
-      }
-    },
-    [editor],
-  );
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      editor.dispatchCommand(
+        e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
+        undefined,
+      );
+      return;
+    }
+    const isMod = IS_APPLE ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+    if (e.code === 'KeyG' && isMod && !e.altKey) {
+      e.preventDefault();
+      editor.dispatchCommand(
+        e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
+        undefined,
+      );
+    } else if (
+      (e.code === 'KeyF' && isMod && !e.altKey && !e.shiftKey) ||
+      (!IS_APPLE &&
+        e.code === 'KeyH' &&
+        e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey &&
+        !e.shiftKey) ||
+      (IS_APPLE && e.code === 'KeyF' && e.metaKey && e.altKey && !e.ctrlKey)
+    ) {
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    }
+  };
 
   if (!isOpen) {
     return null;
@@ -880,6 +869,7 @@ function FindReplacePanel({
       <div className="find-replace-row">
         <input
           ref={searchInputRef}
+          autoFocus={true}
           className="find-replace-input"
           type="text"
           placeholder="Find..."

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -221,6 +221,7 @@ export function $replaceMatch(
       points.anchorOffset,
       points.focusOffset - points.anchorOffset,
       finalText,
+      true,
     );
     return;
   }
@@ -825,15 +826,16 @@ function FindReplacePanel({
       return;
     }
     if (e.key === 'Tab') {
-      const panel = e.currentTarget as HTMLElement;
+      const panel: HTMLElement = e.currentTarget as HTMLElement;
       const focusables = Array.from(
         panel.querySelectorAll<HTMLElement>('input, button'),
       );
       if (focusables.length === 0) {
         return;
       }
-      const active = panel.ownerDocument.activeElement as HTMLElement;
-      const idx = focusables.indexOf(active);
+      const active = panel.ownerDocument.activeElement;
+      const idx =
+        active instanceof HTMLElement ? focusables.indexOf(active) : -1;
       const next = e.shiftKey
         ? idx <= 0
           ? focusables.length - 1

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -11,17 +11,22 @@ import type {JSX} from 'react';
 
 import './FindReplace.css';
 
+import {
+  computed,
+  effect,
+  namedSignals,
+  watchedSignal,
+} from '@lexical/extension';
 import {ReactExtension} from '@lexical/react/ReactExtension';
+import {useExtensionSignalValue} from '@lexical/react/useExtensionSignalValue';
 import {createDOMRange, createRectsFromDOMRange} from '@lexical/selection';
 import {$dfsWithSlotsIterator} from '@lexical/utils';
 import {
-  $createRangeSelection,
   $getNodeByKeyOrThrow,
   $getRoot,
   $isElementNode,
   $isLineBreakNode,
   $isTextNode,
-  $setSelection,
   COMMAND_PRIORITY_LOW,
   configExtension,
   createCommand,
@@ -33,18 +38,16 @@ import {
   mergeRegister,
   type NodeKey,
 } from 'lexical';
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export interface TextMatch {
   end: number;
+  matchText: string;
   start: number;
 }
 
@@ -62,6 +65,14 @@ export interface MatchPoints {
   format: number;
 }
 
+// ---------------------------------------------------------------------------
+// Pure functions
+// ---------------------------------------------------------------------------
+
+const EMPTY_MATCHES: TextMatch[] = Object.freeze<TextMatch[]>(
+  [],
+) as TextMatch[];
+
 export function findMatches(
   text: string,
   searchTerm: string,
@@ -69,7 +80,7 @@ export function findMatches(
   isRegex: boolean,
 ): TextMatch[] {
   if (!searchTerm || !text) {
-    return [];
+    return EMPTY_MATCHES;
   }
 
   const pattern = isRegex ? searchTerm : escapeRegExp(searchTerm);
@@ -79,24 +90,38 @@ export function findMatches(
   try {
     regex = new RegExp(pattern, flags);
   } catch {
-    return [];
+    return EMPTY_MATCHES;
   }
 
   const matches: TextMatch[] = [];
   let match: RegExpExecArray | null;
   while ((match = regex.exec(text)) !== null) {
     if (match[0].length === 0) {
-      // prevent infinite loop on zero-length matches
       regex.lastIndex++;
       continue;
     }
-    matches.push({end: match.index + match[0].length, start: match.index});
+    matches.push({
+      end: match.index + match[0].length,
+      matchText: match[0],
+      start: match.index,
+    });
   }
   return matches;
 }
 
 function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function expandReplacement(
+  template: string,
+  matchText: string,
+  searchRegex: RegExp | null,
+): string {
+  if (!searchRegex) {
+    return template;
+  }
+  return matchText.replace(searchRegex, template);
 }
 
 export function $buildOffsetMap(): OffsetEntry[] {
@@ -107,7 +132,7 @@ export function $buildOffsetMap(): OffsetEntry[] {
   for (const {node, depth} of $dfsWithSlotsIterator()) {
     if ($isElementNode(node) && !node.isInline() && depth > 0) {
       if (prevNonInlineDepth !== null && depth <= prevNonInlineDepth) {
-        offset += 2; // mirrors DOUBLE_LINE_BREAK separators from ElementNode.getTextContent()
+        offset += 2;
       }
       prevNonInlineDepth = depth;
     }
@@ -177,30 +202,55 @@ function findEntryForOffset(
 export function $replaceMatch(
   points: MatchPoints,
   replacementText: string,
+  match?: TextMatch,
+  searchRegex?: RegExp | null,
 ): void {
-  const selection = $createRangeSelection();
-  selection.anchor.set(points.anchorKey, points.anchorOffset, 'text');
-  selection.focus.set(points.focusKey, points.focusOffset, 'text');
+  const finalText =
+    match && searchRegex
+      ? expandReplacement(replacementText, match.matchText, searchRegex)
+      : replacementText;
+  const anchorNode = $getNodeByKeyOrThrow(points.anchorKey);
+  const focusNode = $getNodeByKeyOrThrow(points.focusKey);
+  if (!$isTextNode(anchorNode) || !$isTextNode(focusNode)) {
+    return;
+  }
+  const selection = anchorNode.select(0, 0);
+  selection.setTextNodeRange(
+    anchorNode,
+    points.anchorOffset,
+    focusNode,
+    points.focusOffset,
+  );
   selection.format = points.format;
-  $setSelection(selection);
-  selection.insertText(replacementText);
+  selection.insertText(finalText);
 }
 
 export function $replaceAllMatches(
   matches: TextMatch[],
   offsetMap: OffsetEntry[],
   replacementText: string,
+  searchRegex?: RegExp | null,
 ): number {
   let count = 0;
-  // Replace back-to-front so earlier offsets in the pre-built map stay valid
   for (let i = matches.length - 1; i >= 0; i--) {
     const points = $resolveMatchToPoints(matches[i], offsetMap);
     if (points) {
-      $replaceMatch(points, replacementText);
+      $replaceMatch(points, replacementText, matches[i], searchRegex);
       count++;
     }
   }
   return count;
+}
+
+function buildSearchRegex(
+  searchTerm: string,
+  caseSensitive: boolean,
+): RegExp | null {
+  try {
+    return new RegExp(searchTerm, caseSensitive ? '' : 'i');
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -318,10 +368,20 @@ function $updateHighlights(
       state.allHighlight!.add(range);
       if (i === currentIndex) {
         state.currentHighlight!.add(range);
+        scrollRangeIntoView(range);
       }
     }
   } else {
     $updateOverlayHighlights(editor, matches, currentIndex, offsetMap, state);
+  }
+}
+
+function scrollRangeIntoView(range: Range): void {
+  const rect = range.getBoundingClientRect();
+  const viewportHeight = window.innerHeight;
+  if (rect.top < 0 || rect.bottom > viewportHeight) {
+    const el = range.startContainer.parentElement;
+    el?.scrollIntoView({behavior: 'smooth', block: 'center'});
   }
 }
 
@@ -353,7 +413,6 @@ function getOverlayContainer(
   const doc = root.ownerDocument;
   const parent = root.parentElement!;
   if (getComputedStyle(parent).position === 'static') {
-    // overlay spans need a positioned ancestor
     state.originalParentPosition = parent.style.position;
     parent.style.position = 'relative';
   }
@@ -410,6 +469,9 @@ function $updateOverlayHighlights(
     }
     const rects = createRectsFromDOMRange(editor, range);
     const isCurrent = i === currentIndex;
+    if (isCurrent) {
+      scrollRangeIntoView(range);
+    }
     for (const rect of rects) {
       const span = doc.createElement('span');
       span.style.position = 'absolute';
@@ -427,44 +489,298 @@ function $updateOverlayHighlights(
 }
 
 // ---------------------------------------------------------------------------
-// Extension definitions
+// Commands
 // ---------------------------------------------------------------------------
 
-export const OPEN_FIND_REPLACE_COMMAND: LexicalCommand<void> =
-  /* @__PURE__ */ createCommand('OPEN_FIND_REPLACE_COMMAND');
+export const TOGGLE_FIND_REPLACE_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('TOGGLE_FIND_REPLACE_COMMAND');
+
+export const CLOSE_FIND_REPLACE_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('CLOSE_FIND_REPLACE_COMMAND');
+
+export const FIND_NEXT_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('FIND_NEXT_COMMAND');
+
+export const FIND_PREV_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('FIND_PREV_COMMAND');
+
+export const REPLACE_CURRENT_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('REPLACE_CURRENT_COMMAND');
+
+export const REPLACE_ALL_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('REPLACE_ALL_COMMAND');
+
+const SET_SEARCH_TERM_COMMAND: LexicalCommand<string> =
+  /* @__PURE__ */ createCommand('SET_SEARCH_TERM_COMMAND');
+
+const SET_REPLACE_TERM_COMMAND: LexicalCommand<string> =
+  /* @__PURE__ */ createCommand('SET_REPLACE_TERM_COMMAND');
+
+const TOGGLE_CASE_SENSITIVE_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('TOGGLE_CASE_SENSITIVE_COMMAND');
+
+const TOGGLE_REGEX_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('TOGGLE_REGEX_COMMAND');
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
 
 export const FindReplaceExtension = /* @__PURE__ */ defineExtension({
-  name: '@lexical/playground/FindReplace',
-  register: editor => {
-    return editor.registerCommand(
-      KEY_DOWN_COMMAND,
-      event => {
-        const isFindReplace =
-          (event.code === 'KeyH' &&
-            event.ctrlKey &&
-            !event.metaKey &&
-            !event.altKey &&
-            !event.shiftKey) ||
-          (IS_APPLE &&
-            event.code === 'KeyF' &&
-            event.metaKey &&
-            event.altKey &&
-            !event.ctrlKey);
-        const isFind =
-          event.code === 'KeyF' &&
-          !event.altKey &&
-          !event.shiftKey &&
-          (IS_APPLE
-            ? event.metaKey && !event.ctrlKey
-            : event.ctrlKey && !event.metaKey);
-        if (isFindReplace || isFind) {
-          event.preventDefault();
-          editor.dispatchCommand(OPEN_FIND_REPLACE_COMMAND, undefined);
-          return true;
-        }
+  build: editor => {
+    const named = namedSignals({
+      caseSensitive: false,
+      currentIndex: 0,
+      isOpen: false,
+      isRegex: false,
+      replaceTerm: '',
+      searchTerm: '',
+    });
+
+    const cachedText = watchedSignal(
+      () => editor.read(() => $getRoot().getTextContent()),
+      s =>
+        editor.registerTextContentListener(text => {
+          s.value = text;
+        }),
+    );
+
+    const matches = computed(() => {
+      if (!named.isOpen.value) {
+        return EMPTY_MATCHES;
+      }
+      return findMatches(
+        cachedText.value,
+        named.searchTerm.value,
+        named.caseSensitive.value,
+        named.isRegex.value,
+      );
+    });
+
+    const effectiveIndex = computed(() => {
+      const m = matches.value;
+      const idx = named.currentIndex.value;
+      return m.length > 0 ? Math.min(idx, m.length - 1) : 0;
+    });
+
+    const regexError = computed(() => {
+      if (!named.isRegex.value || !named.searchTerm.value) {
         return false;
-      },
-      COMMAND_PRIORITY_LOW,
+      }
+      try {
+        RegExp(named.searchTerm.value);
+        return false;
+      } catch {
+        return true;
+      }
+    });
+
+    return {...named, cachedText, effectiveIndex, matches, regexError};
+  },
+  name: '@lexical/playground/FindReplace',
+  register: (editor, _config, state) => {
+    const output = state.getOutput();
+    const highlightState = createHighlightState(editor.getKey());
+
+    return mergeRegister(
+      editor.registerCommand(
+        TOGGLE_FIND_REPLACE_COMMAND,
+        () => {
+          output.isOpen.value = !output.isOpen.peek();
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        CLOSE_FIND_REPLACE_COMMAND,
+        () => {
+          output.isOpen.value = false;
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        FIND_NEXT_COMMAND,
+        () => {
+          const len = output.matches.peek().length;
+          if (len > 0) {
+            output.currentIndex.value = (output.currentIndex.peek() + 1) % len;
+          }
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        FIND_PREV_COMMAND,
+        () => {
+          const len = output.matches.peek().length;
+          if (len > 0) {
+            output.currentIndex.value =
+              (output.currentIndex.peek() - 1 + len) % len;
+          }
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        REPLACE_CURRENT_COMMAND,
+        () => {
+          const m = output.matches.peek();
+          if (m.length === 0) {
+            return true;
+          }
+          const idx = output.effectiveIndex.peek();
+          const replaceText = output.replaceTerm.peek();
+          const regex = output.isRegex.peek()
+            ? buildSearchRegex(
+                output.searchTerm.peek(),
+                output.caseSensitive.peek(),
+              )
+            : null;
+          editor.update(
+            () => {
+              const offsetMap = $buildOffsetMap();
+              const points = $resolveMatchToPoints(m[idx], offsetMap);
+              if (points) {
+                $replaceMatch(points, replaceText, m[idx], regex);
+              }
+            },
+            {discrete: true},
+          );
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        REPLACE_ALL_COMMAND,
+        () => {
+          const m = output.matches.peek();
+          if (m.length === 0) {
+            return true;
+          }
+          const replaceText = output.replaceTerm.peek();
+          const regex = output.isRegex.peek()
+            ? buildSearchRegex(
+                output.searchTerm.peek(),
+                output.caseSensitive.peek(),
+              )
+            : null;
+          editor.update(
+            () => {
+              const offsetMap = $buildOffsetMap();
+              $replaceAllMatches(m, offsetMap, replaceText, regex);
+            },
+            {discrete: true},
+          );
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        SET_SEARCH_TERM_COMMAND,
+        term => {
+          output.searchTerm.value = term;
+          output.currentIndex.value = 0;
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        SET_REPLACE_TERM_COMMAND,
+        term => {
+          output.replaceTerm.value = term;
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        TOGGLE_CASE_SENSITIVE_COMMAND,
+        () => {
+          output.caseSensitive.value = !output.caseSensitive.peek();
+          output.currentIndex.value = 0;
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        TOGGLE_REGEX_COMMAND,
+        () => {
+          output.isRegex.value = !output.isRegex.peek();
+          output.currentIndex.value = 0;
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
+        KEY_DOWN_COMMAND,
+        event => {
+          const isFindReplace =
+            (!IS_APPLE &&
+              event.code === 'KeyH' &&
+              event.ctrlKey &&
+              !event.metaKey &&
+              !event.altKey &&
+              !event.shiftKey) ||
+            (IS_APPLE &&
+              event.code === 'KeyF' &&
+              event.metaKey &&
+              event.altKey &&
+              !event.ctrlKey);
+          const isFind =
+            event.code === 'KeyF' &&
+            !event.altKey &&
+            !event.shiftKey &&
+            (IS_APPLE
+              ? event.metaKey && !event.ctrlKey
+              : event.ctrlKey && !event.metaKey);
+          if (isFindReplace || isFind) {
+            event.preventDefault();
+            editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+            return true;
+          }
+          if (output.isOpen.peek()) {
+            const isMod = IS_APPLE
+              ? event.metaKey && !event.ctrlKey
+              : event.ctrlKey && !event.metaKey;
+            if (event.code === 'KeyG' && isMod && !event.altKey) {
+              event.preventDefault();
+              editor.dispatchCommand(
+                event.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
+                undefined,
+              );
+              return true;
+            }
+          }
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      effect(() => {
+        const m = output.matches.value;
+        const idx = output.effectiveIndex.value;
+        const open = output.isOpen.value;
+
+        clearHighlights(highlightState);
+        if (!open || m.length === 0) {
+          return;
+        }
+        editor.read(() => {
+          $updateHighlights(editor, m, idx, highlightState);
+        });
+      }),
+
+      () => disposeHighlightState(highlightState),
     );
   },
 });
@@ -477,74 +793,32 @@ function FindReplacePanel({
   context,
 }: DecoratorComponentProps): JSX.Element | null {
   const [editor] = context;
-  const [isOpen, setIsOpen] = useState(false);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [replaceTerm, setReplaceTerm] = useState('');
-  const [caseSensitive, setCaseSensitive] = useState(false);
-  const [isRegex, setIsRegex] = useState(false);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [cachedText, setCachedText] = useState(() =>
-    editor.read(() => $getRoot().getTextContent()),
+
+  const isOpen = useExtensionSignalValue(FindReplaceExtension, 'isOpen');
+  const searchTerm = useExtensionSignalValue(
+    FindReplaceExtension,
+    'searchTerm',
   );
+  const replaceTerm = useExtensionSignalValue(
+    FindReplaceExtension,
+    'replaceTerm',
+  );
+  const caseSensitive = useExtensionSignalValue(
+    FindReplaceExtension,
+    'caseSensitive',
+  );
+  const isRegex = useExtensionSignalValue(FindReplaceExtension, 'isRegex');
+  const matches = useExtensionSignalValue(FindReplaceExtension, 'matches');
+  const effectiveIndex = useExtensionSignalValue(
+    FindReplaceExtension,
+    'effectiveIndex',
+  );
+  const regexError = useExtensionSignalValue(
+    FindReplaceExtension,
+    'regexError',
+  );
+
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const highlightStateRef = useRef<HighlightState>(
-    createHighlightState(editor.getKey()),
-  );
-
-  useEffect(() => {
-    return mergeRegister(
-      editor.registerTextContentListener(text => {
-        setCachedText(text);
-      }),
-      editor.registerCommand(
-        OPEN_FIND_REPLACE_COMMAND,
-        () => {
-          setIsOpen(prev => !prev);
-          return true;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
-    );
-  }, [editor]);
-
-  useEffect(() => {
-    const state = highlightStateRef.current;
-    return () => disposeHighlightState(state);
-  }, []);
-
-  const regexError = useMemo(() => {
-    if (!isRegex || !searchTerm) {
-      return false;
-    }
-    try {
-      RegExp(searchTerm);
-      return false;
-    } catch {
-      return true;
-    }
-  }, [searchTerm, isRegex]);
-
-  const matches = useMemo(() => {
-    if (!isOpen) {
-      return [];
-    }
-    return findMatches(cachedText, searchTerm, caseSensitive, isRegex);
-  }, [cachedText, searchTerm, caseSensitive, isRegex, isOpen]);
-
-  const effectiveIndex =
-    matches.length > 0 ? Math.min(currentIndex, matches.length - 1) : 0;
-
-  useLayoutEffect(() => {
-    const state = highlightStateRef.current;
-    if (!isOpen || matches.length === 0) {
-      clearHighlights(state);
-      return () => clearHighlights(state);
-    }
-    editor.read(() => {
-      $updateHighlights(editor, matches, effectiveIndex, state);
-    });
-    return () => clearHighlights(state);
-  }, [editor, matches, effectiveIndex, isOpen]);
 
   useEffect(() => {
     if (isOpen && searchInputRef.current) {
@@ -552,70 +826,46 @@ function FindReplacePanel({
     }
   }, [isOpen]);
 
-  const handleNext = useCallback(() => {
-    setCurrentIndex(prev =>
-      matches.length > 0 ? (prev + 1) % matches.length : 0,
-    );
-  }, [matches.length]);
-
-  const handlePrev = useCallback(() => {
-    setCurrentIndex(prev =>
-      matches.length > 0 ? (prev - 1 + matches.length) % matches.length : 0,
-    );
-  }, [matches.length]);
-
-  const handleReplace = useCallback(() => {
-    if (matches.length === 0) {
-      return;
-    }
-    editor.update(
-      () => {
-        const offsetMap = $buildOffsetMap();
-        const points = $resolveMatchToPoints(
-          matches[effectiveIndex],
-          offsetMap,
-        );
-        if (points) {
-          $replaceMatch(points, replaceTerm);
-        }
-      },
-      {discrete: true},
-    );
-  }, [editor, matches, effectiveIndex, replaceTerm]);
-
-  const handleReplaceAll = useCallback(() => {
-    if (matches.length === 0) {
-      return;
-    }
-    editor.update(
-      () => {
-        const offsetMap = $buildOffsetMap();
-        $replaceAllMatches(matches, offsetMap, replaceTerm);
-      },
-      {discrete: true},
-    );
-  }, [editor, matches, replaceTerm]);
-
-  const handleClose = useCallback(() => {
-    setIsOpen(false);
-    editor.focus();
-  }, [editor]);
-
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        handleClose();
-      } else if (e.key === 'Enter') {
+        editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
+        editor.focus();
+        return;
+      }
+      if (e.key === 'Enter') {
         e.preventDefault();
-        if (e.shiftKey) {
-          handlePrev();
-        } else {
-          handleNext();
-        }
+        editor.dispatchCommand(
+          e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
+          undefined,
+        );
+        return;
+      }
+      const isMod = IS_APPLE
+        ? e.metaKey && !e.ctrlKey
+        : e.ctrlKey && !e.metaKey;
+      if (e.code === 'KeyG' && isMod && !e.altKey) {
+        e.preventDefault();
+        editor.dispatchCommand(
+          e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
+          undefined,
+        );
+      } else if (
+        (e.code === 'KeyF' && isMod && !e.altKey && !e.shiftKey) ||
+        (!IS_APPLE &&
+          e.code === 'KeyH' &&
+          e.ctrlKey &&
+          !e.metaKey &&
+          !e.altKey &&
+          !e.shiftKey) ||
+        (IS_APPLE && e.code === 'KeyF' && e.metaKey && e.altKey && !e.ctrlKey)
+      ) {
+        e.preventDefault();
+        searchInputRef.current?.focus();
       }
     },
-    [handleClose, handleNext, handlePrev],
+    [editor],
   );
 
   if (!isOpen) {
@@ -639,8 +889,7 @@ function FindReplacePanel({
           placeholder="Find..."
           value={searchTerm}
           onChange={e => {
-            setSearchTerm(e.target.value);
-            setCurrentIndex(0);
+            editor.dispatchCommand(SET_SEARCH_TERM_COMMAND, e.target.value);
           }}
           aria-label="Search text"
         />
@@ -653,9 +902,11 @@ function FindReplacePanel({
         </span>
         <button
           className="find-replace-btn"
-          onClick={handlePrev}
+          onClick={() => editor.dispatchCommand(FIND_PREV_COMMAND, undefined)}
           disabled={matches.length === 0}
-          title="Previous (Shift+Enter)"
+          title={
+            IS_APPLE ? 'Previous match (⇧⌘G)' : 'Previous match (Ctrl+Shift+G)'
+          }
           aria-label="Previous match">
           <svg viewBox="0 0 16 16">
             <path d="M8 4l5 6H3z" />
@@ -663,9 +914,9 @@ function FindReplacePanel({
         </button>
         <button
           className="find-replace-btn"
-          onClick={handleNext}
+          onClick={() => editor.dispatchCommand(FIND_NEXT_COMMAND, undefined)}
           disabled={matches.length === 0}
-          title="Next (Enter)"
+          title={IS_APPLE ? 'Next match (⌘G)' : 'Next match (Ctrl+G)'}
           aria-label="Next match">
           <svg viewBox="0 0 16 16">
             <path d="M8 12L3 6h10z" />
@@ -675,8 +926,7 @@ function FindReplacePanel({
         <button
           className="find-replace-toggle"
           onClick={() => {
-            setCaseSensitive(v => !v);
-            setCurrentIndex(0);
+            editor.dispatchCommand(TOGGLE_CASE_SENSITIVE_COMMAND, undefined);
           }}
           title="Match case"
           aria-label="Match case"
@@ -686,8 +936,7 @@ function FindReplacePanel({
         <button
           className="find-replace-toggle"
           onClick={() => {
-            setIsRegex(v => !v);
-            setCurrentIndex(0);
+            editor.dispatchCommand(TOGGLE_REGEX_COMMAND, undefined);
           }}
           title="Use regular expression"
           aria-label="Use regular expression"
@@ -697,7 +946,10 @@ function FindReplacePanel({
         <div className="find-replace-separator" />
         <button
           className="find-replace-btn"
-          onClick={handleClose}
+          onClick={() => {
+            editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
+            editor.focus();
+          }}
           title="Close (Escape)"
           aria-label="Close">
           <svg viewBox="0 0 16 16">
@@ -711,19 +963,23 @@ function FindReplacePanel({
           type="text"
           placeholder="Replace..."
           value={replaceTerm}
-          onChange={e => setReplaceTerm(e.target.value)}
+          onChange={e => {
+            editor.dispatchCommand(SET_REPLACE_TERM_COMMAND, e.target.value);
+          }}
           aria-label="Replace text"
         />
         <button
           className="find-replace-action"
-          onClick={handleReplace}
+          onClick={() =>
+            editor.dispatchCommand(REPLACE_CURRENT_COMMAND, undefined)
+          }
           disabled={matches.length === 0}
           aria-label="Replace current match">
           Replace
         </button>
         <button
           className="find-replace-action"
-          onClick={handleReplaceAll}
+          onClick={() => editor.dispatchCommand(REPLACE_ALL_COMMAND, undefined)}
           disabled={matches.length === 0}
           aria-label="Replace all matches">
           All

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -32,6 +32,7 @@ import {
   createCommand,
   defineExtension,
   IS_APPLE,
+  isExactShortcutMatch,
   KEY_DOWN_COMMAND,
   type LexicalCommand,
   type LexicalEditor,
@@ -66,12 +67,14 @@ export interface MatchPoints {
 }
 
 // ---------------------------------------------------------------------------
-// Pure functions
+// Constants
 // ---------------------------------------------------------------------------
 
-const EMPTY_MATCHES: TextMatch[] = Object.freeze<TextMatch[]>(
-  [],
-) as TextMatch[];
+const CONTROL_OR_META = {ctrlKey: !IS_APPLE, metaKey: IS_APPLE};
+
+// ---------------------------------------------------------------------------
+// Pure functions
+// ---------------------------------------------------------------------------
 
 export function findMatches(
   text: string,
@@ -80,7 +83,7 @@ export function findMatches(
   isRegex: boolean,
 ): TextMatch[] {
   if (!searchTerm || !text) {
-    return EMPTY_MATCHES;
+    return [];
   }
 
   const pattern = isRegex ? searchTerm : escapeRegExp(searchTerm);
@@ -90,7 +93,7 @@ export function findMatches(
   try {
     regex = new RegExp(pattern, flags);
   } catch {
-    return EMPTY_MATCHES;
+    return [];
   }
 
   const matches: TextMatch[] = [];
@@ -534,7 +537,7 @@ export const FindReplaceExtension = /* @__PURE__ */ defineExtension({
     });
 
     const cachedText = watchedSignal(
-      () => editor.read(() => $getRoot().getTextContent()),
+      () => editor.read('latest', () => $getRoot().getTextContent()),
       s =>
         editor.registerTextContentListener(text => {
           s.value = text;
@@ -543,7 +546,7 @@ export const FindReplaceExtension = /* @__PURE__ */ defineExtension({
 
     const matches = computed(() => {
       if (!named.isOpen.value) {
-        return EMPTY_MATCHES;
+        return [];
       }
       return findMatches(
         cachedText.value,
@@ -720,35 +723,23 @@ export const FindReplaceExtension = /* @__PURE__ */ defineExtension({
       editor.registerCommand(
         KEY_DOWN_COMMAND,
         event => {
-          const isFindReplace =
-            (!IS_APPLE &&
-              event.code === 'KeyH' &&
-              event.ctrlKey &&
-              !event.metaKey &&
-              !event.altKey &&
-              !event.shiftKey) ||
-            (IS_APPLE &&
-              event.code === 'KeyF' &&
-              event.metaKey &&
-              event.altKey &&
-              !event.ctrlKey);
-          const isFind =
-            event.code === 'KeyF' &&
-            !event.altKey &&
-            !event.shiftKey &&
-            (IS_APPLE
-              ? event.metaKey && !event.ctrlKey
-              : event.ctrlKey && !event.metaKey);
-          if (isFindReplace || isFind) {
+          if (
+            isExactShortcutMatch(event, 'f', CONTROL_OR_META) ||
+            isExactShortcutMatch(event, 'h', {ctrlKey: true}) ||
+            isExactShortcutMatch(event, 'f', {altKey: true, metaKey: true})
+          ) {
             event.preventDefault();
             editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
             return true;
           }
           if (output.isOpen.peek()) {
-            const isMod = IS_APPLE
-              ? event.metaKey && !event.ctrlKey
-              : event.ctrlKey && !event.metaKey;
-            if (event.code === 'KeyG' && isMod && !event.altKey) {
+            if (
+              isExactShortcutMatch(event, 'g', CONTROL_OR_META) ||
+              isExactShortcutMatch(event, 'g', {
+                ...CONTROL_OR_META,
+                shiftKey: true,
+              })
+            ) {
               event.preventDefault();
               editor.dispatchCommand(
                 event.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
@@ -831,22 +822,19 @@ function FindReplacePanel({
       );
       return;
     }
-    const isMod = IS_APPLE ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
-    if (e.code === 'KeyG' && isMod && !e.altKey) {
+    if (
+      isExactShortcutMatch(e, 'g', CONTROL_OR_META) ||
+      isExactShortcutMatch(e, 'g', {...CONTROL_OR_META, shiftKey: true})
+    ) {
       e.preventDefault();
       editor.dispatchCommand(
         e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
         undefined,
       );
     } else if (
-      (e.code === 'KeyF' && isMod && !e.altKey && !e.shiftKey) ||
-      (!IS_APPLE &&
-        e.code === 'KeyH' &&
-        e.ctrlKey &&
-        !e.metaKey &&
-        !e.altKey &&
-        !e.shiftKey) ||
-      (IS_APPLE && e.code === 'KeyF' && e.metaKey && e.altKey && !e.ctrlKey)
+      isExactShortcutMatch(e, 'f', CONTROL_OR_META) ||
+      isExactShortcutMatch(e, 'h', {ctrlKey: true}) ||
+      isExactShortcutMatch(e, 'f', {altKey: true, metaKey: true})
     ) {
       e.preventDefault();
       searchInputRef.current?.focus();

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -205,13 +205,12 @@ function findEntryForOffset(
 export function $replaceMatch(
   points: MatchPoints,
   replacementText: string,
-  match?: TextMatch,
-  searchRegex?: RegExp | null,
+  match: TextMatch,
+  searchRegex: RegExp | null,
 ): void {
-  const finalText =
-    match && searchRegex
-      ? expandReplacement(replacementText, match.matchText, searchRegex)
-      : replacementText;
+  const finalText = searchRegex
+    ? expandReplacement(replacementText, match.matchText, searchRegex)
+    : replacementText;
   const anchorNode = $getNodeByKeyOrThrow(points.anchorKey);
   const focusNode = $getNodeByKeyOrThrow(points.focusKey);
   if (!$isTextNode(anchorNode) || !$isTextNode(focusNode)) {
@@ -232,7 +231,7 @@ export function $replaceAllMatches(
   matches: TextMatch[],
   offsetMap: OffsetEntry[],
   replacementText: string,
-  searchRegex?: RegExp | null,
+  searchRegex: RegExp | null,
 ): number {
   let count = 0;
   for (let i = matches.length - 1; i >= 0; i--) {
@@ -300,7 +299,11 @@ function ensureHighlightRegistered(state: HighlightState, doc: Document): void {
   const style = doc.createElement('style');
   style.textContent =
     `::highlight(${state.allName}) { background-color: rgba(255, 255, 0, 0.4); color: inherit; }\n` +
-    `::highlight(${state.currentName}) { background-color: rgba(255, 165, 0, 0.6); color: inherit; }`;
+    `::highlight(${state.currentName}) { background-color: rgba(255, 165, 0, 0.6); color: inherit; }\n` +
+    `@media (forced-colors: active) {\n` +
+    `  ::highlight(${state.allName}) { background-color: Highlight; color: HighlightText; forced-color-adjust: none; }\n` +
+    `  ::highlight(${state.currentName}) { background-color: Mark; color: MarkText; forced-color-adjust: none; }\n` +
+    `}`;
   doc.head.appendChild(style);
   state.styleElement = style;
 }
@@ -509,16 +512,16 @@ export const REPLACE_CURRENT_COMMAND: LexicalCommand<void> =
 export const REPLACE_ALL_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('REPLACE_ALL_COMMAND');
 
-const SET_SEARCH_TERM_COMMAND: LexicalCommand<string> =
+export const SET_SEARCH_TERM_COMMAND: LexicalCommand<string> =
   /* @__PURE__ */ createCommand('SET_SEARCH_TERM_COMMAND');
 
-const SET_REPLACE_TERM_COMMAND: LexicalCommand<string> =
+export const SET_REPLACE_TERM_COMMAND: LexicalCommand<string> =
   /* @__PURE__ */ createCommand('SET_REPLACE_TERM_COMMAND');
 
-const TOGGLE_CASE_SENSITIVE_COMMAND: LexicalCommand<void> =
+export const TOGGLE_CASE_SENSITIVE_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('TOGGLE_CASE_SENSITIVE_COMMAND');
 
-const TOGGLE_REGEX_COMMAND: LexicalCommand<void> =
+export const TOGGLE_REGEX_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('TOGGLE_REGEX_COMMAND');
 
 // ---------------------------------------------------------------------------

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -338,7 +338,7 @@ function $updateHighlights(
 ): void {
   clearHighlights(state);
 
-  if (matches.length === 0) {
+  if (matches.length === 0 || !editor.getRootElement()) {
     return;
   }
 
@@ -377,12 +377,8 @@ function $updateHighlights(
 }
 
 function scrollRangeIntoView(range: Range): void {
-  const rect = range.getBoundingClientRect();
-  const viewportHeight = window.innerHeight;
-  if (rect.top < 0 || rect.bottom > viewportHeight) {
-    const el = range.startContainer.parentElement;
-    el?.scrollIntoView({behavior: 'smooth', block: 'center'});
-  }
+  const el = range.startContainer.parentElement;
+  el?.scrollIntoView({behavior: 'smooth', block: 'nearest'});
 }
 
 function clearHighlights(state: HighlightState): void {

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -216,6 +216,14 @@ export function $replaceMatch(
   if (!$isTextNode(anchorNode) || !$isTextNode(focusNode)) {
     return;
   }
+  if (points.anchorKey === points.focusKey) {
+    anchorNode.spliceText(
+      points.anchorOffset,
+      points.focusOffset - points.anchorOffset,
+      finalText,
+    );
+    return;
+  }
   const selection = anchorNode.select(0, 0);
   selection.setTextNodeRange(
     anchorNode,
@@ -816,6 +824,27 @@ function FindReplacePanel({
       editor.focus();
       return;
     }
+    if (e.key === 'Tab') {
+      const panel = e.currentTarget as HTMLElement;
+      const focusables = Array.from(
+        panel.querySelectorAll<HTMLElement>('input, button'),
+      );
+      if (focusables.length === 0) {
+        return;
+      }
+      const active = panel.ownerDocument.activeElement as HTMLElement;
+      const idx = focusables.indexOf(active);
+      const next = e.shiftKey
+        ? idx <= 0
+          ? focusables.length - 1
+          : idx - 1
+        : idx >= focusables.length - 1
+          ? 0
+          : idx + 1;
+      e.preventDefault();
+      focusables[next].focus();
+      return;
+    }
     if (e.key === 'Enter') {
       e.preventDefault();
       editor.dispatchCommand(
@@ -855,94 +884,77 @@ function FindReplacePanel({
       onKeyDown={handleKeyDown}
       role="dialog"
       aria-label="Find and Replace">
-      <div className="find-replace-row">
-        <input
-          ref={searchInputRef}
-          autoFocus={true}
-          className="find-replace-input"
-          type="text"
-          placeholder="Find..."
-          value={searchTerm}
-          onChange={e => {
-            editor.dispatchCommand(SET_SEARCH_TERM_COMMAND, e.target.value);
-          }}
-          aria-label="Search text"
-        />
-        <span className="find-replace-count">
-          {regexError
-            ? 'Invalid regex'
-            : matches.length > 0
-              ? `${effectiveIndex + 1} / ${matches.length}`
-              : 'No results'}
-        </span>
-        <button
-          className="find-replace-btn"
-          onClick={() => editor.dispatchCommand(FIND_PREV_COMMAND, undefined)}
-          disabled={matches.length === 0}
-          title={
-            IS_APPLE ? 'Previous match (⇧⌘G)' : 'Previous match (Ctrl+Shift+G)'
-          }
-          aria-label="Previous match">
-          <svg viewBox="0 0 16 16">
-            <path d="M8 4l5 6H3z" />
-          </svg>
-        </button>
-        <button
-          className="find-replace-btn"
-          onClick={() => editor.dispatchCommand(FIND_NEXT_COMMAND, undefined)}
-          disabled={matches.length === 0}
-          title={IS_APPLE ? 'Next match (⌘G)' : 'Next match (Ctrl+G)'}
-          aria-label="Next match">
-          <svg viewBox="0 0 16 16">
-            <path d="M8 12L3 6h10z" />
-          </svg>
-        </button>
-        <div className="find-replace-separator" />
-        <button
-          className="find-replace-toggle"
-          onClick={() => {
-            editor.dispatchCommand(TOGGLE_CASE_SENSITIVE_COMMAND, undefined);
-          }}
-          title="Match case"
-          aria-label="Match case"
-          aria-pressed={caseSensitive}>
-          Aa
-        </button>
-        <button
-          className="find-replace-toggle"
-          onClick={() => {
-            editor.dispatchCommand(TOGGLE_REGEX_COMMAND, undefined);
-          }}
-          title="Use regular expression"
-          aria-label="Use regular expression"
-          aria-pressed={isRegex}>
-          .*
-        </button>
-        <div className="find-replace-separator" />
-        <button
-          className="find-replace-btn"
-          onClick={() => {
-            editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
-            editor.focus();
-          }}
-          title="Close (Escape)"
-          aria-label="Close">
-          <svg viewBox="0 0 16 16">
-            <path d="M12.2 4.5l-.7-.7L8 7.3 4.5 3.8l-.7.7L7.3 8l-3.5 3.5.7.7L8 8.7l3.5 3.5.7-.7L8.7 8z" />
-          </svg>
-        </button>
-      </div>
-      <div className="find-replace-row">
-        <input
-          className="find-replace-input"
-          type="text"
-          placeholder="Replace..."
-          value={replaceTerm}
-          onChange={e => {
-            editor.dispatchCommand(SET_REPLACE_TERM_COMMAND, e.target.value);
-          }}
-          aria-label="Replace text"
-        />
+      <input
+        ref={searchInputRef}
+        autoFocus={true}
+        className="find-replace-input"
+        style={{gridColumn: 1, gridRow: 1}}
+        type="text"
+        placeholder="Find..."
+        value={searchTerm}
+        onChange={e => {
+          editor.dispatchCommand(SET_SEARCH_TERM_COMMAND, e.target.value);
+        }}
+        aria-label="Search text"
+      />
+      <input
+        className="find-replace-input"
+        style={{gridColumn: 1, gridRow: 2}}
+        type="text"
+        placeholder="Replace..."
+        value={replaceTerm}
+        onChange={e => {
+          editor.dispatchCommand(SET_REPLACE_TERM_COMMAND, e.target.value);
+        }}
+        aria-label="Replace text"
+      />
+      <button
+        className="find-replace-toggle"
+        style={{gridColumn: 3, gridRow: 1}}
+        onClick={() => {
+          editor.dispatchCommand(TOGGLE_CASE_SENSITIVE_COMMAND, undefined);
+        }}
+        title="Match case"
+        aria-label="Match case"
+        aria-pressed={caseSensitive}>
+        Aa
+      </button>
+      <button
+        className="find-replace-toggle"
+        style={{gridColumn: 4, gridRow: 1}}
+        onClick={() => {
+          editor.dispatchCommand(TOGGLE_REGEX_COMMAND, undefined);
+        }}
+        title="Use regular expression"
+        aria-label="Use regular expression"
+        aria-pressed={isRegex}>
+        .*
+      </button>
+      <button
+        className="find-replace-btn"
+        style={{gridColumn: 6, gridRow: 1}}
+        onClick={() => editor.dispatchCommand(FIND_PREV_COMMAND, undefined)}
+        disabled={matches.length === 0}
+        title={
+          IS_APPLE ? 'Previous match (⇧⌘G)' : 'Previous match (Ctrl+Shift+G)'
+        }
+        aria-label="Previous match">
+        <svg viewBox="0 0 16 16">
+          <path d="M8 4l5 6H3z" />
+        </svg>
+      </button>
+      <button
+        className="find-replace-btn"
+        style={{gridColumn: 7, gridRow: 1}}
+        onClick={() => editor.dispatchCommand(FIND_NEXT_COMMAND, undefined)}
+        disabled={matches.length === 0}
+        title={IS_APPLE ? 'Next match (⌘G)' : 'Next match (Ctrl+G)'}
+        aria-label="Next match">
+        <svg viewBox="0 0 16 16">
+          <path d="M8 12L3 6h10z" />
+        </svg>
+      </button>
+      <div className="find-replace-row2-actions">
         <button
           className="find-replace-action"
           onClick={() =>
@@ -960,6 +972,34 @@ function FindReplacePanel({
           All
         </button>
       </div>
+      <button
+        className="find-replace-btn"
+        style={{gridColumn: 9, gridRow: 1}}
+        onClick={() => {
+          editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
+          editor.focus();
+        }}
+        title="Close (Escape)"
+        aria-label="Close">
+        <svg viewBox="0 0 16 16">
+          <path d="M12.2 4.5l-.7-.7L8 7.3 4.5 3.8l-.7.7L7.3 8l-3.5 3.5.7.7L8 8.7l3.5 3.5.7-.7L8.7 8z" />
+        </svg>
+      </button>
+      <span className="find-replace-count" style={{gridColumn: 2, gridRow: 1}}>
+        {regexError
+          ? 'Invalid regex'
+          : matches.length > 0
+            ? `${effectiveIndex + 1} / ${matches.length}`
+            : 'No results'}
+      </span>
+      <div
+        className="find-replace-separator"
+        style={{gridColumn: 5, gridRow: 1}}
+      />
+      <div
+        className="find-replace-separator"
+        style={{gridColumn: 8, gridRow: 1}}
+      />
     </div>,
     portalTarget,
   );

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -725,7 +725,6 @@ export const FindReplaceExtension = /* @__PURE__ */ defineExtension({
         event => {
           if (
             isExactShortcutMatch(event, 'f', CONTROL_OR_META) ||
-            isExactShortcutMatch(event, 'h', {ctrlKey: true}) ||
             isExactShortcutMatch(event, 'f', {altKey: true, metaKey: true})
           ) {
             event.preventDefault();
@@ -833,7 +832,6 @@ function FindReplacePanel({
       );
     } else if (
       isExactShortcutMatch(e, 'f', CONTROL_OR_META) ||
-      isExactShortcutMatch(e, 'h', {ctrlKey: true}) ||
       isExactShortcutMatch(e, 'f', {altKey: true, metaKey: true})
     ) {
       e.preventDefault();

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -1,0 +1,745 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {DecoratorComponentProps} from '@lexical/react/ReactPluginHostExtension';
+import type {JSX} from 'react';
+
+import './FindReplace.css';
+
+import {ReactExtension} from '@lexical/react/ReactExtension';
+import {createDOMRange, createRectsFromDOMRange} from '@lexical/selection';
+import {$dfsWithSlotsIterator} from '@lexical/utils';
+import {
+  $createRangeSelection,
+  $getNodeByKeyOrThrow,
+  $getRoot,
+  $isElementNode,
+  $isLineBreakNode,
+  $isTextNode,
+  $setSelection,
+  COMMAND_PRIORITY_LOW,
+  configExtension,
+  createCommand,
+  defineExtension,
+  IS_APPLE,
+  KEY_DOWN_COMMAND,
+  type LexicalCommand,
+  type LexicalEditor,
+  mergeRegister,
+  type NodeKey,
+} from 'lexical';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {createPortal} from 'react-dom';
+
+export interface TextMatch {
+  end: number;
+  start: number;
+}
+
+export interface OffsetEntry {
+  globalEnd: number;
+  globalStart: number;
+  key: NodeKey;
+}
+
+export interface MatchPoints {
+  anchorKey: NodeKey;
+  anchorOffset: number;
+  focusKey: NodeKey;
+  focusOffset: number;
+  format: number;
+}
+
+export function findMatches(
+  text: string,
+  searchTerm: string,
+  caseSensitive: boolean,
+  isRegex: boolean,
+): TextMatch[] {
+  if (!searchTerm || !text) {
+    return [];
+  }
+
+  const pattern = isRegex ? searchTerm : escapeRegExp(searchTerm);
+  const flags = 'g' + (caseSensitive ? '' : 'i');
+
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern, flags);
+  } catch {
+    return [];
+  }
+
+  const matches: TextMatch[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    if (match[0].length === 0) {
+      // prevent infinite loop on zero-length matches
+      regex.lastIndex++;
+      continue;
+    }
+    matches.push({end: match.index + match[0].length, start: match.index});
+  }
+  return matches;
+}
+
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function $buildOffsetMap(): OffsetEntry[] {
+  const entries: OffsetEntry[] = [];
+  let offset = 0;
+  let prevNonInlineDepth: number | null = null;
+
+  for (const {node, depth} of $dfsWithSlotsIterator()) {
+    if ($isElementNode(node) && !node.isInline() && depth > 0) {
+      if (prevNonInlineDepth !== null && depth <= prevNonInlineDepth) {
+        offset += 2; // mirrors DOUBLE_LINE_BREAK separators from ElementNode.getTextContent()
+      }
+      prevNonInlineDepth = depth;
+    }
+
+    if ($isLineBreakNode(node)) {
+      offset += 1;
+    } else if ($isTextNode(node)) {
+      const len = node.getTextContentSize();
+      entries.push({
+        globalEnd: offset + len,
+        globalStart: offset,
+        key: node.__key,
+      });
+      offset += len;
+    }
+  }
+
+  return entries;
+}
+
+export function $resolveMatchToPoints(
+  match: TextMatch,
+  offsetMap: OffsetEntry[],
+): MatchPoints | null {
+  const anchorEntry = findEntryForOffset(offsetMap, match.start);
+  const focusEntry = findEntryForOffset(offsetMap, match.end - 1);
+  if (!anchorEntry || !focusEntry) {
+    return null;
+  }
+
+  const anchorOffset = match.start - anchorEntry.globalStart;
+  const focusOffset = match.end - focusEntry.globalStart;
+  const isSingleNode = anchorEntry.key === focusEntry.key;
+  const anchorNode = $getNodeByKeyOrThrow(anchorEntry.key);
+  const format =
+    isSingleNode && $isTextNode(anchorNode) ? anchorNode.getFormat() : 0;
+
+  return {
+    anchorKey: anchorEntry.key,
+    anchorOffset,
+    focusKey: focusEntry.key,
+    focusOffset,
+    format,
+  };
+}
+
+function findEntryForOffset(
+  offsetMap: OffsetEntry[],
+  offset: number,
+): OffsetEntry | null {
+  let lo = 0;
+  let hi = offsetMap.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const entry = offsetMap[mid];
+    if (offset < entry.globalStart) {
+      hi = mid - 1;
+    } else if (offset >= entry.globalEnd) {
+      lo = mid + 1;
+    } else {
+      return entry;
+    }
+  }
+  return null;
+}
+
+export function $replaceMatch(
+  points: MatchPoints,
+  replacementText: string,
+): void {
+  const selection = $createRangeSelection();
+  selection.anchor.set(points.anchorKey, points.anchorOffset, 'text');
+  selection.focus.set(points.focusKey, points.focusOffset, 'text');
+  selection.format = points.format;
+  $setSelection(selection);
+  selection.insertText(replacementText);
+}
+
+export function $replaceAllMatches(
+  matches: TextMatch[],
+  offsetMap: OffsetEntry[],
+  replacementText: string,
+): number {
+  let count = 0;
+  // Replace back-to-front so earlier offsets in the pre-built map stay valid
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const points = $resolveMatchToPoints(matches[i], offsetMap);
+    if (points) {
+      $replaceMatch(points, replacementText);
+      count++;
+    }
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Highlight rendering (scoped per editor instance)
+// ---------------------------------------------------------------------------
+
+const SUPPORTS_CSS_HIGHLIGHTS =
+  typeof Highlight !== 'undefined' &&
+  typeof CSS !== 'undefined' &&
+  'highlights' in CSS;
+
+interface HighlightState {
+  allHighlight: Highlight | null;
+  allName: string;
+  currentHighlight: Highlight | null;
+  currentName: string;
+  overlayContainer: HTMLDivElement | null;
+  originalParentPosition: string | null;
+  styleElement: HTMLStyleElement | null;
+}
+
+function createHighlightState(editorKey: string): HighlightState {
+  return {
+    allHighlight: null,
+    allName: `lexical-find-replace-match-${editorKey}`,
+    currentHighlight: null,
+    currentName: `lexical-find-replace-current-${editorKey}`,
+    originalParentPosition: null,
+    overlayContainer: null,
+    styleElement: null,
+  };
+}
+
+function ensureHighlightRegistered(state: HighlightState, doc: Document): void {
+  if (state.allHighlight) {
+    return;
+  }
+  // eslint-disable-next-line compat/compat -- guarded by SUPPORTS_CSS_HIGHLIGHTS
+  state.allHighlight = new Highlight();
+  // eslint-disable-next-line compat/compat -- guarded by SUPPORTS_CSS_HIGHLIGHTS
+  state.currentHighlight = new Highlight();
+  CSS.highlights.set(state.allName, state.allHighlight);
+  CSS.highlights.set(state.currentName, state.currentHighlight);
+  const style = doc.createElement('style');
+  style.textContent =
+    `::highlight(${state.allName}) { background-color: rgba(255, 255, 0, 0.4); color: inherit; }\n` +
+    `::highlight(${state.currentName}) { background-color: rgba(255, 165, 0, 0.6); color: inherit; }`;
+  doc.head.appendChild(style);
+  state.styleElement = style;
+}
+
+function disposeHighlightState(state: HighlightState): void {
+  if (state.allHighlight) {
+    state.allHighlight.clear();
+    CSS.highlights.delete(state.allName);
+    state.allHighlight = null;
+  }
+  if (state.currentHighlight) {
+    state.currentHighlight.clear();
+    CSS.highlights.delete(state.currentName);
+    state.currentHighlight = null;
+  }
+  if (state.styleElement) {
+    state.styleElement.remove();
+    state.styleElement = null;
+  }
+  if (state.overlayContainer) {
+    if (state.originalParentPosition !== null) {
+      const parent = state.overlayContainer.parentElement;
+      if (parent) {
+        parent.style.position = state.originalParentPosition;
+      }
+      state.originalParentPosition = null;
+    }
+    state.overlayContainer.remove();
+    state.overlayContainer = null;
+  }
+}
+
+function $updateHighlights(
+  editor: LexicalEditor,
+  matches: TextMatch[],
+  currentIndex: number,
+  state: HighlightState,
+): void {
+  clearHighlights(state);
+
+  if (matches.length === 0) {
+    return;
+  }
+
+  const offsetMap = $buildOffsetMap();
+
+  if (SUPPORTS_CSS_HIGHLIGHTS) {
+    const doc = editor.getRootElement()?.ownerDocument ?? document;
+    ensureHighlightRegistered(state, doc);
+
+    for (let i = 0; i < matches.length; i++) {
+      const points = $resolveMatchToPoints(matches[i], offsetMap);
+      if (!points) {
+        continue;
+      }
+      const anchorNode = $getNodeByKeyOrThrow(points.anchorKey);
+      const focusNode = $getNodeByKeyOrThrow(points.focusKey);
+      const range = createDOMRange(
+        editor,
+        anchorNode,
+        points.anchorOffset,
+        focusNode,
+        points.focusOffset,
+      );
+      if (!range) {
+        continue;
+      }
+      state.allHighlight!.add(range);
+      if (i === currentIndex) {
+        state.currentHighlight!.add(range);
+      }
+    }
+  } else {
+    $updateOverlayHighlights(editor, matches, currentIndex, offsetMap, state);
+  }
+}
+
+function clearHighlights(state: HighlightState): void {
+  if (state.allHighlight) {
+    state.allHighlight.clear();
+  }
+  if (state.currentHighlight) {
+    state.currentHighlight.clear();
+  }
+  clearOverlayHighlights(state);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy fallback: overlay spans
+// ---------------------------------------------------------------------------
+
+function getOverlayContainer(
+  editor: LexicalEditor,
+  state: HighlightState,
+): HTMLDivElement {
+  if (state.overlayContainer) {
+    return state.overlayContainer;
+  }
+  const root = editor.getRootElement();
+  if (!root) {
+    throw new Error('No root element');
+  }
+  const doc = root.ownerDocument;
+  const parent = root.parentElement!;
+  if (getComputedStyle(parent).position === 'static') {
+    // overlay spans need a positioned ancestor
+    state.originalParentPosition = parent.style.position;
+    parent.style.position = 'relative';
+  }
+  const container = doc.createElement('div');
+  container.style.position = 'absolute';
+  container.style.top = '0';
+  container.style.left = '0';
+  container.style.pointerEvents = 'none';
+  parent.appendChild(container);
+  state.overlayContainer = container;
+  return container;
+}
+
+function clearOverlayHighlights(state: HighlightState): void {
+  if (state.overlayContainer) {
+    state.overlayContainer.innerHTML = '';
+  }
+}
+
+function $updateOverlayHighlights(
+  editor: LexicalEditor,
+  matches: TextMatch[],
+  currentIndex: number,
+  offsetMap: OffsetEntry[],
+  state: HighlightState,
+): void {
+  const container = getOverlayContainer(editor, state);
+  container.innerHTML = '';
+  const rootElement = editor.getRootElement();
+  if (!rootElement) {
+    return;
+  }
+  const doc = rootElement.ownerDocument;
+  const containerRect = container.offsetParent
+    ? container.offsetParent.getBoundingClientRect()
+    : rootElement.getBoundingClientRect();
+
+  for (let i = 0; i < matches.length; i++) {
+    const points = $resolveMatchToPoints(matches[i], offsetMap);
+    if (!points) {
+      continue;
+    }
+    const anchorNode = $getNodeByKeyOrThrow(points.anchorKey);
+    const focusNode = $getNodeByKeyOrThrow(points.focusKey);
+    const range = createDOMRange(
+      editor,
+      anchorNode,
+      points.anchorOffset,
+      focusNode,
+      points.focusOffset,
+    );
+    if (!range) {
+      continue;
+    }
+    const rects = createRectsFromDOMRange(editor, range);
+    const isCurrent = i === currentIndex;
+    for (const rect of rects) {
+      const span = doc.createElement('span');
+      span.style.position = 'absolute';
+      span.style.top = `${rect.top - containerRect.top}px`;
+      span.style.left = `${rect.left - containerRect.left}px`;
+      span.style.width = `${rect.width}px`;
+      span.style.height = `${rect.height}px`;
+      span.style.backgroundColor = isCurrent
+        ? 'rgba(255, 165, 0, 0.6)'
+        : 'rgba(255, 255, 0, 0.4)';
+      span.style.pointerEvents = 'none';
+      container.appendChild(span);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extension definitions
+// ---------------------------------------------------------------------------
+
+export const OPEN_FIND_REPLACE_COMMAND: LexicalCommand<void> =
+  /* @__PURE__ */ createCommand('OPEN_FIND_REPLACE_COMMAND');
+
+export const FindReplaceExtension = /* @__PURE__ */ defineExtension({
+  name: '@lexical/playground/FindReplace',
+  register: editor => {
+    return editor.registerCommand(
+      KEY_DOWN_COMMAND,
+      event => {
+        const isFindReplace =
+          (event.code === 'KeyH' &&
+            event.ctrlKey &&
+            !event.metaKey &&
+            !event.altKey &&
+            !event.shiftKey) ||
+          (IS_APPLE &&
+            event.code === 'KeyF' &&
+            event.metaKey &&
+            event.altKey &&
+            !event.ctrlKey);
+        const isFind =
+          event.code === 'KeyF' &&
+          !event.altKey &&
+          !event.shiftKey &&
+          (IS_APPLE
+            ? event.metaKey && !event.ctrlKey
+            : event.ctrlKey && !event.metaKey);
+        if (isFindReplace || isFind) {
+          event.preventDefault();
+          editor.dispatchCommand(OPEN_FIND_REPLACE_COMMAND, undefined);
+          return true;
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+  },
+});
+
+// ---------------------------------------------------------------------------
+// React UI
+// ---------------------------------------------------------------------------
+
+function FindReplacePanel({
+  context,
+}: DecoratorComponentProps): JSX.Element | null {
+  const [editor] = context;
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [replaceTerm, setReplaceTerm] = useState('');
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [isRegex, setIsRegex] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [cachedText, setCachedText] = useState(() =>
+    editor.read(() => $getRoot().getTextContent()),
+  );
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const highlightStateRef = useRef<HighlightState>(
+    createHighlightState(editor.getKey()),
+  );
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerTextContentListener(text => {
+        setCachedText(text);
+      }),
+      editor.registerCommand(
+        OPEN_FIND_REPLACE_COMMAND,
+        () => {
+          setIsOpen(prev => !prev);
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+  }, [editor]);
+
+  useEffect(() => {
+    const state = highlightStateRef.current;
+    return () => disposeHighlightState(state);
+  }, []);
+
+  const regexError = useMemo(() => {
+    if (!isRegex || !searchTerm) {
+      return false;
+    }
+    try {
+      RegExp(searchTerm);
+      return false;
+    } catch {
+      return true;
+    }
+  }, [searchTerm, isRegex]);
+
+  const matches = useMemo(() => {
+    if (!isOpen) {
+      return [];
+    }
+    return findMatches(cachedText, searchTerm, caseSensitive, isRegex);
+  }, [cachedText, searchTerm, caseSensitive, isRegex, isOpen]);
+
+  const effectiveIndex =
+    matches.length > 0 ? Math.min(currentIndex, matches.length - 1) : 0;
+
+  useLayoutEffect(() => {
+    const state = highlightStateRef.current;
+    if (!isOpen || matches.length === 0) {
+      clearHighlights(state);
+      return () => clearHighlights(state);
+    }
+    editor.read(() => {
+      $updateHighlights(editor, matches, effectiveIndex, state);
+    });
+    return () => clearHighlights(state);
+  }, [editor, matches, effectiveIndex, isOpen]);
+
+  useEffect(() => {
+    if (isOpen && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [isOpen]);
+
+  const handleNext = useCallback(() => {
+    setCurrentIndex(prev =>
+      matches.length > 0 ? (prev + 1) % matches.length : 0,
+    );
+  }, [matches.length]);
+
+  const handlePrev = useCallback(() => {
+    setCurrentIndex(prev =>
+      matches.length > 0 ? (prev - 1 + matches.length) % matches.length : 0,
+    );
+  }, [matches.length]);
+
+  const handleReplace = useCallback(() => {
+    if (matches.length === 0) {
+      return;
+    }
+    editor.update(
+      () => {
+        const offsetMap = $buildOffsetMap();
+        const points = $resolveMatchToPoints(
+          matches[effectiveIndex],
+          offsetMap,
+        );
+        if (points) {
+          $replaceMatch(points, replaceTerm);
+        }
+      },
+      {discrete: true},
+    );
+  }, [editor, matches, effectiveIndex, replaceTerm]);
+
+  const handleReplaceAll = useCallback(() => {
+    if (matches.length === 0) {
+      return;
+    }
+    editor.update(
+      () => {
+        const offsetMap = $buildOffsetMap();
+        $replaceAllMatches(matches, offsetMap, replaceTerm);
+      },
+      {discrete: true},
+    );
+  }, [editor, matches, replaceTerm]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    editor.focus();
+  }, [editor]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleClose();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) {
+          handlePrev();
+        } else {
+          handleNext();
+        }
+      }
+    },
+    [handleClose, handleNext, handlePrev],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const rootElement = editor.getRootElement();
+  const portalTarget = rootElement?.ownerDocument?.body ?? document.body;
+
+  return createPortal(
+    <div
+      className="find-replace-panel"
+      onKeyDown={handleKeyDown}
+      role="dialog"
+      aria-label="Find and Replace">
+      <div className="find-replace-row">
+        <input
+          ref={searchInputRef}
+          className="find-replace-input"
+          type="text"
+          placeholder="Find..."
+          value={searchTerm}
+          onChange={e => {
+            setSearchTerm(e.target.value);
+            setCurrentIndex(0);
+          }}
+          aria-label="Search text"
+        />
+        <span className="find-replace-count">
+          {regexError
+            ? 'Invalid regex'
+            : matches.length > 0
+              ? `${effectiveIndex + 1} / ${matches.length}`
+              : 'No results'}
+        </span>
+        <button
+          className="find-replace-btn"
+          onClick={handlePrev}
+          disabled={matches.length === 0}
+          title="Previous (Shift+Enter)"
+          aria-label="Previous match">
+          <svg viewBox="0 0 16 16">
+            <path d="M8 4l5 6H3z" />
+          </svg>
+        </button>
+        <button
+          className="find-replace-btn"
+          onClick={handleNext}
+          disabled={matches.length === 0}
+          title="Next (Enter)"
+          aria-label="Next match">
+          <svg viewBox="0 0 16 16">
+            <path d="M8 12L3 6h10z" />
+          </svg>
+        </button>
+        <div className="find-replace-separator" />
+        <button
+          className="find-replace-toggle"
+          onClick={() => {
+            setCaseSensitive(v => !v);
+            setCurrentIndex(0);
+          }}
+          title="Match case"
+          aria-label="Match case"
+          aria-pressed={caseSensitive}>
+          Aa
+        </button>
+        <button
+          className="find-replace-toggle"
+          onClick={() => {
+            setIsRegex(v => !v);
+            setCurrentIndex(0);
+          }}
+          title="Use regular expression"
+          aria-label="Use regular expression"
+          aria-pressed={isRegex}>
+          .*
+        </button>
+        <div className="find-replace-separator" />
+        <button
+          className="find-replace-btn"
+          onClick={handleClose}
+          title="Close (Escape)"
+          aria-label="Close">
+          <svg viewBox="0 0 16 16">
+            <path d="M12.2 4.5l-.7-.7L8 7.3 4.5 3.8l-.7.7L7.3 8l-3.5 3.5.7.7L8 8.7l3.5 3.5.7-.7L8.7 8z" />
+          </svg>
+        </button>
+      </div>
+      <div className="find-replace-row">
+        <input
+          className="find-replace-input"
+          type="text"
+          placeholder="Replace..."
+          value={replaceTerm}
+          onChange={e => setReplaceTerm(e.target.value)}
+          aria-label="Replace text"
+        />
+        <button
+          className="find-replace-action"
+          onClick={handleReplace}
+          disabled={matches.length === 0}
+          aria-label="Replace current match">
+          Replace
+        </button>
+        <button
+          className="find-replace-action"
+          onClick={handleReplaceAll}
+          disabled={matches.length === 0}
+          aria-label="Replace all matches">
+          All
+        </button>
+      </div>
+    </div>,
+    portalTarget,
+  );
+}
+
+export const ReactFindReplaceExtension = /* @__PURE__ */ defineExtension({
+  dependencies: [
+    FindReplaceExtension,
+    /* @__PURE__ */ configExtension(ReactExtension, {
+      decorators: [FindReplacePanel],
+    }),
+  ],
+  name: '@lexical/playground/ReactFindReplace',
+});


### PR DESCRIPTION
## Description

Adds a find-and-replace panel to the playground. The panel opens via Ctrl+F (find) or Cmd+Option+F (find and replace), and supports case-sensitive search, regex mode, match navigation, single replace, and replace-all.

Search runs against `registerTextContentListener`'s cached text — no tree traversal per keystroke, following the direction suggested in #8776. When matches exist, `$buildOffsetMap` walks the tree once via `$dfsWithSlotsIterator` to map global text offsets back to individual TextNode keys and local offsets. Highlights render through the CSS Custom Highlight API (`::highlight()`) on modern browsers, with a positioned-overlay-span fallback for browsers that don't support it. The dual-path approach mirrors `@lexical/yjs` SyncCursors.ts.

Replace uses `select()` + `setTextNodeRange()` + `insertText()` so that single-node replacements preserve the original text format (bold, italic, etc.). Replace-all processes matches back-to-front in a single `editor.update()` so earlier offsets stay valid.

### What changed (review feedback)

**1. Logic moved from React to Extension (`namedSignals` / commands)**

All search state (`searchTerm`, `replaceTerm`, `caseSensitive`, `isRegex`, `currentIndex`, `isOpen`) lives in `namedSignals` inside `FindReplaceExtension.build()`. Derived values (`matches`, `cachedText`) use `watchedSignal` and `computed`. Side effects (highlight rendering, match navigation, replace) run in `effect()` inside `register()`. The React panel is now a thin view — `useExtensionSignalValue` for reads, `editor.dispatchCommand()` for writes. The only remaining React hook is `useRef` for the search input focus ref.

**2. Regex capture group replacement (`$1`, `$2`, `$&`)**

`expandReplacement(template, matchText, searchRegex)` delegates to `String.prototype.replace`, so `$1`/`$2`/`$&`/`$$` all work natively. `findMatches` now returns `matchText` per match. Non-regex mode treats `$1` as a literal.

**3. Panel keyboard shortcuts**

Shortcuts that previously only worked with editor focus now also work when the panel itself has focus, via `onKeyDown` on the panel container:

| Shortcut | Action |
|---|---|
| Cmd+G / Ctrl+G | Next match |
| Shift+Cmd+G / Shift+Ctrl+G | Previous match |
| Cmd+F / Ctrl+F | Focus search input (blocks browser find) |
| Cmd+Option+F | Toggle panel (blocks browser default) |
| Enter / Shift+Enter | Next / previous match |
| Escape | Close panel |

**4. Scroll into view**

When navigating to a match that's off-screen, the match element scrolls into view (`scrollIntoView({behavior: 'smooth', block: 'nearest'})`). Works in both the CSS Highlights path and the overlay-span fallback.

### Design notes

- The offset map assumes `getTextContent()` inserts `\n\n` between sibling block elements and `\n` for `LineBreakNode`. If this convention changes in core, the map would need updating.
- Highlight names include `editor.getKey()` to avoid `CSS.highlights` collisions when multiple editors share a document.
- Invalid regex patterns show "Invalid regex" in the match counter rather than a silent "No results".

Closes #8776

## Test plan

- [x] `pnpm vitest run --project unit -- FindReplace` — 46 tests pass:
  - 14 `findMatches` + 3 zero-length regex edge cases (`.*`, `a*`, `x?`)
  - 7 `$buildOffsetMap`
  - 3 `$resolveMatchToPoints`
  - 6 `expandReplacement` (`$1`/`$2`, `$&`, `$$`, non-regex literal, no-group fallback)
  - 5 `$replaceMatch` (basic, format preservation, empty string, regex capture group, non-regex `$1` literal)
  - 4 `$replaceAllMatches` (basic, shorter, longer, regex capture group)
  - 4 Extension command dispatch integration (toggle, close, matches recompute, next/prev cycle)
- [x] e2e regression: `Ctrl+H` binding removed — `deleteBackward` tests pass (previously intercepted by the `Ctrl+H` handler)
- [x] tsc / eslint / prettier clean
- [x] Manual playground (Chrome, Firefox, Safari):
  - S1. Open/close: Cmd+F opens panel with search focused, Cmd+Option+F opens panel, Escape closes + clears highlights + restores editor focus, X button same as Escape
  - S2. Search + highlight: single match "1 / 1", multiple matches "1 / 3" with first in orange, no match "No results", live count update on text edit
  - S3. Next/previous navigation: Enter advances (1/3 → 2/3), Shift+Enter goes back, Cmd+G / Shift+Cmd+G from panel focus, Cmd+G from editor focus, wraps at end (3/3 → 1/3)
  - S4. Panel focus shortcuts: Cmd+F re-focuses search input (blocks browser find), Cmd+Option+F re-focuses (blocks browser default)
  - S5. Case sensitive / regex toggles: Aa toggle "Hello HELLO hello" → 3 → 1, regex toggle `\d+` → "No results" → "1 / 2", invalid regex `[invalid` → "Invalid regex"
  - S6. Single replace: "hello" → "goodbye" preserves surrounding text, empty replacement deletes matched text
  - S7. Replace all: 3 × "foo" → "qux" in one operation
  - S8. Regex capture groups: `(\w+)@(\w+)` + `$2/$1` → "user@host" → "host/user", `$&` whole-match reference, capture group replace-all, non-regex `$1` stays literal
  - S9. Formatted text: bold+plain boundary search highlights across nodes, replace inside bold preserves bold format
  - S10. Complex structures: multi-paragraph search, list item search
  - S11. Scroll into view: navigating to off-screen match scrolls it into the viewport