### PR TITLE
[lexical-list] Chore: Rename isNestedListNode to $isNestedListNode

### DIFF
--- a/dev-examples/dom-import/src/wordPaste.ts
+++ b/dev-examples/dom-import/src/wordPaste.ts
@@ -109,7 +109,7 @@ function $buildWordListTree(
       stack.pop();
     }
     if (item.level > stack[stack.length - 1].level) {
-      // Lexical's nested-list convention (see `isNestedListNode` in
+      // Lexical's nested-list convention (see `$isNestedListNode` in
       // @lexical/list): a sublist lives inside its OWN ListItemNode
       // wrapper that is a sibling of the items above it, not inside
       // the previous content item. The wrapper has no own content,

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -47,7 +47,7 @@ import {
 
 import {$createListNode, $isListNode, type ListNode, type ListType} from './';
 import {$handleIndent, $handleOutdent, mergeLists} from './formatList';
-import {isNestedListNode} from './utils';
+import {$isNestedListNode} from './utils';
 
 export type SerializedListItemNode = Spread<
   {
@@ -218,7 +218,7 @@ export class ListItemNode extends ElementNode {
       element.dir = direction;
     }
 
-    if (isNestedListNode(this)) {
+    if ($isNestedListNode(this)) {
       return {
         after(containerElement) {
           if (isHTMLElement(containerElement)) {
@@ -371,8 +371,8 @@ export class ListItemNode extends ElementNode {
     if (
       prevSibling &&
       nextSibling &&
-      isNestedListNode(prevSibling) &&
-      isNestedListNode(nextSibling)
+      $isNestedListNode(prevSibling) &&
+      $isNestedListNode(nextSibling)
     ) {
       mergeLists(prevSibling.getFirstChild(), nextSibling.getFirstChild());
       nextSibling.remove();

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -398,7 +398,7 @@ export class ListItemNode extends ElementNode {
   }
 
   collapseAtStart(selection: RangeSelection): boolean {
-    if (isNestedListNode(this)) {
+    if ($isNestedListNode(this)) {
       return false;
     }
 

--- a/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
@@ -259,7 +259,7 @@ function $buildWordListTree(
       stack.pop();
     }
     // Open a new sublist if we just stepped deeper. Lexical's
-    // nested-list convention (see `isNestedListNode` in @lexical/list):
+    // nested-list convention (see `$isNestedListNode` in @lexical/list):
     // a sublist lives inside its OWN ListItemNode wrapper that is a
     // sibling of the content items above it, not inside the previous
     // one. The wrapper holds the sublist as its first (and only) child.

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -40,8 +40,8 @@ import {
   $getAllListItems,
   $getNewListStart,
   $getTopListNode,
+  $isNestedListNode,
   $removeHighestEmptyListParent,
-  isNestedListNode,
 } from './utils';
 
 function $isSelectingEmptyListItem(
@@ -229,8 +229,8 @@ export function mergeLists(list1: ListNode, list2: ListNode): void {
   if (
     listItem1 &&
     listItem2 &&
-    isNestedListNode(listItem1) &&
-    isNestedListNode(listItem2)
+    $isNestedListNode(listItem1) &&
+    $isNestedListNode(listItem2)
   ) {
     mergeLists(listItem1.getFirstChild(), listItem2.getFirstChild());
     listItem2.remove();
@@ -364,7 +364,7 @@ export function $handleIndent(listItemNode: ListItemNode): void {
   // go through each node and decide where to move it.
   const removed = new Set<NodeKey>();
 
-  if (isNestedListNode(listItemNode) || removed.has(listItemNode.getKey())) {
+  if ($isNestedListNode(listItemNode) || removed.has(listItemNode.getKey())) {
     return;
   }
 
@@ -374,7 +374,7 @@ export function $handleIndent(listItemNode: ListItemNode): void {
   const previousSibling = listItemNode.getPreviousSibling();
   // if there are nested lists on either side, merge them all together.
 
-  if (isNestedListNode(nextSibling) && isNestedListNode(previousSibling)) {
+  if ($isNestedListNode(nextSibling) && $isNestedListNode(previousSibling)) {
     const innerList = previousSibling.getFirstChild();
 
     if ($isListNode(innerList)) {
@@ -388,7 +388,7 @@ export function $handleIndent(listItemNode: ListItemNode): void {
         removed.add(nextSibling.getKey());
       }
     }
-  } else if (isNestedListNode(nextSibling)) {
+  } else if ($isNestedListNode(nextSibling)) {
     // if the ListItemNode is next to a nested ListNode, merge them
     const innerList = nextSibling.getFirstChild();
 
@@ -399,7 +399,7 @@ export function $handleIndent(listItemNode: ListItemNode): void {
         firstChild.insertBefore(listItemNode);
       }
     }
-  } else if (isNestedListNode(previousSibling)) {
+  } else if ($isNestedListNode(previousSibling)) {
     const innerList = previousSibling.getFirstChild();
 
     if ($isListNode(innerList)) {
@@ -434,7 +434,7 @@ export function $handleIndent(listItemNode: ListItemNode): void {
 export function $handleOutdent(listItemNode: ListItemNode): void {
   // go through each node and decide where to move it.
 
-  if (isNestedListNode(listItemNode)) {
+  if ($isNestedListNode(listItemNode)) {
     return;
   }
   const parentList = listItemNode.getParent();

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -137,7 +137,7 @@ const NestedListNodeBrand: unique symbol = Symbol.for(
  * @param node - The node to be checked.
  * @returns true if the node is a ListItemNode and has a ListNode child, false otherwise.
  */
-export function isNestedListNode(
+export function $isNestedListNode(
   node: LexicalNode | null | undefined,
 ): node is Spread<
   {getFirstChild(): ListNode; [NestedListNodeBrand]: never},


### PR DESCRIPTION
## Description

`isNestedListNode` calls node methods which require editor context, so per the rules-of-lexical convention it should carry the `$` prefix. The function is internal to the package (not exported from `index.ts`), so it is renamed outright with no deprecated alias.

- Rename `isNestedListNode` to `$isNestedListNode` in `packages/lexical-list/src/utils.ts`
- Update all internal call sites and imports in `formatList.ts` and `LexicalListItemNode.ts`
- Update doc-comment references in `ListImportExtension.test.ts` and `dev-examples/dom-import/src/wordPaste.ts`

## Test plan

Existing test coverage