### PR TITLE
 [lexical-playground] Bug Fix: Keep cell background color modal open on first click

### DIFF
--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -904,7 +904,6 @@ function TableCellActionMenuContainer({
             ref={menuRootRef}>
             <i className="chevron-down" />
           </button>
-          {colorPickerModal}
           {isMenuOpen && (
             <TableActionMenu
               contextRef={menuRootRef}
@@ -917,6 +916,7 @@ function TableCellActionMenuContainer({
           )}
         </>
       )}
+      {colorPickerModal}
     </div>
   );
 }


### PR DESCRIPTION
## Description

**Current behavior:** In `TableCellActionMenuContainer`, the modal returned by`useModal()` is rendered *inside* the `tableCellNode != null` conditional. On the first click anywhere inside the "Cell background color" modal (the panel chrome,hex input, swatches, saturation area, or hue slider), focus/selection leaves the editor, `SELECTION_CHANGE_COMMAND` fires and `$moveMenu()` runs. 

Since the selection is no longer a range/table selection inside the editor root, `disable()` is called -> `setTableMenuCellNode(null)` -> the conditional unmounts `{colorPickerModal}` and the modal disappears on that first interaction. Clicking the cell again re-mounts it (the `useModal` state lives in the still-mounted container), which is why it "comes back" and then behaves normally.

**Changes in this PR:** Move `{colorPickerModal}` outside the `tableCellNode != null` conditional. The `Modal` is already a portal to `document.body`, so its JSX position has no layout effect, and it no longer unmounts when the selection leaves the editor. The modal now stays open on the first click and only closes via the close button, the overlay, or Escape.

Closes #8804

## Test plan

### Before

1. Open the playground and insert a table (Insert -> Table)
2. Click a cell -> click the cell action button (chevron) -> **Background color**
3. Click anywhere inside the modal (e.g. the hex input or the color area)

The modal immediately disappears on that first click.


https://github.com/user-attachments/assets/5e174e60-cbd4-4f65-9e90-39479dcde78f



### After
Same steps: the modal stays open on the first click, the cell background updates
live as a color is picked, and the modal only closes via the close button, the
overlay, or Escape.

https://github.com/user-attachments/assets/c3eb1dbe-f9ae-47b9-a99e-68a84464c47c
