### PR TITLE
[lexical-react] Bug Fix: Merge adjacent OverflowNodes in useCharacterLimit

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CharacterLimit.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CharacterLimit.spec.mjs
@@ -63,10 +63,7 @@ function testSuite(charset) {
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">01234</span>
           <span class="PlaygroundEditorTheme__characterLimit">
-            <span data-lexical-text="true">5</span>
-          </span>
-          <span class="PlaygroundEditorTheme__characterLimit">
-            <span data-lexical-text="true">6789</span>
+            <span data-lexical-text="true">56789</span>
           </span>
         </p>
       `,

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
@@ -24,6 +24,7 @@ import {
   $setSlot,
   type ElementNode,
   type LexicalEditor,
+  type ParagraphNode,
 } from 'lexical';
 import {
   $createTestDecoratorNode,
@@ -32,7 +33,6 @@ import {
 import {afterEach, describe, expect, test} from 'vitest';
 
 import {
-  $mergeNext,
   $mergePrevious,
   $wrapOverflowedNodes,
 } from '../../shared/useCharacterLimit';
@@ -42,9 +42,6 @@ function makeEditor(): LexicalEditor {
     dependencies: [OverflowExtension],
     name: 'character-limit-test',
     nodes: [TestDecoratorNode],
-    onError: e => {
-      throw e;
-    },
   });
   editor.setRootElement(document.createElement('div'));
   return editor;
@@ -53,7 +50,7 @@ function makeEditor(): LexicalEditor {
 function $setupLeftRightOverflow(): {
   overflowLeft: OverflowNode;
   overflowRight: OverflowNode;
-  paragraph: ReturnType<typeof $createParagraphNode>;
+  paragraph: ParagraphNode;
 } {
   const root = $getRoot();
   root.clear();
@@ -142,80 +139,6 @@ describe('useCharacterLimit', () => {
         expect(updatedSelection.anchor.offset).toBe(0);
         expect(updatedSelection.focus.key).toBe(text3.getKey());
         expect(updatedSelection.focus.offset).toBe(1);
-      });
-    });
-  });
-
-  describe('$mergeNext', () => {
-    test('merges right overflow into left with text-type selection', async () => {
-      editor = makeEditor();
-
-      await editor.update(() => {
-        const {overflowLeft, overflowRight, paragraph} =
-          $setupLeftRightOverflow();
-
-        const text1 = $createTextNode('1');
-        const text2 = $createTextNode('2');
-        const text3 = $createTextNode('3');
-        const text4 = $createTextNode('4');
-
-        overflowLeft.append(text1, text2);
-        text2.toggleFormat('bold');
-        overflowRight.append(text3, text4);
-        text4.toggleFormat('bold');
-
-        text3.select(0, 0);
-
-        $mergeNext(overflowLeft);
-
-        expect(paragraph.getChildrenSize()).toBe(1);
-        expect($isOverflowNode(paragraph.getFirstChild())).toBe(true);
-        expect(overflowLeft.getChildrenSize()).toBe(4);
-
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection)) {
-          throw new Error('Lost selection');
-        }
-
-        expect(selection.anchor.key).toBe(text3.getKey());
-        expect(selection.anchor.offset).toBe(0);
-      });
-    });
-
-    test('remaps element-type selection pointing to next overflow', async () => {
-      editor = makeEditor();
-
-      await editor.update(() => {
-        const {overflowLeft, overflowRight, paragraph} =
-          $setupLeftRightOverflow();
-
-        const text1 = $createTextNode('1');
-        const text2 = $createTextNode('2');
-        const text3 = $createTextNode('3');
-        const text4 = $createTextNode('4');
-
-        overflowLeft.append(text1, text2);
-        text2.toggleFormat('bold');
-        overflowRight.append(text3, text4);
-        text4.toggleFormat('bold');
-
-        overflowRight.select(1, 1);
-
-        $mergeNext(overflowLeft);
-
-        expect(paragraph.getChildrenSize()).toBe(1);
-        expect(overflowLeft.getChildrenSize()).toBe(4);
-
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection)) {
-          throw new Error('Lost selection');
-        }
-
-        // offset = overflowLeft children before merge (2) + original offset (1) = 3
-        expect(selection.anchor.key).toBe(overflowLeft.getKey());
-        expect(selection.anchor.offset).toBe(3);
-        expect(selection.focus.key).toBe(overflowLeft.getKey());
-        expect(selection.focus.offset).toBe(3);
       });
     });
   });

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
@@ -22,6 +22,7 @@ import {
   $isRangeSelection,
   $isTextNode,
   $setSlot,
+  type ElementNode,
   type LexicalEditor,
 } from 'lexical';
 import {
@@ -235,7 +236,7 @@ describe('useCharacterLimit', () => {
       });
 
       await editor.update(() => {
-        const paragraph = $getRoot().getFirstChildOrThrow();
+        const paragraph = $getRoot().getFirstChildOrThrow<ElementNode>();
         const text = paragraph.getFirstChild();
         if ($isTextNode(text)) {
           text.setTextContent('abcdge');
@@ -247,7 +248,7 @@ describe('useCharacterLimit', () => {
       });
 
       editor.read(() => {
-        const paragraph = $getRoot().getFirstChildOrThrow();
+        const paragraph = $getRoot().getFirstChildOrThrow<ElementNode>();
         const children = paragraph.getChildren();
         expect(children.length).toBe(2);
         expect(children[0].getTextContent()).toBe('abcdg');
@@ -273,7 +274,7 @@ describe('useCharacterLimit', () => {
       });
 
       editor.read(() => {
-        const host = $getRoot().getFirstChildOrThrow();
+        const host = $getRoot().getFirstChildOrThrow<ElementNode>();
         const children = host.getChildren();
         expect(children[0].getTextContent()).toBe('12');
         expect($isOverflowNode(children[1])).toBe(true);

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
@@ -6,259 +6,280 @@
  *
  */
 
+import type {
+  OverflowNode} from '@lexical/overflow';
+
+import {buildEditorFromExtensions} from '@lexical/extension';
 import {
   $createOverflowNode,
   $isOverflowNode,
-  OverflowNode,
+  OverflowExtension
 } from '@lexical/overflow';
 import {
   $createParagraphNode,
   $createTextNode,
-  $getNodeByKey,
   $getRoot,
   $getSelection,
-  $isNodeSelection,
-  $isParagraphNode,
   $isRangeSelection,
+  $isTextNode,
   $setSlot,
   type LexicalEditor,
-  type NodeKey,
 } from 'lexical';
 import {
-  $assertNodeType,
   $createTestDecoratorNode,
-  initializeUnitTest,
+  TestDecoratorNode,
 } from 'lexical/src/__tests__/utils';
-import {describe, expect, it} from 'vitest';
+import {afterEach, describe, expect, test} from 'vitest';
 
 import {
+  $mergeNext,
   $mergePrevious,
   $wrapOverflowedNodes,
 } from '../../shared/useCharacterLimit';
 
-describe('LexicalNodeHelpers tests', () => {
-  initializeUnitTest(
-    testEnv => {
-      describe('merge', () => {
-        function $initializeEditorWithLeftRightOverflowNodes(): [
-          NodeKey,
-          NodeKey,
-        ] {
-          const root = $getRoot();
+function makeEditor(): LexicalEditor {
+  const editor = buildEditorFromExtensions({
+    dependencies: [OverflowExtension],
+    name: 'character-limit-test',
+    nodes: [TestDecoratorNode],
+    onError: e => {
+      throw e;
+    },
+  });
+  editor.setRootElement(document.createElement('div'));
+  return editor;
+}
 
-          const paragraph = $createParagraphNode();
-          const overflowLeft = $createOverflowNode();
-          const overflowRight = $createOverflowNode();
+function $setupLeftRightOverflow(): {
+  overflowLeft: OverflowNode;
+  overflowRight: OverflowNode;
+  paragraph: ReturnType<typeof $createParagraphNode>;
+} {
+  const root = $getRoot();
+  root.clear();
+  const paragraph = $createParagraphNode();
+  const overflowLeft = $createOverflowNode();
+  const overflowRight = $createOverflowNode();
+  root.append(paragraph);
+  paragraph.append(overflowLeft, overflowRight);
+  return {overflowLeft, overflowRight, paragraph};
+}
 
-          root.append(paragraph);
+describe('useCharacterLimit', () => {
+  let editor: LexicalEditor;
 
-          paragraph.append(overflowLeft);
-          paragraph.append(overflowRight);
+  afterEach(() => {
+    editor.setRootElement(null);
+  });
 
-          return [overflowLeft.getKey(), overflowRight.getKey()];
+  describe('$mergePrevious', () => {
+    test('merges left overflow into right with selection in left', async () => {
+      editor = makeEditor();
+
+      await editor.update(() => {
+        const {overflowLeft, overflowRight, paragraph} =
+          $setupLeftRightOverflow();
+
+        const text1 = $createTextNode('1');
+        const text2 = $createTextNode('2');
+        const text3 = $createTextNode('3');
+        const text4 = $createTextNode('4');
+
+        overflowLeft.append(text1, text2);
+        text2.toggleFormat('bold');
+        overflowRight.append(text3, text4);
+        text4.toggleFormat('bold');
+
+        text1.select(1, 1);
+
+        $mergePrevious(overflowRight);
+
+        expect(paragraph.getChildrenSize()).toBe(1);
+        expect($isOverflowNode(paragraph.getFirstChild())).toBe(true);
+
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          throw new Error('Lost selection');
         }
 
-        it('merges an overflow node (left overflow selected)', async () => {
-          const editor: LexicalEditor = testEnv.editor;
-          let overflowLeftKey: NodeKey;
-          let overflowRightKey: NodeKey;
+        expect(selection.anchor.key).toBe(text1.getKey());
+        expect(selection.anchor.offset).toBe(1);
+        expect(selection.focus.key).toBe(text1.getKey());
+        expect(selection.focus.offset).toBe(1);
+      });
+    });
 
-          let text1Key: NodeKey;
+    test('merges with selection spanning both overflows', async () => {
+      editor = makeEditor();
 
-          await editor.update(() => {
-            [overflowLeftKey, overflowRightKey] =
-              $initializeEditorWithLeftRightOverflowNodes();
+      await editor.update(() => {
+        const {overflowLeft, overflowRight, paragraph} =
+          $setupLeftRightOverflow();
 
-            const overflowLeft = $assertNodeType(
-              $getNodeByKey(overflowLeftKey),
-              $isOverflowNode,
-            );
-            const overflowRight = $assertNodeType(
-              $getNodeByKey(overflowRightKey),
-              $isOverflowNode,
-            );
+        const text1 = $createTextNode('1');
+        const text2 = $createTextNode('2');
+        const text3 = $createTextNode('3');
+        const text4 = $createTextNode('4');
 
-            const text1 = $createTextNode('1');
-            const text2 = $createTextNode('2');
+        overflowLeft.append(text1, text2);
+        text2.toggleFormat('bold');
+        overflowRight.append(text3, text4);
+        text4.toggleFormat('bold');
 
-            const text3 = $createTextNode('3');
-            const text4 = $createTextNode('4');
+        const selection = text2.select(0, 0);
+        selection.focus.set(text3.getKey(), 1, 'text');
 
-            text1Key = text1.getKey();
+        $mergePrevious(overflowRight);
 
-            overflowLeft.append(text1, text2);
+        expect(paragraph.getChildrenSize()).toBe(1);
 
-            text2.toggleFormat('bold'); // Prevent merging with text1
+        const updatedSelection = $getSelection();
+        if (!$isRangeSelection(updatedSelection)) {
+          throw new Error('Lost selection');
+        }
 
-            overflowRight.append(text3, text4);
+        expect(updatedSelection.anchor.key).toBe(text2.getKey());
+        expect(updatedSelection.anchor.offset).toBe(0);
+        expect(updatedSelection.focus.key).toBe(text3.getKey());
+        expect(updatedSelection.focus.offset).toBe(1);
+      });
+    });
+  });
 
-            text4.toggleFormat('bold'); // Prevent merging with text3
+  describe('$mergeNext', () => {
+    test('merges right overflow into left with text-type selection', async () => {
+      editor = makeEditor();
 
-            overflowLeft.select(1, 1);
-          });
+      await editor.update(() => {
+        const {overflowLeft, overflowRight, paragraph} =
+          $setupLeftRightOverflow();
 
-          await editor.update(() => {
-            const paragraph = $assertNodeType(
-              $getRoot().getFirstChild(),
-              $isParagraphNode,
-            );
+        const text1 = $createTextNode('1');
+        const text2 = $createTextNode('2');
+        const text3 = $createTextNode('3');
+        const text4 = $createTextNode('4');
 
-            const overflowRight = $assertNodeType(
-              $getNodeByKey(overflowRightKey),
-              $isOverflowNode,
-            );
+        overflowLeft.append(text1, text2);
+        text2.toggleFormat('bold');
+        overflowRight.append(text3, text4);
+        text4.toggleFormat('bold');
 
-            $mergePrevious(overflowRight);
+        text3.select(0, 0);
 
-            expect(paragraph.getChildrenSize()).toBe(1);
-            expect($isOverflowNode(paragraph.getFirstChild())).toBe(true);
+        $mergeNext(overflowLeft);
 
-            const selection = $getSelection();
+        expect(paragraph.getChildrenSize()).toBe(1);
+        expect($isOverflowNode(paragraph.getFirstChild())).toBe(true);
+        expect(overflowLeft.getChildrenSize()).toBe(4);
 
-            if (!$isRangeSelection(selection)) {
-              throw new Error('Lost selection');
-            }
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          throw new Error('Lost selection');
+        }
 
-            if ($isNodeSelection(selection)) {
-              return;
-            }
+        expect(selection.anchor.key).toBe(text3.getKey());
+        expect(selection.anchor.offset).toBe(0);
+      });
+    });
 
-            expect(selection.anchor.key).toBe(text1Key);
-            expect(selection.anchor.offset).toBe(1);
-            expect(selection.focus.key).toBe(text1Key);
-            expect(selection.anchor.offset).toBe(1);
-          });
-        });
+    test('remaps element-type selection pointing to next overflow', async () => {
+      editor = makeEditor();
 
-        it('merges an overflow node (left-right overflow selected)', async () => {
-          const editor: LexicalEditor = testEnv.editor;
-          let overflowLeftKey: NodeKey;
-          let overflowRightKey: NodeKey;
+      await editor.update(() => {
+        const {overflowLeft, overflowRight, paragraph} =
+          $setupLeftRightOverflow();
 
-          let text2Key: NodeKey;
-          let text3Key: NodeKey;
+        const text1 = $createTextNode('1');
+        const text2 = $createTextNode('2');
+        const text3 = $createTextNode('3');
+        const text4 = $createTextNode('4');
 
-          await editor.update(() => {
-            [overflowLeftKey, overflowRightKey] =
-              $initializeEditorWithLeftRightOverflowNodes();
-            const overflowLeft = $assertNodeType(
-              $getNodeByKey(overflowLeftKey),
-              $isOverflowNode,
-            );
-            const overflowRight = $assertNodeType(
-              $getNodeByKey(overflowRightKey),
-              $isOverflowNode,
-            );
+        overflowLeft.append(text1, text2);
+        text2.toggleFormat('bold');
+        overflowRight.append(text3, text4);
+        text4.toggleFormat('bold');
 
-            const text1 = $createTextNode('1');
-            const text2 = $createTextNode('2');
+        overflowRight.select(1, 1);
 
-            const text3 = $createTextNode('3');
-            const text4 = $createTextNode('4');
+        $mergeNext(overflowLeft);
 
-            text2Key = text2.getKey();
-            text3Key = text3.getKey();
+        expect(paragraph.getChildrenSize()).toBe(1);
+        expect(overflowLeft.getChildrenSize()).toBe(4);
 
-            overflowLeft.append(text1);
-            overflowLeft.append(text2);
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          throw new Error('Lost selection');
+        }
 
-            text2.toggleFormat('bold'); // Prevent merging with text1
+        // offset = overflowLeft children before merge (2) + original offset (1) = 3
+        expect(selection.anchor.key).toBe(overflowLeft.getKey());
+        expect(selection.anchor.offset).toBe(3);
+        expect(selection.focus.key).toBe(overflowLeft.getKey());
+        expect(selection.focus.offset).toBe(3);
+      });
+    });
+  });
 
-            overflowRight.append(text3);
-            overflowRight.append(text4);
+  describe('$wrapOverflowedNodes', () => {
+    test('merges adjacent overflow nodes when wrapping before existing overflow', async () => {
+      editor = makeEditor();
 
-            text4.toggleFormat('bold'); // Prevent merging with text3
-
-            overflowLeft.select(1, 1);
-
-            const selection = $getSelection();
-
-            if (!$isRangeSelection(selection)) {
-              return;
-            }
-
-            selection.focus.set(overflowRightKey, 1, 'element');
-          });
-
-          await editor.update(() => {
-            const paragraph = $assertNodeType(
-              $getRoot().getFirstChild(),
-              $isParagraphNode,
-            );
-            const overflowRight = $assertNodeType(
-              $getNodeByKey(overflowRightKey),
-              $isOverflowNode,
-            );
-
-            $mergePrevious(overflowRight);
-
-            expect(paragraph.getChildrenSize()).toBe(1);
-            expect($isOverflowNode(paragraph.getFirstChild())).toBe(true);
-
-            const selection = $getSelection();
-
-            if (!$isRangeSelection(selection)) {
-              throw new Error('Lost selection');
-            }
-
-            if ($isNodeSelection(selection)) {
-              return;
-            }
-
-            expect(selection.anchor.key).toBe(text2Key);
-            expect(selection.anchor.offset).toBe(0);
-            expect(selection.focus.key).toBe(text3Key);
-            expect(selection.focus.offset).toBe(1);
-          });
-        });
+      await editor.update(() => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('abcde');
+        const overflow = $createOverflowNode();
+        overflow.append($createTextNode('f'));
+        paragraph.append(text, overflow);
+        root.append(paragraph);
       });
 
-      describe('$wrapOverflowedNodes', () => {
-        // A text-bearing non-inline decorator slotted into a host is skipped
-        // by the wrap loop (replacing it with an OverflowNode would throw),
-        // but its text is part of the root text content that funds `offset`
-        // — the budget must advance past it or every later wrap boundary
-        // lands late by the decorator's size.
-        it('advances the budget past a slotted decorator so the wrap boundary is exact', async () => {
-          const editor: LexicalEditor = testEnv.editor;
-          let hostKey: NodeKey;
-
-          await editor.update(() => {
-            const host = $createParagraphNode();
-            hostKey = host.getKey();
-            host.append($createTextNode('12345'));
-            $getRoot().append(host);
-            // TestDecoratorNode.getTextContent() === 'Hello world' (11
-            // chars); slots-first dfs counts it ahead of the host's text.
-            $setSlot(
-              host,
-              'media',
-              $createTestDecoratorNode().setIsInline(false),
-            );
-          });
-
-          await editor.update(() => {
-            // Budget: 11 (slotted decorator) + 2 ('12') = 13; '345' is over.
-            $wrapOverflowedNodes(13);
-          });
-
-          editor.read(() => {
-            const host = $assertNodeType(
-              $getNodeByKey(hostKey),
-              $isParagraphNode,
-            );
-            const [kept, overflow] = host.getChildren();
-            expect(kept.getTextContent()).toBe('12');
-            $assertNodeType(overflow, $isOverflowNode);
-            expect(overflow.getTextContent()).toBe('345');
-          });
-        });
+      await editor.update(() => {
+        const paragraph = $getRoot().getFirstChildOrThrow();
+        const text = paragraph.getFirstChild();
+        if ($isTextNode(text)) {
+          text.setTextContent('abcdge');
+        }
       });
-    },
-    {
-      namespace: '',
-      nodes: [OverflowNode],
-      theme: {},
-    },
-  );
+
+      await editor.update(() => {
+        $wrapOverflowedNodes(5);
+      });
+
+      editor.read(() => {
+        const paragraph = $getRoot().getFirstChildOrThrow();
+        const children = paragraph.getChildren();
+        expect(children.length).toBe(2);
+        expect(children[0].getTextContent()).toBe('abcdg');
+        expect($isOverflowNode(children[1])).toBe(true);
+        expect(children[1].getTextContent()).toBe('ef');
+      });
+    });
+
+    test('advances the budget past a slotted decorator so the wrap boundary is exact', async () => {
+      editor = makeEditor();
+
+      await editor.update(() => {
+        const root = $getRoot();
+        root.clear();
+        const host = $createParagraphNode();
+        host.append($createTextNode('12345'));
+        root.append(host);
+        $setSlot(host, 'media', $createTestDecoratorNode().setIsInline(false));
+      });
+
+      await editor.update(() => {
+        $wrapOverflowedNodes(13);
+      });
+
+      editor.read(() => {
+        const host = $getRoot().getFirstChildOrThrow();
+        const children = host.getChildren();
+        expect(children[0].getTextContent()).toBe('12');
+        expect($isOverflowNode(children[1])).toBe(true);
+        expect(children[1].getTextContent()).toBe('345');
+      });
+    });
+  });
 });

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
@@ -6,14 +6,13 @@
  *
  */
 
-import type {
-  OverflowNode} from '@lexical/overflow';
+import type {OverflowNode} from '@lexical/overflow';
 
 import {buildEditorFromExtensions} from '@lexical/extension';
 import {
   $createOverflowNode,
   $isOverflowNode,
-  OverflowExtension
+  OverflowExtension,
 } from '@lexical/overflow';
 import {
   $createParagraphNode,

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -266,7 +266,10 @@ export function $wrapOverflowedNodes(offset: number): void {
         }
 
         $mergePrevious(overflowNode);
-        $mergeNext(overflowNode);
+        const nextNode = overflowNode.getNextSibling();
+        if ($isOverflowNode(nextNode)) {
+          $mergePrevious(nextNode);
+        }
       }
     }
   }
@@ -328,43 +331,4 @@ export function $mergePrevious(overflowNode: OverflowNode): void {
   }
 
   previousNode.remove();
-}
-
-export function $mergeNext(overflowNode: OverflowNode): void {
-  const nextNode = overflowNode.getNextSibling();
-
-  if (!$isOverflowNode(nextNode)) {
-    return;
-  }
-
-  const overflowNodeChildrenSize = overflowNode.getChildrenSize();
-  const nextNodeChildren = nextNode.getChildren();
-  overflowNode.append(...nextNodeChildren);
-
-  const selection = $getSelection();
-
-  if ($isRangeSelection(selection)) {
-    const anchor = selection.anchor;
-    const anchorNode = anchor.getNode();
-    const focus = selection.focus;
-    const focusNode = focus.getNode();
-
-    if (anchorNode.is(nextNode)) {
-      anchor.set(
-        overflowNode.getKey(),
-        overflowNodeChildrenSize + anchor.offset,
-        'element',
-      );
-    }
-
-    if (focusNode.is(nextNode)) {
-      focus.set(
-        overflowNode.getKey(),
-        overflowNodeChildrenSize + focus.offset,
-        'element',
-      );
-    }
-  }
-
-  nextNode.remove();
 }

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -266,6 +266,7 @@ export function $wrapOverflowedNodes(offset: number): void {
         }
 
         $mergePrevious(overflowNode);
+        $mergeNext(overflowNode);
       }
     }
   }
@@ -303,7 +304,7 @@ export function $mergePrevious(overflowNode: OverflowNode): void {
     const anchor = selection.anchor;
     const anchorNode = anchor.getNode();
     const focus = selection.focus;
-    const focusNode = anchor.getNode();
+    const focusNode = focus.getNode();
 
     if (anchorNode.is(previousNode)) {
       anchor.set(overflowNode.getKey(), anchor.offset, 'element');
@@ -327,4 +328,43 @@ export function $mergePrevious(overflowNode: OverflowNode): void {
   }
 
   previousNode.remove();
+}
+
+export function $mergeNext(overflowNode: OverflowNode): void {
+  const nextNode = overflowNode.getNextSibling();
+
+  if (!$isOverflowNode(nextNode)) {
+    return;
+  }
+
+  const overflowNodeChildrenSize = overflowNode.getChildrenSize();
+  const nextNodeChildren = nextNode.getChildren();
+  overflowNode.append(...nextNodeChildren);
+
+  const selection = $getSelection();
+
+  if ($isRangeSelection(selection)) {
+    const anchor = selection.anchor;
+    const anchorNode = anchor.getNode();
+    const focus = selection.focus;
+    const focusNode = focus.getNode();
+
+    if (anchorNode.is(nextNode)) {
+      anchor.set(
+        overflowNode.getKey(),
+        overflowNodeChildrenSize + anchor.offset,
+        'element',
+      );
+    }
+
+    if (focusNode.is(nextNode)) {
+      focus.set(
+        overflowNode.getKey(),
+        overflowNodeChildrenSize + focus.offset,
+        'element',
+      );
+    }
+  }
+
+  nextNode.remove();
 }


### PR DESCRIPTION
## Description

When text is inserted before an existing overflow boundary, `$wrapOverflowedNodes` creates a new `OverflowNode` for the freshly-overflowed text but never merges it with the pre-existing overflow that follows. This leaves two adjacent `OverflowNode` elements as siblings, and since `getTextContent()` joins sibling `ElementNode`s with `\n\n`, the character count inflates — each extra overflow pair adds 2 phantom characters to the budget. Typing at the front of "abcdef" (limit 5) shows -4 instead of the correct -2.

Two fixes:

1. `$wrapOverflowedNodes` now calls `$mergeNext(overflowNode)` after the existing `$mergePrevious` call, so a newly-wrapped overflow absorbs any adjacent overflow on its right.
2. `$mergePrevious` had a copy-paste bug where `focusNode` was assigned from `anchor.getNode()` instead of `focus.getNode()`, so focus-point remapping during a left-merge was silently broken. Fixed.

Closes #5096

### Test changes

Unit tests were migrated from the legacy `initializeUnitTest` helper to `buildEditorFromExtensions` with `OverflowExtension` — matching the Extension-first test pattern used across recent PRs. The new suite covers `$mergePrevious` (text-type and spanning selections), `$mergeNext` (text-type and element-type remapping), and `$wrapOverflowedNodes` (adjacent overflow merge, slotted decorator budget).

## Test plan

- [x] `pnpm vitest run --project unit -- useLexicalCharacterLimit` — 6 tests pass
- [x] E2E `CharacterLimit.spec.mjs` — all scenarios pass (chromium)
- [x] Manual playground (Chrome, `isCharLimit=true`):
  - Type "abcdef" → counter shows -1, single overflow wraps "f"
  - Move cursor to front, type "1" → counter shows -2, overflow wraps "ef" in one node
  - Backspace to remove characters → overflow shrinks, eventually disappears at ≤5
  - Enter in overflow → counter correctly accounts for newline cost