### PR TITLE
[lexical-table] Feature: Add $moveTableRow function & Add missing export for $unmergeCellNode

### DIFF
--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -307,6 +307,8 @@ declare export function $deleteTableColumn__EXPERIMENTAL(): void;
 
 declare export function $unmergeCell(): void;
 
+declare export function $unmergeCellNode(cellNode: TableCellNode): void;
+
 declare export function $computeTableMap(
   table: TableNode,
   cellA: TableCellNode,

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -478,4 +478,10 @@ declare export function $moveTableColumn(
   targetColumn: number,
 ): void;
 
+declare export function $moveTableRow(
+  tableNode: TableNode,
+  originRow: number,
+  targetRow: number,
+): void;
+
 declare export function $mergeCells(cellNodes: TableCellNode[]): TableCellNode | null;

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -1339,6 +1339,43 @@ export function $moveTableColumn(
   }
 }
 
+/**
+ * Moves a row from one position to another within a simple (non-merged) table.
+ *
+ * @param tableNode The table node to modify.
+ * @param originRow The index of the row to move.
+ * @param targetRow The index to move the row to.
+ */
+export function $moveTableRow(
+  tableNode: TableNode,
+  originRow: number,
+  targetRow: number,
+): void {
+  if (originRow === targetRow) {
+    return;
+  }
+  const rows = tableNode.getChildren().filter($isTableRowNode);
+  const rowCount = rows.length;
+  if (
+    originRow < 0 ||
+    originRow >= rowCount ||
+    targetRow < 0 ||
+    targetRow >= rowCount
+  ) {
+    return;
+  }
+  if (!$isSimpleTable(tableNode)) {
+    return;
+  }
+  const originRowNode = rows[originRow];
+  const targetRowNode = rows[targetRow];
+  if (targetRow > originRow) {
+    targetRowNode.insertAfter(originRowNode);
+  } else {
+    targetRowNode.insertBefore(originRowNode);
+  }
+}
+
 export function $getTableCellNodeRect(tableCellNode: TableCellNode): {
   rowIndex: number;
   columnIndex: number;

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -948,6 +948,13 @@ export function $unmergeCell(): void {
   return $unmergeCellNode(cellNode);
 }
 
+/**
+ * Unmerges the given cell, splitting it back into individual cells.
+ * Unlike {@link $unmergeCell}, this does not depend on the current
+ * selection. No-op if the cell is not merged.
+ *
+ * @param cellNode The merged cell to split.
+ */
 export function $unmergeCellNode(cellNode: TableCellNode): void {
   const [cell, row, grid] = $getNodeTriplet(cellNode);
   const colSpan = cell.__colSpan;

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -29,6 +29,7 @@ import {
   defineExtension,
   type LexicalEditorWithDispose,
 } from 'lexical';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 
 function $createTestTable(rows: number, columns: number): TableNode {
@@ -46,34 +47,24 @@ function $createTestTable(rows: number, columns: number): TableNode {
 }
 
 function $getTableCellTexts(tableNode: TableNode): string[][] {
-  return tableNode.getChildren().map(row => {
-    if (!$isTableRowNode(row)) {
-      return [];
-    }
-    return row.getChildren().map(cell => {
-      if (!$isTableCellNode(cell)) {
-        return '';
-      }
-      return cell.getTextContent();
-    });
-  });
+  return tableNode.getChildren().map(row =>
+    $assertNodeType(row, $isTableRowNode)
+      .getChildren()
+      .map(cell => $assertNodeType(cell, $isTableCellNode).getTextContent()),
+  );
 }
 
 function $getHeaderStates(
   table: TableNode,
   flag: (typeof TableCellHeaderStates)[keyof typeof TableCellHeaderStates],
 ): boolean[][] {
-  return table.getChildren().map(row => {
-    if (!$isTableRowNode(row)) {
-      return [];
-    }
-    return row.getChildren().map(cell => {
-      if (!$isTableCellNode(cell)) {
-        return false;
-      }
-      return cell.hasHeaderState(flag);
-    });
-  });
+  return table.getChildren().map(row =>
+    $assertNodeType(row, $isTableRowNode)
+      .getChildren()
+      .map(cell =>
+        $assertNodeType(cell, $isTableCellNode).hasHeaderState(flag),
+      ),
+  );
 }
 
 let editor: LexicalEditorWithDispose;
@@ -109,20 +100,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 0, 2);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c1', 'r0c2', 'r0c0', 'r0c3'],
         ['r1c1', 'r1c2', 'r1c0', 'r1c3'],
@@ -141,20 +126,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 3, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c3', 'r0c1', 'r0c2'],
         ['r1c0', 'r1c3', 'r1c1', 'r1c2'],
@@ -173,20 +152,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 2, 0);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c2', 'r0c0', 'r0c1'],
         ['r1c2', 'r1c0', 'r1c1'],
@@ -205,20 +178,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 0, 2);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c1', 'r0c2', 'r0c0'],
         ['r1c1', 'r1c2', 'r1c0'],
