### PR TITLE
[lexical-code-shiki] Bug Fix: force re-tokenize after async language load

### DIFF
--- a/packages/lexical-code-shiki/src/FacadeShiki.ts
+++ b/packages/lexical-code-shiki/src/FacadeShiki.ts
@@ -87,12 +87,9 @@ export function loadCodeLanguage(
         if (editor && codeNodeKey) {
           editor.update(() => {
             const codeNode = $getNodeByKey(codeNodeKey);
-            if (
-              $isCodeNode(codeNode) &&
-              codeNode.getLanguage() === language &&
-              !codeNode.getIsSyntaxHighlightSupported()
-            ) {
+            if ($isCodeNode(codeNode) && codeNode.getLanguage() === language) {
               codeNode.setIsSyntaxHighlightSupported(true);
+              codeNode.markDirty();
             }
           });
         }


### PR DESCRIPTION
When switching a code block to a language whose grammar was not yet loaded by Shiki, the highlight was not updated if the previous language had already set `isSyntaxHighlightSupported` to `true`. The async callback in `loadCodeLanguage()` only dirty'd the node if the flag was `false`, causing a no-op and leaving stale tokens in place.

This PR ensures the `CodeNode` is always marked dirty after the grammar resolves, so the node transform re-runs regardless of the previous highlighting state.

The node is manually marked as dirty to guard against a future regression where setIsSyntaxHighlightSupported could become a no-op when the value hasn't changed.

## Test plan

### Before

- Create a code block with language `markdown` (loaded)
- Switch the language to `typescript` (not yet loaded)
- Observe that the highlighting remains as `markdown` tokens
- A second attempt to set `typescript` works because the grammar is now cached

https://github.com/user-attachments/assets/beb77108-b942-4d7f-b58d-6c8da58f9aae


### After

- The same steps now correctly re-tokenize with `typescript` on the first try
- The `CodeNode` transform triggers as expected once the async language load completes

https://github.com/user-attachments/assets/fc00fa7a-0442-4679-9fe2-ba358992967d