### PR TITLE
[lexical-extension][lexical-react] Feature: OnChangeExtension to replace OnChangePlugin

### DIFF
--- a/packages/lexical-extension/src/OnChangeExtension.ts
+++ b/packages/lexical-extension/src/OnChangeExtension.ts
@@ -20,6 +20,7 @@ import {effect} from './signals';
 export interface OnChangeConfig {
   ignoreHistoryMergeTagChange: boolean;
   ignoreSelectionChange: boolean;
+  skipInitialization: boolean;
   onChange:
     | undefined
     | ((
@@ -31,9 +32,8 @@ export interface OnChangeConfig {
 
 /**
  * Calls `onChange` with the latest {@link EditorState} whenever the editor
- * updates. By default, updates that only change the selection, and updates that
- * are part of a history merge, are ignored; set `ignoreSelectionChange` or
- * `ignoreHistoryMergeTagChange` to control that filtering.
+ * updates. By default, initial update and updates that are part of a history merge
+ * are ignored; set {@link OnChangeConfig} options to control that filtering.
  */
 export const OnChangeExtension = /* @__PURE__ */ defineExtension({
   build: (editor, config, state) => namedSignals(config),
@@ -41,11 +41,16 @@ export const OnChangeExtension = /* @__PURE__ */ defineExtension({
     ignoreHistoryMergeTagChange: true,
     ignoreSelectionChange: false,
     onChange: undefined,
+    skipInitialization: true,
   }),
   name: '@lexical/extension/OnChange',
   register(editor, config, state) {
-    const {ignoreHistoryMergeTagChange, ignoreSelectionChange, onChange} =
-      state.getOutput();
+    const {
+      ignoreHistoryMergeTagChange,
+      ignoreSelectionChange,
+      skipInitialization,
+      onChange,
+    } = state.getOutput();
     return effect(() => {
       const onChangeHandler = onChange && onChange.value;
       if (onChangeHandler) {
@@ -63,7 +68,7 @@ export const OnChangeExtension = /* @__PURE__ */ defineExtension({
                 dirtyLeaves.size === 0) ||
               (ignoreHistoryMergeTagChange.value &&
                 tags.has(HISTORY_MERGE_TAG)) ||
-              prevEditorState.isEmpty()
+              (skipInitialization.value && prevEditorState.isEmpty())
             ) {
               return;
             }

--- a/packages/lexical-extension/src/OnChangeExtension.ts
+++ b/packages/lexical-extension/src/OnChangeExtension.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  defineExtension,
+  type EditorState,
+  HISTORY_MERGE_TAG,
+  type LexicalEditor,
+  safeCast,
+} from 'lexical';
+
+import {namedSignals} from './namedSignals';
+import {effect} from './signals';
+
+export interface OnChangeConfig {
+  ignoreHistoryMergeTagChange: boolean;
+  ignoreSelectionChange: boolean;
+  onChange:
+    | undefined
+    | ((
+        editorState: EditorState,
+        editor: LexicalEditor,
+        tags: Set<string>,
+      ) => void);
+}
+
+/**
+ * Calls `onChange` with the latest {@link EditorState} whenever the editor
+ * updates. By default, updates that only change the selection, and updates that
+ * are part of a history merge, are ignored; set `ignoreSelectionChange` or
+ * `ignoreHistoryMergeTagChange` to control that filtering.
+ */
+export const OnChangeExtension = /* @__PURE__ */ defineExtension({
+  build: (editor, config, state) => namedSignals(config),
+  config: /* @__PURE__ */ safeCast<OnChangeConfig>({
+    ignoreHistoryMergeTagChange: true,
+    ignoreSelectionChange: false,
+    onChange: undefined,
+  }),
+  name: '@lexical/extension/OnChange',
+  register(editor, config, state) {
+    const {ignoreHistoryMergeTagChange, ignoreSelectionChange, onChange} =
+      state.getOutput();
+    return effect(() => {
+      const onChangeHandler = onChange && onChange.value;
+      if (onChangeHandler) {
+        return editor.registerUpdateListener(
+          ({
+            editorState,
+            dirtyElements,
+            dirtyLeaves,
+            prevEditorState,
+            tags,
+          }) => {
+            if (
+              (ignoreSelectionChange.value &&
+                dirtyElements.size === 0 &&
+                dirtyLeaves.size === 0) ||
+              (ignoreHistoryMergeTagChange.value &&
+                tags.has(HISTORY_MERGE_TAG)) ||
+              prevEditorState.isEmpty()
+            ) {
+              return;
+            }
+
+            onChangeHandler(editorState, editor, tags);
+          },
+        );
+      }
+    });
+  },
+});

--- a/packages/lexical-extension/src/__tests__/unit/OnChangeExtension.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/OnChangeExtension.test.ts
@@ -31,6 +31,7 @@ describe('OnChangeExtension', () => {
     );
     expect(output.ignoreHistoryMergeTagChange.value).toBe(true);
     expect(output.ignoreSelectionChange.value).toBe(false);
+    expect(output.skipInitialization.value).toBe(true);
     expect(output.onChange.value).toBe(undefined);
   });
 
@@ -55,7 +56,7 @@ describe('OnChangeExtension', () => {
     }).not.toThrow();
   });
 
-  test('ignores the very first update, where prevEditorState is empty', () => {
+  test('ignores the first update, where prevEditorState is empty', () => {
     const onChange = vi.fn();
     using editor = buildEditorFromExtensions({
       dependencies: [configExtension(OnChangeExtension, {onChange})],
@@ -68,6 +69,27 @@ describe('OnChangeExtension', () => {
       {discrete: true},
     );
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('does not ignores the first update, where prevEditorState is empty, skipInitialization is false, and ignoreHistoryMergeTagChange is false ', () => {
+    const onChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [
+        configExtension(OnChangeExtension, {
+          ignoreHistoryMergeTagChange: false,
+          onChange,
+          skipInitialization: false,
+        }),
+      ],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   test('calls onChange with the latest editor state, editor instance, and tags', () => {

--- a/packages/lexical-extension/src/__tests__/unit/OnChangeExtension.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/OnChangeExtension.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {
+  buildEditorFromExtensions,
+  configExtension,
+  getExtensionDependencyFromEditor,
+  OnChangeExtension,
+} from '@lexical/extension';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  HISTORY_MERGE_TAG,
+} from 'lexical';
+import {describe, expect, test, vi} from 'vitest';
+
+describe('OnChangeExtension', () => {
+  test('exposes the default config values as signals', () => {
+    using editor = buildEditorFromExtensions({
+      dependencies: [OnChangeExtension],
+      name: 'OnChangeTest',
+    });
+    const {output} = getExtensionDependencyFromEditor(
+      editor,
+      OnChangeExtension,
+    );
+    expect(output.ignoreHistoryMergeTagChange.value).toBe(true);
+    expect(output.ignoreSelectionChange.value).toBe(false);
+    expect(output.onChange.value).toBe(undefined);
+  });
+
+  test('does not register a listener or throw when onChange is not configured', () => {
+    using editor = buildEditorFromExtensions({
+      dependencies: [OnChangeExtension],
+      name: 'OnChangeTest',
+    });
+    expect(() => {
+      editor.update(
+        () => {
+          $getRoot().append($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      editor.update(
+        () => {
+          $getRoot().append($createParagraphNode());
+        },
+        {discrete: true},
+      );
+    }).not.toThrow();
+  });
+
+  test('ignores the very first update, where prevEditorState is empty', () => {
+    const onChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [configExtension(OnChangeExtension, {onChange})],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('calls onChange with the latest editor state, editor instance, and tags', () => {
+    const onChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [configExtension(OnChangeExtension, {onChange})],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        );
+      },
+      {discrete: true},
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [editorState, editorArg, tags] = onChange.mock.calls[0];
+    expect(editorArg).toBe(editor);
+    expect(tags).toBeInstanceOf(Set);
+    expect(editorState).toBe(editor.getEditorState());
+  });
+
+  test('calls onChange for selection-only updates by default', () => {
+    const onChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [configExtension(OnChangeExtension, {onChange})],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        );
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $getRoot().selectEnd();
+      },
+      {discrete: true},
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores selection-only updates when ignoreSelectionChange is true', () => {
+    const onChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [
+        configExtension(OnChangeExtension, {
+          ignoreSelectionChange: true,
+          onChange,
+        }),
+      ],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        );
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $getRoot().selectEnd();
+      },
+      {discrete: true},
+    );
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores updates tagged with HISTORY_MERGE_TAG by default', () => {
+    const onChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [configExtension(OnChangeExtension, {onChange})],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true, tag: HISTORY_MERGE_TAG},
+    );
+    expect(onChange).not.toHaveBeenCalled();
+
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onChange for HISTORY_MERGE_TAG updates when ignoreHistoryMergeTagChange is false', () => {
+    const onChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [
+        configExtension(OnChangeExtension, {
+          ignoreHistoryMergeTagChange: false,
+          onChange,
+        }),
+      ],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true, tag: HISTORY_MERGE_TAG},
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [, , tags] = onChange.mock.calls[0];
+    expect(tags.has(HISTORY_MERGE_TAG)).toBe(true);
+  });
+
+  test('reactively swaps the onChange handler when the config signal changes', () => {
+    const firstOnChange = vi.fn();
+    const secondOnChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [
+        configExtension(OnChangeExtension, {onChange: firstOnChange}),
+      ],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    expect(firstOnChange).toHaveBeenCalledTimes(1);
+    expect(secondOnChange).not.toHaveBeenCalled();
+
+    getExtensionDependencyFromEditor(
+      editor,
+      OnChangeExtension,
+    ).output.onChange.value = secondOnChange;
+
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    expect(firstOnChange).toHaveBeenCalledTimes(1);
+    expect(secondOnChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('stops calling onChange once it is cleared', () => {
+    const onChange = vi.fn();
+    using editor = buildEditorFromExtensions({
+      dependencies: [configExtension(OnChangeExtension, {onChange})],
+      name: 'OnChangeTest',
+    });
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    getExtensionDependencyFromEditor(
+      editor,
+      OnChangeExtension,
+    ).output.onChange.value = undefined;
+
+    editor.update(
+      () => {
+        $getRoot().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/lexical-extension/src/index.ts
+++ b/packages/lexical-extension/src/index.ts
@@ -73,6 +73,7 @@ export {
   NormalizeTripleClickSelectionExtension,
   type NormalizeTripleClickSelectionOutput,
 } from './NormalizeTripleClickSelectionExtension';
+export {type OnChangeConfig, OnChangeExtension} from './OnChangeExtension';
 export {
   type PreventSelectAllConfig,
   PreventSelectAllExtension,

--- a/packages/lexical-react/src/LexicalOnChangePlugin.ts
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.ts
@@ -17,6 +17,9 @@ import useLayoutEffect from './shared/useLayoutEffect';
  * are part of a history merge, are ignored; set `ignoreSelectionChange` or
  * `ignoreHistoryMergeTagChange` to control that filtering.
  *
+ * This is a legacy plugin. When building an editor with the extension API,
+ * configure {@link OnChangeExtension} instead.
+ *
  * @returns `null`, this plugin renders no DOM of its own.
  */
 export function OnChangePlugin({

--- a/packages/lexical-website/docs/extensions/included-extensions.md
+++ b/packages/lexical-website/docs/extensions/included-extensions.md
@@ -49,6 +49,7 @@ Framework-agnostic accessibility extensions. See [Keyboard Accessibility](/docs/
 - [NodeSelectionDataSelectedExtension](/docs/api/modules/lexical_extension#nodeselectiondataselectedextension) - Mirrors a node's `NodeSelection` membership onto its host DOM as a `data-selected` attribute so CSS can outline selected `ElementNode` hosts; configured per node type (experimental)
 - [NormalizeInlineElementsExtension](/docs/api/modules/lexical_extension#normalizeinlineelementsextension) - Removes empty inline elements, included by default with `RichTextExtension` and `PlainTextExtension`
 - [NormalizeTripleClickSelectionExtension](/docs/api/modules/lexical_extension#normalizetripleclickselectionextension) - Corrects over-selection after triple click events, included by default with `RichTextExtension` and `PlainTextExtension`
+- [OnChangeExtension](/docs/api/modules/lexical_extension#onchangeextension) - Subscribes an external callback to update the editor state
 - [PreventSelectAllExtension](/docs/api/modules/lexical_extension#preventselectallextension) - Prevents select all (Ctrl/Cmd+A) inside input/textarea elements from selecting the editor content, included by default with `SelectBlockExtension`
 - [RootElementExtension](/docs/api/modules/lexical_extension#rootelementextension) - Exposes the editor's root element as a reactive `Signal<HTMLElement | null>`
 - [SelectBlockExtension](/docs/api/modules/lexical_extension#selectblockextension) - Select all (Ctrl/Cmd+A) selects the nearest block element first, pressing it again selects the whole document


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

The `OnChangeExtension` extension has been added to replace the React `OnChangePlugin`

A new option `skipInitialization` has been added to the extension with a default value of `true` to ensure backward compatibility with the plugin. This option is useful if you need to track the initialization of the editor's state. For example, when the initial state is passed via HTML and needs to be serialized during initialization to normalize the source HTML string

<details><summary>Example of normalizing the source HTML when pasting from Google Docs</summary>

[Playground link](https://playground.lexical.dev/#doc=H4sIAAAAAAAAE-2aTY_TMBCG_woarnFJdst-hAWJG0ek5QYcpsk0sdaxI3vSUlb978gpWpY9IQfJapxektiN34n9jD_GfgSqJRt7z8gE5SNYY9hfq1aq2pKG8uuLh5oYpYIyz2BrbIc83namJihB-xQFGTg-KJ8AGTD9YCjhzt8eep9YmZpEK5tWyaZlyGBH1kmjoSwyeEr_cvpzP-iKB2Sff8zC9ftAfcZmku6rSLq1tIHKyGyFxo4m6b-P3N7fILIBiic1wA7VMK0FotdALPRPKQv8MeGXmkRLvxWDLLGmJ8uHSWaUkauhWF3eBJow3f_fRf74Dm0jtWATOvTOAoG8D_WA2RCwMcymWyBIE4LoY9GHyPqxVz6uR53Y4meZAUb3uq3RLJz8GdoMs-j3i7cJd_wjAVvspDqkzMBHK8ecOBBksQcf1E44snKbrB9URpnQUNAsPOB1Pv6SBWCD1UNjzaBrkTwLbFG7Hi3pxAfGffLBsXXCXcJpdjxhlTILAp6yEoZgh1ZicGe4YHD-GPiLqKky9lRW0iTo0A7x_DnYkWVZoRKoZJM0Bht05HcQk0Vh30om4Xqskp4f9HZBYEFA7C2GbiGfPwfRA_mxt88-kVLmn2yYtEn3JnagNN4uXewWjl73sc6G_peK_575s55UjU-lHpT6Y4XXkrr2wTZv0TOtFwoKdTNg43Nb7lRIqePR4b_c8ejLdXyPO6qhLK5vLm_zYn11e3VxkYEzg638e58VHk7R0edvQ75aX69yOP4CvezpjKMsAAA)

https://github.com/user-attachments/assets/69d21bd0-70ce-48a8-91f6-ada25d15ee0b

</details> 

## Test plan

### Before

`OnChangePlugin` can only be used in React applications. The closest way to subscribe to onChange is to subscribe to the signal from the `EditorStateExtension`, but it will be updated on any update, including editor initialization and selection changes

### After

For backward compatibility `OnChangeExtension` with similar props/options has been added. Each option has been tested in the file `packages/lexical-extension/src/__tests__/unit/OnChangeExtension.test.ts`