### PR TITLE
Add a 7-day pnpm minimumReleaseAge to match the Dependabot cooldown

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,8 @@ packages:
   - 'dev-examples/*'
   - '!examples/**/*'
   - '!scripts/__tests__/integration/fixtures/**/*'
+
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@lexical/*'
+  - 'lexical'


### PR DESCRIPTION
## Why

Companion to the 7-day Dependabot `cooldown` already in `.github/dependabot.yml`. The cooldown only delays Dependabot's own update PRs; it does nothing for fresh versions pulled in transitively via `^` range resolution on ordinary installs. `minimumReleaseAge` closes that gap at the resolver level, keeping the lockfile ahead of the internal registry's quarantine window (and installable once Metaccio is enforced on laptops).

## What

- `minimumReleaseAge: 10080` (7 days, in minutes) — the resolver never selects a version younger than the window, for direct or transitive deps.
- Kept equal to the Dependabot cooldown so both windows stay in lockstep.
- `lexical` / `@lexical/*` excluded (first-party, quarantine-exempt).

## Notes

- **No lockfile churn:** lexical's lockfile already pins mature versions, and `minimumReleaseAge` only affects *future* resolutions. This is a preventive gate.
- **Graceful fallback confirmed** on pnpm 10.34.1: an in-range resolution falls back to the newest *mature* version rather than erroring; frozen-lockfile CI is unaffected.