### PR TITLE
[lexical-rich-text][lexical-plain-text] Bug Fix: don't cancel dragover for text drags so native drops work again

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -21,7 +21,7 @@ import {
   $moveCharacter,
   $shouldOverrideDefaultCharacterSelection,
 } from '@lexical/selection';
-import {eventFiles, objectKlassEquals} from '@lexical/utils';
+import {objectKlassEquals} from '@lexical/utils';
 import {
   $getSelection,
   $getSlotFrame,
@@ -38,7 +38,6 @@ import {
   DELETE_CHARACTER_COMMAND,
   DELETE_LINE_COMMAND,
   DELETE_WORD_COMMAND,
-  DRAGOVER_COMMAND,
   DRAGSTART_COMMAND,
   DROP_COMMAND,
   INSERT_LINE_BREAK_COMMAND,
@@ -427,20 +426,6 @@ export function registerPlainText(editor: LexicalEditor): () => void {
     editor.registerCommand<DragEvent>(
       DROP_COMMAND,
       event => $handlePlainTextDrop(event, editor),
-      COMMAND_PRIORITY_EDITOR,
-    ),
-    editor.registerCommand<DragEvent>(
-      DRAGOVER_COMMAND,
-      event => {
-        const [isFileTransfer] = eventFiles(event);
-        if (isFileTransfer) {
-          return false;
-        }
-        // contenteditable is not a native drop target; preventDefault() is
-        // required on dragover to allow the drop event to fire in Firefox.
-        event.preventDefault();
-        return true;
-      },
       COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand<DragEvent>(

--- a/packages/lexical-playground/__tests__/e2e/TextDragDrop.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextDragDrop.spec.mjs
@@ -14,6 +14,7 @@ import {
 import {
   assertHTML,
   evaluate,
+  expect,
   focusEditor,
   html,
   initialize,
@@ -61,9 +62,10 @@ async function dragSelectionToOffset(page, sourceText, clientTextOffset) {
         dataTransfer,
       });
       editable.dispatchEvent(dragoverEvent);
-      if (!dragoverEvent.defaultPrevented) {
+      if (dragoverEvent.defaultPrevented) {
         throw new Error(
-          'dragover was not prevented; drop will not fire in Firefox',
+          'dragover over text must not be prevented; canceling it suppresses ' +
+            'the native editable drop handling that external text drops rely on',
         );
       }
       editable.dispatchEvent(
@@ -188,5 +190,58 @@ test.describe('Text drag and drop', () => {
         </p>
       `,
     );
+  });
+
+  test('native drop of text from a non-Lexical drag source inserts it', async ({
+    page,
+    browserName,
+    isCollab,
+  }) => {
+    // The other tests dispatch synthetic drag events, which never run the
+    // browser's default actions and so can't detect a handler that breaks
+    // native drop handling (e.g. an unconditional preventDefault() on
+    // dragover tells the browser the page owns the drop, suppressing the
+    // native editable insertFromDrop that external text drops rely on).
+    // Playwright's mouse API composes a real drag through the browser's
+    // drag controller, but only Chromium supports that interception.
+    test.skip(browserName !== 'chromium');
+    test.skip(!!isCollab);
+    await focusEditor(page);
+    await page.keyboard.type('hello world');
+
+    // Inject a draggable element that is not part of any Lexical editor.
+    await evaluate(page, () => {
+      const source = document.createElement('div');
+      source.id = 'external-drag-source';
+      source.textContent = 'DRAG ME';
+      source.draggable = true;
+      source.style.cssText =
+        'position:fixed;top:4px;left:4px;z-index:99999;padding:8px;';
+      source.addEventListener('dragstart', e => {
+        e.dataTransfer.setData('text/plain', 'EXTERNAL');
+      });
+      document.body.appendChild(source);
+    });
+
+    const source = await page.locator('#external-drag-source').boundingBox();
+    const target = await page
+      .locator('div[contenteditable="true"]')
+      .first()
+      .boundingBox();
+
+    await page.mouse.move(
+      source.x + source.width / 2,
+      source.y + source.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(source.x + 40, source.y + 40, {steps: 5});
+    await page.mouse.move(target.x + target.width / 2, target.y + 20, {
+      steps: 15,
+    });
+    await page.mouse.up();
+
+    await expect(
+      page.locator('div[contenteditable="true"]').first(),
+    ).toContainText('EXTERNAL');
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1749,9 +1749,22 @@ export function registerRichText(
         if (isFileTransfer && !$isRangeSelection(selection)) {
           return false;
         }
-        // contenteditable is not a native drop target; preventDefault() is
-        // required on dragover to allow the drop event to fire in Firefox.
-        event.preventDefault();
+        // Do NOT call event.preventDefault() here for text drags. Canceling
+        // dragover tells the browser the page will handle the drop itself,
+        // which suppresses the native editable drop behavior (drop caret
+        // tracking and the beforeinput insertFromDrop that $doDrop relies on
+        // for drags that don't originate in a Lexical editor). The only
+        // exception is a decorator node, which the browser can't show a drop
+        // caret for anyway and whose drops are fully handled by DROP_COMMAND.
+        const x = event.clientX;
+        const y = event.clientY;
+        const eventRange = caretFromPoint(x, y, editor.getRootElement());
+        if (eventRange !== null) {
+          const node = $getNearestNodeFromDOMNode(eventRange.node);
+          if ($isDecoratorNode(node)) {
+            event.preventDefault();
+          }
+        }
         return true;
       },
       COMMAND_PRIORITY_EDITOR,


### PR DESCRIPTION
## Description

The dragover spec-hardening change (#8663) made DRAGOVER_COMMAND call event.preventDefault() unconditionally for non-file drags in both registerRichText and registerPlainText. Canceling dragover tells the browser the page will handle the drop itself, so Chromium (and WebKit) stop tracking the drop caret and skip the native editable drop handling (beforeinput insertFromDrop). Since $doDrop deliberately returns false for drags that don't originate in a Lexical editor and relies on that native flow, any text dragged in from a non-Lexical source was silently discarded in both RichTextExtension and PlainTextExtension.

The synthetic-event e2e tests couldn't catch this because dispatchEvent never runs browser default actions, and the premise of the change was wrong: editable elements are valid drop targets per the HTML spec, so Firefox fires drop on contenteditable without dragover being canceled.

This PR restores the previous behavior:

- lexical-rich-text: only cancel dragover when the pointer is over a DecoratorNode (no native drop caret exists there and DROP_COMMAND fully handles those drops).
- lexical-plain-text: remove the DRAGOVER_COMMAND handler entirely (there was none before #8663).
- TextDragDrop.spec.mjs: invert the helper assertion so a reintroduced unconditional preventDefault trips it, and add a Chromium-only e2e test driving a real native drag from a non-Lexical drag source through Playwright's drag interception.

## Test plan

### Before

Dragging text from a non-Lexical source (another app, a draggable element, a textarea) and dropping it into the editor is a silent no-op in both rich-text and plain-text editors: dragover is canceled, drop fires unhandled, and the browser's native insertFromDrop never runs. The new e2e test ("native drop of text from a non-Lexical drag source inserts it") fails on the previous code.

### After

External text drops insert at the drop point again in both rich-text and plain-text modes, and same-editor selection drags keep working via the Lexical drag-marker path. Verified with the full TextDragDrop e2e suite in Chromium (rich-text and plain-text modes), the ShadowDOM file drop e2e test, unit tests, tsc, ESLint, and Prettier.
