### PR TITLE
[lexical-table][lexical-playground] Feature: $setTableRowIsHeader and $setTableColumnIsHeader utilities

### DIFF
--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -9,7 +9,6 @@
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {
-  $computeTableMapSkipCellCheck,
   $deleteTableColumnAtSelection,
   $deleteTableRowAtSelection,
   $getNodeTriplet,
@@ -22,6 +21,8 @@ import {
   $isTableCellNode,
   $isTableSelection,
   $mergeCells,
+  $setTableColumnIsHeader,
+  $setTableRowIsHeader,
   $unmergeCell,
   getTableElement,
   getTableObserverFromTableElement,
@@ -335,28 +336,9 @@ function TableActionMenu({
   const toggleTableRowIsHeader = useCallback(() => {
     editor.update(() => {
       const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
-
-      const tableRowIndex = $getTableRowIndexFromTableCellNode(tableCellNode);
-
-      const [gridMap] = $computeTableMapSkipCellCheck(tableNode, null, null);
-
-      const rowCells = new Set<TableCellNode>();
-
-      const newStyle =
-        tableCellNode.getHeaderStyles() ^ TableCellHeaderStates.ROW;
-
-      for (let col = 0; col < gridMap[tableRowIndex].length; col++) {
-        const mapCell = gridMap[tableRowIndex][col];
-
-        if (!mapCell?.cell) {
-          continue;
-        }
-
-        if (!rowCells.has(mapCell.cell)) {
-          rowCells.add(mapCell.cell);
-          mapCell.cell.setHeaderStyles(newStyle, TableCellHeaderStates.ROW);
-        }
-      }
+      const rowIndex = $getTableRowIndexFromTableCellNode(tableCellNode);
+      const isHeader = !tableCellNode.hasHeaderState(TableCellHeaderStates.ROW);
+      $setTableRowIsHeader(tableNode, rowIndex, isHeader);
       clearTableSelection();
       onClose();
     });
@@ -365,28 +347,11 @@ function TableActionMenu({
   const toggleTableColumnIsHeader = useCallback(() => {
     editor.update(() => {
       const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
-
-      const tableColumnIndex =
-        $getTableColumnIndexFromTableCellNode(tableCellNode);
-
-      const [gridMap] = $computeTableMapSkipCellCheck(tableNode, null, null);
-
-      const columnCells = new Set<TableCellNode>();
-      const newStyle =
-        tableCellNode.getHeaderStyles() ^ TableCellHeaderStates.COLUMN;
-
-      for (let row = 0; row < gridMap.length; row++) {
-        const mapCell = gridMap[row][tableColumnIndex];
-
-        if (!mapCell?.cell) {
-          continue;
-        }
-
-        if (!columnCells.has(mapCell.cell)) {
-          columnCells.add(mapCell.cell);
-          mapCell.cell.setHeaderStyles(newStyle, TableCellHeaderStates.COLUMN);
-        }
-      }
+      const columnIndex = $getTableColumnIndexFromTableCellNode(tableCellNode);
+      const isHeader = !tableCellNode.hasHeaderState(
+        TableCellHeaderStates.COLUMN,
+      );
+      $setTableColumnIsHeader(tableNode, columnIndex, isHeader);
       clearTableSelection();
       onClose();
     });

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -1569,3 +1569,58 @@ export function $insertTableIntoGrid(
 
   return true;
 }
+
+export function $setTableRowIsHeader(
+  tableNode: TableNode,
+  rowIndex: number,
+  isHeader: boolean,
+): void {
+  const [gridMap] = $computeTableMapSkipCellCheck(tableNode, null, null);
+  invariant(
+    rowIndex >= 0 && rowIndex < gridMap.length,
+    'Table row index %s out of range',
+    String(rowIndex),
+  );
+  const rowMap = gridMap[rowIndex];
+  const headerState = isHeader
+    ? TableCellHeaderStates.ROW
+    : TableCellHeaderStates.NO_STATUS;
+  const visited = new Set<TableCellNode>();
+  for (let col = 0; col < rowMap.length; col++) {
+    const mapCell = rowMap[col];
+    if (mapCell == null) {
+      continue;
+    }
+    if (!visited.has(mapCell.cell)) {
+      visited.add(mapCell.cell);
+      mapCell.cell.setHeaderStyles(headerState, TableCellHeaderStates.ROW);
+    }
+  }
+}
+
+export function $setTableColumnIsHeader(
+  tableNode: TableNode,
+  columnIndex: number,
+  isHeader: boolean,
+): void {
+  const [gridMap] = $computeTableMapSkipCellCheck(tableNode, null, null);
+  invariant(
+    gridMap.length > 0 && columnIndex >= 0 && columnIndex < gridMap[0].length,
+    'Table column index %s out of range',
+    String(columnIndex),
+  );
+  const headerState = isHeader
+    ? TableCellHeaderStates.COLUMN
+    : TableCellHeaderStates.NO_STATUS;
+  const visited = new Set<TableCellNode>();
+  for (let row = 0; row < gridMap.length; row++) {
+    const mapCell = gridMap[row][columnIndex];
+    if (mapCell == null) {
+      continue;
+    }
+    if (!visited.has(mapCell.cell)) {
+      visited.add(mapCell.cell);
+      mapCell.cell.setHeaderStyles(headerState, TableCellHeaderStates.COLUMN);
+    }
+  }
+}

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -14,6 +14,9 @@ import {
   $isTableNode,
   $isTableRowNode,
   $moveTableColumn,
+  $setTableColumnIsHeader,
+  $setTableRowIsHeader,
+  TableCellHeaderStates,
   TableCellNode,
   TableNode,
   TableRowNode,
@@ -51,6 +54,23 @@ function $getTableCellTexts(tableNode: TableNode): string[][] {
         return '';
       }
       return cell.getTextContent();
+    });
+  });
+}
+
+function $getHeaderStates(
+  table: TableNode,
+  flag: (typeof TableCellHeaderStates)[keyof typeof TableCellHeaderStates],
+): boolean[][] {
+  return table.getChildren().map(row => {
+    if (!$isTableRowNode(row)) {
+      return [];
+    }
+    return row.getChildren().map(cell => {
+      if (!$isTableCellNode(cell)) {
+        return false;
+      }
+      return cell.hasHeaderState(flag);
     });
   });
 }
@@ -489,6 +509,557 @@ describe('$moveTableColumn', () => {
         }
         expect(row.getChildrenSize()).toBe(4);
       });
+    });
+  });
+});
+
+describe('$setTableRowIsHeader', () => {
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    editor = createEditor({
+      namespace: 'test',
+      nodes: [TableNode, TableCellNode, TableRowNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+      theme: {},
+    });
+    editor._headless = true;
+  });
+
+  test('sets a row as header', () => {
+    editor.update(
+      () => {
+        $getRoot().append($createTestTable(3, 3));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableRowIsHeader(table, 0, true);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [true, true, true],
+        [false, false, false],
+        [false, false, false],
+      ]);
+    });
+  });
+
+  test('clears a header row', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        const headerRow = $createTableRowNode();
+        for (let c = 0; c < 3; c++) {
+          const cell = $createTableCellNode(TableCellHeaderStates.ROW);
+          cell.append($createParagraphNode().append($createTextNode(`h${c}`)));
+          headerRow.append(cell);
+        }
+        table.append(headerRow);
+        const bodyRow = $createTableRowNode();
+        for (let c = 0; c < 3; c++) {
+          const cell = $createTableCellNode();
+          cell.append($createParagraphNode().append($createTextNode(`b${c}`)));
+          bodyRow.append(cell);
+        }
+        table.append(bodyRow);
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableRowIsHeader(table, 0, false);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [false, false, false],
+        [false, false, false],
+      ]);
+    });
+  });
+
+  test('preserves COLUMN bits when setting ROW header', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        const row = $createTableRowNode();
+        const cell0 = $createTableCellNode(TableCellHeaderStates.COLUMN);
+        cell0.append($createParagraphNode());
+        const cell1 = $createTableCellNode();
+        cell1.append($createParagraphNode());
+        row.append(cell0, cell1);
+        table.append(row);
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableRowIsHeader(table, 0, true);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [true, true],
+      ]);
+      expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
+        [true, false],
+      ]);
+    });
+  });
+
+  test('handles colSpan cells', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        const row = $createTableRowNode();
+        const spanCell = $createTableCellNode();
+        spanCell.setColSpan(2);
+        spanCell.append($createParagraphNode());
+        const normalCell = $createTableCellNode();
+        normalCell.append($createParagraphNode());
+        row.append(spanCell, normalCell);
+        table.append(row);
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableRowIsHeader(table, 0, true);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [true, true],
+      ]);
+    });
+  });
+
+  test('handles rowSpan cells', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        const row0 = $createTableRowNode();
+        const spanCell = $createTableCellNode();
+        spanCell.setRowSpan(2);
+        spanCell.append($createParagraphNode());
+        const cell01 = $createTableCellNode();
+        cell01.append($createParagraphNode());
+        row0.append(spanCell, cell01);
+
+        const row1 = $createTableRowNode();
+        const cell11 = $createTableCellNode();
+        cell11.append($createParagraphNode());
+        row1.append(cell11);
+
+        table.append(row0, row1);
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableRowIsHeader(table, 0, true);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [true, true],
+        [false],
+      ]);
+    });
+  });
+
+  test('sets a middle row as header', () => {
+    editor.update(
+      () => {
+        $getRoot().append($createTestTable(3, 3));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableRowIsHeader(table, 1, true);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [false, false, false],
+        [true, true, true],
+        [false, false, false],
+      ]);
+    });
+  });
+
+  test('throws on out-of-range row index', () => {
+    editor.update(
+      () => {
+        $getRoot().append($createTestTable(3, 3));
+      },
+      {discrete: true},
+    );
+
+    expect(() => {
+      editor.update(
+        () => {
+          const table = $getRoot().getFirstChild();
+          if (!$isTableNode(table)) {
+            throw new Error('Expected table node');
+          }
+          $setTableRowIsHeader(table, 5, true);
+        },
+        {discrete: true},
+      );
+    }).toThrow();
+  });
+
+  test('clears ROW from BOTH header state, preserving COLUMN', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        const row = $createTableRowNode();
+        const cell = $createTableCellNode(TableCellHeaderStates.BOTH);
+        cell.append($createParagraphNode());
+        row.append(cell);
+        table.append(row);
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableRowIsHeader(table, 0, false);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [false],
+      ]);
+      expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
+        [true],
+      ]);
+    });
+  });
+});
+
+describe('$setTableColumnIsHeader', () => {
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    editor = createEditor({
+      namespace: 'test',
+      nodes: [TableNode, TableCellNode, TableRowNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+      theme: {},
+    });
+    editor._headless = true;
+  });
+
+  test('sets a column as header', () => {
+    editor.update(
+      () => {
+        $getRoot().append($createTestTable(3, 3));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableColumnIsHeader(table, 0, true);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
+        [true, false, false],
+        [true, false, false],
+        [true, false, false],
+      ]);
+    });
+  });
+
+  test('clears a header column', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        for (let r = 0; r < 3; r++) {
+          const row = $createTableRowNode();
+          const headerCell = $createTableCellNode(TableCellHeaderStates.COLUMN);
+          headerCell.append($createParagraphNode());
+          const normalCell = $createTableCellNode();
+          normalCell.append($createParagraphNode());
+          row.append(headerCell, normalCell);
+          table.append(row);
+        }
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableColumnIsHeader(table, 0, false);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
+        [false, false],
+        [false, false],
+        [false, false],
+      ]);
+    });
+  });
+
+  test('preserves ROW bits when setting COLUMN header', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        const row = $createTableRowNode();
+        const cell0 = $createTableCellNode(TableCellHeaderStates.ROW);
+        cell0.append($createParagraphNode());
+        const cell1 = $createTableCellNode(TableCellHeaderStates.ROW);
+        cell1.append($createParagraphNode());
+        row.append(cell0, cell1);
+        table.append(row);
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableColumnIsHeader(table, 0, true);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
+        [true, false],
+      ]);
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [true, true],
+      ]);
+    });
+  });
+
+  test('handles rowSpan cells', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        const row0 = $createTableRowNode();
+        const spanCell = $createTableCellNode();
+        spanCell.setRowSpan(2);
+        spanCell.append($createParagraphNode());
+        const cell01 = $createTableCellNode();
+        cell01.append($createParagraphNode());
+        row0.append(spanCell, cell01);
+
+        const row1 = $createTableRowNode();
+        const cell11 = $createTableCellNode();
+        cell11.append($createParagraphNode());
+        row1.append(cell11);
+
+        table.append(row0, row1);
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableColumnIsHeader(table, 0, true);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
+        [true, false],
+        [false],
+      ]);
+    });
+  });
+
+  test('throws on out-of-range column index', () => {
+    editor.update(
+      () => {
+        $getRoot().append($createTestTable(3, 3));
+      },
+      {discrete: true},
+    );
+
+    expect(() => {
+      editor.update(
+        () => {
+          const table = $getRoot().getFirstChild();
+          if (!$isTableNode(table)) {
+            throw new Error('Expected table node');
+          }
+          $setTableColumnIsHeader(table, 5, true);
+        },
+        {discrete: true},
+      );
+    }).toThrow();
+  });
+
+  test('clears COLUMN from BOTH header state, preserving ROW', () => {
+    editor.update(
+      () => {
+        const table = $createTableNode();
+        const row = $createTableRowNode();
+        const cell = $createTableCellNode(TableCellHeaderStates.BOTH);
+        cell.append($createParagraphNode());
+        row.append(cell);
+        table.append(row);
+        $getRoot().append(table);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $setTableColumnIsHeader(table, 0, false);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
+        [false],
+      ]);
+      expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
+        [true],
+      ]);
     });
   });
 });

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -93,6 +93,8 @@ export {
   $mergeCells,
   $moveTableColumn,
   $removeTableRowAtIndex,
+  $setTableColumnIsHeader,
+  $setTableRowIsHeader,
   $unmergeCell,
 } from './LexicalTableUtils';
 export {


### PR DESCRIPTION
## Description

Adds two public utility functions to `@lexical/table` for setting row-level and column-level header state: `$setTableRowIsHeader(tableNode, rowIndex, isHeader)` and `$setTableColumnIsHeader(tableNode, colIndex, isHeader)`.

The playground's table action menu contained ~56 lines of inline header toggle logic — iterating the table map, deduplicating merged cells, and applying header bitmask operations. This PR extracts that logic into reusable library functions. The playground now calls these utilities in ~22 lines, and any consumer can use the same API for header manipulation without reimplementing the map iteration and merged-cell deduplication.

Both functions use `$computeTableMapSkipCellCheck` to build the rectangular grid map (handling colSpan/rowSpan), iterate the target row or column, deduplicate merged cells via `Set<TableCellNode>`, and call `setHeaderStyles(state, mask)` — which preserves the orthogonal header bit (e.g., setting ROW header on a COLUMN-header cell keeps the COLUMN bit intact).

### Design notes

**Index-based API** — The functions take a numeric row/column index rather than a cell node. This matches `$moveTableColumn(tableNode, colIndex, ...)` and directly serves the two main use cases: toggling from a context menu (index available via `$getTableRowIndexFromTableCellNode`) and restoring headers after row/column insertion (index known from the insertion point). A cell-based convenience is trivial to add on top if needed.

**`set` over `toggle`** — The `isHeader: boolean` parameter explicitly sets state rather than toggling. This avoids ambiguity with merged cells spanning header/non-header rows and is safer for post-insertion restoration where the caller knows the desired state. Toggle is a one-liner at the call site: `$setTableRowIsHeader(table, row, !cell.hasHeaderState(TableCellHeaderStates.ROW))`.

Closes #8812

## Test plan

- [x] 14 new unit tests covering: set/clear header, preserve orthogonal bits, colSpan, rowSpan, middle row/column, out-of-range invariant, BOTH→clear single bit
- [x] `npm run test-unit` — 3697 passed (211 test files)
- [x] E2E gate — 768 passed (chromium)
- [x] Manual playground (Chrome, Firefox, Safari):
  - Toggle row/column header on/off via context menu
  - Merged cells across header boundaries update correctly
  - Toggling one axis preserves the other axis's header state