### PR TITLE
Support opt-in default target/rel for links via theme

### DIFF
--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -64,6 +64,29 @@ export type SerializedLinkNode = Spread<
 
 type LinkHTMLElementType = HTMLAnchorElement | HTMLSpanElement;
 
+/**
+ * Resolves the anchor class name and the render-time default `target`/`rel`
+ * from `theme.link`, which may be a plain class-name string (historical) or an
+ * object with optional `class`, `target`, and `rel`. The defaults are applied
+ * only at render time (see {@link LinkNode.updateLinkDOM}) and never written to
+ * the node's serialized state.
+ */
+function getLinkThemeConfig(config: EditorConfig): {
+  className: string | undefined;
+  defaultTarget: null | string;
+  defaultRel: null | string;
+} {
+  const theme = config.theme.link;
+  if (theme != null && typeof theme === 'object') {
+    return {
+      className: theme.class,
+      defaultRel: theme.rel != null ? theme.rel : null,
+      defaultTarget: theme.target != null ? theme.target : null,
+    };
+  }
+  return {className: theme || undefined, defaultRel: null, defaultTarget: null};
+}
+
 const SUPPORTED_URL_PROTOCOLS = new Set([
   'http:',
   'https:',
@@ -119,7 +142,7 @@ export class LinkNode extends ElementNode {
   createDOM(config: EditorConfig): LinkHTMLElementType {
     const element = $getDocument().createElement('a');
     this.updateLinkDOM(null, element, config);
-    addClassNamesToElement(element, config.theme.link);
+    addClassNamesToElement(element, getLinkThemeConfig(config).className);
     return element;
   }
 
@@ -132,10 +155,17 @@ export class LinkNode extends ElementNode {
       if (!prevNode || prevNode.__url !== this.__url) {
         anchor.href = this.sanitizeUrl(this.__url);
       }
+      const {defaultTarget, defaultRel} = getLinkThemeConfig(config);
+      // Render-time defaults from the theme are applied only when the node has
+      // no explicit value for the attribute. This never mutates the node's
+      // serialized state, so it stays opt-in and non-destructive.
+      const defaults = {rel: defaultRel, target: defaultTarget, title: null};
       for (const attr of ['target', 'rel', 'title'] as const) {
         const key = `__${attr}` as const;
-        const value = this[key];
-        if (!prevNode || prevNode[key] !== value) {
+        const value = this[key] != null ? this[key] : defaults[attr];
+        const prevValue =
+          prevNode && prevNode[key] != null ? prevNode[key] : defaults[attr];
+        if (!prevNode || prevValue !== value) {
           if (value) {
             anchor[attr] = value;
           } else {

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -241,6 +241,42 @@ describe('LexicalLinkNode tests', () => {
       });
     });
 
+    test('LinkNode.createDOM() applies theme.link default target and rel', async () => {
+      const {editor} = testEnv;
+
+      const themeConfig = Object.freeze({
+        namespace: '',
+        theme: {
+          link: {
+            class: 'my-link-class',
+            rel: 'noopener noreferrer',
+            target: '_blank',
+          },
+        },
+      });
+
+      await editor.update(() => {
+        // A link with no explicit target/rel picks up the theme defaults at
+        // render time...
+        const linkNode = $createLinkNode('https://example.com/foo');
+        expect(linkNode.createDOM(themeConfig).outerHTML).toBe(
+          '<a href="https://example.com/foo" target="_blank" rel="noopener noreferrer" class="my-link-class"></a>',
+        );
+        // ...but the defaults are render-only and never written to state.
+        expect(linkNode.getTarget()).toBe(null);
+        expect(linkNode.getRel()).toBe(null);
+
+        // An explicit target/rel on the node overrides the theme defaults.
+        const explicitNode = $createLinkNode('https://example.com/bar', {
+          rel: 'noreferrer',
+          target: '_self',
+        });
+        expect(explicitNode.createDOM(themeConfig).outerHTML).toBe(
+          '<a href="https://example.com/bar" target="_self" rel="noreferrer" class="my-link-class"></a>',
+        );
+      });
+    });
+
     test('LinkNode.createDOM() sanitizes javascript: URLs', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -367,7 +367,9 @@ export type EditorThemeClasses = {
   tableCellHeader?: EditorThemeClassName,
   mark?: EditorThemeClassName,
   markOverlap?: EditorThemeClassName,
-  link?: EditorThemeClassName,
+  link?:
+    | EditorThemeClassName
+    | {class?: EditorThemeClassName, target?: string, rel?: string},
   quote?: EditorThemeClassName,
   code?: EditorThemeClassName,
   codeHighlight?: {[string]: EditorThemeClassName},

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -103,6 +103,34 @@ export type Klass<T extends LexicalNode> =
 
 export type EditorThemeClassName = string;
 
+/**
+ * Theme configuration for {@link LinkNode}. Either a plain class name string
+ * (applied to the rendered `<a>`, the historical behavior) or an object that
+ * additionally supplies render-time default `target`/`rel` attributes.
+ *
+ * The defaults are applied by {@link LinkNode} at DOM render time only when the
+ * node has no explicit value for that attribute. They are NOT written to the
+ * node's serialized state, so enabling them does not rewrite saved content and
+ * a node created without a `target` still round-trips as having no `target`.
+ * This makes "open links in a new tab by default" opt-in and non-destructive.
+ */
+export type LinkNodeThemeClasses =
+  | EditorThemeClassName
+  | {
+      /** Class name(s) applied to the rendered anchor element. */
+      class?: EditorThemeClassName;
+      /**
+       * Default `target` applied to links that have no explicit target
+       * (e.g. `'_blank'` to open links in a new tab by default).
+       */
+      target?: string;
+      /**
+       * Default `rel` applied to links that have no explicit rel
+       * (e.g. `'noopener noreferrer'`, recommended alongside `target: '_blank'`).
+       */
+      rel?: string;
+    };
+
 export interface TextNodeThemeClasses {
   base?: EditorThemeClassName;
   bold?: EditorThemeClassName;
@@ -191,7 +219,7 @@ export interface EditorThemeClasses {
   hr?: EditorThemeClassName;
   hrSelected?: EditorThemeClassName;
   image?: EditorThemeClassName;
-  link?: EditorThemeClassName;
+  link?: LinkNodeThemeClasses;
   list?: {
     ul?: EditorThemeClassName;
     ulDepth?: EditorThemeClassName[];


### PR DESCRIPTION
## Description

There's currently no first-party, non-destructive way to make `LinkNode`s open in a new tab **by default** — i.e. to apply a default `target`/`rel` to links that don't carry an explicit one. This matters for consumers who render Lexical content from saved state or imported HTML (read-only views, server-rendered output), where most links have no `target` attribute.

Today the options are:
- `LinkExtension.attributes` — only applied via `TOGGLE_LINK_COMMAND` and paste. Links created by `importDOM` / `importJSON` (loading saved content) get no default.
- Subclass `LinkNode` + node replacement — works, but forces a non-standard node type into serialized content.
- A DOM click listener — sidesteps the node entirely and doesn't affect the rendered `<a target>` / exported HTML.

## What this adds

An **opt-in, render-time-only** default via the theme. `theme.link` now accepts an object in addition to the historical class-name string:

```ts
const theme = {
  link: {
    class: 'editor-link',      // same as the old string form
    target: '_blank',          // default target for links with no explicit target
    rel: 'noopener noreferrer' // default rel for links with no explicit rel
  },
};
```

`LinkNode.updateLinkDOM` applies the theme default for `target`/`rel` **only when the node has no explicit value**, purely at DOM render time.

Key properties:
- *Non-destructive:* the defaults are never written to serialized state — `getTarget()` / `getRel()` stay `null`, JSON round-trips unchanged. No editable-editor serialization surprise.
- *Covers every path:* toggle, paste, AutoLink, `importDOM`, and `importJSON` all render through `createDOM`/`updateLinkDOM`, so they all pick up the default.
- *Opt-in & backward compatible:* `theme.link` as a string behaves exactly as before. An explicit `target`/`rel` on the node always overrides the theme default.

The existing `ClickableLinkExtension.newTab` remains the knob for read-only *click* behavior; this PR is about the rendered anchor attributes.

## Changes

- `EditorThemeClasses.link` widened to `string | { class?, target?, rel? }` (`LinkNodeThemeClasses`), plus the matching Flow type.
- `LinkNode.createDOM` / `updateLinkDOM` resolve the class name and render-time defaults via a small `getLinkThemeConfig` helper.

## Test plan

- Added unit tests in `LexicalLinkNode.test.ts`:
  - a link with no explicit target/rel picks up `theme.link.target`/`rel` at render time, while `getTarget()`/`getRel()` remain `null`;
  - an explicit target/rel on the node overrides the theme defaults.
- `vitest --project unit` for `LexicalLinkNode.test.ts`: 66/66 passing.
- `tsc` and `eslint` clean on the changed files.

---
_Raised on behalf of @potatowagon by Navi (AI assistant)._