@@ -237,20 +204,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 1, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1', 'r0c2'],
         ['r1c0', 'r1c1', 'r1c2'],
@@ -269,20 +230,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 5, 0);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1', 'r0c2'],
         ['r1c0', 'r1c1', 'r1c2'],
@@ -301,20 +256,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 0, 10);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1', 'r0c2'],
         ['r1c0', 'r1c1', 'r1c2'],
@@ -333,20 +282,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, -1, 0);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1', 'r0c2'],
         ['r1c0', 'r1c1', 'r1c2'],
@@ -367,20 +310,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 0, 2);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect(table.getColWidths()).toEqual([200, 300, 100, 400]);
     });
   });
@@ -421,32 +358,22 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 0, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       // Should be unchanged because table has merged cells
       const rows = table.getChildren();
-      if (!$isTableRowNode(rows[0])) {
-        throw new Error('Expected row node');
-      }
-      const firstRowCells = rows[0].getChildren();
+      const firstRow = $assertNodeType(rows[0], $isTableRowNode);
+      const firstRowCells = firstRow.getChildren();
       expect(firstRowCells.length).toBe(2); // merged cell + normal cell
-      if (!$isTableCellNode(firstRowCells[0])) {
-        throw new Error('Expected cell node');
-      }
-      expect(firstRowCells[0].getColSpan()).toBe(2);
-      expect(firstRowCells[0].getTextContent()).toBe('merged');
+      const mergedCell = $assertNodeType(firstRowCells[0], $isTableCellNode);
+      expect(mergedCell.getColSpan()).toBe(2);
+      expect(mergedCell.getTextContent()).toBe('merged');
     });
   });
 
@@ -461,20 +388,14 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 0, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c1', 'r0c0'],
         ['r1c1', 'r1c0'],
@@ -494,28 +415,19 @@ describe('$moveTableColumn', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableColumn(table, 1, 3);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       // Verify row and column count is preserved
       const rows = table.getChildren();
       expect(rows.length).toBe(3);
       rows.forEach(row => {
-        if (!$isTableRowNode(row)) {
-          throw new Error('Expected row node');
-        }
-        expect(row.getChildrenSize()).toBe(4);
+        expect($assertNodeType(row, $isTableRowNode).getChildrenSize()).toBe(4);
       });
     });
   });
@@ -533,20 +445,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 0, 2);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r1c0', 'r1c1'],
         ['r2c0', 'r2c1'],
@@ -567,20 +473,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 3, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1'],
         ['r3c0', 'r3c1'],
@@ -601,20 +501,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 2, 0);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r2c0', 'r2c1'],
         ['r0c0', 'r0c1'],
@@ -635,20 +529,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 0, 3);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r1c0', 'r1c1'],
         ['r2c0', 'r2c1'],
@@ -669,20 +557,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 1, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1'],
         ['r1c0', 'r1c1'],
@@ -702,20 +584,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 3, 0);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1'],
         ['r1c0', 'r1c1'],
@@ -735,20 +611,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 0, 3);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1'],
         ['r1c0', 'r1c1'],
@@ -768,20 +638,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, -1, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r0c0', 'r0c1'],
         ['r1c0', 'r1c1'],
@@ -826,32 +690,22 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 0, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       // Should be unchanged because table has merged cells
       const rows = table.getChildren();
-      if (!$isTableRowNode(rows[0])) {
-        throw new Error('Expected row node');
-      }
-      const firstRowCells = rows[0].getChildren();
+      const firstRow = $assertNodeType(rows[0], $isTableRowNode);
+      const firstRowCells = firstRow.getChildren();
       expect(firstRowCells.length).toBe(2); // merged cell + normal cell
