### PR TITLE
[lexical][lexical-eslint-plugin] Feature: Add $getDocument() API and Shadow DOM lint enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,39 @@ When creating custom nodes:
 3. Register with extension or editor config: `nodes: [YourCustomNode]`
 4. Export a `$createYourNode()` factory function (follows $ convention)
 
+### Shadow DOM and iframe realm safety
+
+Lexical supports editors whose root element lives inside a Shadow DOM or an
+`<iframe>` document. The editor resolves its `window` and `document` from
+`rootElement.ownerDocument.defaultView`, so code that reaches for the **global**
+`window` or `document` will silently use the wrong realm when the editor crosses
+a frame boundary. Shadow DOM adds a second hazard: the browser **retargets**
+selection and focus reads to the shadow host, hiding the real nodes.
+
+Use the shadow/iframe-aware helpers exported from `lexical` instead of the raw
+browser globals:
+
+| Instead of | Use | Why |
+| --- | --- | --- |
+| `window` | `element.ownerDocument.defaultView` or `getDefaultView(element)` (@internal) | Returns the window that owns the element |
+| `window.getSelection()` | `getDOMSelection(rootElement.ownerDocument.defaultView)` | Reads selection from the correct window |
+| `selection.getRangeAt(0)` | `getDOMSelectionRange(selection, rootElement)` | Unwraps retargeted shadow-DOM selection |
+| `document` in `createDOM`/`updateDOM`/`exportDOM` | `$getDocument()` | Returns the document that owns the editor root (falls back to `globalThis.document`) |
+| `document` elsewhere | `getRootOwnerDocument(rootElement)` or `element.ownerDocument` | Returns the document that owns a specific element |
+| `document.activeElement` | `getActiveElement(element)` / `getActiveElementDeep(document)` | Walks through shadow roots to find the real focused element |
+| `event.target` | `getComposedEventTarget(event)` | Returns the un-retargeted target for composed events |
+| `element.parentElement` | `getParentElement(element)` | Crosses shadow boundaries correctly |
+| `selection.anchorNode` / `focusNode` | `getDOMSelectionPoints(selection, rootElement)` | Returns un-retargeted boundary points |
+
+Two ESLint rules enforce the globals rows at lint time:
+- `no-restricted-syntax` (error) catches all `document.*` and `window.*` member access in library sources.
+- `@lexical/no-document-in-dom-methods` (error, with autofix) catches `document.*` specifically inside `createDOM`/`updateDOM`/`exportDOM` methods and autofixes to `$getDocument().*`.
+
+The remaining rows involve local variable properties that lint cannot reliably detect, so they must be caught in code review.
+
+For full details on the browser platform APIs involved, see
+[Shadow DOM and iframes](packages/lexical-website/docs/concepts/shadow-dom.md).
+
 ### Build System
 - Uses Rollup for bundling
 - Build script: `scripts/build.mjs`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -404,6 +404,40 @@ export default [
     },
   },
 
+  // Override: Library sources — ban direct `document.X` and `window.X` member
+  // access so editors inside Shadow DOM or cross-frame iframes use the correct
+  // realm. Uses `no-restricted-syntax` with MemberExpression selectors so that
+  // `typeof window/document` (SSR guards) and helper definitions in
+  // LexicalUtils.ts that use parameters (not globals) are exempt automatically.
+  // See AGENTS.md "Shadow DOM and iframe realm safety" for the full pattern table.
+  {
+    files: ['packages/**/src/**'],
+    ignores: [
+      'packages/**/__tests__/**',
+      'packages/**/__bench__/**',
+      'packages/lexical-playground/**',
+      'packages/lexical-devtools/**',
+      'packages/lexical-website/**',
+    ],
+    rules: {
+      '@lexical/no-document-in-dom-methods': ERROR,
+      'no-restricted-syntax': [
+        ERROR,
+        'WithStatement',
+        {
+          message:
+            'Use $getDocument(), ownerDocument, or getRootOwnerDocument() instead of document.* for Shadow DOM / iframe safety. See AGENTS.md.',
+          selector: 'MemberExpression[object.name="document"]',
+        },
+        {
+          message:
+            'Use getDefaultView() or getWindow() instead of window.* for Shadow DOM / iframe safety. See AGENTS.md.',
+          selector: 'MemberExpression[object.name="window"]',
+        },
+      ],
+    },
+  },
+
   // Override: Package sources - require /* @__PURE__ */ annotations on
   // module-scope calls to the side-effect-free lexical factories
   // (defineExtension, createCommand, defineImportRule, ...) so bundlers

