### PR TITLE
[lexical] Chore: Fix tmp package dependency vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,8 @@
       "webpack-dev-server": ">=5.2.4",
       "onnxruntime-node": "link:./stubs/empty",
       "sharp": "link:./stubs/empty",
-      "yjs": "$yjs"
+      "yjs": "$yjs",
+      "tmp": ">=0.2.6"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   onnxruntime-node: link:./stubs/empty
   sharp: link:./stubs/empty
   yjs: ^13.6.31
+  tmp: '>=0.2.6'
 
 importers:
 
@@ -11842,8 +11843,8 @@ packages:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -26257,7 +26258,7 @@ snapshots:
     dependencies:
       tldts-core: 7.0.30
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -26836,7 +26837,7 @@ snapshots:
       source-map-support: 0.5.21
       strip-bom: 5.0.0
       strip-json-comments: 5.0.2
-      tmp: 0.2.5
+      tmp: 0.2.7
       update-notifier: 7.3.1
       watchpack: 2.4.4
       zip-dir: 2.0.0


### PR DESCRIPTION
## Description
Updated package.json to manually override the version of the dependency tmp to >=0.2.6 to address the security vulnerability.

Repository: [facebook/lexical](https://github.com/facebook/lexical)
Manifest file: [pnpm-lock.yaml](https://github.com/facebook/lexical/blob/main/pnpm-lock.yaml)
Package name: tmp
Affected versions: <  0.2.6
Fixed in version: 0.2.6

## Test plan

### Before

N/A

### After

N/A