### PR TITLE
[lexical-mdast][lexical-markdown] Bug Fix: Roundtrip overlapping inline formats

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -55,6 +55,7 @@ import {
   $setState,
   COMPOSITION_END_TAG,
   KEY_ENTER_COMMAND,
+  TEXT_TYPE_TO_FORMAT,
   type TextNode,
 } from 'lexical';
 import {assert, describe, expect, it} from 'vitest';
@@ -1193,6 +1194,144 @@ describe('Markdown', () => {
     expect(exported).toBe(
       '````markdown\n```js\nconsole.log("hello");\n```\n````',
     );
+  });
+
+  describe('overlapping inline formats (#4895)', () => {
+    type Run = [text: string, format: number];
+
+    const BOLD = TEXT_TYPE_TO_FORMAT.bold;
+    const ITALIC = TEXT_TYPE_TO_FORMAT.italic;
+    const STRIKE = TEXT_TYPE_TO_FORMAT.strikethrough;
+    const INLINE_CODE = TEXT_TYPE_TO_FORMAT.code;
+
+    function overlapEditor() {
+      return createHeadlessEditor({
+        nodes: [
+          HeadingNode,
+          ListNode,
+          ListItemNode,
+          QuoteNode,
+          CodeNode,
+          LinkNode,
+        ],
+      });
+    }
+
+    /** Reads the document back as merged (text, format) runs. */
+    function $textRuns(): Run[] {
+      const out: Run[] = [];
+      for (const node of $getRoot().getAllTextNodes()) {
+        const format = node.getFormat();
+        const text = node.getTextContent();
+        const last = out[out.length - 1];
+        if (last && last[1] === format) {
+          last[0] += text;
+        } else {
+          out.push([text, format]);
+        }
+      }
+      return out;
+    }
+
+    /**
+     * Builds a one-paragraph document from explicit text-node format runs,
+     * asserts the exported markdown, and verifies that re-importing the
+     * export restores the same formatting.
+     */
+    function expectRoundTrip(runs: Run[], expected: string): void {
+      const editor = overlapEditor();
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          for (const [text, format] of runs) {
+            paragraph.append($createTextNode(text).setFormat(format));
+          }
+          $getRoot().clear().append(paragraph);
+        },
+        {discrete: true},
+      );
+      const markdown = editor.read(() =>
+        $convertToMarkdownString(TRANSFORMERS),
+      );
+      expect(markdown).toBe(expected);
+      const reimported = overlapEditor();
+      reimported.update(
+        () => {
+          $convertFromMarkdownString(markdown, TRANSFORMERS);
+        },
+        {discrete: true},
+      );
+      expect(reimported.read($textRuns)).toEqual(runs);
+    }
+
+    it('round-trips bold overlapping italic (the issue example)', () => {
+      expectRoundTrip(
+        [
+          ['he', 0],
+          ['llo', BOLD],
+          ['wor', BOLD | ITALIC],
+          ['ld', ITALIC],
+          ['!', 0],
+        ],
+        'he**llo*wor****ld*!',
+      );
+    });
+
+    it('round-trips italic overlapping bold', () => {
+      expectRoundTrip(
+        [
+          ['a', 0],
+          ['b', ITALIC],
+          ['c', ITALIC | BOLD],
+          ['d', BOLD],
+          ['e', 0],
+        ],
+        'a*b**c*****d**e',
+      );
+    });
+
+    it('round-trips strikethrough overlapping bold', () => {
+      expectRoundTrip(
+        [
+          ['a', STRIKE],
+          ['b', STRIKE | BOLD],
+          ['c', BOLD],
+        ],
+        '~~a**b**~~**c**',
+      );
+    });
+
+    it('round-trips a code span inside a bold run', () => {
+      expectRoundTrip(
+        [
+          ['a', BOLD],
+          ['b', BOLD | INLINE_CODE],
+          ['c', BOLD],
+        ],
+        '**a`b`c**',
+      );
+    });
+
+    it('imports a partially consumed delimiter run like CommonMark', () => {
+      // `**llo*wor****ld*` pairs `*wor*` first, leaving `***` of the four-
+      // marker run; the remaining `**` must still close the `**` opener
+      // (rule of 3 re-measured on the remaining lengths) and the final `*`
+      // opens the trailing emphasis.
+      const editor = overlapEditor();
+      editor.update(
+        () => {
+          $convertFromMarkdownString('he**llo*wor****ld*!', TRANSFORMERS);
+        },
+        {discrete: true},
+      );
+      expect(editor.read($textRuns)).toEqual([
+        ['he', 0],
+        ['llo', BOLD],
+        ['wor', BOLD | ITALIC],
+        ['ld', ITALIC],
+        ['!', 0],
+      ]);
+    });
   });
 
   describe('list marker', () => {

--- a/packages/lexical-markdown/src/importTextFormatTransformer.ts
+++ b/packages/lexical-markdown/src/importTextFormatTransformer.ts
@@ -16,7 +16,6 @@ interface Delimiter {
   index: number;
   char: string;
   length: number;
-  originalLength: number;
   canOpen: boolean;
   canClose: boolean;
   active: boolean;
@@ -252,7 +251,6 @@ function scanDelimiters(
         char,
         index: i,
         length: len,
-        originalLength: len,
       });
     }
 
@@ -284,7 +282,14 @@ function processEmphasis(
       continue;
     }
 
-    const bottomKey = `${closer.char}${closer.canOpen}`;
+    // The "no opener below this point" shortcut must be keyed by everything
+    // the opener search outcome depends on: the marker, whether the closer
+    // can also open (toggles the rule of 3), and the closer's length mod 3
+    // (the rule of 3 blocks different openers per class — CommonMark's
+    // openers_bottom is likewise per length-mod-3). The length key uses the
+    // *current* length: a partially consumed closer switches class and must
+    // rescan openers a shorter closer already gave up on (#4895).
+    const bottomKey = `${closer.char}${closer.canOpen}${closer.length % 3}`;
     const bottom = openersBottom[bottomKey] ?? -1;
     let foundOpener = false;
 
@@ -300,13 +305,18 @@ function processEmphasis(
         continue;
       }
 
-      // Rule of 3
+      // Rule of 3, on the *remaining* lengths: a delimiter run partially
+      // consumed by an earlier pairing is re-measured, matching micromark
+      // (the CommonMark reference this models). Using the original lengths
+      // instead would refuse pairings like the `**` opener with the two
+      // markers left of a `****` run in `**llo*wor****`, so the exporter's
+      // own output for overlapping formats would not re-import (#4895).
       if (opener.canClose || closer.canOpen) {
-        const sum = opener.originalLength + closer.originalLength;
+        const sum = opener.length + closer.length;
         if (
           sum % 3 === 0 &&
-          opener.originalLength % 3 !== 0 &&
-          closer.originalLength % 3 !== 0
+          opener.length % 3 !== 0 &&
+          closer.length % 3 !== 0
         ) {
           continue;
         }

--- a/packages/lexical-mdast/src/MdastExport.ts
+++ b/packages/lexical-mdast/src/MdastExport.ts
@@ -42,8 +42,9 @@ import {
   $exportLineBreak,
   $isBlockLevelNode,
   exportText,
-  phrasingFromFormattedText,
+  phrasingFromTextRuns,
   TEXT_FORMAT_MASK,
+  type TextRun,
 } from './handlers';
 import {
   emphasisMarkerState,
@@ -178,41 +179,40 @@ const SYNTAX_TO_MARKDOWN: ToMarkdownExtension = {
 };
 
 /**
- * Accumulates adjacent plain text nodes that share a format so they serialize
- * to a single delimiter pair (e.g. `**ab**` rather than `**a****b**`). Shared
- * by the inline and block export walks.
+ * Accumulates adjacent plain text nodes so a whole stretch of formatted text
+ * serializes together: nodes sharing a format merge into a single delimiter
+ * pair (`**ab**` rather than `**a****b**`), and nodes whose formats *overlap*
+ * (bold, bold+italic, italic) nest inside shared containers so the emitted
+ * delimiters re-parse to the same formatting. Shared by the inline and block
+ * export walks.
  */
 class TextRunAccumulator {
-  private format = -1;
-  private value = '';
+  private runs: TextRun[] = [];
 
   /**
-   * Returns `true` when `child` was absorbed. A format change flushes the
-   * previous run into `out` first. The caller decides *which* text nodes
-   * are eligible (plain text with no export rule of its own); this only
+   * Returns `true` when `child` was absorbed. The caller decides *which* text
+   * nodes are eligible (plain text with no export rule of its own); this only
    * guards the node kind.
    */
-  push(child: LexicalNode, out: PhrasingContent[]): boolean {
+  push(child: LexicalNode): boolean {
     if (!$isTextNode(child)) {
       return false;
     }
     const format = child.getFormat() & TEXT_FORMAT_MASK;
-    if (format === this.format) {
-      this.value += child.getTextContent();
+    const last = this.runs[this.runs.length - 1];
+    if (last !== undefined && last.format === format) {
+      last.value += child.getTextContent();
     } else {
-      this.flushInto(out);
-      this.format = format;
-      this.value = child.getTextContent();
+      this.runs.push({format, value: child.getTextContent()});
     }
     return true;
   }
 
   flushInto(out: PhrasingContent[]): void {
-    if (this.format >= 0) {
-      out.push(phrasingFromFormattedText(this.value, this.format));
+    if (this.runs.length > 0) {
+      out.push(...phrasingFromTextRuns(this.runs));
+      this.runs = [];
     }
-    this.format = -1;
-    this.value = '';
   }
 }
 
@@ -350,7 +350,7 @@ function createNodeExporter(
       if (target === null) {
         continue;
       }
-      if (!(mayAccumulate(target) && runs.push(target, result))) {
+      if (!(mayAccumulate(target) && runs.push(target))) {
         runs.flushInto(result);
         if ($isElementNode(target)) {
           // The registry erases types; phrasing output is the dispatch
@@ -397,7 +397,7 @@ function createNodeExporter(
           runs.flushInto(inline);
           inline.push(asBreak);
         }
-      } else if (mayAccumulate(target) && runs.push(target, inline)) {
+      } else if (mayAccumulate(target) && runs.push(target)) {
         continue;
       } else if ($isBlockLevelNode(target)) {
         flushParagraph();

--- a/packages/lexical-mdast/src/__tests__/unit/MdastImportExport.test.ts
+++ b/packages/lexical-mdast/src/__tests__/unit/MdastImportExport.test.ts
@@ -27,6 +27,7 @@ import {
   $isTextNode,
   $setSelectionFromCaretRange,
   defineExtension,
+  TEXT_TYPE_TO_FORMAT,
   type TextNode,
 } from 'lexical';
 import {$assertNodeType} from 'lexical/src/__tests__/utils';
@@ -110,6 +111,114 @@ describe('@lexical/mdast import/export', () => {
         expect(importExport(markdown)).toBe(markdown);
       });
     }
+  });
+
+  describe('overlapping inline formats (#4895)', () => {
+    type Run = [text: string, format: number];
+
+    /** Builds a one-paragraph document from explicit text-node format runs. */
+    function overlapEditor(runs: Run[]): LexicalEditorWithDispose {
+      // The caller is responsible for disposal (with `using`).
+      const editor = createEditor();
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          for (const [text, format] of runs) {
+            paragraph.append($createTextNode(text).setFormat(format));
+          }
+          $getRoot().clear().append(paragraph);
+        },
+        {discrete: true},
+      );
+      return editor;
+    }
+
+    /** Reads the document back as merged (text, format) runs. */
+    function $textRuns(): Run[] {
+      const out: Run[] = [];
+      for (const node of $getRoot().getAllTextNodes()) {
+        const format = node.getFormat();
+        const text = node.getTextContent();
+        const last = out[out.length - 1];
+        if (last && last[1] === format) {
+          last[0] += text;
+        } else {
+          out.push([text, format]);
+        }
+      }
+      return out;
+    }
+
+    /**
+     * Exports `runs`, asserts the serialized markdown, and verifies that
+     * re-importing the export restores the same formatting.
+     */
+    function expectRoundTrip(runs: Run[], expected: string): void {
+      using editor = overlapEditor(runs);
+      const markdown = editor.read(() => $convertToMarkdownString());
+      expect(markdown).toBe(expected);
+      using reimported = createEditor();
+      reimported.update(
+        () => {
+          $convertFromMarkdownString(markdown);
+        },
+        {discrete: true},
+      );
+      expect(reimported.read($textRuns)).toEqual(runs);
+    }
+
+    const BOLD = TEXT_TYPE_TO_FORMAT.bold;
+    const ITALIC = TEXT_TYPE_TO_FORMAT.italic;
+    const STRIKE = TEXT_TYPE_TO_FORMAT.strikethrough;
+    const CODE = TEXT_TYPE_TO_FORMAT.code;
+
+    it('round-trips bold overlapping italic (the issue example)', () => {
+      expectRoundTrip(
+        [
+          ['he', 0],
+          ['llo', BOLD],
+          ['wor', BOLD | ITALIC],
+          ['ld', ITALIC],
+          ['!', 0],
+        ],
+        'he**llo*wor****ld*!',
+      );
+    });
+
+    it('round-trips italic overlapping bold', () => {
+      expectRoundTrip(
+        [
+          ['a', 0],
+          ['b', ITALIC],
+          ['c', ITALIC | BOLD],
+          ['d', BOLD],
+          ['e', 0],
+        ],
+        'a*b**c*****d**e',
+      );
+    });
+
+    it('round-trips strikethrough overlapping bold', () => {
+      expectRoundTrip(
+        [
+          ['a', STRIKE],
+          ['b', STRIKE | BOLD],
+          ['c', BOLD],
+        ],
+        '~~a**b**~~**c**',
+      );
+    });
+
+    it('round-trips a code span inside a bold run', () => {
+      expectRoundTrip(
+        [
+          ['a', BOLD],
+          ['b', BOLD | CODE],
+          ['c', BOLD],
+        ],
+        '**a`b`c**',
+      );
+    });
   });
 
   it('round-trips an ordered list with a custom start', () => {

--- a/packages/lexical-mdast/src/__tests__/unit/MdastTextRuns.test.ts
+++ b/packages/lexical-mdast/src/__tests__/unit/MdastTextRuns.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {Paragraph, PhrasingContent} from 'mdast';
+
+import {TEXT_TYPE_TO_FORMAT} from 'lexical';
+import {fromMarkdown} from 'mdast-util-from-markdown';
+import {
+  gfmStrikethroughFromMarkdown,
+  gfmStrikethroughToMarkdown,
+} from 'mdast-util-gfm-strikethrough';
+import {toMarkdown} from 'mdast-util-to-markdown';
+import {gfmStrikethrough} from 'micromark-extension-gfm-strikethrough';
+import {describe, expect, it} from 'vitest';
+
+import {
+  phrasingFromFormattedText,
+  phrasingFromTextRuns,
+  type TextRun,
+} from '../../handlers';
+
+/**
+ * Normalizes phrasing into ordered (text, format-bitmask) runs, merging
+ * adjacent equal-format text, so trees of different nesting shape compare
+ * equal exactly when they mean the same formatted text.
+ */
+function formatRuns(
+  nodes: PhrasingContent[],
+  format = 0,
+  out: TextRun[] = [],
+): TextRun[] {
+  for (const node of nodes) {
+    let value: string | null = null;
+    let f = format;
+    if (node.type === 'text') {
+      value = node.value;
+    } else if (node.type === 'inlineCode') {
+      value = node.value;
+      f |= TEXT_TYPE_TO_FORMAT.code;
+    } else if ('children' in node) {
+      const bit =
+        node.type === 'strong'
+          ? TEXT_TYPE_TO_FORMAT.bold
+          : node.type === 'emphasis'
+            ? TEXT_TYPE_TO_FORMAT.italic
+            : node.type === 'delete'
+              ? TEXT_TYPE_TO_FORMAT.strikethrough
+              : 0;
+      formatRuns(node.children as PhrasingContent[], format | bit, out);
+      continue;
+    } else {
+      continue;
+    }
+    const last = out[out.length - 1];
+    if (last && last.format === f) {
+      last.value += value;
+    } else {
+      out.push({format: f, value});
+    }
+  }
+  return out;
+}
+
+/** Serializes phrasing to markdown and re-parses it, comparing format runs. */
+function roundTrips(phrasing: PhrasingContent[]): {md: string; ok: boolean} {
+  const md = toMarkdown(
+    {children: [{children: phrasing, type: 'paragraph'}], type: 'root'},
+    {extensions: [gfmStrikethroughToMarkdown()]},
+  );
+  const back = fromMarkdown(md, {
+    extensions: [gfmStrikethrough()],
+    mdastExtensions: [gfmStrikethroughFromMarkdown()],
+  });
+  const paragraph = back.children[0] as Paragraph;
+  const ok =
+    JSON.stringify(formatRuns(paragraph.children)) ===
+    JSON.stringify(formatRuns(phrasing));
+  return {md, ok};
+}
+
+/** Deterministic PRNG so failures are reproducible. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Generates a random run sequence with adjacent equal formats pre-merged. */
+function randomRuns(
+  rand: () => number,
+  formats: readonly number[],
+  formatProbability: number,
+): TextRun[] {
+  const words = ['he', 'llo', 'wor', 'ld', 'foo', 'bar', 'x'];
+  const count = 1 + Math.floor(rand() * 6);
+  const runs: TextRun[] = [];
+  for (let k = 0; k < count; k++) {
+    let format = 0;
+    for (const f of formats) {
+      if (rand() < formatProbability) {
+        format |= f;
+      }
+    }
+    const value = words[Math.floor(rand() * words.length)];
+    const last = runs[runs.length - 1];
+    if (last && last.format === format) {
+      last.value += value;
+    } else {
+      runs.push({format, value});
+    }
+  }
+  return runs;
+}
+
+describe('phrasingFromTextRuns', () => {
+  it('round-trips arbitrary bold/italic overlap exactly', () => {
+    const rand = mulberry32(99);
+    const formats = [TEXT_TYPE_TO_FORMAT.bold, TEXT_TYPE_TO_FORMAT.italic];
+    for (let trial = 0; trial < 2000; trial++) {
+      const runs = randomRuns(rand, formats, 0.45);
+      const result = roundTrips(phrasingFromTextRuns(runs));
+      expect(
+        result.ok,
+        `trial ${trial}: ${JSON.stringify(runs)} -> ${JSON.stringify(result.md)}`,
+      ).toBe(true);
+    }
+  });
+
+  it('never round-trips worse than per-run nesting, for any format mix', () => {
+    // Strikethrough and inline code delimiters are not flanking-safe in every
+    // position, so a perfect round-trip cannot be promised for every random
+    // sequence — but the grouped nesting must never fail where the old
+    // one-node-per-run nesting succeeded.
+    const rand = mulberry32(12345);
+    const formats = [
+      TEXT_TYPE_TO_FORMAT.bold,
+      TEXT_TYPE_TO_FORMAT.italic,
+      TEXT_TYPE_TO_FORMAT.strikethrough,
+      TEXT_TYPE_TO_FORMAT.code,
+    ];
+    let improved = 0;
+    for (let trial = 0; trial < 2000; trial++) {
+      const runs = randomRuns(rand, formats, 0.35);
+      const oldPhrasing = runs.map(run =>
+        phrasingFromFormattedText(run.value, run.format),
+      );
+      const newPhrasing = phrasingFromTextRuns(runs);
+      // Both shapes must mean the same formatted text.
+      expect(formatRuns(newPhrasing)).toEqual(formatRuns(oldPhrasing));
+      const oldResult = roundTrips(oldPhrasing);
+      const newResult = roundTrips(newPhrasing);
+      if (oldResult.ok && !newResult.ok) {
+        expect.fail(
+          `regression at trial ${trial}: ${JSON.stringify(runs)}\n` +
+            `old ok: ${JSON.stringify(oldResult.md)}\n` +
+            `new bad: ${JSON.stringify(newResult.md)}`,
+        );
+      }
+      if (newResult.ok && !oldResult.ok) {
+        improved++;
+      }
+    }
+    expect(improved).toBeGreaterThan(0);
+  });
+});

--- a/packages/lexical-mdast/src/handlers.ts
+++ b/packages/lexical-mdast/src/handlers.ts
@@ -626,6 +626,122 @@ export function phrasingFromFormattedText(
   return content;
 }
 
+/** A contiguous stretch of plain text sharing one Lexical format bitmask. */
+export interface TextRun {
+  format: number;
+  value: string;
+}
+
+/**
+ * Emphasis-family format bits eligible for cross-run grouping, in tie-break
+ * order matching the single-run nesting of {@link phrasingFromFormattedText}
+ * (strong outside emphasis).
+ */
+const EMPHASIS_FORMATS: readonly [number, 'strong' | 'emphasis'][] = [
+  [FORMAT_BOLD, 'strong'],
+  [FORMAT_ITALIC, 'emphasis'],
+];
+
+/**
+ * Converts a segment of strikethrough-free (or strikethrough-stripped) runs
+ * into nested emphasis/strong phrasing. At each position the wrapper is
+ * chosen greedily: the format bit shared by the longest stretch of upcoming
+ * runs becomes the outer container (ties fall back to strong-outside-emphasis,
+ * matching the single-run nesting), and the covered runs recurse with that
+ * bit cleared. Overlap is not always fully expressible as nesting — the
+ * format that extends furthest keeps a single pair of delimiters and the
+ * other side splits.
+ */
+function phrasingFromEmphasisRuns(runs: readonly TextRun[]): PhrasingContent[] {
+  const out: PhrasingContent[] = [];
+  for (let i = 0; i < runs.length; ) {
+    const {format, value} = runs[i];
+    let wrapper: 'strong' | 'emphasis' | null = null;
+    let wrapperBit = 0;
+    let end = i + 1;
+    for (const [bit, type] of EMPHASIS_FORMATS) {
+      if ((format & bit) === 0) {
+        continue;
+      }
+      let bitEnd = i + 1;
+      while (bitEnd < runs.length && runs[bitEnd].format & bit) {
+        bitEnd++;
+      }
+      if (wrapper === null || bitEnd > end) {
+        wrapper = type;
+        wrapperBit = bit;
+        end = bitEnd;
+      }
+    }
+    if (wrapper === null) {
+      out.push(
+        format & FORMAT_CODE
+          ? {type: 'inlineCode', value}
+          : {type: 'text', value},
+      );
+      i++;
+    } else {
+      out.push({
+        children: phrasingFromEmphasisRuns(
+          runs
+            .slice(i, end)
+            .map(run => ({format: run.format & ~wrapperBit, value: run.value})),
+        ),
+        type: wrapper,
+      });
+      i = end;
+    }
+  }
+  return out;
+}
+
+/**
+ * Converts a sequence of text runs into properly *nested* mdast phrasing.
+ * Runs whose formats overlap (e.g. `llo` bold, `wor` bold+italic, `ld`
+ * italic) must share a container wherever they share a format bit — emitting
+ * each run as its own fully-wrapped sibling produces adjacent delimiter runs
+ * (`**llo*****wor****ld*`) that CommonMark resolves differently, so the
+ * output would not re-parse to the same formatting (issue #4895).
+ *
+ * Strikethrough segments the sequence first and always wraps outermost (the
+ * single-run nesting order): a `~~` delimiter is only reliably flanking next
+ * to text, so `delete` must never land *inside* an emphasis/strong group
+ * where a `*` marker would abut it (`*ld~~**llo**~~*` does not re-parse).
+ * Bold/italic overlap is then grouped greedily within each segment by
+ * {@link phrasingFromEmphasisRuns}.
+ */
+export function phrasingFromTextRuns(
+  runs: readonly TextRun[],
+): PhrasingContent[] {
+  const out: PhrasingContent[] = [];
+  for (let i = 0; i < runs.length; ) {
+    const strike = (runs[i].format & FORMAT_STRIKETHROUGH) !== 0;
+    let end = i + 1;
+    while (
+      end < runs.length &&
+      ((runs[end].format & FORMAT_STRIKETHROUGH) !== 0) === strike
+    ) {
+      end++;
+    }
+    const segment = runs.slice(i, end);
+    if (strike) {
+      out.push({
+        children: phrasingFromEmphasisRuns(
+          segment.map(run => ({
+            format: run.format & ~FORMAT_STRIKETHROUGH,
+            value: run.value,
+          })),
+        ),
+        type: 'delete',
+      });
+    } else {
+      out.push(...phrasingFromEmphasisRuns(segment));
+    }
+    i = end;
+  }
+  return out;
+}
+
 export const exportText = (node: LexicalNode): PhrasingContent | null => {
   if (!$isTextNode(node)) {
     return null;


### PR DESCRIPTION
## Description

Fixes the Markdown round-trip of nested overlapping text formats in both `@lexical/mdast` and `@lexical/markdown`

```
root
  └ (53) paragraph  
    ├ (48) text  "he"
    ├ (49) text  "llo" { format: bold }
    ├ (50) text  "wor" { format: bold, italic }
    ├ (51) text  "ld" { format: italic }
    └ (52) text  "!"
```

Closes #4895

## Test plan

New unit tests (property tests) for round-trip in both packages