### PR TITLE
[lexical-playground] Bug Fix: account for sticky toolbar in scroll padding

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -12,6 +12,14 @@
   --playground-font-size: 16px;
 }
 
+html {
+  /* The page scrolls at the document level while .toolbar is sticky at the
+     top of the viewport (48px rendered: 36px height + 2 * 6px padding).
+     scroll-padding keeps scrollIntoViewIfNeeded and native scrolling from
+     leaving the selection hidden underneath it. */
+  scroll-padding-top: 52px;
+}
+
 body {
   margin: 0;
   font-family:


### PR DESCRIPTION
## Description

The playground page scrolls at the document level while the toolbar is sticky at the top of the viewport (48px rendered: 36px height + 2 * 6px padding). When scrollIntoViewIfNeeded (or native scrolling) brought the selection into view from above, it scrolled the selection line to y=0, leaving it hidden behind the toolbar.

This PR declares scroll-padding-top: 52px on the document element in the playground stylesheet. scrollIntoViewIfNeeded already honors scroll-padding on the document element, so the selection now lands just below the toolbar with a few pixels of breathing room. CSS-only change.

## Test plan

Verified with Playwright against the dev server: fill the editor with 40 lines, scroll the caret's line above the viewport, then type a character to trigger scrollIntoViewIfNeeded.

### Before

Caret line lands at y=0.3px, obscured by the 48px sticky toolbar.

### After

Caret line lands at y=52.3px, fully visible just below the toolbar.
