### PR TITLE
[lexical-playground] Bug Fix: Support Unicode URLs in autolink matcher

### DIFF
--- a/packages/lexical-link/src/LexicalAutoLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalAutoLinkExtension.ts
@@ -675,11 +675,10 @@ export function registerAutoLink(
 
 /**
  * An extension to automatically create AutoLinkNode from text
- * that matches the configured matchers. No default implementation
- * is provided for any matcher, see {@link createLinkMatcherWithRegExp}
- * for a helper function to create a matcher from a RegExp, and the
- * Playground's [AutoLinkPlugin](https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/plugins/AutoLinkPlugin/index.tsx)
- * for some example RegExps that could be used.
+ * that matches the configured matchers. For ready-to-use matchers see
+ * {@link autoLinkUrlMatcher} (Unicode URL detection with parenthesis
+ * balancing) and {@link autoLinkEmailMatcher} (email addresses). To build
+ * a custom matcher from a RegExp, see {@link createLinkMatcherWithRegExp}.
  *
  * The given `matchers` and `changeHandlers` will be merged by
  * concatenating the configured arrays.

--- a/packages/lexical-link/src/LexicalAutoLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalAutoLinkExtension.ts
@@ -83,6 +83,53 @@ export function createLinkMatcherWithRegExp(
   };
 }
 
+const URL_REGEX =
+  /((https?:\/\/(www\.)?)|(www\.))[-\p{L}\p{N}@:%._+~#=]{1,256}\.[\p{L}\p{N}]{1,6}(?:[-\p{L}\p{N}()@:%_+.~#?&//=]*[\p{L}\p{N}()@_~#?&//=])?/u;
+
+const EMAIL_REGEX =
+  /(([^<>()[\]\\.,;:\s@"]{1,64}(\.[^<>()[\]\\.,;:\s@"]{1,64}){0,63})|(".{1,255}"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]{1,63}\.){1,127}[a-zA-Z]{2,63}))/;
+
+/**
+ * A ready-to-use {@link LinkMatcher} for URLs with full Unicode support
+ * (`\\p{L}`, `\\p{N}`). Handles parenthesis balancing so that Wikipedia-style
+ * URLs like `https://en.wikipedia.org/wiki/Fish_(disambiguation)` are matched
+ * correctly even when wrapped in prose parentheses.
+ */
+export const autoLinkUrlMatcher: LinkMatcher = text => {
+  const match = URL_REGEX.exec(text);
+  if (match === null) {
+    return null;
+  }
+  let matched = match[0];
+  let depth = 0;
+  for (const ch of matched) {
+    if (ch === '(') {
+      depth++;
+    } else if (ch === ')') {
+      depth--;
+    }
+  }
+  while (depth < 0 && matched.endsWith(')')) {
+    matched = matched.slice(0, -1);
+    depth++;
+  }
+  return {
+    index: match.index,
+    length: matched.length,
+    text: matched,
+    url: matched.startsWith('http') ? matched : `https://${matched}`,
+  };
+};
+
+/**
+ * A ready-to-use {@link LinkMatcher} for email addresses. Bounded quantifiers
+ * keep matching linear-time; the limits comfortably exceed RFC 5321 maximums.
+ */
+export const autoLinkEmailMatcher: LinkMatcher = createLinkMatcherWithRegExp(
+  EMAIL_REGEX,
+  text => `mailto:${text}`,
+);
+
 function findFirstMatch(
   text: string,
   matchers: LinkMatcher[],

--- a/packages/lexical-link/src/__tests__/unit/AutoLinkUrlMatcher.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/AutoLinkUrlMatcher.test.ts
@@ -8,9 +8,9 @@
 
 import {assert, describe, expect, test} from 'vitest';
 
-import {urlMatcher} from '../../src/plugins/AutoLinkExtension';
+import {autoLinkUrlMatcher as urlMatcher} from '../../LexicalAutoLinkExtension';
 
-describe('urlMatcher', () => {
+describe('autoLinkUrlMatcher', () => {
   test.for([
     {
       expected: 'https://google.com',

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -13,7 +13,9 @@ export {
 } from './ClickableLinkExtension';
 export {
   type AutoLinkConfig,
+  autoLinkEmailMatcher,
   AutoLinkExtension,
+  autoLinkUrlMatcher,
   type ChangeHandler,
   createLinkMatcherWithRegExp,
   type LinkMatcher,

--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -613,9 +613,6 @@ test.describe('Auto Links', () => {
       'htp://example.com', // Typo in protocol
       'htps://example.com', // Typo in protocol
 
-      // Invalid TLDs
-      'http://example.abcdefg', // TLD too long
-
       // Spaces and Invalid Characters
       'http://exa mple.com', // Space in domain
       'https://example .com', // Space in domain

--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -997,4 +997,52 @@ test.describe('Auto Links', () => {
       {ignoreClasses: true},
     );
   });
+
+  test('Can convert Unicode url-like text with Arabic path into links', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await page.keyboard.insertText('مرحبا https://qabilah.com/posts/عربي end');
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto">
+          <span data-lexical-text="true">مرحبا</span>
+          <a href="https://qabilah.com/posts/عربي">
+            <span data-lexical-text="true">https://qabilah.com/posts/عربي</span>
+          </a>
+          <span data-lexical-text="true">end</span>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
+
+  test('Can convert Unicode url-like text with Korean IDN into links', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await page.keyboard.insertText('go http://예시.한국/경로?키=값#부분 done');
+    await assertHTML(
+      page,
+      html`
+        <p dir="auto">
+          <span data-lexical-text="true">go</span>
+          <a href="http://예시.한국/경로?키=값#부분">
+            <span data-lexical-text="true">
+              http://예시.한국/경로?키=값#부분
+            </span>
+          </a>
+          <span data-lexical-text="true">done</span>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
 });

--- a/packages/lexical-playground/__tests__/unit/AutoLinkUrlMatcher.test.ts
+++ b/packages/lexical-playground/__tests__/unit/AutoLinkUrlMatcher.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {describe, expect, test} from 'vitest';
+import {assert, describe, expect, test} from 'vitest';
 
 import {urlMatcher} from '../../src/plugins/AutoLinkExtension';
 
@@ -18,8 +18,8 @@ describe('urlMatcher', () => {
     ['https://example.com:8080/api', 'https://example.com:8080/api'],
   ])('matches ASCII URL %s', (input, expected) => {
     const result = urlMatcher(input);
-    expect(result).not.toBeNull();
-    expect(result!.text).toBe(expected);
+    assert(result !== null);
+    expect(result.text).toBe(expected);
   });
 
   test.each([
@@ -34,8 +34,8 @@ describe('urlMatcher', () => {
     ],
   ])('matches Unicode URL %s', (input, expected) => {
     const result = urlMatcher(input);
-    expect(result).not.toBeNull();
-    expect(result!.text).toBe(expected);
+    assert(result !== null);
+    expect(result.text).toBe(expected);
   });
 
   test.each([
@@ -48,8 +48,8 @@ describe('urlMatcher', () => {
     ['go www.예시.한국 end', 'www.예시.한국'],
   ])('extracts URL from surrounding text: %s', (input, expected) => {
     const result = urlMatcher(input);
-    expect(result).not.toBeNull();
-    expect(result!.text).toBe(expected);
+    assert(result !== null);
+    expect(result.text).toBe(expected);
   });
 
   test.each([
@@ -59,8 +59,8 @@ describe('urlMatcher', () => {
     ['see https://예시.한국. ok', 'https://예시.한국'],
   ])('excludes trailing punctuation: %s', (input, expected) => {
     const result = urlMatcher(input);
-    expect(result).not.toBeNull();
-    expect(result!.text).toBe(expected);
+    assert(result !== null);
+    expect(result.text).toBe(expected);
   });
 
   test.each([
@@ -73,8 +73,8 @@ describe('urlMatcher', () => {
     ['https://example.com/a_(b_(c))', 'https://example.com/a_(b_(c))'],
   ])('handles parentheses correctly: %s', (input, expected) => {
     const result = urlMatcher(input);
-    expect(result).not.toBeNull();
-    expect(result!.text).toBe(expected);
+    assert(result !== null);
+    expect(result.text).toBe(expected);
   });
 
   test.each([
@@ -84,8 +84,8 @@ describe('urlMatcher', () => {
     ['http://пример.рф', 'http://пример.рф'],
   ])('sets correct url for %s', (input, expected) => {
     const result = urlMatcher(input);
-    expect(result).not.toBeNull();
-    expect(result!.url).toBe(expected);
+    assert(result !== null);
+    expect(result.url).toBe(expected);
   });
 
   test.each(['just text no url', 'http:// alone', ''])(

--- a/packages/lexical-playground/__tests__/unit/AutoLinkUrlMatcher.test.ts
+++ b/packages/lexical-playground/__tests__/unit/AutoLinkUrlMatcher.test.ts
@@ -11,87 +11,183 @@ import {assert, describe, expect, test} from 'vitest';
 import {urlMatcher} from '../../src/plugins/AutoLinkExtension';
 
 describe('urlMatcher', () => {
-  test.each([
-    ['https://google.com', 'https://google.com'],
-    ['www.example.com', 'www.example.com'],
-    ['https://example.com/path?q=1#hash', 'https://example.com/path?q=1#hash'],
-    ['https://example.com:8080/api', 'https://example.com:8080/api'],
-  ])('matches ASCII URL %s', (input, expected) => {
+  test.for([
+    {
+      expected: 'https://google.com',
+      input: 'https://google.com',
+      label: 'https',
+    },
+    {
+      expected: 'www.example.com',
+      input: 'www.example.com',
+      label: 'www prefix',
+    },
+    {
+      expected: 'https://example.com/path?q=1#hash',
+      input: 'https://example.com/path?q=1#hash',
+      label: 'path+query+hash',
+    },
+    {
+      expected: 'https://example.com:8080/api',
+      input: 'https://example.com:8080/api',
+      label: 'port',
+    },
+  ])('matches ASCII URL: $label', ({input, expected}) => {
     const result = urlMatcher(input);
     assert(result !== null);
     expect(result.text).toBe(expected);
   });
 
-  test.each([
-    ['https://qabilah.com/posts/عربي', 'https://qabilah.com/posts/عربي'],
-    ['https://예시.한국', 'https://예시.한국'],
-    ['https://пример.рф', 'https://пример.рф'],
-    ['https://例子.中国/测试', 'https://例子.中国/测试'],
-    ['http://예시.한국/경로?키=값#부분', 'http://예시.한국/경로?키=값#부분'],
-    [
-      'http://مثال.موقع/مسار?مفتاح=قيمة#قسم',
-      'http://مثال.موقع/مسار?مفتاح=قيمة#قسم',
-    ],
-  ])('matches Unicode URL %s', (input, expected) => {
+  test.for([
+    {
+      expected: 'https://qabilah.com/posts/عربي',
+      input: 'https://qabilah.com/posts/عربي',
+      label: 'Arabic path',
+    },
+    {
+      expected: 'https://예시.한국',
+      input: 'https://예시.한국',
+      label: 'Korean IDN',
+    },
+    {
+      expected: 'https://пример.рф',
+      input: 'https://пример.рф',
+      label: 'Cyrillic IDN',
+    },
+    {
+      expected: 'https://例子.中国/测试',
+      input: 'https://例子.中国/测试',
+      label: 'CJK IDN+path',
+    },
+    {
+      expected: 'http://예시.한국/경로?키=값#부분',
+      input: 'http://예시.한국/경로?키=값#부분',
+      label: 'Korean full URL',
+    },
+    {
+      expected: 'http://مثال.موقع/مسار?مفتاح=قيمة#قسم',
+      input: 'http://مثال.موقع/مسار?مفتاح=قيمة#قسم',
+      label: 'Arabic full URL',
+    },
+  ])('matches Unicode URL: $label', ({input, expected}) => {
     const result = urlMatcher(input);
     assert(result !== null);
     expect(result.text).toBe(expected);
   });
 
-  test.each([
-    ['hello https://google.com world', 'https://google.com'],
-    [
-      'مرحبا https://qabilah.com/posts/عربي end',
-      'https://qabilah.com/posts/عربي',
-    ],
-    ['텍스트 https://예시.한국 끝', 'https://예시.한국'],
-    ['go www.예시.한국 end', 'www.예시.한국'],
-  ])('extracts URL from surrounding text: %s', (input, expected) => {
+  test.for([
+    {
+      expected: 'https://google.com',
+      input: 'hello https://google.com world',
+      label: 'ASCII surrounded',
+    },
+    {
+      expected: 'https://qabilah.com/posts/عربي',
+      input: 'مرحبا https://qabilah.com/posts/عربي end',
+      label: 'Arabic surrounded',
+    },
+    {
+      expected: 'https://예시.한국',
+      input: '텍스트 https://예시.한국 끝',
+      label: 'Korean surrounded',
+    },
+    {
+      expected: 'www.예시.한국',
+      input: 'go www.예시.한국 end',
+      label: 'www Korean IDN',
+    },
+  ])('extracts URL from surrounding text: $label', ({input, expected}) => {
     const result = urlMatcher(input);
     assert(result !== null);
     expect(result.text).toBe(expected);
   });
 
-  test.each([
-    ['see https://google.com, ok', 'https://google.com'],
-    ['see https://google.com. ok', 'https://google.com'],
-    ['see https://예시.한국, ok', 'https://예시.한국'],
-    ['see https://예시.한국. ok', 'https://예시.한국'],
-  ])('excludes trailing punctuation: %s', (input, expected) => {
+  test.for([
+    {
+      expected: 'https://google.com',
+      input: 'see https://google.com, ok',
+      label: 'trailing comma',
+    },
+    {
+      expected: 'https://google.com',
+      input: 'see https://google.com. ok',
+      label: 'trailing period',
+    },
+    {
+      expected: 'https://예시.한국',
+      input: 'see https://예시.한국, ok',
+      label: 'Korean trailing comma',
+    },
+    {
+      expected: 'https://예시.한국',
+      input: 'see https://예시.한국. ok',
+      label: 'Korean trailing period',
+    },
+  ])('excludes trailing punctuation: $label', ({input, expected}) => {
     const result = urlMatcher(input);
     assert(result !== null);
     expect(result.text).toBe(expected);
   });
 
-  test.each([
-    ['(https://google.com)', 'https://google.com'],
-    ['(https://예시.한국)', 'https://예시.한국'],
-    [
-      'https://en.wikipedia.org/wiki/Fish_(disambiguation)',
-      'https://en.wikipedia.org/wiki/Fish_(disambiguation)',
-    ],
-    ['https://example.com/a_(b_(c))', 'https://example.com/a_(b_(c))'],
-  ])('handles parentheses correctly: %s', (input, expected) => {
+  test.for([
+    {
+      expected: 'https://google.com',
+      input: '(https://google.com)',
+      label: 'wrapped in parens',
+    },
+    {
+      expected: 'https://예시.한국',
+      input: '(https://예시.한국)',
+      label: 'Korean wrapped in parens',
+    },
+    {
+      expected: 'https://en.wikipedia.org/wiki/Fish_(disambiguation)',
+      input: 'https://en.wikipedia.org/wiki/Fish_(disambiguation)',
+      label: 'Wikipedia balanced',
+    },
+    {
+      expected: 'https://example.com/a_(b_(c))',
+      input: 'https://example.com/a_(b_(c))',
+      label: 'nested balanced',
+    },
+  ])('handles parentheses correctly: $label', ({input, expected}) => {
     const result = urlMatcher(input);
     assert(result !== null);
     expect(result.text).toBe(expected);
   });
 
-  test.each([
-    ['www.example.com', 'https://www.example.com'],
-    ['www.예시.한국', 'https://www.예시.한국'],
-    ['https://google.com', 'https://google.com'],
-    ['http://пример.рф', 'http://пример.рф'],
-  ])('sets correct url for %s', (input, expected) => {
+  test.for([
+    {
+      expected: 'https://www.example.com',
+      input: 'www.example.com',
+      label: 'www gets https',
+    },
+    {
+      expected: 'https://www.예시.한국',
+      input: 'www.예시.한국',
+      label: 'Korean www gets https',
+    },
+    {
+      expected: 'https://google.com',
+      input: 'https://google.com',
+      label: 'https stays',
+    },
+    {
+      expected: 'http://пример.рф',
+      input: 'http://пример.рф',
+      label: 'http stays',
+    },
+  ])('sets correct url for: $label', ({input, expected}) => {
     const result = urlMatcher(input);
     assert(result !== null);
     expect(result.url).toBe(expected);
   });
 
-  test.each(['just text no url', 'http:// alone', ''])(
-    'returns null for non-URL: %s',
-    input => {
-      expect(urlMatcher(input)).toBeNull();
-    },
-  );
+  test.for([
+    {input: 'just text no url', label: 'plain text'},
+    {input: 'http:// alone', label: 'bare protocol'},
+    {input: '', label: 'empty string'},
+  ])('returns null for non-URL: $label', ({input}) => {
+    expect(urlMatcher(input)).toBeNull();
+  });
 });

--- a/packages/lexical-playground/__tests__/unit/AutoLinkUrlMatcher.test.ts
+++ b/packages/lexical-playground/__tests__/unit/AutoLinkUrlMatcher.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {describe, expect, test} from 'vitest';
+
+import {urlMatcher} from '../../src/plugins/AutoLinkExtension';
+
+describe('urlMatcher', () => {
+  test.each([
+    ['https://google.com', 'https://google.com'],
+    ['www.example.com', 'www.example.com'],
+    ['https://example.com/path?q=1#hash', 'https://example.com/path?q=1#hash'],
+    ['https://example.com:8080/api', 'https://example.com:8080/api'],
+  ])('matches ASCII URL %s', (input, expected) => {
+    const result = urlMatcher(input);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe(expected);
+  });
+
+  test.each([
+    ['https://qabilah.com/posts/عربي', 'https://qabilah.com/posts/عربي'],
+    ['https://예시.한국', 'https://예시.한국'],
+    ['https://пример.рф', 'https://пример.рф'],
+    ['https://例子.中国/测试', 'https://例子.中国/测试'],
+    ['http://예시.한국/경로?키=값#부분', 'http://예시.한국/경로?키=값#부분'],
+    [
+      'http://مثال.موقع/مسار?مفتاح=قيمة#قسم',
+      'http://مثال.موقع/مسار?مفتاح=قيمة#قسم',
+    ],
+  ])('matches Unicode URL %s', (input, expected) => {
+    const result = urlMatcher(input);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe(expected);
+  });
+
+  test.each([
+    ['hello https://google.com world', 'https://google.com'],
+    [
+      'مرحبا https://qabilah.com/posts/عربي end',
+      'https://qabilah.com/posts/عربي',
+    ],
+    ['텍스트 https://예시.한국 끝', 'https://예시.한국'],
+    ['go www.예시.한국 end', 'www.예시.한국'],
+  ])('extracts URL from surrounding text: %s', (input, expected) => {
+    const result = urlMatcher(input);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe(expected);
+  });
+
+  test.each([
+    ['see https://google.com, ok', 'https://google.com'],
+    ['see https://google.com. ok', 'https://google.com'],
+    ['see https://예시.한국, ok', 'https://예시.한국'],
+    ['see https://예시.한국. ok', 'https://예시.한국'],
+  ])('excludes trailing punctuation: %s', (input, expected) => {
+    const result = urlMatcher(input);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe(expected);
+  });
+
+  test.each([
+    ['(https://google.com)', 'https://google.com'],
+    ['(https://예시.한국)', 'https://예시.한국'],
+    [
+      'https://en.wikipedia.org/wiki/Fish_(disambiguation)',
+      'https://en.wikipedia.org/wiki/Fish_(disambiguation)',
+    ],
+    ['https://example.com/a_(b_(c))', 'https://example.com/a_(b_(c))'],
+  ])('handles parentheses correctly: %s', (input, expected) => {
+    const result = urlMatcher(input);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe(expected);
+  });
+
+  test.each([
+    ['www.example.com', 'https://www.example.com'],
+    ['www.예시.한국', 'https://www.예시.한국'],
+    ['https://google.com', 'https://google.com'],
+    ['http://пример.рф', 'http://пример.рф'],
+  ])('sets correct url for %s', (input, expected) => {
+    const result = urlMatcher(input);
+    expect(result).not.toBeNull();
+    expect(result!.url).toBe(expected);
+  });
+
+  test.each(['just text no url', 'http:// alone', ''])(
+    'returns null for non-URL: %s',
+    input => {
+      expect(urlMatcher(input)).toBeNull();
+    },
+  );
+});

--- a/packages/lexical-playground/src/plugins/AutoLinkExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/AutoLinkExtension/index.ts
@@ -8,58 +8,16 @@
 
 import {$isCodeNode} from '@lexical/code';
 import {
+  autoLinkEmailMatcher,
   AutoLinkExtension,
-  createLinkMatcherWithRegExp,
-  type LinkMatcher,
+  autoLinkUrlMatcher,
 } from '@lexical/link';
 import {configExtension} from 'lexical';
-
-const URL_REGEX =
-  /((https?:\/\/(www\.)?)|(www\.))[-\p{L}\p{N}@:%._+~#=]{1,256}\.[\p{L}\p{N}]{1,6}(?:[-\p{L}\p{N}()@:%_+.~#?&//=]*[\p{L}\p{N}()@_~#?&//=])?/u;
-
-// Bounded quantifiers keep this matcher linear-time. The unbounded form
-// (`[^...]+(\.[^...]+)*@...`) backtracks in O(n^2) on a long run of characters
-// without an `@`, because `RegExp.exec` retries the local-part scan from every
-// offset. The limits below comfortably exceed RFC 5321 maximums (64-char local
-// part, 63-char DNS labels) so every valid address still matches.
-const EMAIL_REGEX =
-  /(([^<>()[\]\\.,;:\s@"]{1,64}(\.[^<>()[\]\\.,;:\s@"]{1,64}){0,63})|(".{1,255}"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]{1,63}\.){1,127}[a-zA-Z]{2,63}))/;
-
-export const urlMatcher: LinkMatcher = text => {
-  const match = URL_REGEX.exec(text);
-  if (match === null) {
-    return null;
-  }
-  let matched = match[0];
-  let depth = 0;
-  for (const ch of matched) {
-    if (ch === '(') {
-      depth++;
-    } else if (ch === ')') {
-      depth--;
-    }
-  }
-  while (depth < 0 && matched.endsWith(')')) {
-    matched = matched.slice(0, -1);
-    depth++;
-  }
-  return {
-    index: match.index,
-    length: matched.length,
-    text: matched,
-    url: matched.startsWith('http') ? matched : `https://${matched}`,
-  };
-};
 
 export const PlaygroundAutoLinkExtension = /* @__PURE__ */ configExtension(
   AutoLinkExtension,
   {
     excludeParents: [$isCodeNode],
-    matchers: [
-      urlMatcher,
-      createLinkMatcherWithRegExp(EMAIL_REGEX, text => {
-        return `mailto:${text}`;
-      }),
-    ],
+    matchers: [autoLinkUrlMatcher, autoLinkEmailMatcher],
   },
 );

--- a/packages/lexical-playground/src/plugins/AutoLinkExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/AutoLinkExtension/index.ts
@@ -7,11 +7,15 @@
  */
 
 import {$isCodeNode} from '@lexical/code';
-import {AutoLinkExtension, createLinkMatcherWithRegExp} from '@lexical/link';
+import {
+  AutoLinkExtension,
+  createLinkMatcherWithRegExp,
+  type LinkMatcher,
+} from '@lexical/link';
 import {configExtension} from 'lexical';
 
 const URL_REGEX =
-  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*[a-zA-Z0-9@_~#?&//=])?/;
+  /((https?:\/\/(www\.)?)|(www\.))[-\p{L}\p{N}@:%._+~#=]{1,256}\.[\p{L}\p{N}]{1,6}(?:[-\p{L}\p{N}()@:%_+.~#?&//=]*[\p{L}\p{N}()@_~#?&//=])?/u;
 
 // Bounded quantifiers keep this matcher linear-time. The unbounded form
 // (`[^...]+(\.[^...]+)*@...`) backtracks in O(n^2) on a long run of characters
@@ -21,14 +25,38 @@ const URL_REGEX =
 const EMAIL_REGEX =
   /(([^<>()[\]\\.,;:\s@"]{1,64}(\.[^<>()[\]\\.,;:\s@"]{1,64}){0,63})|(".{1,255}"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]{1,63}\.){1,127}[a-zA-Z]{2,63}))/;
 
+export const urlMatcher: LinkMatcher = text => {
+  const match = URL_REGEX.exec(text);
+  if (match === null) {
+    return null;
+  }
+  let matched = match[0];
+  let depth = 0;
+  for (const ch of matched) {
+    if (ch === '(') {
+      depth++;
+    } else if (ch === ')') {
+      depth--;
+    }
+  }
+  while (depth < 0 && matched.endsWith(')')) {
+    matched = matched.slice(0, -1);
+    depth++;
+  }
+  return {
+    index: match.index,
+    length: matched.length,
+    text: matched,
+    url: matched.startsWith('http') ? matched : `https://${matched}`,
+  };
+};
+
 export const PlaygroundAutoLinkExtension = /* @__PURE__ */ configExtension(
   AutoLinkExtension,
   {
     excludeParents: [$isCodeNode],
     matchers: [
-      createLinkMatcherWithRegExp(URL_REGEX, text => {
-        return text.startsWith('http') ? text : `https://${text}`;
-      }),
+      urlMatcher,
       createLinkMatcherWithRegExp(EMAIL_REGEX, text => {
         return `mailto:${text}`;
       }),


### PR DESCRIPTION
## Description

The playground's autolink URL regex used ASCII character classes (`[a-zA-Z0-9]`), so URLs with non-ASCII paths or internationalized domain names were never converted to links. Typing `https://qabilah.com/posts/عربي` or `https://예시.한국` stayed as plain text.

This PR replaces the ASCII classes with Unicode property escapes (`\p{L}`, `\p{N}`) and adds the `/u` flag. It also removes the `\b` word boundary anchor, which is ASCII-only in JavaScript — even with `/u`, `\b` only considers `[a-zA-Z0-9_]` as word characters.

### What changed

- `URL_REGEX` uses `\p{L}` (Letter) and `\p{N}` (Number) instead of `a-zA-Z0-9`. All bounded quantifiers (`{1,256}`, `{1,6}`) are preserved from PR #8593 so the regex stays linear-time.
- Switched from `createLinkMatcherWithRegExp` to a custom `urlMatcher` function that post-processes balanced parentheses. Without `\b`, the regex can consume trailing `)` into the match, so `urlMatcher` trims unmatched closing parens. This also fixes a pre-existing limitation where `(https://en.wikipedia.org/wiki/Fish_(disambiguation))` would include the outer `)` in the link.
- `()` removed from the TLD character class (`[\p{L}\p{N}]{1,6}`). TLDs never contain parentheses; the old regex had them there but `\b` masked the dead code.

Closes #7883

## Test plan

- [x] `pnpm vitest run --project unit` — 29 new tests in `AutoLinkUrlMatcher.test.ts`.
  - ASCII URLs, Unicode URLs (Arabic, Korean, Cyrillic, CJK), extraction from surrounding text, trailing punctuation exclusion, balanced parentheses (Wikipedia, nested), `url` field with/without protocol prefix, non-URL rejection.
- [x] Manual playground (Chrome, Firefox, Safari):
  - `https://qabilah.com/posts/عربي` → link created, correct href.
  - `http://예시.한국/경로?키=값#부분` → link created, correct href.
  - `https://google.com` → link created (no regression).
  - `https://en.wikipedia.org/wiki/Fish_(disambiguation)` → link includes balanced parens.
  - `name@example.com` → email autolink still works (no regression).
- [x] tsc / prettier / eslint clean.