### PR TITLE
[scripts] Bug Fix: strip misplaced pure annotations from prod builds

### DIFF
--- a/.github/workflows/internal-registry.yml
+++ b/.github/workflows/internal-registry.yml
@@ -13,6 +13,7 @@ permissions: {}
 
 jobs:
   dependency-check:
+    if: github.repository == 'facebook/lexical'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -347,6 +347,21 @@ async function build(
           format: {ascii_only: true, preserve_annotations: true},
           module: format === 'esm',
         }),
+      isProd && {
+        name: 'strip-misplaced-pure-annotations',
+        renderChunk(/** @type {string} */ source) {
+          // terser prints the annotation of `return /*#__PURE__*/ f()` (added
+          // by @babel/preset-react for JSX) before the `return` keyword, where
+          // it no longer precedes a call expression. Bundlers ignore it there
+          // and rolldown-based Vite warns with INVALID_ANNOTATION (#8785), so
+          // drop those comments; only an annotation directly before a
+          // call/new expression has any effect.
+          return source.replace(
+            /\/\*\s*[#@]__PURE__\s*\*\/(?=\s*return\b)/g,
+            '',
+          );
+        },
+      },
       {
         name: 'lexical-comment-banner',
         renderChunk(source) {


### PR DESCRIPTION
## Description

Vite 7+ (rolldown) emits INVALID_ANNOTATION warnings when bundling the published prod bundles, e.g. `@lexical/react@0.46.0` LexicalErrorBoundary.prod.mjs and LexicalContentEditable.prod.mjs (16 occurrences across `@lexical/react` and `@lexical/devtools-core`).

`@babel/preset-react` marks compiled JSX calls pure
(`return /*#__PURE__*/jsx(...)`), and terser (run with format.preserve_annotations, still present in 5.48.0) re-attaches that comment to the enclosing return statement, printing it before the `return` keyword. A pure annotation is only meaningful directly before a call/new expression, so bundlers ignore it there and rolldown warns.

This PR adds a renderChunk step after terser that drops pure annotations immediately preceding a `return` keyword. This is semantics-preserving (the annotation has no effect in that position) and leaves valid annotations untouched. Dev builds don't run terser and are unaffected.

Closes #8785

## Test plan

### Before

Bundling every `packages/*/dist/*.prod.mjs` with rolldown reports 16 INVALID_ANNOTATION warnings, all of the form
`){/*#__PURE__*/\nreturn o(t,{...` — matching the positions reported in the issue (581..594, 1889..1902).

### After

Rebuilt with `node scripts/build.mjs --prod` and re-ran the same rolldown scan: 0 warnings in 96 files. Valid annotations such as `const E=/*#__PURE__*/a(v)` and module-scope JSX remain in the output.
