### PR TITLE
[lexical-yjs][lexical-react] Feature: Customizable Yjs shared-type root name

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -353,7 +353,7 @@ export default [
             'createBinding',
           ],
           isLexicalProvider: ['updateEditor', 'updateEditorSync'],
-          isSafeDollarFunction: '$createRootNode',
+          isSafeDollarFunction: ['$createRootNode', '$createCollabElementNode'],
         }),
       ],
       '@typescript-eslint/array-type': [ERROR, {default: 'array'}],

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -17,7 +17,7 @@ import {
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   type Binding,
-  createBinding,
+  createYjsBinding,
   type ExcludedProperties,
   type Provider,
   type SyncCursorPositionsFn,
@@ -52,6 +52,8 @@ type CollaborationPluginProps = {
    * Fallback to legacy method if not enabled or not supported.
    */
   selectionHighlight?: boolean;
+  /** Customize the Yjs shared-type key used for the root `XmlText`. Defaults to `'root'`. */
+  rootName?: string;
 };
 
 /**
@@ -75,6 +77,7 @@ export function CollaborationPlugin({
   awarenessData,
   syncCursorPositionsFn,
   selectionHighlight,
+  rootName,
 }: CollaborationPluginProps): JSX.Element {
   const isBindingInitialized = useRef(false);
   const isProviderInitialized = useRef(false);
@@ -116,22 +119,27 @@ export function CollaborationPlugin({
       return;
     }
 
-    isBindingInitialized.current = true;
+    const resolvedDoc = doc || yjsDocMap.get(id);
+    if (!resolvedDoc) {
+      return;
+    }
 
-    const newBinding = createBinding(
+    isBindingInitialized.current = true;
+    const newBinding = createYjsBinding({
+      doc: resolvedDoc,
+      docMap: yjsDocMap,
       editor,
-      provider,
-      id,
-      doc || yjsDocMap.get(id),
-      yjsDocMap,
       excludedProperties,
-    );
+      id,
+      rootName,
+    });
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setBinding(newBinding);
 
     return () => {
       newBinding.root.destroy(newBinding);
     };
-  }, [editor, provider, id, yjsDocMap, doc, excludedProperties]);
+  }, [editor, provider, id, yjsDocMap, doc, excludedProperties, rootName]);
 
   if (!provider || !binding) {
     return <></>;
@@ -232,6 +240,8 @@ type CollaborationPluginV2Props = {
    * Fallback to legacy method if not enabled or not supported.
    */
   selectionHighlight?: boolean;
+  /** Customize the Yjs shared-type key used for the root `XmlElement`. Defaults to `'root-v2'`. */
+  rootName?: string;
 };
 
 /**
@@ -254,6 +264,7 @@ export function CollaborationPluginV2__EXPERIMENTAL({
   excludedProperties,
   awarenessData,
   selectionHighlight,
+  rootName,
 }: CollaborationPluginV2Props): JSX.Element {
   const collabContext = useCollaborationContext(username, cursorColor);
   const {yjsDocMap, name, color} = collabContext;
@@ -273,6 +284,7 @@ export function CollaborationPluginV2__EXPERIMENTAL({
       __shouldBootstrapUnsafe,
       awarenessData,
       excludedProperties,
+      rootName,
       selectionHighlight,
     },
   );

--- a/packages/lexical-yjs/src/Bindings.ts
+++ b/packages/lexical-yjs/src/Bindings.ts
@@ -64,14 +64,10 @@ export type ExcludedProperties = Map<Klass<LexicalNode>, Set<string>>;
 function createBaseBinding(
   editor: LexicalEditor,
   id: string,
-  doc: Doc | null | undefined,
+  doc: Doc,
   docMap: Map<string, Doc>,
   excludedProperties?: ExcludedProperties,
 ): BaseBinding {
-  invariant(
-    doc !== undefined && doc !== null,
-    'createBinding: doc is null or undefined',
-  );
   const binding = {
     clientID: doc.clientID,
     cursorHighlightSheet: null,
@@ -88,6 +84,46 @@ function createBaseBinding(
   return binding;
 }
 
+/** Options for {@link createYjsBinding}. */
+export interface CreateYjsBindingOptions {
+  editor: LexicalEditor;
+  /** Identifier for this binding, used as the key in `docMap`. */
+  id: string;
+  doc: Doc;
+  docMap: Map<string, Doc>;
+  excludedProperties?: ExcludedProperties;
+  /** The key used to look up the root `XmlText` shared type on the Yjs `Doc`. Defaults to `'root'`. */
+  rootName?: string;
+}
+
+/**
+ * Create a V1 Yjs {@link Binding} that connects a {@link LexicalEditor} to a
+ * Yjs `Doc` for real-time collaboration.
+ *
+ * For the legacy positional-argument API, see {@link createBinding}.
+ */
+export function createYjsBinding({
+  editor,
+  id,
+  doc,
+  docMap,
+  excludedProperties,
+  rootName = 'root',
+}: CreateYjsBindingOptions): Binding {
+  const rootXmlText = doc.get(rootName, XmlText) as XmlText;
+  const root: CollabElementNode = $createCollabElementNode(
+    rootXmlText,
+    null,
+    'root',
+  );
+  root._key = 'root';
+  return {
+    ...createBaseBinding(editor, id, doc, docMap, excludedProperties),
+    collabNodeMap: new Map(),
+    root,
+  };
+}
+
 export function createBinding(
   editor: LexicalEditor,
   provider: Provider,
@@ -100,18 +136,7 @@ export function createBinding(
     doc !== undefined && doc !== null,
     'createBinding: doc is null or undefined',
   );
-  const rootXmlText = doc.get('root', XmlText) as XmlText;
-  const root: CollabElementNode = $createCollabElementNode(
-    rootXmlText,
-    null,
-    'root',
-  );
-  root._key = 'root';
-  return {
-    ...createBaseBinding(editor, id, doc, docMap, excludedProperties),
-    collabNodeMap: new Map(),
-    root,
-  };
+  return createYjsBinding({doc, docMap, editor, excludedProperties, id});
 }
 
 export function createBindingV2__EXPERIMENTAL(

--- a/packages/lexical-yjs/src/__tests__/unit/CreateYjsBinding.test.ts
+++ b/packages/lexical-yjs/src/__tests__/unit/CreateYjsBinding.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {createBinding, createYjsBinding, type Provider} from '@lexical/yjs';
+import {defineExtension} from 'lexical';
+import {describe, expect, test} from 'vitest';
+import {Doc, XmlText} from 'yjs';
+
+import {type CollabElementNode} from '../../CollabElementNode';
+
+function getRootXmlText(root: CollabElementNode): XmlText {
+  return (root as unknown as {_xmlText: XmlText})._xmlText;
+}
+
+function createTestDoc(): {doc: Doc; docMap: Map<string, Doc>} {
+  const doc = new Doc();
+  return {doc, docMap: new Map<string, Doc>([['test', doc]])};
+}
+
+describe('createYjsBinding', () => {
+  test('uses default rootName "root"', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({name: 'yjs-binding-test'}),
+    );
+    const {doc, docMap} = createTestDoc();
+
+    const binding = createYjsBinding({doc, docMap, editor, id: 'test'});
+
+    expect(binding.root).toBeDefined();
+    expect(doc.get('root', XmlText)).toBe(getRootXmlText(binding.root));
+  });
+
+  test('uses custom rootName', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({name: 'yjs-binding-test'}),
+    );
+    const {doc, docMap} = createTestDoc();
+
+    const binding = createYjsBinding({
+      doc,
+      docMap,
+      editor,
+      id: 'test',
+      rootName: 'customRoot',
+    });
+
+    expect(binding.root).toBeDefined();
+    expect(doc.get('customRoot', XmlText)).toBe(getRootXmlText(binding.root));
+    expect(doc.share.has('root')).toBe(false);
+  });
+
+  test('different rootNames create independent shared types', () => {
+    using editor1 = buildEditorFromExtensions(
+      defineExtension({name: 'yjs-binding-test-a'}),
+    );
+    using editor2 = buildEditorFromExtensions(
+      defineExtension({name: 'yjs-binding-test-b'}),
+    );
+    const {doc, docMap} = createTestDoc();
+
+    const binding1 = createYjsBinding({
+      doc,
+      docMap,
+      editor: editor1,
+      id: 'test',
+      rootName: 'editor-a',
+    });
+
+    const binding2 = createYjsBinding({
+      doc,
+      docMap,
+      editor: editor2,
+      id: 'test',
+      rootName: 'editor-b',
+    });
+
+    const xmlA = getRootXmlText(binding1.root);
+    const xmlB = getRootXmlText(binding2.root);
+    expect(xmlA).not.toBe(xmlB);
+    expect(doc.get('editor-a', XmlText)).toBe(xmlA);
+    expect(doc.get('editor-b', XmlText)).toBe(xmlB);
+  });
+});
+
+describe('createBinding (legacy wrapper)', () => {
+  test('delegates to createYjsBinding with default rootName', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({name: 'yjs-binding-legacy'}),
+    );
+    const {doc, docMap} = createTestDoc();
+
+    const binding = createBinding(
+      editor,
+      null as unknown as Provider,
+      'test',
+      doc,
+      docMap,
+    );
+
+    expect(binding.root).toBeDefined();
+    expect(doc.get('root', XmlText)).toBe(getRootXmlText(binding.root));
+  });
+
+  test('throws invariant when doc is null', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({name: 'yjs-binding-legacy'}),
+    );
+    const docMap = new Map<string, Doc>();
+
+    expect(() =>
+      createBinding(editor, null as unknown as Provider, 'test', null, docMap),
+    ).toThrow('createBinding: doc is null or undefined');
+  });
+});

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -81,9 +81,14 @@ export type {
   Binding,
   BindingV2,
   ClientID,
+  CreateYjsBindingOptions,
   ExcludedProperties,
 } from './Bindings';
