### PR TITLE
[lexical] Bug Fix: $getDocument() should fall back to the global document when there is no active editor

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -99,6 +99,7 @@ import {
   errorOnReadOnly,
   getActiveEditor,
   getActiveEditorState,
+  internalGetActiveEditor,
   internalGetActiveEditorState,
   isCurrentlyReadOnlyMode,
   triggerCommandListeners,
@@ -2120,15 +2121,25 @@ export function getRootOwnerDocument(
 
 /**
  * Returns the {@link Document} that owns the active editor's root element.
- * Falls back to `globalThis.document` when the editor has no root element
- * (e.g. headless mode with {@link @lexical/headless!withDOM | withDOM}).
+ * Falls back to `globalThis.document` when there is no active editor (e.g.
+ * a node method such as `createDOM` / `exportDOM` is invoked headlessly,
+ * outside of `editor.update()` / `editor.read()`), or when the active
+ * editor has no root element (e.g. headless mode with
+ * {@link @lexical/headless!withDOM | withDOM}).
  *
  * Use this inside `createDOM`, `updateDOM`, and `exportDOM` instead of the
  * bare `document` global so the node works correctly when the editor lives
  * inside a Shadow DOM or a cross-origin `<iframe>`.
+ *
+ * Unlike most `$`-prefixed helpers, this does NOT require an ambient active
+ * editor: it must remain callable from `createDOM` / `exportDOM`, which are
+ * public methods that consumers may legitimately call while serializing
+ * nodes headlessly. Throwing here would silently break every node whose DOM
+ * methods were migrated off the bare `document` global.
  */
 export function $getDocument(): Document {
-  return getRootOwnerDocument($getEditor()._rootElement);
+  const editor = internalGetActiveEditor();
+  return getRootOwnerDocument(editor !== null ? editor._rootElement : null);
 }
 
 /**

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -1293,5 +1293,14 @@ describe('$getDocument', () => {
       const doc = testEnv.editor.read(() => $getDocument());
       expect(doc).toBe(document);
     });
+
+    test('returns globalThis.document when called with no active editor', () => {
+      // Regression test for headless createDOM/exportDOM: $getDocument() must
+      // not throw when invoked outside editor.update()/read() (i.e. with no
+      // ambient active editor), so that nodes migrated off the bare `document`
+      // global can still be serialized headlessly.
+      expect(() => $getDocument()).not.toThrow();
+      expect($getDocument()).toBe(document);
+    });
   });
 });


### PR DESCRIPTION
## Description

#8788 added the `$getDocument()` API and migrated a number of node `createDOM()` bodies from the bare `document` global to it:

```ts
export function $getDocument(): Document {
  return getRootOwnerDocument($getEditor()._rootElement);
}
```

`$getEditor()` throws (`"Unable to find an active editor ... can only be used synchronously during the callback of editor.update(), editor.read(), ..."`) when there is no active editor. As a result, #8788 silently added a new precondition to every node it migrated: `createDOM()` / `exportDOM()` now require an ambient active editor.

Any consumer that serializes nodes **headlessly** — calling `node.exportDOM(editor)` / `node.createDOM(config, editor)` **outside** `editor.read()` / `editor.update()` — now throws. Note the `editor` is already passed to those methods as an argument, but `$getDocument()` ignores it and relies on the ambient `$getEditor()`.

This is a backwards-incompatible tightening of public methods with no shim or deprecation. The blast radius is every node migrated by #8788 (`ListNode`, `LinkNode`, `TableNode`, `DecoratorBlockNode`, `TextNode`, `ParagraphNode`, …), and any external consumer doing headless `exportDOM` is one upgrade away from the same throw.

### Fix

Make `$getDocument()` tolerate the no-active-editor case. It uses the active editor's root-owner document when an editor is present, and otherwise falls back to the global `document`:

```ts
export function $getDocument(): Document {
  const editor = internalGetActiveEditor();
  return getRootOwnerDocument(editor !== null ? editor._rootElement : null);
}
```

- `internalGetActiveEditor()` is the existing **non-throwing** active-editor lookup (returns `LexicalEditor | null`).
- `getRootOwnerDocument(null)` already returns the global `document`, so the fallback path reuses existing behavior.
- When an editor **is** active, behavior is unchanged — the Shadow DOM / cross-origin `<iframe>` benefit from #8788 is preserved.
- When there is **no** active editor, this restores the pre-#8788 behavior (use the global `document`) instead of throwing.

The doc comment for `$getDocument()` is updated to state that — unlike most `$`-prefixed helpers — it does **not** require an ambient active editor, precisely because it must remain callable from `createDOM` / `exportDOM` during headless serialization.

## Test plan

Added a regression unit test in `packages/lexical/src/__tests__/unit/LexicalUtils.test.ts` covering the no-active-editor case, alongside the two existing `$getDocument` tests.

### Before

Calling a migrated node's `exportDOM` outside `editor.read()`/`update()` throws:

```ts
const editor = createHeadlessEditor({nodes: [ListNode], /* ... */});
let list;
editor.update(() => { list = $createListNode('bullet'); $getRoot().append(list); }, {discrete: true});
list.exportDOM(editor); // ❌ throws: "Unable to find an active editor ..."
```

```
FAIL  ListNode.exportDOM(editor) does not throw outside read/update
  → Unable to find an active editor. This method can only be used synchronously
    during the callback of editor.update(), editor.read(), ...
```

### After

```
✓ $getDocument > returns ownerDocument when rootElement is mounted
✓ $getDocument > returns globalThis.document when rootElement is null
✓ $getDocument > returns globalThis.document when called with no active editor  (new)

Test Files  1 passed (1)
     Tests  50 passed (50)
```

The headless `ListNode.exportDOM(editor)` call above returns the expected `<ul>` element instead of throwing. `pnpm tsc`, `prettier --check`, and `eslint` all pass on the changed files.
