### PR TITLE
[lexical-playground] Bug Fix: Clear inline font-size when converting to heading

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -198,6 +198,9 @@ export const formatHeading = (
       $addUpdateTag(SKIP_SELECTION_FOCUS_TAG);
       const selection = $getSelection();
       $setBlocksType(selection, () => $createHeadingNode(headingSize));
+      if (selection) {
+        $patchStyleText(selection, {'font-size': null});
+      }
     });
   }
 };

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -198,8 +198,9 @@ export const formatHeading = (
       $addUpdateTag(SKIP_SELECTION_FOCUS_TAG);
       const selection = $getSelection();
       $setBlocksType(selection, () => $createHeadingNode(headingSize));
-      if (selection) {
-        $patchStyleText(selection, {'font-size': null});
+      const updatedSelection = $getSelection();
+      if (updatedSelection) {
+        $patchStyleText(updatedSelection, {'font-size': null});
       }
     });
   }


### PR DESCRIPTION
## Description

Converting text with a custom font-size to a heading (H1/H2/H3) had no visible effect on the text size. The inline `font-size` style on the text nodes took CSS precedence over the heading class's `font-size`, so the heading always appeared at whatever size the user had set manually.

After `$setBlocksType` converts the block, `$patchStyleText` now clears the `font-size` inline style so the heading class controls the size. Other inline styles (bold, color, font-family) are preserved since they don't conflict with the heading's core visual identity.

Closes #5509

## Test plan

- [x] Manual playground: type text → set font-size to 20px → select → convert to H1 → text renders at H1's 24px, not 20px
- [x] Manual playground: convert H1 back to paragraph → text uses default paragraph size
- [x] Manual playground: text with mixed sizes (some default, some custom) → convert to H2 → all text renders at H2 size
- [x] Undo (Cmd+Z) after heading conversion restores both block type and font-size in one step
- [x] tsc / eslint / prettier clean