### PR TITLE
[lexical-playground][lexical-website] Feature: Add Vercel Analytics and Speed Insights

### DIFF
--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -40,6 +40,8 @@
     "@lexical/text": "workspace:*",
     "@lexical/utils": "workspace:*",
     "@lexical/yjs": "workspace:*",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "date-fns": "^4.1.0",
     "katex": "^0.16.10",
     "lexical": "workspace:*",

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -52,6 +52,8 @@ import {
   RichTextExtension,
 } from '@lexical/rich-text';
 import {TableExtension} from '@lexical/table';
+import {Analytics} from '@vercel/analytics/react';
+import {SpeedInsights} from '@vercel/speed-insights/react';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -482,6 +484,8 @@ export default function PlaygroundApp(): JSX.Element {
           />
         </svg>
       </a>
+      <Analytics />
+      <SpeedInsights />
     </SettingsContext>
   );
 }

--- a/packages/lexical-website/package.json
+++ b/packages/lexical-website/package.json
@@ -37,6 +37,8 @@
     "@mdx-js/react": "^3.1.1",
     "@mermaid-js/layout-elk": "^0.2.1",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "clsx": "^2.1.1",
     "docusaurus-plugin-typedoc": "^1.4.2",
     "fs-extra": "^11.3.4",

--- a/packages/lexical-website/src/theme/Root.tsx
+++ b/packages/lexical-website/src/theme/Root.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {Analytics} from '@vercel/analytics/react';
+import {SpeedInsights} from '@vercel/speed-insights/react';
+import * as React from 'react';
+
+// Docusaurus wraps the entire app in the theme `Root` component, so it is the
+// canonical place to mount app-wide clients. Both Vercel components render
+// nothing during SSR and only activate after hydration in the browser.
+export default function Root({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <>
+      {children}
+      <Analytics />
+      <SpeedInsights />
+    </>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,6 +1061,12 @@ importers:
       '@lexical/yjs':
         specifier: workspace:*
         version: link:../lexical-yjs
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.5)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.5)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1388,6 +1394,12 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.5)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.5)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -5572,9 +5584,64 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: 19.2.5
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
   '@vercel/oidc@3.0.5':
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
     engines: {node: '>= 20'}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: 19.2.5
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
@@ -18445,7 +18512,15 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/analytics@2.0.1(react@19.2.5)':
+    optionalDependencies:
+      react: 19.2.5
+
   '@vercel/oidc@3.0.5': {}
+
+  '@vercel/speed-insights@2.0.0(react@19.2.5)':
+    optionalDependencies:
+      react: 19.2.5
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
## Description

Both the Lexical playground (`playground.lexical.dev`) and the Lexical website (`lexical.dev`) are deployed on Vercel, but neither was reporting to Vercel Analytics or Speed Insights. This adds both modules to each site.

- **Playground** (Vite + React SPA): renders `<Analytics />` and `<SpeedInsights />` from `@vercel/analytics/react` and `@vercel/speed-insights/react` at the root of `PlaygroundApp`.
- **Website** (Docusaurus): adds a `src/theme/Root.tsx` swizzle that mounts the same two components app-wide. Both render nothing during SSR and only activate after hydration.

## Test plan

- `pnpm run tsc` (playground) and `pnpm --filter @lexical/website run tsc` pass.
- `eslint` + `prettier` clean on changed files.
- `pnpm install --frozen-lockfile` passes.
- Analytics/Speed Insights beacons only fire on the Vercel deployment; verify in the Vercel dashboards after deploy.