### PR TITLE
[lexical-react] Bug Fix: Count block separators in character limit overflow wrapping

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CharacterLimit.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CharacterLimit.spec.mjs
@@ -261,7 +261,9 @@ function testSuite(charset) {
             <span data-lexical-text="true">3456</span>
           </p>
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
-            <span data-lexical-text="true">7</span>
+            <span class="PlaygroundEditorTheme__characterLimit">
+              <span data-lexical-text="true">7</span>
+            </span>
           </p>
         `,
       );
@@ -337,13 +339,13 @@ function testSuite(charset) {
     await page.keyboard.type('7');
     await assertHTML(
       page,
-      '<ul class="PlaygroundEditorTheme__ul" dir="auto"><li value="1" class="PlaygroundEditorTheme__listItem"><span data-lexical-text="true">1234</span></li><li value="2" class="PlaygroundEditorTheme__listItem"><span data-lexical-text="true">5</span><span class="PlaygroundEditorTheme__characterLimit"><span data-lexical-text="true">6</span></span></li><li value="3" class="PlaygroundEditorTheme__listItem"><span class="PlaygroundEditorTheme__characterLimit"><span data-lexical-text="true">7</span></span></li></ul>',
+      '<ul class="PlaygroundEditorTheme__ul" dir="auto"><li value="1" class="PlaygroundEditorTheme__listItem"><span data-lexical-text="true">1234</span></li><li value="2" class="PlaygroundEditorTheme__listItem"><span class="PlaygroundEditorTheme__characterLimit"><span data-lexical-text="true">56</span></span></li><li value="3" class="PlaygroundEditorTheme__listItem"><span class="PlaygroundEditorTheme__characterLimit"><span data-lexical-text="true">7</span></span></li></ul>',
     );
 
     await pressBackspace(page, 3);
     await assertHTML(
       page,
-      '<ul class="PlaygroundEditorTheme__ul" dir="auto"><li value="1" class="PlaygroundEditorTheme__listItem"><span data-lexical-text="true">1234</span></li><li value="2" class="PlaygroundEditorTheme__listItem"><span data-lexical-text="true">5</span></li></ul>',
+      '<ul class="PlaygroundEditorTheme__ul" dir="auto"><li value="1" class="PlaygroundEditorTheme__listItem"><span data-lexical-text="true">1234</span></li><li value="2" class="PlaygroundEditorTheme__listItem"><span class="PlaygroundEditorTheme__characterLimit"><span data-lexical-text="true">5</span></span></li></ul>',
     );
   });
 

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
@@ -19,6 +19,7 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $isParagraphNode,
   $isRangeSelection,
   $isTextNode,
   $setSlot,
@@ -30,7 +31,7 @@ import {
   $createTestDecoratorNode,
   TestDecoratorNode,
 } from 'lexical/src/__tests__/utils';
-import {afterEach, describe, expect, test} from 'vitest';
+import {afterEach, assert, describe, expect, test} from 'vitest';
 
 import {
   $mergePrevious,
@@ -177,6 +178,104 @@ describe('useCharacterLimit', () => {
         expect(children[0].getTextContent()).toBe('abcdg');
         expect($isOverflowNode(children[1])).toBe(true);
         expect(children[1].getTextContent()).toBe('ef');
+      });
+    });
+
+    test('counts \\n\\n separators between paragraphs (#6329)', async () => {
+      editor = makeEditor();
+
+      await editor.update(() => {
+        const root = $getRoot();
+        root.clear();
+        root.append(
+          $createParagraphNode().append($createTextNode('123')),
+          $createParagraphNode().append($createTextNode('456')),
+        );
+      });
+
+      await editor.update(() => {
+        // "123\n\n456" — offset 5 means "123" (3) + separator (2) = 5,
+        // so all of P2 should be overflow.
+        $wrapOverflowedNodes(5);
+      });
+
+      editor.read(() => {
+        const root = $getRoot();
+        const p1 = root.getChildAtIndex(0);
+        const p2 = root.getChildAtIndex(1);
+        assert($isParagraphNode(p1));
+        assert($isParagraphNode(p2));
+        expect(p1.getTextContent()).toBe('123');
+        expect($isOverflowNode(p1.getFirstChild())).toBe(false);
+        const overflow = p2.getFirstChild();
+        assert($isOverflowNode(overflow));
+        expect(overflow.getTextContent()).toBe('456');
+      });
+    });
+
+    test('splits text correctly with separator budget (#6329)', async () => {
+      editor = makeEditor();
+
+      await editor.update(() => {
+        const root = $getRoot();
+        root.clear();
+        root.append(
+          $createParagraphNode().append($createTextNode('12')),
+          $createParagraphNode().append($createTextNode('3456')),
+        );
+      });
+
+      await editor.update(() => {
+        // "12\n\n3456" — offset 5 means "12" (2) + separator (2) + "3" (1) = 5,
+        // so "456" in P2 should be overflow.
+        $wrapOverflowedNodes(5);
+      });
+
+      editor.read(() => {
+        const root = $getRoot();
+        const p2 = root.getChildAtIndex(1);
+        assert($isParagraphNode(p2));
+        const [kept, overflow] = p2.getChildren();
+        expect(kept.getTextContent()).toBe('3');
+        assert($isOverflowNode(overflow));
+        expect(overflow.getTextContent()).toBe('456');
+      });
+    });
+
+    test('counts multiple separators across three paragraphs (#6329)', async () => {
+      editor = makeEditor();
+
+      await editor.update(() => {
+        const root = $getRoot();
+        root.clear();
+        root.append(
+          $createParagraphNode().append($createTextNode('abc')),
+          $createParagraphNode().append($createTextNode('de')),
+          $createParagraphNode().append($createTextNode('fgh')),
+        );
+      });
+
+      await editor.update(() => {
+        // "abc\n\nde\n\nfgh" — offset 9 means "abc"(3)+sep(2)+"de"(2)+sep(2)=9,
+        // so all of P3 should be overflow.
+        $wrapOverflowedNodes(9);
+      });
+
+      editor.read(() => {
+        const root = $getRoot();
+        const p1 = root.getChildAtIndex(0);
+        const p2 = root.getChildAtIndex(1);
+        const p3 = root.getChildAtIndex(2);
+        assert($isParagraphNode(p1));
+        assert($isParagraphNode(p2));
+        assert($isParagraphNode(p3));
+        expect(p1.getTextContent()).toBe('abc');
+        expect($isOverflowNode(p1.getFirstChild())).toBe(false);
+        expect(p2.getTextContent()).toBe('de');
+        expect($isOverflowNode(p2.getFirstChild())).toBe(false);
+        const overflow = p3.getFirstChild();
+        assert($isOverflowNode(overflow));
+        expect(overflow.getTextContent()).toBe('fgh');
       });
     });
 

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -180,6 +180,18 @@ export function $wrapOverflowedNodes(offset: number): void {
   for (let i = 0; i < dfsNodesLength; i += 1) {
     const {node} = dfsNodes[i];
 
+    // ElementNode.getTextContent() inserts '\n\n' after each non-inline
+    // element child that is not the last child. findOffset counts those
+    // separators (via $rootTextContent), so the DFS must count them too.
+    const prevSibling = node.getPreviousSibling();
+    if (
+      prevSibling !== null &&
+      $isElementNode(prevSibling) &&
+      !prevSibling.isInline()
+    ) {
+      accumulatedLength += 2;
+    }
+
     // Slot value roots (a non-inline DecoratorNode slotted into a host) are
     // leaf nodes with __parent === null; wrapping them in OverflowNode would
     // call node.replace() and throw, so they stay out of the wrap loop. Their

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -184,11 +184,7 @@ export function $wrapOverflowedNodes(offset: number): void {
     // element child that is not the last child. findOffset counts those
     // separators (via $rootTextContent), so the DFS must count them too.
     const prevSibling = node.getPreviousSibling();
-    if (
-      prevSibling !== null &&
-      $isElementNode(prevSibling) &&
-      !prevSibling.isInline()
-    ) {
+    if ($isElementNode(prevSibling) && !prevSibling.isInline()) {
       accumulatedLength += 2;
     }
 


### PR DESCRIPTION
## Description

`findOffset` computes the wrap boundary from `$rootTextContent()`, which includes `\n\n` separators between non-inline block elements (via `ElementNode.getTextContent`). The DFS in `$wrapOverflowedNodes` only accumulates leaf text lengths and never accounts for those separators, so the overflow highlight lands too late when the content spans multiple paragraphs. With a limit of 5 and two paragraphs "123" / "456", the separator eats 2 of the budget but the DFS doesn't know — it thinks 2 more characters fit and only wraps "6" instead of all of "456".

The fix mirrors `ElementNode.getTextContent`'s separator condition in the DFS: when a node's previous sibling is a non-inline `ElementNode`, add 2 to the accumulated length before evaluating the node.

Closes #6329

## Test plan

- [x] `pnpm vitest run --project unit -- useLexicalCharacterLimit` — 7 tests pass
- [x] Manual playground (Chrome/Firefox/Safari, `isCharLimit=true`):
  - Type "123", Enter, "456" → counter shows -3, all of "456" is red
  - Type "12", Enter, "3456" → counter shows -3, "3" is normal, "456" is red
  - Delete characters from the first paragraph → overflow shrinks and eventually disappears
- [x] tsc / prettier / eslint clean