-export {createBinding, createBindingV2__EXPERIMENTAL} from './Bindings';
+export {
+  createBinding,
+  createBindingV2__EXPERIMENTAL,
+  createYjsBinding,
+} from './Bindings';
 
 export function createUndoManager(
   binding: BaseBinding,


### PR DESCRIPTION
## Description

Adds a `rootName` option to customize the Yjs shared-type key, which was previously hardcoded to `'root'`. This lets multiple editors share a single Yjs `Doc` using independent shared types, and lets providers like pluv.io structure their Yjs documents without needing to know Lexical's internal key.

### Design

etrepum suggested either a `(doc: Doc) => XmlText` function or a string key. This PR uses a string (`rootName`) because the binding already calls `doc.get(name, XmlText)` internally — a factory function would let callers construct the `XmlText` themselves, but that creates a risk of passing in a shared type from a different `Doc` or one with an unexpected structure. A string keeps the binding in control of the shared-type lifecycle while still solving the customization need.

Following the same comment's suggestion, this introduces `createYjsBinding(options)` with a clean options-object API. `createBinding` is preserved as a backwards-compatible wrapper that delegates to it.

`rootName` is threaded through both `CollaborationPlugin` (V1) and `CollaborationPluginV2__EXPERIMENTAL` (V2) as an optional prop.

Closes #7537

## Test plan

- [x] `pnpm vitest run packages/lexical-yjs/src/__tests__/unit/CreateYjsBinding.test.ts` — 5 tests pass:
  - Default `rootName` uses `'root'`
  - Custom `rootName` creates the correct shared type
  - Different `rootName` values create independent shared types
  - Legacy `createBinding` delegates correctly
  - `createBinding` throws invariant on null doc
- [x] tsc clean (no errors in modified packages)
- [x] eslint + prettier clean via pre-commit hook