### PR TITLE
[lexical-link] Bug Fix: disable link opening for disabled autolink in…

### DIFF
--- a/packages/lexical-link/src/ClickableLinkExtension.ts
+++ b/packages/lexical-link/src/ClickableLinkExtension.ts
@@ -22,7 +22,7 @@ import {
 } from 'lexical';
 
 import {LinkExtension} from './LexicalLinkExtension';
-import {$isLinkNode} from './LexicalLinkNode';
+import {$isAutoLinkNode, $isLinkNode} from './LexicalLinkNode';
 
 function findMatchingDOM<T extends Node>(
   startNode: Node,
@@ -63,12 +63,15 @@ export function registerClickableLink(
 
     let url = null;
     let urlTarget = null;
+    let isUnlinkedAutolink = false;
     nearestEditor.update(() => {
       const clickedNode = $getNearestNodeFromDOMNode(target);
       if (clickedNode !== null) {
         const maybeLinkNode = $findMatchingParent(clickedNode, $isElementNode);
         if (!stores.disabled.peek()) {
           if ($isLinkNode(maybeLinkNode)) {
+            isUnlinkedAutolink =
+              $isAutoLinkNode(maybeLinkNode) && maybeLinkNode.getIsUnlinked();
             url = maybeLinkNode.sanitizeUrl(maybeLinkNode.getURL());
             urlTarget = maybeLinkNode.getTarget();
           } else {
@@ -82,7 +85,7 @@ export function registerClickableLink(
       }
     });
 
-    if (url === null || url === '') {
+    if (url === null || url === '' || isUnlinkedAutolink) {
       return;
     }
 


### PR DESCRIPTION
## Description
When using `ClickableLinkExtension` & `AutoLinkExtension` together, an unexpected behaviour happens when clicking an unlinked AutoLinkNode. The link is opened as if it was still linked.

This PR prevents this unexpected behaviour.

## Test plan

### Before

https://github.com/user-attachments/assets/ac03fd4f-e8dd-48cf-90ff-a74fb0f33a7d


### After

https://github.com/user-attachments/assets/88b110c4-0220-4fe0-bc55-d175b7c88737