### PR TITLE
Skip scrollIntoViewIfNeeded when the selection rect is above the editor (Safari RTL caret jump)

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1586,7 +1586,7 @@ export function scrollIntoViewIfNeeded(
   // caret in RTL text) return a degenerate or out-of-bounds selection rect —
   // Safari also reports such a collapsed caret as `selection.type === 'Range'`,
   // which routes execution here (see the `#1482` comment in
-  // `updateDOMSelection`). Feeding that bogus rect to the scroller jumps the
+  // `$updateDOMSelection`). Feeding that bogus rect to the scroller jumps the
   // viewport up on every keystroke. Skip the scroll when the selection rect lies
   // entirely above rootElement. See #2495.
   const rootRect = rootElement.getBoundingClientRect();
@@ -1626,7 +1626,10 @@ export function scrollIntoViewIfNeeded(
         targetBottom -= scrollPaddingBottom;
       }
     } else {
-      const targetRect = element.getBoundingClientRect();
+      // Reuse the rect already measured for the guard above on the first
+      // iteration (element === rootElement) to avoid a second layout flush.
+      const targetRect =
+        element === rootElement ? rootRect : element.getBoundingClientRect();
       targetTop = targetRect.top;
       targetBottom = targetRect.bottom;
     }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1581,6 +1581,18 @@ export function scrollIntoViewIfNeeded(
   if (doc === null || defaultView === null) {
     return;
   }
+  // A caret that lives inside the editor cannot have a rect that sits entirely
+  // above the editor's own box. Some browsers (notably Safari, for a collapsed
+  // caret in RTL text) return a degenerate or out-of-bounds selection rect —
+  // Safari also reports such a collapsed caret as `selection.type === 'Range'`,
+  // which routes execution here (see the `#1482` comment in
+  // `updateDOMSelection`). Feeding that bogus rect to the scroller jumps the
+  // viewport up on every keystroke. Skip the scroll when the selection rect lies
+  // entirely above rootElement. See #2495.
+  const rootRect = rootElement.getBoundingClientRect();
+  if (selectionRect.bottom < rootRect.top) {
+    return;
+  }
   let {top: currentTop, bottom: currentBottom} = selectionRect;
   let targetTop = 0;
   let targetBottom = 0;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1581,14 +1581,14 @@ export function scrollIntoViewIfNeeded(
   if (doc === null || defaultView === null) {
     return;
   }
-  // A caret that lives inside the editor cannot have a rect that sits entirely
-  // above the editor's own box. Some browsers (notably Safari, for a collapsed
-  // caret in RTL text) return a degenerate or out-of-bounds selection rect —
-  // Safari also reports such a collapsed caret as `selection.type === 'Range'`,
-  // which routes execution here (see the `#1482` comment in
-  // `$updateDOMSelection`). Feeding that bogus rect to the scroller jumps the
-  // viewport up on every keystroke. Skip the scroll when the selection rect lies
-  // entirely above rootElement. See #2495.
+  // A caret inside the editor can never sit entirely above the editor's own top
+  // edge. Safari violates this for a collapsed caret in RTL text: it returns a
+  // degenerate, out-of-bounds selection rect and reports the caret as
+  // `selection.type === 'Range'`, which routes execution here (the `#1482` case
+  // in `$updateDOMSelection`). Feeding that rect to the scroller jumps the
+  // viewport up on every keystroke. Guard only this above-the-editor case — a
+  // rect below the editor is the normal "scroll the caret into view" path and is
+  // deliberately left untouched. See #2495.
   const rootRect = rootElement.getBoundingClientRect();
   if (selectionRect.bottom < rootRect.top) {
     return;

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -607,6 +607,31 @@ describe('LexicalUtils tests', () => {
         doc.documentElement.style.scrollPaddingTop = '';
       }
     });
+
+    test('scrollIntoViewIfNeeded ignores a selection rect that lies entirely above the editor', () => {
+      const {editor} = testEnv;
+      const rootElement = editor.getRootElement()!;
+
+      // Safari returns a degenerate/out-of-bounds rect for a collapsed caret in
+      // RTL text (and reports it as type "Range", which routes execution into
+      // this scroll path). The caret is reported above the editor's own box;
+      // scrolling to it jumps the viewport up on every keystroke. See #2495.
+      const scrollBySpy = vi
+        .spyOn(window, 'scrollBy')
+        .mockImplementation(() => {});
+      const rootRectSpy = vi
+        .spyOn(rootElement, 'getBoundingClientRect')
+        .mockReturnValue(new DOMRect(0, 200, 300, 400));
+
+      try {
+        const bogusRect = new DOMRect(0, -40, 0, 18); // top -40, bottom -22
+        scrollIntoViewIfNeeded(editor, bogusRect, rootElement);
+        expect(scrollBySpy).not.toHaveBeenCalled();
+      } finally {
+        scrollBySpy.mockRestore();
+        rootRectSpy.mockRestore();
+      }
+    });
   });
 });
 describe('$applyNodeReplacement', () => {


### PR DESCRIPTION
## Description

Typing in an RTL script (Arabic, Hebrew, …) in a contenteditable Lexical editor **on Safari** scrolls the window upward on every space/backspace, pushing the editor off-screen. Chrome and Firefox are unaffected.

### Root cause

Two Safari-specific behaviors combine, and both flow through `scrollIntoViewIfNeeded`:

1. Safari reports a **collapsed caret as `selection.type === 'Range'`** (Chrome/Firefox report `'Caret'`). In `$updateDOMSelection` this trips the existing special-case guarded by the *"Badly interpreted range selection when collapsed - #1482"* comment, so Lexical skips its early-return, re-applies the DOM selection, and runs the scroll block on every keystroke.
2. The scroll block derives `selectionRect` from `getRangeAt(0).getBoundingClientRect()`. For a **collapsed caret in RTL text, Safari returns a degenerate / out-of-bounds rect** (negative or zero `top`), worst at whitespace/line boundaries — i.e. after space/backspace.

With `selectionRect.top < targetTop`, `scrollIntoViewIfNeeded` issues `scrollBy(0, negative)` on the window, so the viewport jumps up and the caret is scrolled away from — the opposite of "scroll into view."

### Fix

A caret that lives inside the editor cannot have a rect that sits **entirely above the editor's own box**. When it does, the rect is unreliable, so skip the scroll. This is the browser-agnostic geometry guard proposed in #2495 (which reported the same scroll code from a different, non-RTL angle and was never merged).

```ts
const rootRect = rootElement.getBoundingClientRect();
if (selectionRect.bottom < rootRect.top) {
  return;
}
```

It's a pure geometry check — no browser sniffing, no RTL special-casing. Legitimate scrolling is unaffected: a genuinely off-screen caret has an in-bounds rect and still scrolls into view (covered by the existing `scrollIntoViewIfNeeded respects scroll-padding` test, which passes unchanged).

### Test plan

Added a unit test in `LexicalUtils.test.ts` asserting that a selection rect lying entirely above `rootElement` does not call `window.scrollBy`.

The live bug requires Safari's native RTL keyboard-input path (headless WebKit and Playwright don't reproduce it — a collapsed caret there reports `'Caret'`, not `'Range'`), so the regression is expressed as a unit test with a mocked bogus rect rather than an e2e test. Verified end-to-end against Lexical 0.44.0 in real Safari/WebKit by faithfully simulating the two documented Safari behaviors (collapsed `type === 'Range'` + a bogus caret rect); removing either makes the jump disappear.

Found via a production RTL bug in [basecamp/lexxy](https://github.com/basecamp/lexxy), which carries an equivalent build-time guard as an interim workaround until a fixed Lexical release ships.