-      if (!$isTableCellNode(firstRowCells[0])) {
-        throw new Error('Expected cell node');
-      }
-      expect(firstRowCells[0].getColSpan()).toBe(2);
-      expect(firstRowCells[0].getTextContent()).toBe('merged');
+      const mergedCell = $assertNodeType(firstRowCells[0], $isTableCellNode);
+      expect(mergedCell.getColSpan()).toBe(2);
+      expect(mergedCell.getTextContent()).toBe('merged');
     });
   });
 
@@ -866,20 +720,14 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 0, 1);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r1c0', 'r1c1', 'r1c2'],
         ['r0c0', 'r0c1', 'r0c2'],
@@ -914,35 +762,25 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 0, 2);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getTableCellTexts(table)).toEqual([
         ['r1c0', 'r1c1'],
         ['r2c0', 'r2c1'],
         ['r0c0', 'r0c1'],
       ]);
       const rows = table.getChildren();
-      const movedRow = rows[2];
-      if (!$isTableRowNode(movedRow)) {
-        throw new Error('Expected row node');
-      }
+      const movedRow = $assertNodeType(rows[2], $isTableRowNode);
       movedRow.getChildren().forEach(cell => {
-        if (!$isTableCellNode(cell)) {
-          throw new Error('Expected cell node');
-        }
-        expect(cell.getHeaderStyles()).toBe(TableCellHeaderStates.ROW);
+        expect($assertNodeType(cell, $isTableCellNode).getHeaderStyles()).toBe(
+          TableCellHeaderStates.ROW,
+        );
       });
     });
   });
@@ -958,28 +796,19 @@ describe('$moveTableRow', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $moveTableRow(table, 1, 3);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       // Verify row and column count is preserved
       const rows = table.getChildren();
       expect(rows.length).toBe(4);
       rows.forEach(row => {
-        if (!$isTableRowNode(row)) {
-          throw new Error('Expected row node');
-        }
-        expect(row.getChildrenSize()).toBe(3);
+        expect($assertNodeType(row, $isTableRowNode).getChildrenSize()).toBe(3);
       });
     });
   });
@@ -996,20 +825,14 @@ describe('$setTableRowIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableRowIsHeader(table, 0, true);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
         [true, true, true],
         [false, false, false],
@@ -1043,20 +866,14 @@ describe('$setTableRowIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableRowIsHeader(table, 0, false);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
         [false, false, false],
         [false, false, false],
@@ -1082,20 +899,14 @@ describe('$setTableRowIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableRowIsHeader(table, 0, true);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
         [true, true],
       ]);
@@ -1124,20 +935,14 @@ describe('$setTableRowIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableRowIsHeader(table, 0, true);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
         [true, true],
       ]);
