### PR TITLE
[lexical-playground] Bug Fix: Use viewBox dimensions for unsized Excalidraw output

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -103,14 +103,19 @@ export default function ExcalidrawImage({
       });
       removeStyleFromSvg_HACK(svg);
 
-      svg.setAttribute('width', '100%');
-      svg.setAttribute('height', '100%');
+      if (width === 'inherit' && height === 'inherit') {
+        svg.style.maxWidth = '100%';
+        svg.style.height = 'auto';
+      } else {
+        svg.setAttribute('width', '100%');
+        svg.setAttribute('height', '100%');
+      }
       svg.setAttribute('display', 'block');
 
       setSvg(svg);
     };
-    setContent();
-  }, [elements, files, appState]);
+    setContent().catch(console.error);
+  }, [elements, files, appState, width, height]);
 
   const containerStyle: React.CSSProperties = {};
   if (width !== 'inherit') {

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -15,7 +15,7 @@ import type {JSX} from 'react';
 
 import {exportToSvg} from '@excalidraw/excalidraw';
 import * as React from 'react';
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 
 type ImageType = 'svg' | 'canvas';
 
@@ -102,20 +102,27 @@ export default function ExcalidrawImage({
         files,
       });
       removeStyleFromSvg_HACK(svg);
-
-      if (width === 'inherit' && height === 'inherit') {
-        svg.style.maxWidth = '100%';
-        svg.style.height = 'auto';
-      } else {
-        svg.setAttribute('width', '100%');
-        svg.setAttribute('height', '100%');
-      }
       svg.setAttribute('display', 'block');
 
       setSvg(svg);
     };
     setContent().catch(console.error);
-  }, [elements, files, appState, width, height]);
+  }, [elements, files, appState]);
+
+  const svgHtml = useMemo(() => {
+    if (Svg == null) {
+      return '';
+    }
+    const clone = Svg.cloneNode(true) as SVGElement;
+    if (width === 'inherit' && height === 'inherit') {
+      clone.style.maxWidth = '100%';
+      clone.style.height = 'auto';
+    } else {
+      clone.setAttribute('width', '100%');
+      clone.setAttribute('height', '100%');
+    }
+    return clone.outerHTML;
+  }, [Svg, width, height]);
 
   const containerStyle: React.CSSProperties = {};
   if (width !== 'inherit') {
@@ -136,7 +143,7 @@ export default function ExcalidrawImage({
       }}
       className={rootClassName ?? ''}
       style={containerStyle}
-      dangerouslySetInnerHTML={{__html: Svg?.outerHTML ?? ''}}
+      dangerouslySetInnerHTML={{__html: svgHtml}}
     />
   );
 }


### PR DESCRIPTION
## Description

The ExcalidrawImage component unconditionally overrides the exported SVG's width and height to `100%`, so even a small drawing fills the entire editor width. `removeStyleFromSvg_HACK` already reads the viewBox and sets the correct pixel dimensions, but lines 106–107 immediately overwrite them.

This PR keeps the viewBox dimensions when the user hasn't explicitly resized the image (both `width` and `height` are `'inherit'`). The SVG gets `max-width: 100%; height: auto` so it scales down proportionally if it's wider than the editor. When the user has resized via the drag handles, the existing `100%`/`100%` fill behavior is preserved.

Also adds `.catch(console.error)` to the fire-and-forget `exportToSvg` call so failed exports surface in the console instead of silently swallowing.

Closes #7414

## Test plan

- [x] Manual playground (Chrome):
  - Insert Excalidraw, draw a small rectangle, save → image renders at the drawing's actual size, not stretched to full width.
  - Draw shapes wider than the editor → image scales down proportionally via `max-width: 100%`.
  - Resize with drag handles, save → image fills the container at the specified size (existing behavior preserved).
- [x] tsc / prettier / eslint clean.