### PR TITLE
[lexical-table] Bug Fix: Forward document-level copy events for read-only table selections

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -43,6 +43,7 @@ import {
   type ChildCaret,
   COMMAND_PRIORITY_HIGH,
   CONTROLLED_TEXT_INSERTION_COMMAND,
+  COPY_COMMAND,
   CUT_COMMAND,
   DELETE_CHARACTER_COMMAND,
   DELETE_LINE_COMMAND,
@@ -835,23 +836,43 @@ export function applyTableHandlers(
   );
 
   // When TableSelection clears native selection ranges (removeAllRanges),
-  // browsers redirect paste events to <body> instead of the rootElement.
-  // Intercept at the document level and forward to PASTE_COMMAND.
+  // browsers redirect copy/paste events to <body> instead of the rootElement.
+  // Intercept at the document level and forward to the corresponding command.
   const doc = rootElement.ownerDocument;
+  const shouldInterceptClipboardEvent = (event: ClipboardEvent): boolean => {
+    if (event.defaultPrevented) {
+      return false;
+    }
+
+    if (
+      event.target === rootElement ||
+      rootElement.contains(event.target as Node)
+    ) {
+      return false;
+    }
+
+    return editor.read('latest', () => {
+      const selection = $getSelection();
+      return (
+        rootElement.contains(doc.activeElement) &&
+        $isTableSelection(selection) &&
+        $isSelectionInTable(selection, tableNode)
+      );
+    });
+  };
+
+  tableObserver.listenersToRemove.add(
+    registerEventListener(doc, 'copy', (event: ClipboardEvent) => {
+      if (shouldInterceptClipboardEvent(event)) {
+        event.preventDefault();
+        editor.dispatchCommand(COPY_COMMAND, event);
+      }
+    }),
+  );
+
   tableObserver.listenersToRemove.add(
     registerEventListener(doc, 'paste', (event: ClipboardEvent) => {
-      if (event.defaultPrevented) {
-        return;
-      }
-      const shouldIntercept = editor.read('latest', () => {
-        const selection = $getSelection();
-        return (
-          rootElement.contains(doc.activeElement) &&
-          $isTableSelection(selection) &&
-          $isSelectionInTable(selection, tableNode)
-        );
-      });
-      if (shouldIntercept) {
+      if (shouldInterceptClipboardEvent(event)) {
         event.preventDefault();
         editor.dispatchCommand(PASTE_COMMAND, event);
       }

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -16,6 +16,7 @@ import {
   $deleteTableRowAtSelection,
   $isTableRowNode,
   $isTableSelection,
+  registerTableSelectionObserver,
   type TableMapType,
   type TableNode,
   type TableSelection,
@@ -28,17 +29,23 @@ import {
   $isParagraphNode,
   $isTextNode,
   $setSelection,
+  COMMAND_PRIORITY_EDITOR,
+  COPY_COMMAND,
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 
 describe('table selection', () => {
   initializeUnitTest(testEnv => {
     let tableNode: TableNode;
     let tableMap: TableMapType;
     let tableSelection: TableSelection;
+    let unregisterTableSelectionObserver: (() => void) | null = null;
 
     beforeEach(() => {
+      unregisterTableSelectionObserver = registerTableSelectionObserver(
+        testEnv.editor,
+      );
       testEnv.editor.update(() => {
         tableNode = $createTableNode();
         $getRoot()
@@ -66,6 +73,45 @@ describe('table selection', () => {
         );
         $setSelection(tableSelection);
       });
+    });
+
+    describe('regression #8832', () => {
+      test('forwards document-level copy events for table selections in read-only mode', async () => {
+        const copyEvents: ClipboardEvent[] = [];
+
+        testEnv.editor.update(() => {
+          testEnv.editor.setEditable(false);
+          const selection = $getSelection();
+          expect($isTableSelection(selection)).toBe(true);
+        });
+
+        testEnv.editor.registerCommand(
+          COPY_COMMAND,
+          event => {
+            copyEvents.push(event);
+            return true;
+          },
+          COMMAND_PRIORITY_EDITOR,
+        );
+
+        const rootElement = testEnv.editor.getRootElement();
+        rootElement?.focus();
+
+        const event = new ClipboardEvent('copy', {
+          bubbles: true,
+          cancelable: true,
+        });
+        rootElement?.ownerDocument.dispatchEvent(event);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(copyEvents).toHaveLength(1);
+      });
+    });
+
+    afterEach(() => {
+      unregisterTableSelectionObserver?.();
+      unregisterTableSelectionObserver = null;
     });
 
     describe('regression #7076', () => {


### PR DESCRIPTION
## Description

This PR fixes copy handling for table selections in read-only mode by forwarding qualifying document-level copy events into Lexical's `COPY_COMMAND` pipeline.

### Background

When investigating this issue, I found that the clipboard serialization path itself was functioning correctly once reached. The problem was that, for read-only table selections, the browser could dispatch the copy event outside of the editor root, preventing `COPY_COMMAND` from being dispatched.

Lexical already contains a document-level forwarding mechanism for the corresponding paste scenario. This change mirrors that existing pattern for copy events.

### Changes

* Add a document-level copy listener for table selections.
* Forward qualifying document-level copy events to `COPY_COMMAND`.
* Add a regression test covering document-level copy for a read-only table selection.

Closes #8832

## Test plan

### Before

* Added a regression test for a read-only table selection receiving a document-level copy event.
* The new test fails on the base branch because `COPY_COMMAND` is not dispatched.

### After

* The regression test passes with this change.
* `COPY_COMMAND` is dispatched for the document-level copy event.
* Existing `LexicalTableSelection` unit tests continue to pass (`14/14` passing).

**Commands run**

```bash
pnpm vitest --run packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx --project unit
```

Result:

* ✅ 1 test file passed
* ✅ 14/14 tests passed
