### PR TITLE
[Breaking Change][lexical] Bug Fix: Preserve DOM element when composing on segmented TextNode middle

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -15,6 +15,7 @@ import invariant from '@lexical/internal/invariant';
 import warnOnlyOnce from '@lexical/internal/warnOnlyOnce';
 
 import {
+  $createTextNode,
   $getPreviousSelection,
   $getRoot,
   $getSelection,
@@ -1040,10 +1041,12 @@ function $handleBeforeInput(event: InputEvent): boolean {
     case 'insertFromComposition': {
       const skipRedundantInsert = hadOrphanedCompositionEvents;
       hadOrphanedCompositionEvents = false;
+      const prevCompositionKey = editor._compositionKey;
       $setCompositionKey(null);
       if (!skipRedundantInsert) {
         dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, event);
       }
+      $cleanupComposedSubclass(prevCompositionKey);
       break;
     }
 
@@ -1389,6 +1392,34 @@ function $handleCompositionEnd(event: CompositionEvent): boolean {
   return true;
 }
 
+function $cleanupComposedSubclass(compositionKey: NodeKey | null): void {
+  if (compositionKey === null) {
+    return;
+  }
+  const composedNode = $getNodeByKey(compositionKey);
+  if (
+    !$isTextNode(composedNode) ||
+    composedNode.getType() === 'text' ||
+    $isTokenOrSegmented(composedNode) ||
+    !composedNode.isAttached()
+  ) {
+    return;
+  }
+  const sel = $getSelection();
+  const offset =
+    $isRangeSelection(sel) && sel.anchor.key === compositionKey
+      ? sel.anchor.offset
+      : null;
+  const replacement = $createTextNode(composedNode.getTextContent());
+  replacement.setFormat(composedNode.getFormat());
+  replacement.setStyle(composedNode.getStyle());
+  composedNode.replace(replacement);
+  if (offset !== null) {
+    const safeOffset = Math.min(offset, replacement.getTextContentSize());
+    replacement.select(safeOffset, safeOffset);
+  }
+}
+
 function $onCompositionEndImpl(editor: LexicalEditor, data?: string): boolean {
   const compositionKey = editor._compositionKey;
   $setCompositionKey(null);
@@ -1433,6 +1464,7 @@ function $onCompositionEndImpl(editor: LexicalEditor, data?: string): boolean {
           true,
         );
       }
+      $cleanupComposedSubclass(compositionKey);
       return false;
     } else if (data[data.length - 1] === '\n') {
       const selection = $getSelection();
@@ -1445,6 +1477,7 @@ function $onCompositionEndImpl(editor: LexicalEditor, data?: string): boolean {
           selection.anchor.set(focus.key, focus.offset, focus.type);
         }
         dispatchCommand(editor, KEY_ENTER_COMMAND, null);
+        $cleanupComposedSubclass(compositionKey);
         return false;
       }
     }
@@ -1467,6 +1500,7 @@ function $onCompositionEndImpl(editor: LexicalEditor, data?: string): boolean {
   }
 
   $updateSelectedTextFromDOM(true, editor, data);
+  $cleanupComposedSubclass(compositionKey);
   return false;
 }
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1002,6 +1002,9 @@ export class RangeSelection implements BaseSelection {
       }
     } else if (firstNode.isSegmented() && startOffset !== firstNodeTextLength) {
       if ($getCompositionKey() !== null) {
+        // Preserve the DOM element for the browser's composition tracker.
+        // The subclass instance stays in normal mode until composition ends,
+        // when $cleanupComposedSubclass replaces it with a plain TextNode.
         firstNode = firstNode
           .setMode('normal')
           .setFormat(format)

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1001,10 +1001,17 @@ export class RangeSelection implements BaseSelection {
         return;
       }
     } else if (firstNode.isSegmented() && startOffset !== firstNodeTextLength) {
-      const textNode = $createTextNode(firstNode.getTextContent());
-      textNode.setFormat(format);
-      firstNode.replace(textNode);
-      firstNode = textNode;
+      if ($getCompositionKey() !== null) {
+        firstNode = firstNode
+          .setMode('normal')
+          .setFormat(format)
+          .setStyle(style);
+      } else {
+        const textNode = $createTextNode(firstNode.getTextContent());
+        textNode.setFormat(format);
+        firstNode.replace(textNode);
+        firstNode = textNode;
+      }
     } else if (!this.isCollapsed() && text !== '') {
       // When the firstNode or lastNode parents are elements that
       // do not allow text to be inserted before or after, we first

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -27,6 +27,7 @@ import {
   $isRangeSelection,
   $isTextNode,
   $selectAll,
+  $setCompositionKey,
   $setSelection,
   createEditor,
   ElementNode,
@@ -837,6 +838,72 @@ describe('LexicalSelection tests', () => {
           });
         });
       });
