### PR TITLE
[lexical-playground] Bug Fix: restore RTL checkbox position in checklist

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -508,6 +508,11 @@
   position: absolute;
   transform: translateY(-50%);
 }
+.PlaygroundEditorTheme__listItemUnchecked[dir='rtl']:before,
+.PlaygroundEditorTheme__listItemChecked[dir='rtl']:before {
+  left: auto;
+  right: 0;
+}
 .PlaygroundEditorTheme__listItemChecked {
   text-decoration: line-through;
 }
@@ -539,6 +544,10 @@
   height: 0.4em;
   transform: translateY(-50%) rotate(45deg);
   border-width: 0 0.1em 0.1em 0;
+}
+.PlaygroundEditorTheme__listItemChecked[dir='rtl']:after {
+  left: auto;
+  right: 0.35em;
 }
 .PlaygroundEditorTheme__nestedListItem {
   list-style-type: none;


### PR DESCRIPTION
## Description

In RTL, the checklist checkbox renders on the wrong (left) side. `v0.35.0` was reported as the cause, but tracing the CSS history shows the actual regression came from #7558, which reworked the checkbox marker to em-based units and, in the process, dropped the two `[dir='rtl']` positioning overrides that used to mirror the marker to the right:

```css
.PlaygroundEditorTheme__listItemUnchecked[dir='rtl']:before,
.PlaygroundEditorTheme__listItemChecked[dir='rtl']:before {
  left: auto;
  right: 0;
}
```

Since then the `:before` box and `:after` checkmark stay pinned to `left`, so the marker sits on the left in RTL.

Notably, the click hit-test in `packages/lexical-list/src/checkList.ts` already handles RTL correctly (it targets `rect.right` when `target.dir === 'rtl'`). So the marker was drawn on the left while the clickable area was on the right, i.e. the toggle target and the visible checkbox disagreed. Re-adding the RTL CSS overrides (mirrored to the right in the new em-based scheme) fixes the visual position and realigns it with the existing hit-test.

This is a minimal, CSS-only change scoped to the playground theme. The reporter also mentioned that the click logic expected left-side clicks, but that is no longer the case on `main` (RTL detection was added in #7429), so no plugin change is needed.

Closes #7929

## Test plan

- `pnpm vitest --project unit --no-watch packages/lexical-list/src/__tests__/unit/checkList.test.tsx` -> 4/4 pass (no regression).
- `prettier --check` clean on the touched file.
- Visual verification of the em-based marker in RTL vs LTR (below). CSS positioning is not unit-testable; the checklist marker is not covered by the playground e2e in a way that asserts pixel side, so the device/e2e render is deferred to CI.

### Before

RTL checkbox renders on the left (wrong).

### After

RTL checkbox renders on the right (correct); LTR unchanged.

![before-after](https://raw.githubusercontent.com/ryanda9910/lexical/evidence-7929/checklist-rtl.png)
