### PR TITLE
Open playground links in a new tab

### DIFF
--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -273,7 +273,7 @@ const AppExtension = /* @__PURE__ */ defineExtension({
     MentionsExtension,
     /* @__PURE__ */ configExtension(LinkExtension, {validateUrl}),
     PlaygroundAutoLinkExtension,
-    ClickableLinkExtension,
+    /* @__PURE__ */ configExtension(ClickableLinkExtension, {newTab: true}),
     SelectionAlwaysOnDisplayExtension,
     /* @__PURE__ */ configExtension(SelectBlockExtension, {
       cascadeSelection: true,


### PR DESCRIPTION
## Description

In the Lexical playground, clicking a link in read-only mode navigates the **current** tab away from the playground. This is jarring — you lose your editor state just by following a link.

The playground's `ClickableLinkExtension` was added with its default config (`newTab: false`). In read-only mode, `registerClickableLink` handles the click and calls:

```js
window.open(url, stores.newTab.peek() || ... || urlTarget === '_blank' ? '_blank' : '_self');
```

Since `newTab` is `false`, and the playground's default link attributes don't set `target="_blank"` (the `hasLinkAttributes` setting defaults to `false`), links open with `_self`.

## Fix

Configure the extension in the playground with `newTab: true`:

```diff
-    ClickableLinkExtension,
+    configExtension(ClickableLinkExtension, {newTab: true}),
```

Now clicked links in the playground open in a new tab, keeping the editor open. `newTab` is an existing, documented config field on `ClickableLinkConfig` — no API changes.

## Test plan

1. `cd packages/lexical-playground && npm run dev`
2. Type text, select it, add a link via the toolbar.
3. Toggle the editor to read-only mode.
4. Click the link → it opens in a **new** tab; the playground stays open in the current tab.

---
_Raised on behalf of @potatowagon by Navi (AI assistant)._