@@ -1169,20 +974,14 @@ describe('$setTableRowIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableRowIsHeader(table, 0, true);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
         [true, true],
         [false],
@@ -1200,20 +999,14 @@ describe('$setTableRowIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableRowIsHeader(table, 1, true);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
         [false, false, false],
         [true, true, true],
@@ -1233,10 +1026,10 @@ describe('$setTableRowIsHeader', () => {
     expect(() => {
       editor.update(
         () => {
-          const table = $getRoot().getFirstChild();
-          if (!$isTableNode(table)) {
-            throw new Error('Expected table node');
-          }
+          const table = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isTableNode,
+          );
           $setTableRowIsHeader(table, 5, true);
         },
         {discrete: true},
@@ -1260,20 +1053,14 @@ describe('$setTableRowIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableRowIsHeader(table, 0, false);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
         [false],
       ]);
@@ -1295,20 +1082,14 @@ describe('$setTableColumnIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableColumnIsHeader(table, 0, true);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
         [true, false, false],
         [true, false, false],
@@ -1337,20 +1118,14 @@ describe('$setTableColumnIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableColumnIsHeader(table, 0, false);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
         [false, false],
         [false, false],
@@ -1377,20 +1152,14 @@ describe('$setTableColumnIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableColumnIsHeader(table, 0, true);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
         [true, false],
       ]);
@@ -1425,20 +1194,14 @@ describe('$setTableColumnIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableColumnIsHeader(table, 0, true);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
         [true, false],
         [false],
@@ -1457,10 +1220,10 @@ describe('$setTableColumnIsHeader', () => {
     expect(() => {
       editor.update(
         () => {
-          const table = $getRoot().getFirstChild();
-          if (!$isTableNode(table)) {
-            throw new Error('Expected table node');
-          }
+          const table = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isTableNode,
+          );
           $setTableColumnIsHeader(table, 5, true);
         },
         {discrete: true},
@@ -1484,20 +1247,14 @@ describe('$setTableColumnIsHeader', () => {
 
     editor.update(
       () => {
-        const table = $getRoot().getFirstChild();
-        if (!$isTableNode(table)) {
-          throw new Error('Expected table node');
-        }
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         $setTableColumnIsHeader(table, 0, false);
       },
       {discrete: true},
     );
 
     editor.read('latest', () => {
-      const table = $getRoot().getFirstChild();
-      if (!$isTableNode(table)) {
-        throw new Error('Expected table node');
-      }
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
       expect($getHeaderStates(table, TableCellHeaderStates.COLUMN)).toEqual([
         [false],
       ]);

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {buildEditorFromExtensions} from '@lexical/extension';
 import {
   $createTableCellNode,
   $createTableNode,
@@ -18,18 +19,17 @@ import {
   $setTableColumnIsHeader,
   $setTableRowIsHeader,
   TableCellHeaderStates,
-  TableCellNode,
-  TableNode,
-  TableRowNode,
+  TableExtension,
+  type TableNode,
 } from '@lexical/table';
 import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
-  createEditor,
-  type LexicalEditor,
+  defineExtension,
+  type LexicalEditorWithDispose,
 } from 'lexical';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 
 function $createTestTable(rows: number, columns: number): TableNode {
   const tableNode = $createTableNode();
@@ -76,21 +76,28 @@ function $getHeaderStates(
   });
 }
 
+let editor: LexicalEditorWithDispose;
+
+beforeEach(() => {
+  editor = buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [TableExtension],
+      name: 'LexicalTableUtils-test',
+    }),
+  );
+  editor.update(
+    () => {
+      $getRoot().clear();
+    },
+    {discrete: true},
+  );
+});
+
+afterEach(() => {
+  editor.dispose();
+});
+
 describe('$moveTableColumn', () => {
-  let editor: LexicalEditor;
-
-  beforeEach(() => {
-    editor = createEditor({
-      namespace: 'test',
-      nodes: [TableNode, TableCellNode, TableRowNode],
-      onError: (error: Error) => {
-        throw error;
-      },
-      theme: {},
-    });
-    editor._headless = true;
-  });
-
   test('moves a column forward', () => {
     editor.update(
       () => {
@@ -515,20 +522,6 @@ describe('$moveTableColumn', () => {
 });
 
 describe('$moveTableRow', () => {
-  let editor: LexicalEditor;
-
-  beforeEach(() => {
-    editor = createEditor({
-      namespace: 'test',
-      nodes: [TableNode, TableCellNode, TableRowNode],
-      onError: (error: Error) => {
-        throw error;
-      },
-      theme: {},
-    });
-    editor._headless = true;
-  });
-
   test('moves a row forward', () => {
     editor.update(
       () => {
@@ -993,20 +986,6 @@ describe('$moveTableRow', () => {
 });
 
 describe('$setTableRowIsHeader', () => {
-  let editor: LexicalEditor;
-
-  beforeEach(() => {
-    editor = createEditor({
-      namespace: 'test',
-      nodes: [TableNode, TableCellNode, TableRowNode],
-      onError: (error: Error) => {
-        throw error;
-      },
-      theme: {},
-    });
-    editor._headless = true;
-  });
-
   test('sets a row as header', () => {
     editor.update(
       () => {
@@ -1306,20 +1285,6 @@ describe('$setTableRowIsHeader', () => {
 });
 
 describe('$setTableColumnIsHeader', () => {
-  let editor: LexicalEditor;
-
-  beforeEach(() => {
-    editor = createEditor({
-      namespace: 'test',
-      nodes: [TableNode, TableCellNode, TableRowNode],
-      onError: (error: Error) => {
-        throw error;
-      },
-      theme: {},
-    });
-    editor._headless = true;
-  });
-
   test('sets a column as header', () => {
     editor.update(
       () => {

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -14,6 +14,7 @@ import {
   $isTableNode,
   $isTableRowNode,
   $moveTableColumn,
+  $moveTableRow,
   $setTableColumnIsHeader,
   $setTableRowIsHeader,
   TableCellHeaderStates,
@@ -508,6 +509,484 @@ describe('$moveTableColumn', () => {
           throw new Error('Expected row node');
         }
         expect(row.getChildrenSize()).toBe(4);
+      });
+    });
+  });
+});
+
+describe('$moveTableRow', () => {
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    editor = createEditor({
+      namespace: 'test',
+      nodes: [TableNode, TableCellNode, TableRowNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+      theme: {},
+    });
+    editor._headless = true;
+  });
+
+  test('moves a row forward', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(4, 2));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 0, 2);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r1c0', 'r1c1'],
+        ['r2c0', 'r2c1'],
+        ['r0c0', 'r0c1'],
+        ['r3c0', 'r3c1'],
+      ]);
+    });
+  });
+
+  test('moves a row backward', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(4, 2));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 3, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r0c0', 'r0c1'],
+        ['r3c0', 'r3c1'],
+        ['r1c0', 'r1c1'],
+        ['r2c0', 'r2c1'],
+      ]);
+    });
+  });
+
+  test('moves a row to the first position', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(4, 2));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 2, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r2c0', 'r2c1'],
+        ['r0c0', 'r0c1'],
+        ['r1c0', 'r1c1'],
+        ['r3c0', 'r3c1'],
+      ]);
+    });
+  });
+
+  test('moves a row to the last position', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(4, 2));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 0, 3);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r1c0', 'r1c1'],
+        ['r2c0', 'r2c1'],
+        ['r3c0', 'r3c1'],
+        ['r0c0', 'r0c1'],
+      ]);
+    });
+  });
+
+  test('is a no-op when origin equals target', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(3, 2));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 1, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r0c0', 'r0c1'],
+        ['r1c0', 'r1c1'],
+        ['r2c0', 'r2c1'],
+      ]);
+    });
+  });
+
+  test('is a no-op when origin is out of bounds', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(3, 2));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 3, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r0c0', 'r0c1'],
+        ['r1c0', 'r1c1'],
+        ['r2c0', 'r2c1'],
+      ]);
+    });
+  });
+
+  test('is a no-op when target is out of bounds', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(3, 2));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 0, 3);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r0c0', 'r0c1'],
+        ['r1c0', 'r1c1'],
+        ['r2c0', 'r2c1'],
+      ]);
+    });
+  });
+
+  test('is a no-op when origin is negative', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(3, 2));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, -1, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r0c0', 'r0c1'],
+        ['r1c0', 'r1c1'],
+        ['r2c0', 'r2c1'],
+      ]);
+    });
+  });
+
+  test('does not modify table with merged cells', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const tableNode = $createTableNode();
+        // Row 0: cell spanning 2 columns, then a normal cell
+        const row0 = $createTableRowNode();
+        const mergedCell = $createTableCellNode();
+        mergedCell.setColSpan(2);
+        mergedCell.append(
+          $createParagraphNode().append($createTextNode('merged')),
+        );
+        const normalCell = $createTableCellNode();
+        normalCell.append(
+          $createParagraphNode().append($createTextNode('r0c2')),
+        );
+        row0.append(mergedCell, normalCell);
+
+        // Row 1: 3 normal cells
+        const row1 = $createTableRowNode();
+        for (let c = 0; c < 3; c++) {
+          const cell = $createTableCellNode();
+          cell.append(
+            $createParagraphNode().append($createTextNode(`r1c${c}`)),
+          );
+          row1.append(cell);
+        }
+
+        tableNode.append(row0, row1);
+        root.append(tableNode);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 0, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      // Should be unchanged because table has merged cells
+      const rows = table.getChildren();
+      if (!$isTableRowNode(rows[0])) {
+        throw new Error('Expected row node');
+      }
+      const firstRowCells = rows[0].getChildren();
+      expect(firstRowCells.length).toBe(2); // merged cell + normal cell
+      if (!$isTableCellNode(firstRowCells[0])) {
+        throw new Error('Expected cell node');
+      }
+      expect(firstRowCells[0].getColSpan()).toBe(2);
+      expect(firstRowCells[0].getTextContent()).toBe('merged');
+    });
+  });
+
+  test('swaps adjacent rows', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(2, 3));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 0, 1);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r1c0', 'r1c1', 'r1c2'],
+        ['r0c0', 'r0c1', 'r0c2'],
+      ]);
+    });
+  });
+
+  test('moves header cells along with the row', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const tableNode = $createTableNode();
+        for (let r = 0; r < 3; r++) {
+          const row = $createTableRowNode();
+          for (let c = 0; c < 2; c++) {
+            const cell = $createTableCellNode(
+              r === 0
+                ? TableCellHeaderStates.ROW
+                : TableCellHeaderStates.NO_STATUS,
+            );
+            cell.append(
+              $createParagraphNode().append($createTextNode(`r${r}c${c}`)),
+            );
+            row.append(cell);
+          }
+          tableNode.append(row);
+        }
+        root.append(tableNode);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 0, 2);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      expect($getTableCellTexts(table)).toEqual([
+        ['r1c0', 'r1c1'],
+        ['r2c0', 'r2c1'],
+        ['r0c0', 'r0c1'],
+      ]);
+      const rows = table.getChildren();
+      const movedRow = rows[2];
+      if (!$isTableRowNode(movedRow)) {
+        throw new Error('Expected row node');
+      }
+      movedRow.getChildren().forEach(cell => {
+        if (!$isTableCellNode(cell)) {
+          throw new Error('Expected cell node');
+        }
+        expect(cell.getHeaderStyles()).toBe(TableCellHeaderStates.ROW);
+      });
+    });
+  });
+
+  test('preserves table structure after move', () => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.append($createTestTable(4, 3));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $getRoot().getFirstChild();
+        if (!$isTableNode(table)) {
+          throw new Error('Expected table node');
+        }
+        $moveTableRow(table, 1, 3);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $getRoot().getFirstChild();
+      if (!$isTableNode(table)) {
+        throw new Error('Expected table node');
+      }
+      // Verify row and column count is preserved
+      const rows = table.getChildren();
+      expect(rows.length).toBe(4);
+      rows.forEach(row => {
+        if (!$isTableRowNode(row)) {
+          throw new Error('Expected row node');
+        }
+        expect(row.getChildrenSize()).toBe(3);
       });
     });
   });

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -92,6 +92,7 @@ export {
   $isSimpleTable,
   $mergeCells,
   $moveTableColumn,
+  $moveTableRow,
   $removeTableRowAtIndex,
   $setTableColumnIsHeader,
   $setTableRowIsHeader,

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -97,6 +97,7 @@ export {
   $setTableColumnIsHeader,
   $setTableRowIsHeader,
   $unmergeCell,
+  $unmergeCellNode,
 } from './LexicalTableUtils';
 export {
   TableImportRules,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

#### 1. Adds `$moveTableRow(tableNode, originRow, targetRow)` to `@lexical/table`, the row counterpart of `$moveTableColumn` (added in #8063).

- Moves a row from one index to another within a simple (non-merged) table.
- Exported from the package entry point, declared in `flow/LexicalTable.js.flow`, and documented with JSDoc.

#### 2. Fixes a missing export while touching the entry point: `$unmergeCellNode` (added in #7408) was never re-exported from `src/index.ts`
same issue as `$insertTableRowAtNode` / `$insertTableColumnAtNode`, which were fixed in #8791.
Without it, unmerging a specific cell requires moving the selection into the cell first (`cellNode.selectEnd()` + `$unmergeCell()`). This PR adds the export, the Flow declaration, and JSDoc.


## Test plan

Added unit tests for `$moveTableRow` (12 cases in `LexicalTableUtils.test.ts`):

- Moves a row forward / backward / to the first and last position, swaps adjacent rows
- No-op cases: `originRow === targetRow`, out-of-bounds or negative indices, tables with merged cells
- Header cells move along with the row, and table structure is preserved after the move

### Before

```ts
import {$moveTableRow} from '@lexical/table';
// => Module '"@lexical/table"' has no exported member '$moveTableRow'.

import {$unmergeCellNode} from '@lexical/table';
// => Module '"@lexical/table"' has no exported member '$unmergeCellNode'.

// Unmerging a specific cell requires selection manipulation:
cellNode.selectEnd();
$unmergeCell();
```

Rows can only be reordered by removing and re-inserting them manually.

### After

```ts
import {$moveTableRow, $unmergeCellNode} from '@lexical/table';

$moveTableRow(tableNode, 0, 2); // moves the first row to index 2
$unmergeCellNode(cellNode); // no selection manipulation needed
```

`npm run test-unit -- LexicalTableUtils.test` — 38 tests pass (12 new, 26 existing).