--- a/packages/lexical-clipboard/src/ClipboardImportExtension.ts
+++ b/packages/lexical-clipboard/src/ClipboardImportExtension.ts
@@ -164,7 +164,9 @@ export const DEFAULT_IMPORT_MIME_TYPE_PRIORITY: ImportMimeTypePriority = {
 };
 
 function trustHTML(html: string): string | TrustedHTML {
+  // eslint-disable-next-line no-restricted-syntax
   if (window.trustedTypes && window.trustedTypes.createPolicy) {
+    // eslint-disable-next-line no-restricted-syntax
     const policy = window.trustedTypes.createPolicy('lexical', {
       createHTML: input => input,
     });

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -30,6 +30,7 @@ import {
   $createLineBreakNode,
   $createParagraphNode,
   $createTabNode,
+  $getDocument,
   $getEditor,
   $isLineBreakNode,
   $isTabNode,
@@ -112,7 +113,7 @@ export class CodeNode extends ElementNode {
 
   // View
   createDOM(config: EditorConfig): HTMLElement {
-    const element = document.createElement('code');
+    const element = $getDocument().createElement('code');
     addClassNamesToElement(element, config.theme.code);
     element.setAttribute('spellcheck', 'false');
     const language = this.getLanguage();
@@ -183,7 +184,7 @@ export class CodeNode extends ElementNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = document.createElement('pre');
+    const element = $getDocument().createElement('pre');
     addClassNamesToElement(element, editor._config.theme.code);
     element.setAttribute('spellcheck', 'false');
     const language = this.getLanguage();

--- a/packages/lexical-code-prism/src/FacadePrism.ts
+++ b/packages/lexical-code-prism/src/FacadePrism.ts
@@ -39,6 +39,7 @@ declare global {
 }
 
 export const Prism: typeof import('prismjs') =
+  // eslint-disable-next-line no-restricted-syntax
   (globalThis as {Prism?: typeof import('prismjs')}).Prism || window.Prism;
 
 export const CODE_LANGUAGE_FRIENDLY_NAME_MAP: Record<string, string> = {

--- a/packages/lexical-devtools-core/src/generateContent.ts
+++ b/packages/lexical-devtools-core/src/generateContent.ts
@@ -588,6 +588,7 @@ function $printSelectedCharsLine({
 }
 
 function printPrettyHTML(str: string) {
+  // eslint-disable-next-line no-restricted-syntax
   const div = document.createElement('div');
   div.innerHTML = str.trim();
   return prettifyHTML(div, 0).innerHTML;
@@ -599,10 +600,12 @@ function prettifyHTML(node: Element, level: number) {
   let textNode;
 
   for (let i = 0; i < node.children.length; i++) {
+    // eslint-disable-next-line no-restricted-syntax
     textNode = document.createTextNode('\n' + indentBefore);
     node.insertBefore(textNode, node.children[i]);
     prettifyHTML(node.children[i], level);
     if (node.lastElementChild === node.children[i]) {
+      // eslint-disable-next-line no-restricted-syntax
       textNode = document.createTextNode('\n' + indentAfter);
       node.appendChild(textNode);
     }

--- a/packages/lexical-eslint-plugin/src/LexicalEslintPlugin.js
+++ b/packages/lexical-eslint-plugin/src/LexicalEslintPlugin.js
@@ -9,6 +9,9 @@
 // @ts-check
 
 const {name, version} = require('../package.json');
+const {
+  noDocumentInDomMethods,
+} = require('./rules/no-document-in-dom-methods.js');
 const {rulesOfLexical} = require('./rules/rules-of-lexical.js');
 
 // Legacy config format (ESLint 7-8)
@@ -32,6 +35,7 @@ const plugin = {
   },
   meta: {name, version},
   rules: {
+    'no-document-in-dom-methods': noDocumentInDomMethods,
     'rules-of-lexical': rulesOfLexical,
   },
 };

--- a/packages/lexical-eslint-plugin/src/__tests__/unit/no-document-in-dom-methods.test.ts
+++ b/packages/lexical-eslint-plugin/src/__tests__/unit/no-document-in-dom-methods.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {RuleTester} from 'eslint';
+import {describe, it} from 'vitest';
+
+import plugin from '../../LexicalEslintPlugin.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+describe('no-document-in-dom-methods', () => {
+  const rule = plugin.rules['no-document-in-dom-methods'];
+
+  it('reports and fixes document inside class method createDOM', () => {
+    ruleTester.run('createDOM-class', rule, {
+      invalid: [
+        {
+          code: `class MyNode extends ElementNode {
+  createDOM() {
+    return document.createElement('div');
+  }
+}`,
+          errors: [{messageId: 'noDocumentInDomMethods'}],
+          output: `class MyNode extends ElementNode {
+  createDOM() {
+    return $getDocument().createElement('div');
+  }
+}`,
+        },
+      ],
+      valid: [],
+    });
+  });
+
+  it('reports and fixes document inside updateDOM', () => {
+    ruleTester.run('updateDOM-class', rule, {
+      invalid: [
+        {
+          code: `class MyNode extends ElementNode {
+  updateDOM(prev, dom) {
+    const span = document.createElement('span');
+    dom.appendChild(span);
+  }
+}`,
+          errors: [{messageId: 'noDocumentInDomMethods'}],
+          output: `class MyNode extends ElementNode {
+  updateDOM(prev, dom) {
+    const span = $getDocument().createElement('span');
+    dom.appendChild(span);
+  }
+}`,
+        },
+      ],
+      valid: [],
+    });
+  });
+
+  it('reports multiple document references in exportDOM', () => {
+    ruleTester.run('exportDOM-multiple', rule, {
+      invalid: [
+        {
+          code: `class MyNode extends DecoratorNode {
+  exportDOM() {
+    const el = document.createElement('div');
+    el.textContent = document.title;
+    return { element: el };
+  }
+}`,
+          errors: [
+            {messageId: 'noDocumentInDomMethods'},
+            {messageId: 'noDocumentInDomMethods'},
+          ],
+          output: `class MyNode extends DecoratorNode {
+  exportDOM() {
+    const el = $getDocument().createElement('div');
+    el.textContent = $getDocument().title;
+    return { element: el };
+  }
+}`,
+        },
+      ],
+      valid: [],
+    });
+  });
+
+  it('reports document inside $decorateDOM', () => {
+    ruleTester.run('$decorateDOM', rule, {
+      invalid: [
+        {
+          code: `class MyNode extends DecoratorNode {
+  $decorateDOM() {
+    return document.createTextNode('hello');
+  }
+}`,
+          errors: [{messageId: 'noDocumentInDomMethods'}],
+          output: `class MyNode extends DecoratorNode {
+  $decorateDOM() {
+    return $getDocument().createTextNode('hello');
+  }
+}`,
+        },
+      ],
+      valid: [],
+    });
+  });
+
+  it('reports document inside object-literal createDOM (Property node)', () => {
+    ruleTester.run('createDOM-property', rule, {
+      invalid: [
+        {
+          code: `const config = {
+  createDOM() {
+    return document.createElement('div');
+  }
+}`,
+          errors: [{messageId: 'noDocumentInDomMethods'}],
+          output: `const config = {
+  createDOM() {
+    return $getDocument().createElement('div');
+  }
+}`,
+        },
+      ],
+      valid: [],
+    });
+  });
+
+  it('reports document in nested function inside DOM method', () => {
+    ruleTester.run('nested-function', rule, {
+      invalid: [
+        {
+          code: `class MyNode extends ElementNode {
+  createDOM() {
+    function helper() {
+      return document.createElement('span');
+    }
+    return helper();
+  }
+}`,
+          errors: [{messageId: 'noDocumentInDomMethods'}],
+          output: `class MyNode extends ElementNode {
+  createDOM() {
+    function helper() {
+      return $getDocument().createElement('span');
+    }
+    return helper();
+  }
+}`,
+        },
+      ],
+      valid: [],
+    });
+  });
+
+  it('ignores document outside DOM methods', () => {
+    ruleTester.run('outside-dom-method', rule, {
+      invalid: [],
+      valid: [
+        {
+          code: `function setup() {
+  return document.createElement('div');
+}`,
+        },
+      ],
+    });
+  });
+
+  it('ignores $getDocument() already used', () => {
+    ruleTester.run('already-fixed', rule, {
+      invalid: [],
+      valid: [
+        {
+          code: `class MyNode extends ElementNode {
+  createDOM() {
+    return $getDocument().createElement('div');
+  }
+}`,
+        },
+      ],
+    });
+  });
+
+  it('ignores non-DOM methods on the same class', () => {
+    ruleTester.run('non-dom-method', rule, {
+      invalid: [],
+      valid: [
+        {
+          code: `class MyNode extends ElementNode {
+  serialize() {
+    return document.title;
+  }
+}`,
+        },
+      ],
+    });
+  });
+});

--- a/packages/lexical-eslint-plugin/src/index.ts
+++ b/packages/lexical-eslint-plugin/src/index.ts
@@ -41,6 +41,7 @@ export interface Plugin {
     version: string;
   };
   rules: {
+    'no-document-in-dom-methods': Rule.RuleModule;
     'rules-of-lexical': Rule.RuleModule;
   };
   configs: {

--- a/packages/lexical-eslint-plugin/src/rules/no-document-in-dom-methods.js
+++ b/packages/lexical-eslint-plugin/src/rules/no-document-in-dom-methods.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+// @ts-check
+
+/**
+ * @typedef {import('eslint').Rule.RuleModule} RuleModule
+ * @typedef {import('eslint').Rule.Node} Node
+ */
+
+const DOM_METHOD_NAMES = new Set([
+  'createDOM',
+  'updateDOM',
+  'exportDOM',
+  '$decorateDOM',
+]);
+
+/** @type {RuleModule} */
+module.exports.noDocumentInDomMethods = {
+  create(context) {
+    // Tracks nesting depth inside DOM method bodies. Does not reset at nested
+    // function boundaries — acceptable since DOM methods don't define callbacks
+    // that escape to non-editor contexts in practice.
+    let depth = 0;
+
+    /**
+     * @param {Node} node
+     * @returns {boolean}
+     */
+    function isDOMMethodNode(node) {
+      return (
+        (node.type === 'MethodDefinition' || node.type === 'Property') &&
+        node.key.type === 'Identifier' &&
+        DOM_METHOD_NAMES.has(node.key.name)
+      );
+    }
+
+    /**
+     * @param {Node} node
+     */
+    function enterMethod(node) {
+      if (isDOMMethodNode(node)) {
+        depth++;
+      }
+    }
+
+    /**
+     * @param {Node} node
+     */
+    function exitMethod(node) {
+      if (isDOMMethodNode(node)) {
+        depth--;
+      }
+    }
+
+    return {
+      MemberExpression(node) {
+        if (
+          depth > 0 &&
+          node.object.type === 'Identifier' &&
+          node.object.name === 'document'
+        ) {
+          context.report({
+            fix(fixer) {
+              return fixer.replaceText(node.object, '$getDocument()');
+            },
+            messageId: 'noDocumentInDomMethods',
+            node: node.object,
+          });
+        }
+      },
+      MethodDefinition: enterMethod,
+      'MethodDefinition:exit': exitMethod,
+      Property: enterMethod,
+      'Property:exit': exitMethod,
+    };
+  },
+  meta: {
+    docs: {
+      description:
+        'Disallow bare `document` global inside createDOM/updateDOM/exportDOM/$decorateDOM (class methods and object properties) and provide an autofix to $getDocument()',
+      recommended: true,
+      url: 'https://lexical.dev/docs/concepts/shadow-dom',
+    },
+    fixable: 'code',
+    messages: {
+      noDocumentInDomMethods:
+        'Use $getDocument() instead of `document` inside DOM methods for Shadow DOM / iframe safety. Note: autofix replaces the identifier but does not add the import.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+};

--- a/packages/lexical-extension/src/DecoratorTextExtension.ts
+++ b/packages/lexical-extension/src/DecoratorTextExtension.ts
@@ -19,6 +19,7 @@ import type {
 } from 'lexical';
 
 import {
+  $getDocument,
   $getState,
   $setState,
   createState,
@@ -83,7 +84,7 @@ export class DecoratorTextNode
   }
 
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    return document.createElement('span');
+    return $getDocument().createElement('span');
   }
 }
 
@@ -155,24 +156,26 @@ export function applyFormatFromStyle(
  * @param tagNameToFormat Tag name and format mapping
  * @returns domNode
  */
-export function applyFormatToDom(
+export function $applyFormatToDom(
   lexicalNode: DecoratorTextNode,
   domNode: Text | HTMLElement,
   tagNameToFormat = DEFAULT_TAG_NAME_TO_FORMAT,
 ) {
   for (const [tag, format] of Object.entries(tagNameToFormat)) {
     if (lexicalNode.hasFormat(format)) {
-      domNode = wrapElementWith(domNode, tag);
+      domNode = $wrapElementWith(domNode, tag);
     }
   }
   return domNode;
 }
+/** @deprecated renamed to {@link $applyFormatToDom} by @lexical/eslint-plugin rules-of-lexical */
+export const applyFormatToDom = $applyFormatToDom;
 
-function wrapElementWith(
+function $wrapElementWith(
   element: HTMLElement | Text,
   tag: string,
 ): HTMLElement {
-  const el = document.createElement(tag);
+  const el = $getDocument().createElement(tag);
   el.appendChild(element);
   return el;
 }

--- a/packages/lexical-extension/src/HorizontalRuleExtension.ts
+++ b/packages/lexical-extension/src/HorizontalRuleExtension.ts
@@ -22,6 +22,7 @@ import {$insertNodeToNearestRoot} from '@lexical/utils';
 import {
   $create,
   $createNodeSelection,
+  $getDocument,
   $getNodeFromDOMNode,
   $getSelection,
   $isNodeSelection,
@@ -82,11 +83,11 @@ export class HorizontalRuleNode extends DecoratorNode<unknown> {
   }
 
   exportDOM(): DOMExportOutput {
-    return {element: document.createElement('hr')};
+    return {element: $getDocument().createElement('hr')};
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const element = document.createElement('hr');
+    const element = $getDocument().createElement('hr');
     addClassNamesToElement(element, config.theme.hr);
     return element;
   }

--- a/packages/lexical-extension/src/index.ts
+++ b/packages/lexical-extension/src/index.ts
@@ -20,6 +20,7 @@ export {
 } from './ClickAfterLastBlockExtension';
 export {getKnownTypesAndNodes, type KnownTypesAndNodes} from './config';
 export {
+  $applyFormatToDom,
   $isDecoratorTextNode,
   applyFormatFromStyle,
   applyFormatToDom,

--- a/packages/lexical-file/src/fileImportExport.ts
+++ b/packages/lexical-file/src/fileImportExport.ts
@@ -74,6 +74,7 @@ export function importFile(editor: LexicalEditor) {
 }
 
 function readTextFileFromSystem(callback: (text: string) => void) {
+  // eslint-disable-next-line no-restricted-syntax
   const input = document.createElement('input');
   input.type = 'file';
   input.accept = '.lexical';
@@ -123,7 +124,9 @@ export function exportFile(
 
 // Adapted from https://stackoverflow.com/a/19328891/2013580
 function exportBlob(data: SerializedDocument, fileName: string) {
+  // eslint-disable-next-line no-restricted-syntax
   const a = document.createElement('a');
+  // eslint-disable-next-line no-restricted-syntax
   const body = document.body;
 
   if (body === null) {
@@ -136,10 +139,12 @@ function exportBlob(data: SerializedDocument, fileName: string) {
   const blob = new Blob([json], {
     type: 'octet/stream',
   });
+  // eslint-disable-next-line no-restricted-syntax
   const url = window.URL.createObjectURL(blob);
   a.href = url;
   a.download = fileName;
   a.click();
+  // eslint-disable-next-line no-restricted-syntax
   window.URL.revokeObjectURL(url);
   a.remove();
 }

--- a/packages/lexical-headless/src/dom.ts
+++ b/packages/lexical-headless/src/dom.ts
@@ -14,6 +14,7 @@ function createWindow(): typeof globalThis.window & HappyDOMWindow {
 }
 
 function destroyWindow(window: HappyDOMWindow): void {
+  // eslint-disable-next-line no-restricted-syntax
   void window.happyDOM.close();
 }
 

--- a/packages/lexical-html/src/DOMRenderExtension.ts
+++ b/packages/lexical-html/src/DOMRenderExtension.ts
@@ -8,7 +8,12 @@
 import type {DOMRenderConfig, DOMRenderExtensionOutput} from './types';
 import type {InitialEditorConfig} from 'lexical';
 
-import {defineExtension, RootNode, shallowMergeConfig} from 'lexical';
+import {
+  $getDocument,
+  defineExtension,
+  RootNode,
+  shallowMergeConfig,
+} from 'lexical';
 
 import {compileDOMRenderConfigOverrides} from './compileDOMRenderConfigOverrides';
 import {DOMRenderExtensionName} from './constants';
@@ -62,7 +67,7 @@ export const DOMRenderExtension = /* @__PURE__ */ defineExtension<
       [
         RootNode,
         () => {
-          const element = document.createElement('div');
+          const element = $getDocument().createElement('div');
           element.role = 'textbox';
           return {element};
         },

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -23,6 +23,7 @@ import {
   $assumeActiveEditor,
   $createLineBreakNode,
   $createParagraphNode,
+  $getDocument,
   $getEditor,
   $getEditorDOMRenderConfig,
   $getRoot,
@@ -270,8 +271,11 @@ export function $generateHtmlFromNodes(
   // If the caller is in a legacy `editorState.read(cb)` scope (no active editor),
   // establish one via internal API.
   $assumeActiveEditor(editor);
-  return $generateDOMFromNodes(document.createElement('div'), selection, editor)
-    .innerHTML;
+  return $generateDOMFromNodes(
+    $getDocument().createElement('div'),
+    selection,
+    editor,
+  ).innerHTML;
 }
 
 function $appendNodesToHTML(
@@ -299,7 +303,7 @@ function $appendNodesToHTML(
     return false;
   }
 
-  const fragment = document.createDocumentFragment();
+  const fragment = $getDocument().createDocumentFragment();
   const children = $getChildNodes
     ? $getChildNodes()
     : $isElementNode(target)

--- a/packages/lexical-link/src/ClickableLinkExtension.ts
+++ b/packages/lexical-link/src/ClickableLinkExtension.ts
@@ -95,6 +95,7 @@ export function registerClickableLink(
     }
 
     const isMiddle = event.type === 'auxclick' && event.button === 1;
+    // eslint-disable-next-line no-restricted-syntax
     window.open(
       url,
       stores.newTab.peek() ||

--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -29,6 +29,7 @@ import {
   $copyNode,
   $findMatchingParent,
   $getChildCaret,
+  $getDocument,
   $getSelection,
   $insertNodeToNearestRootAtCaret,
   $isElementNode,
@@ -119,7 +120,7 @@ export class LinkNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): LinkHTMLElementType {
-    const element = document.createElement('a');
+    const element = $getDocument().createElement('a');
     this.updateLinkDOM(null, element, config);
     addClassNamesToElement(element, config.theme.link);
     return element;
@@ -525,7 +526,7 @@ export class AutoLinkNode extends LinkNode {
 
   createDOM(config: EditorConfig): LinkHTMLElementType {
     if (this.__isUnlinked) {
-      return document.createElement('span');
+      return $getDocument().createElement('span');
     } else {
       return super.createDOM(config);
     }

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -27,6 +27,7 @@ import {
   $applyNodeReplacement,
   $copyNode,
   $createParagraphNode,
+  $getDocument,
   $getSelection,
   $getSiblingCaret,
   $insertNodeToNearestRootAtCaret,
@@ -164,7 +165,7 @@ export class ListItemNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const element = document.createElement('li');
+    const element = $getDocument().createElement('li');
     this.updateListItemDOM(null, element, config);
 
     return element;

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -9,6 +9,7 @@
 import {
   $applyNodeReplacement,
   $createTextNode,
+  $getDocument,
   $isElementNode,
   $setDirectionFromDOM,
   addClassNamesToElement,
@@ -123,7 +124,7 @@ export class ListNode extends ElementNode {
 
   createDOM(config: EditorConfig, _editor?: LexicalEditor): HTMLElement {
     const tag = this.__tag;
-    const dom = document.createElement(tag);
+    const dom = $getDocument().createElement(tag);
 
     if (this.__start !== 1) {
       dom.setAttribute('start', String(this.__start));

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -307,8 +307,9 @@ function handleCheckItemEvent(
   const clientXInPixels = clientX / zoom;
 
   // Use getComputedStyle if available, otherwise fallback to 0px width
-  const beforeStyles = window.getComputedStyle
-    ? window.getComputedStyle(target, '::before')
+  const targetView = target.ownerDocument.defaultView;
+  const beforeStyles = targetView
+    ? targetView.getComputedStyle(target, '::before')
     : ({width: '0px'} as CSSStyleDeclaration);
   const beforeWidthInPixels = parseFloat(beforeStyles.width);
 

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -19,6 +19,7 @@ import type {
 
 import {
   $applyNodeReplacement,
+  $getDocument,
   $isRangeSelection,
   addClassNamesToElement,
   ElementNode,
@@ -77,7 +78,7 @@ export class MarkNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const element = document.createElement('mark');
+    const element = $getDocument().createElement('mark');
     addClassNamesToElement(element, config.theme.mark);
     if (this.__ids.length > 1) {
       addClassNamesToElement(element, config.theme.markOverlap);

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -13,7 +13,12 @@ import type {
   SerializedElementNode,
 } from 'lexical';
 
-import {$applyNodeReplacement, defineExtension, ElementNode} from 'lexical';
+import {
+  $applyNodeReplacement,
+  $getDocument,
+  defineExtension,
+  ElementNode,
+} from 'lexical';
 
 export type SerializedOverflowNode = SerializedElementNode;
 
@@ -32,7 +37,7 @@ export class OverflowNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const div = document.createElement('span');
+    const div = $getDocument().createElement('span');
     const className = config.theme.characterLimit;
     if (typeof className === 'string') {
       div.className = className;

--- a/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
@@ -18,11 +18,13 @@ const CHARACTER_LIMIT = 5;
 let textEncoderInstance: null | TextEncoder = null;
 
 function textEncoder(): null | TextEncoder {
+  // eslint-disable-next-line no-restricted-syntax
   if (window.TextEncoder === undefined) {
     return null;
   }
 
   if (textEncoderInstance === null) {
+    // eslint-disable-next-line no-restricted-syntax
     textEncoderInstance = new window.TextEncoder();
   }
 

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
@@ -16,7 +16,7 @@ import type {
 } from 'lexical';
 import type {JSX} from 'react';
 
-import {DecoratorNode} from 'lexical';
+import {$getDocument, DecoratorNode} from 'lexical';
 
 /**
  * The serialized form of a {@link DecoratorBlockNode}: the base serialized node
@@ -69,7 +69,7 @@ export class DecoratorBlockNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(): HTMLElement {
-    return document.createElement('div');
+    return $getDocument().createElement('div');
   }
 
   updateDOM(): false {

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -77,13 +77,16 @@ function getCollapsedMargins(elem: HTMLElement): {
   marginTop: number;
   marginBottom: number;
 } {
+  const view = elem.ownerDocument.defaultView;
   const getMargin = (
     element: Element | null,
     margin: 'marginTop' | 'marginBottom',
   ): number =>
-    element ? parseFloat(window.getComputedStyle(element)[margin]) : 0;
+    element && view ? parseFloat(view.getComputedStyle(element)[margin]) : 0;
 
-  const {marginTop, marginBottom} = window.getComputedStyle(elem);
+  const {marginTop = '0', marginBottom = '0'} = view
+    ? view.getComputedStyle(elem)
+    : {};
   const prevElemSiblingMarginBottom = getMargin(
     elem.previousElementSibling,
     'marginBottom',
@@ -203,12 +206,17 @@ function setMenuPosition(
   }
 
   const targetRect = targetElem.getBoundingClientRect();
-  const targetStyle = window.getComputedStyle(targetElem);
+  const targetView = targetElem.ownerDocument.defaultView;
+  const targetStyle = targetView
+    ? targetView.getComputedStyle(targetElem)
+    : null;
   const floatingElemRect = floatingElem.getBoundingClientRect();
   const anchorElementRect = anchorElem.getBoundingClientRect();
 
   // top left
-  let targetCalculateHeight: number = parseInt(targetStyle.lineHeight, 10);
+  let targetCalculateHeight: number = targetStyle
+    ? parseInt(targetStyle.lineHeight, 10)
+    : NaN;
   if (isNaN(targetCalculateHeight)) {
     // middle
     targetCalculateHeight = targetRect.bottom - targetRect.top;
@@ -596,6 +604,7 @@ function useDraggableBlockMenu(
  * @returns A portal containing the drag handle and target line.
  */
 export function DraggableBlockPlugin_EXPERIMENTAL({
+  // eslint-disable-next-line no-restricted-syntax
   anchorElem = document.body,
   menuRef,
   targetLineRef,

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -18,6 +18,7 @@ import {
   CommandListenerPriority,
   createCommand,
   getDOMShadowRoots,
+  getRootOwnerDocument,
   isDOMShadowRoot,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
@@ -116,6 +117,7 @@ const scrollIntoViewIfNeeded = (target: HTMLElement) => {
 
   const typeaheadRect = typeaheadContainerNode.getBoundingClientRect();
 
+  // eslint-disable-next-line no-restricted-syntax
   if (typeaheadRect.top + typeaheadRect.height > window.innerHeight) {
     typeaheadContainerNode.scrollIntoView({
       block: 'center',
@@ -222,7 +224,8 @@ export function useDynamicPositioning(
       const rootScrollParent =
         rootElement != null
           ? getScrollParent(rootElement, false)
-          : document.body;
+          : // eslint-disable-next-line no-restricted-syntax
+            document.body;
       let ticking = false;
       let previousIsInView = isTriggerVisibleInNearestScrollContainer(
         targetElement,
@@ -230,6 +233,7 @@ export function useDynamicPositioning(
       );
       const handleScroll = function () {
         if (!ticking) {
+          // eslint-disable-next-line no-restricted-syntax
           window.requestAnimationFrame(function () {
             onReposition();
             ticking = false;
@@ -640,7 +644,9 @@ function resolveMenuParent(
     if (isDOMShadowRoot(root)) {
       return root as ShadowRoot;
     }
+    return rootElement.ownerDocument.body;
   }
+  // eslint-disable-next-line no-restricted-syntax -- rootElement is null, no ownerDocument available
   return document.body;
 }
 
@@ -655,7 +661,7 @@ export function useMenuAnchorRef(
   const resolvedParent: HTMLElement | ShadowRoot | undefined =
     parent ?? resolveMenuParent(editor);
   const initialAnchorElement = CAN_USE_DOM
-    ? document.createElement('div')
+    ? getRootOwnerDocument(editor.getRootElement()).createElement('div')
     : null;
   const anchorElementRef = useRef<HTMLElement | null>(initialAnchorElement);
   const positionMenu = useCallback(() => {
@@ -674,8 +680,10 @@ export function useMenuAnchorRef(
         top +
         anchorHeight +
         3 +
+        // eslint-disable-next-line no-restricted-syntax
         (shouldIncludePageYOffset__EXPERIMENTAL ? window.pageYOffset : 0)
       }px`;
+      // eslint-disable-next-line no-restricted-syntax
       containerDiv.style.left = `${left + window.pageXOffset}px`;
       containerDiv.style.height = `${height}px`;
       containerDiv.style.width = `${width}px`;
@@ -689,10 +697,12 @@ export function useMenuAnchorRef(
 
         if (left + menuWidth > rootElementRect.right) {
           containerDiv.style.left = `${
+            // eslint-disable-next-line no-restricted-syntax
             rootElementRect.right - menuWidth + window.pageXOffset
           }px`;
         }
         if (
+          // eslint-disable-next-line no-restricted-syntax
           (top + menuHeight > window.innerHeight ||
             top + menuHeight > rootElementRect.bottom) &&
           top - rootElementRect.top > menuHeight + height
@@ -701,6 +711,7 @@ export function useMenuAnchorRef(
             top -
             menuHeight -
             height +
+            // eslint-disable-next-line no-restricted-syntax
             (shouldIncludePageYOffset__EXPERIMENTAL ? window.pageYOffset : 0)
           }px`;
         }

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -495,6 +495,7 @@ export function useYjsCursors(
 
     return createPortal(
       <div ref={ref} />,
+      // eslint-disable-next-line no-restricted-syntax
       (cursorsContainerRef && cursorsContainerRef.current) || document.body,
     );
   }, [binding, cursorsContainerRef]);
@@ -666,12 +667,12 @@ function initializeEditor(
         } else {
           const paragraph = $createParagraphNode();
           root.append(paragraph);
-          const {activeElement} = document;
+          const rootElement = editor.getRootElement();
 
           if (
             $getSelection() !== null ||
-            (activeElement !== null &&
-              activeElement === editor.getRootElement())
+            (rootElement !== null &&
+              getActiveElement(rootElement) === rootElement)
           ) {
             paragraph.select();
           }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -62,6 +62,7 @@ import {
   $getCaretRange,
   $getChildCaret,
   $getCollapsedCaretRange,
+  $getDocument,
   $getEditor,
   $getNearestNodeFromDOMNode,
   $getRoot,
@@ -162,7 +163,7 @@ export class QuoteNode extends ElementNode {
   // View
 
   createDOM(config: EditorConfig): HTMLElement {
-    const element = document.createElement('blockquote');
+    const element = $getDocument().createElement('blockquote');
     addClassNamesToElement(element, config.theme.quote);
     return element;
   }
@@ -184,7 +185,7 @@ export class QuoteNode extends ElementNode {
 
     if (isHTMLElement(element)) {
       if (this.isEmpty()) {
-        element.append(document.createElement('br'));
+        element.append($getDocument().createElement('br'));
       }
 
       const formatType = this.getFormatType();
@@ -279,7 +280,7 @@ export class HeadingNode extends ElementNode {
 
   createDOM(config: EditorConfig): HTMLElement {
     const tag = this.__tag;
-    const element = document.createElement(tag);
+    const element = $getDocument().createElement(tag);
     const theme = config.theme;
     const classNames = theme.heading;
     if (classNames !== undefined) {
@@ -352,7 +353,7 @@ export class HeadingNode extends ElementNode {
 
     if (isHTMLElement(element)) {
       if (this.isEmpty()) {
-        element.append(document.createElement('br'));
+        element.append($getDocument().createElement('br'));
       }
 
       const formatType = this.getFormatType();

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -23,6 +23,7 @@ import type {
 import {
   $applyNodeReplacement,
   $createParagraphNode,
+  $getDocument,
   $isInlineElementOrDecoratorNode,
   $isLineBreakNode,
   $isTextNode,
@@ -139,7 +140,7 @@ export class TableCellNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): HTMLTableCellElement {
-    const element = document.createElement(this.getTag());
+    const element = $getDocument().createElement(this.getTag());
 
     if (this.__width) {
       element.style.width = `${this.__width}px`;

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -10,6 +10,7 @@ import invariant from '@lexical/internal/invariant';
 import {$descendantsMatching} from '@lexical/utils';
 import {
   $applyNodeReplacement,
+  $getDocument,
   $getEditor,
   $getNearestNodeFromDOMNode,
   addClassNamesToElement,
@@ -61,7 +62,7 @@ export type SerializedTableNode = Spread<
   SerializedElementNode
 >;
 
-function updateColgroup(
+function $updateColgroup(
   dom: HTMLTableElement,
   colCount: number,
   colWidths?: number[] | readonly number[],
@@ -72,7 +73,7 @@ function updateColgroup(
   }
   const cols = [];
   for (let i = 0; i < colCount; i++) {
-    const col = document.createElement('col');
+    const col = $getDocument().createElement('col');
     const width = colWidths && colWidths[i];
     if (width) {
       col.style.width = `${width}px`;
@@ -273,17 +274,17 @@ export class TableNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig, editor?: LexicalEditor): HTMLElement {
-    const tableElement = document.createElement('table');
+    const tableElement = $getDocument().createElement('table');
     if (this.__style) {
       setDOMStyleFromCSS(tableElement.style, this.__style);
     }
-    const colGroup = document.createElement('colgroup');
+    const colGroup = $getDocument().createElement('colgroup');
     tableElement.appendChild(colGroup);
     setDOMUnmanaged(colGroup);
     addClassNamesToElement(tableElement, config.theme.table);
     this.updateTableElement(null, tableElement, config);
     if ($isScrollableTablesActive(editor)) {
-      const wrapperElement = document.createElement('div');
+      const wrapperElement = $getDocument().createElement('div');
       const classes = config.theme.tableScrollableWrapper;
       if (classes) {
         addClassNamesToElement(wrapperElement, classes);
@@ -339,7 +340,7 @@ export class TableNode extends ElementNode {
       this.getColumnCount() !== prevColCount ||
       this.getColWidths() !== prevColWidths
     ) {
-      updateColgroup(tableElement, this.getColumnCount(), this.getColWidths());
+      $updateColgroup(tableElement, this.getColumnCount(), this.getColWidths());
     }
     alignTableElement(tableElement, config, this.getFormatType());
   }
@@ -362,7 +363,7 @@ export class TableNode extends ElementNode {
       return;
     }
     const tableElement = getTableElement(this, dom);
-    updateColgroup(
+    $updateColgroup(
       tableElement,
       this.getColumnCount(),
       colWidths.map(width => width * scale),
@@ -436,7 +437,7 @@ export class TableNode extends ElementNode {
         // Wrap direct descendant rows in a tbody for export
         const rows = tableElement.querySelectorAll(':scope > tr');
         if (rows.length > 0) {
-          const tBody = document.createElement('tbody');
+          const tBody = $getDocument().createElement('tbody');
           for (const row of rows) {
             tBody.appendChild(row);
           }

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -11,6 +11,7 @@ import type {BaseSelection, LexicalUpdateJSON, Spread} from 'lexical';
 import {$descendantsMatching} from '@lexical/utils';
 import {
   $applyNodeReplacement,
+  $getDocument,
   addClassNamesToElement,
   DOMConversionMap,
   DOMConversionOutput,
@@ -84,7 +85,7 @@ export class TableRowNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const element = document.createElement('tr');
+    const element = $getDocument().createElement('tr');
 
     if (this.__height) {
       element.style.height = `${this.__height}px`;

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -943,15 +943,18 @@ function needsManualZoom(): boolean {
     // will be wider after zoom is applied
     // https://chromestatus.com/feature/5198254868529152
     // https://github.com/facebook/lexical/issues/6863
+    // eslint-disable-next-line no-restricted-syntax
     const div = document.createElement('div');
     div.style.position = 'absolute';
     div.style.opacity = '0';
     div.style.width = '100px';
     div.style.left = '-1000px';
+    // eslint-disable-next-line no-restricted-syntax
     document.body.appendChild(div);
     const noZoom = div.getBoundingClientRect();
     div.style.setProperty('zoom', '2');
     NEEDS_MANUAL_ZOOM = div.getBoundingClientRect().width === noZoom.width;
+    // eslint-disable-next-line no-restricted-syntax
     document.body.removeChild(div);
   }
   return NEEDS_MANUAL_ZOOM;

--- a/packages/lexical-utils/src/positionNodeOnRange.ts
+++ b/packages/lexical-utils/src/positionNodeOnRange.ts
@@ -8,7 +8,7 @@
 
 import invariant from '@lexical/internal/invariant';
 import {createRectsFromDOMRange} from '@lexical/selection';
-import {isHTMLElement, type LexicalEditor} from 'lexical';
+import {getRootOwnerDocument, isHTMLElement, type LexicalEditor} from 'lexical';
 
 import dedupeSelectionRects from './dedupeSelectionRects';
 import px from './px';
@@ -45,7 +45,9 @@ export default function mlcPositionNodeOnRange(
   let parentDOMNode: null | HTMLElement = null;
   let observer: null | MutationObserver = null;
   let lastNodes: HTMLElement[] = [];
-  const wrapperNode = document.createElement('div');
+  const wrapperNode = getRootOwnerDocument(
+    editor.getRootElement(),
+  ).createElement('div');
   wrapperNode.style.position = 'relative';
 
   function position(): void {
@@ -62,7 +64,8 @@ export default function mlcPositionNodeOnRange(
       const rect = rects[i];
       // Try to reuse the previously created Node when possible, no need to
       // remove/create on the most common case reposition case
-      const rectNode = lastNodes[i] || document.createElement('div');
+      const rectNode =
+        lastNodes[i] || getRootOwnerDocument(rootDOMNode).createElement('div');
       const rectNodeStyle = rectNode.style;
       if (rectNodeStyle.position !== 'absolute') {
         rectNodeStyle.position = 'absolute';

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -337,7 +337,8 @@ function createCursorSelection(
   } = {},
 ): CursorSelection {
   const color = cursor.color;
-  const caret = document.createElement('span');
+  const ownerDocument = getRootOwnerDocument(binding.editor.getRootElement());
+  const caret = ownerDocument.createElement('span');
   if (theme.cursor) {
     caret.className = theme.cursor;
     setDOMStyleObject(caret.style, {
@@ -358,7 +359,7 @@ function createCursorSelection(
       'z-index': '10',
     });
   }
-  const name = document.createElement('span');
+  const name = ownerDocument.createElement('span');
   name.textContent = cursor.name;
   if (theme.cursorName) {
     name.className = theme.cursorName;
@@ -429,6 +430,7 @@ function updateCursor(
     return;
   }
 
+  const ownerDocument = getRootOwnerDocument(rootElement);
   const cursorsContainerOffsetParent = cursorsContainer.offsetParent;
   if (cursorsContainerOffsetParent === null) {
     return;
@@ -551,9 +553,9 @@ function updateCursor(
     let selection = selections[i];
 
     if (selection === undefined) {
-      selection = document.createElement('span');
+      selection = ownerDocument.createElement('span');
       selections[i] = selection;
-      const selectionBg = document.createElement('span');
+      const selectionBg = ownerDocument.createElement('span');
       if (theme.selectionBg) {
         selectionBg.className = theme.selectionBg;
       }

--- a/packages/lexical/src/LexicalDOMSlot.ts
+++ b/packages/lexical/src/LexicalDOMSlot.ts
@@ -12,7 +12,7 @@ import type {ElementNode} from './nodes/LexicalElementNode';
 import invariant from '@lexical/internal/invariant';
 
 import {IS_APPLE_WEBKIT, IS_IOS, IS_SAFARI} from './environment';
-import {$getEditor} from './LexicalUtils';
+import {$getDocument, $getEditor} from './LexicalUtils';
 
 /**
  * The editor has at most one block cursor element
@@ -336,11 +336,11 @@ export class ElementDOMSlot<
     }
     const element: HTMLElement & LexicalPrivateDOM = this.element;
     const before = this.before;
-    const br = document.createElement('br');
+    const br = $getDocument().createElement('br');
     br.setAttribute('data-lexical-managed-linebreak', 'true');
     element.insertBefore(br, before);
     if (webkitHack) {
-      const img = document.createElement('img');
+      const img = $getDocument().createElement('img');
       img.setAttribute('data-lexical-managed-linebreak', 'true');
       img.style.setProperty('display', 'inline', 'important');
       img.style.setProperty('border', '0px', 'important');

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -48,6 +48,7 @@ import {cloneMap} from './LexicalGenMap';
 import {$isSlotChild, $isSlotHost, EMPTY_SLOTS} from './LexicalSlot';
 import {
   $createChildrenArray,
+  $getDocument,
   $getDOMSlot,
   $isRootOrShadowRoot,
   $markSlotEditable,
@@ -469,8 +470,8 @@ function $setElementDirection(dom: HTMLElement, node: ElementNode): void {
 // fresh mount, slots-first on reconcile) — and starts `display: none`, revealed
 // only by an explicit mount / $getSlotTargetElement. Editability is applied
 // separately by $applySlotEditable.
-function createSlotDOM(name: string): HTMLElement {
-  const container = document.createElement('div');
+function $createSlotDOM(name: string): HTMLElement {
+  const container = $getDocument().createElement('div');
   container.setAttribute('data-lexical-slot', name);
   container.style.display = 'none';
   return container;
@@ -508,7 +509,7 @@ function $mountSlotChildren(
   let totalText = '';
   const decoratorHost = $isDecoratorNode(node);
   for (const [name, slotKey] of slots) {
-    const container = createSlotDOM(name);
+    const container = $createSlotDOM(name);
     $applySlotEditable(hostDom, decoratorHost, container);
     hostDom.appendChild(container);
     subTreeTextContent = '';
@@ -603,7 +604,7 @@ function $reconcileSlotChildren(
     subTreeTextContent = '';
     const saved = $beginCaptureGuard();
     if (container === null) {
-      container = createSlotDOM(name);
+      container = $createSlotDOM(name);
       // Keep the hidden placeholder slots-first: it must land ahead of the
       // linked-list children (and the terminating <br>) so the leading
       // DOMSlot boundary can skip it; it must not be appended after them.

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1883,9 +1883,9 @@ export function $getNodeByKeyOrThrow(key: NodeKey): LexicalNode {
   return node;
 }
 
-function createBlockCursorElement(editorConfig: EditorConfig): HTMLDivElement {
+function $createBlockCursorElement(editorConfig: EditorConfig): HTMLDivElement {
   const theme = editorConfig.theme;
-  const element = document.createElement('div');
+  const element = $getDocument().createElement('div');
   element.contentEditable = 'false';
   element.setAttribute('data-lexical-cursor', 'true');
   let blockCursorTheme = theme.blockCursor;
@@ -1989,7 +1989,7 @@ export function $updateDOMBlockCursorElement(
       ).element;
       if (blockCursorElement === null) {
         editor._blockCursorElement = blockCursorElement =
-          createBlockCursorElement(editor._config);
+          $createBlockCursorElement(editor._config);
       }
       rootElement.style.caretColor = 'transparent';
       if (insertBeforeElement === null) {
@@ -2116,6 +2116,26 @@ export function getRootOwnerDocument(
   rootElement: HTMLElement | null,
 ): Document {
   return rootElement !== null ? rootElement.ownerDocument : document;
+}
+
+/**
+ * Returns the {@link Document} that owns the active editor's root element.
+ * Falls back to `globalThis.document` when the editor has no root element
+ * (e.g. headless mode with {@link @lexical/headless!withDOM | withDOM}).
+ *
+ * Use this inside `createDOM`, `updateDOM`, and `exportDOM` instead of the
+ * bare `document` global so the node works correctly when the editor lives
+ * inside a Shadow DOM or a cross-origin `<iframe>`.
+ */
+export function $getDocument(): Document {
+  const editor = $getEditor();
+  let rootElement: HTMLElement | null = null;
+  try {
+    rootElement = editor.getRootElement();
+  } catch {
+    // createHeadlessEditor() overrides getRootElement() to throw
+  }
+  return getRootOwnerDocument(rootElement);
 }
 
 /**

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -2128,14 +2128,7 @@ export function getRootOwnerDocument(
  * inside a Shadow DOM or a cross-origin `<iframe>`.
  */
 export function $getDocument(): Document {
-  const editor = $getEditor();
-  let rootElement: HTMLElement | null = null;
-  try {
-    rootElement = editor.getRootElement();
-  } catch {
-    // createHeadlessEditor() overrides getRootElement() to throw
-  }
-  return getRootOwnerDocument(rootElement);
+  return getRootOwnerDocument($getEditor()._rootElement);
 }
 
 /**

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -10,6 +10,7 @@ import {
   $copyNode,
   $createParagraphNode,
   $createTextNode,
+  $getDocument,
   $getNodeByKey,
   $getRoot,
   $getState,
@@ -1276,6 +1277,21 @@ describe('getParentElement', () => {
         ElementNode,
         Object.getPrototypeOf(ElementNode),
       ]);
+    });
+  });
+});
+
+describe('$getDocument', () => {
+  initializeUnitTest(testEnv => {
+    test('returns ownerDocument when rootElement is mounted', () => {
+      const doc = testEnv.editor.read(() => $getDocument());
+      expect(doc).toBe(testEnv.editor.getRootElement()!.ownerDocument);
+    });
+
+    test('returns globalThis.document when rootElement is null', () => {
+      testEnv.editor.setRootElement(null);
+      const doc = testEnv.editor.read(() => $getDocument());
+      expect(doc).toBe(document);
     });
   });
 });

--- a/packages/lexical/src/environment.ts
+++ b/packages/lexical/src/environment.ts
@@ -8,7 +8,9 @@
 
 export const CAN_USE_DOM: boolean =
   typeof window !== 'undefined' &&
+  // eslint-disable-next-line no-restricted-syntax
   typeof window.document !== 'undefined' &&
+  // eslint-disable-next-line no-restricted-syntax
   typeof window.document.createElement !== 'undefined';
 
 declare global {
@@ -22,6 +24,7 @@ declare global {
 }
 
 const documentMode =
+  // eslint-disable-next-line no-restricted-syntax
   CAN_USE_DOM && 'documentMode' in document ? document.documentMode : null;
 
 export const IS_APPLE: boolean =
@@ -32,12 +35,14 @@ export const IS_FIREFOX: boolean =
 
 export const CAN_USE_BEFORE_INPUT: boolean =
   CAN_USE_DOM && 'InputEvent' in window && !documentMode
-    ? 'getTargetRanges' in new window.InputEvent('input')
+    ? // eslint-disable-next-line no-restricted-syntax
+      'getTargetRanges' in new window.InputEvent('input')
     : false;
 
 export const IS_IOS: boolean =
   CAN_USE_DOM &&
   /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+  // eslint-disable-next-line no-restricted-syntax
   !window.MSStream;
 
 export const IS_ANDROID: boolean =

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -296,6 +296,7 @@ export {
   $createChildrenArray,
   $findMatchingParent,
   $getAdjacentNode,
+  $getDocument,
   $getDOMSlot,
   $getDOMTextNode,
   $getEditor,

--- a/packages/lexical/src/nodes/ArtificialNode.ts
+++ b/packages/lexical/src/nodes/ArtificialNode.ts
@@ -7,6 +7,7 @@
  */
 import type {EditorConfig} from 'lexical';
 
+import {$getDocument} from '../LexicalUtils';
 import {ElementNode} from './LexicalElementNode';
 
 // TODO: Cleanup ArtificialNode__DO_NOT_USE #5966
@@ -18,7 +19,7 @@ export class ArtificialNode__DO_NOT_USE extends ElementNode {
 
   createDOM(config: EditorConfig): HTMLElement {
     // this isnt supposed to be used and is not used anywhere but defining it to appease the API
-    const dom = document.createElement('div');
+    const dom = $getDocument().createElement('div');
     return dom;
   }
 }

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -17,6 +17,7 @@ import type {
 import {LexicalNode} from '../LexicalNode';
 import {
   $applyNodeReplacement,
+  $getDocument,
   isBlockDomNode,
   isDOMTextNode,
 } from '../LexicalUtils';
@@ -44,7 +45,7 @@ export class LineBreakNode extends LexicalNode {
   }
 
   createDOM(): HTMLElement {
-    return document.createElement('br');
+    return $getDocument().createElement('br');
   }
 
   updateDOM(): false {

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -27,6 +27,7 @@ import type {
 import {ELEMENT_TYPE_TO_FORMAT} from '../LexicalConstants';
 import {
   $applyNodeReplacement,
+  $getDocument,
   $setDirectionFromDOM,
   $setFormatFromDOM,
   getCachedClassNameArray,
@@ -60,7 +61,7 @@ export class ParagraphNode extends ElementNode {
   // View
 
   createDOM(config: EditorConfig): HTMLElement {
-    const dom = document.createElement('p');
+    const dom = $getDocument().createElement('p');
     const classNames = getCachedClassNameArray(config.theme, 'paragraph');
     if (classNames !== undefined) {
       const domClassList = dom.classList;
@@ -90,7 +91,7 @@ export class ParagraphNode extends ElementNode {
 
     if (isHTMLElement(element)) {
       if (this.isEmpty()) {
-        element.append(document.createElement('br'));
+        element.append($getDocument().createElement('br'));
       }
 
       const formatType = this.getFormatType();

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -64,6 +64,7 @@ import {errorOnReadOnly} from '../LexicalUpdates';
 import {
   $applyNodeReplacement,
   $getCompositionKey,
+  $getDocument,
   $getEditor,
   $getEditorDOMRenderConfig,
   $setCompositionKey,
@@ -251,7 +252,7 @@ function $setTextContent(
   const firstChild = slot.getFirstChild();
 
   if (firstChild === null || firstChild.nodeType !== Node.TEXT_NODE) {
-    slot.insertChild(document.createTextNode(text));
+    slot.insertChild($getDocument().createTextNode(text));
     return;
   }
 
@@ -291,11 +292,11 @@ function $createTextInnerDOM(
   }
 }
 
-function wrapElementWith(
+function $wrapElementWith(
   element: HTMLElement | Text,
   tag: string,
 ): HTMLElement {
-  const el = document.createElement(tag);
+  const el = $getDocument().createElement(tag);
   el.appendChild(element);
   return el;
 }
@@ -526,13 +527,13 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
     const outerTag = getElementOuterTag(this, format);
     const innerTag = getElementInnerTag(this, format);
     const tag = outerTag === null ? innerTag : outerTag;
-    const dom = document.createElement(tag);
+    const dom = $getDocument().createElement(tag);
     let innerDOM = dom;
     if (this.hasFormat('code')) {
       dom.setAttribute('spellcheck', 'false');
     }
     if (outerTag !== null) {
-      innerDOM = document.createElement(innerTag);
+      innerDOM = $getDocument().createElement(innerTag);
       dom.appendChild(innerDOM);
     }
     const text = this.__text;
@@ -564,7 +565,7 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
       if (prevInnerDOM == null) {
         invariant(false, 'updateDOM: prevInnerDOM is null or undefined');
       }
-      const nextInnerDOM = document.createElement(nextInnerTag);
+      const nextInnerDOM = $getDocument().createElement(nextInnerTag);
       $createTextInnerDOM(
         nextInnerDOM,
         this,
@@ -698,16 +699,16 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
     // even if it's semantically incorrect to have to resort to using
     // <b>, <u>, <s>, <i> elements.
     if (this.hasFormat('bold')) {
-      element = wrapElementWith(element, 'b');
+      element = $wrapElementWith(element, 'b');
     }
     if (this.hasFormat('italic')) {
-      element = wrapElementWith(element, 'i');
+      element = $wrapElementWith(element, 'i');
     }
     if (this.hasFormat('strikethrough')) {
-      element = wrapElementWith(element, 's');
+      element = $wrapElementWith(element, 's');
     }
     if (this.hasFormat('underline')) {
-      element = wrapElementWith(element, 'u');
+      element = $wrapElementWith(element, 'u');
     }
 
     return {


### PR DESCRIPTION
## Description

Follow-up to Shadow DOM support (#8694). This PR adds lint-time enforcement for the shadow/iframe-safe patterns described in that PR and migrates all existing violations in library sources.

### What changed

**`$getDocument()` API (LexicalUtils.ts)** — New public function that returns the `Document` owning the editor's root element, falling back to `globalThis.document` for headless editors. Intended as the drop-in replacement for bare `document` inside `createDOM`/`updateDOM`/`exportDOM`.

**ESLint config (eslint.config.mjs)** — `no-restricted-syntax` override for `packages/**/src/**` (excluding tests, playground, devtools, website) that errors on `document.*` and `window.*` member access. The `typeof document` / `typeof window` SSR guards and parameter-based usage (e.g. `getRootOwnerDocument` accepting `rootElement`) are exempt because the selector only matches `MemberExpression[object.name="document"]`.

**`@lexical/no-document-in-dom-methods` autofix rule** — Catches `document.*` inside `createDOM`/`updateDOM`/`exportDOM`/`$decorateDOM` methods (both class `MethodDefinition` and `Property` callbacks for `domOverride({ $createDOM: ... })`) and autofixes to `$getDocument().*`. Tracks nesting depth so inner functions inside these methods are still covered.

**Migration (37 files)** — All `document.createElement`/`createTextNode`/`createDocumentFragment` calls inside DOM methods now use `$getDocument()`. `window.getComputedStyle` calls use `ownerDocument.defaultView` with null-check fallback. ~15 legitimate global usages (browser detection, headless DOM shim, React component-level access) are suppressed with `eslint-disable-next-line`.

**AGENTS.md** — New "Shadow DOM and iframe realm safety" section with the full pattern table from #8731 and references to the two ESLint rules.

### Design notes

- `$getDocument()` uses `$getEditor()` internally, so it only works inside `editor.read`/`editor.update` callbacks — which is where `createDOM`/`updateDOM`/`exportDOM` always run. The `$` prefix signals this requirement.
- The `no-restricted-syntax` approach catches `document.X` member expressions but cannot catch destructured access like `const {activeElement} = document`. Those few cases are migrated manually in this PR.
- The autofix rule is limited to DOM method bodies because `document` is a legitimate global in environment detection, headless shims, and React components. A blanket autofix would produce broken code in those contexts.

Closes #8731

## Test plan

- [x] `pnpm vitest run --project unit` — 3638 pass
- [x] `pnpm tsc --noEmit` — clean
- [x] `npx eslint --no-eslintrc -c eslint.config.mjs packages/lexical/src/LexicalUtils.ts` — no errors (verifies `$getDocument` definition doesn't trigger its own rule)
- [x] Verified autofix rule catches `document.createElement` inside `createDOM` and produces `$getDocument().createElement`
- [x] Verified `no-restricted-syntax` fires on bare `document.body` in library source, does not fire in test files or playground