+    });
+  });
+});
+
+describe('Segmented node composition (#5065)', () => {
+  initializeUnitTest(testEnv => {
+    test('insertText during composition preserves node key', () => {
+      testEnv.editor.update(
+        () => {
+          const segmented = $createTextNode('JohnSmith').setMode('segmented');
+          $getRoot().clear().append($createParagraphNode().append(segmented));
+          const key = segmented.getKey();
+
+          $setCompositionKey(key);
+          const sel = segmented.select(4, 4);
+          sel.insertText('');
+
+          const latest = segmented.getLatest();
+          expect(latest.getKey()).toBe(key);
+          expect(latest.isSegmented()).toBe(false);
+          expect(latest.getTextContent()).toBe('JohnSmith');
+        },
+        {discrete: true},
+      );
+    });
+
+    test('insertText without composition replaces segmented node', () => {
+      testEnv.editor.update(
+        () => {
+          const segmented = $createTextNode('JohnSmith').setMode('segmented');
+          $getRoot().clear().append($createParagraphNode().append(segmented));
+
+          const sel = segmented.select(4, 4);
+          sel.insertText('');
+
+          expect(segmented.isAttached()).toBe(false);
+          const allText = $getRoot().getAllTextNodes();
+          expect(allText).toHaveLength(1);
+          expect(allText[0].getKey()).not.toBe(segmented.getKey());
+          expect(allText[0].getTextContent()).toBe('JohnSmith');
+        },
+        {discrete: true},
+      );
+    });
+
+    test('insertText during composition preserves format and style', () => {
+      testEnv.editor.update(
+        () => {
+          const segmented = $createTextNode('JohnSmith')
+            .setMode('segmented')
+            .setFormat('bold');
+          $getRoot().clear().append($createParagraphNode().append(segmented));
+          const key = segmented.getKey();
+
+          $setCompositionKey(key);
+          const sel = segmented.select(4, 4);
+          sel.format = 1; // bold
+          sel.insertText('');
+
+          const latest = segmented.getLatest();
+          expect(latest.isAttached()).toBe(true);
+          expect(latest.getKey()).toBe(key);
+          expect(latest.getFormat()).toBe(1);
+        },
+        {discrete: true},
+      );
     });
   });
 });

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -826,6 +826,12 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
   /**
    * Sets the mode of the node.
    *
+   * Note: during IME composition, a segmented TextNode may be temporarily
+   * switched to normal mode to preserve the DOM element that the browser's
+   * composition tracker is bound to. Subclass transforms or method overrides
+   * that assume the node is always in segmented mode should account for this
+   * transient state.
+   *
    * @returns this TextNode.
    */
   setMode(type: TextModeType): this {


### PR DESCRIPTION
## Breaking Change

During IME composition, a segmented TextNode may be temporarily switched to normal mode to preserve the DOM element that the browser's composition tracker is bound to. Subclass transforms or method overrides that assume the node is always in segmented mode should account for this transient state.

## Description

IME composition breaks when it starts in the middle of a segmented TextNode (e.g. MentionNode). Typing a few characters, the composition text appears correctly, but the mention's background color bleeds into the composed text and the cursor briefly flashes before the first character on Chrome.

The root cause is in `insertText`: when the caret is in the middle of a segmented node, the code calls `replace()` to swap it with a plain TextNode. This destroys the original DOM element and creates a new one — but the browser's composition tracker is bound to the original element, so the replacement breaks the active composition session.

### Fix

During composition (`$getCompositionKey() !== null`), use `setMode('normal')` instead of `replace()`. This changes the node's internal mode while keeping the same node key, so the reconciler calls `updateDOM` on the existing DOM element rather than creating a new one. The browser's composition tracker stays attached and input continues normally.

After composition ends, the node is still a subclass instance (e.g. MentionNode) in normal mode, which means subclass-specific DOM styling (background color, class names from `createDOM`) persists. A new `$cleanupComposedSubclass` function replaces the subclass instance with a plain TextNode at composition end, clearing the stale styling. This runs from all four browser composition-end paths:

1. Chrome: `COMPOSITION_END_COMMAND` → `$onCompositionEndImpl`
2. Firefox: `onInput` defer → `$onCompositionEndImpl`
3. Safari non-Backspace: `insertFromComposition` in `$handleBeforeInput`
4. Safari Backspace: `$handleKeyDown` → `$onCompositionEndImpl`

Closes #5065

## Test plan

- [x] `pnpm vitest run --project unit` — all pass (3 new tests in `LexicalSelection.test.ts`).
  - "insertText during composition preserves node key" — verifies key preservation and mode change.
  - "insertText without composition replaces segmented node" — verifies existing replace behavior unchanged.
  - "insertText during composition preserves format and style" — verifies format/style carry over and node stays attached.
  - Tests 1 and 3 fail on pre-fix code, confirming they guard the new behavior.
- [x] Manual playground (Chrome, Firefox, Safari):
  - Type `@` to insert a MentionNode, place cursor in the middle of the mention text, start IME composition (Korean/Japanese/Chinese).
  - Chrome: no cursor flash before first character, mention background clears after composition ends.
  - Firefox: composition works, background clears on commit.
  - Safari: composition works, background clears on commit (including when ending with Return or Backspace).
- [x] tsc / prettier / eslint clean.