### PR TITLE
[lexical-table] Feature: Skip colgroup element in table DOM with undefined col widths

### DIFF
--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -68,7 +68,7 @@ function $updateColgroup(
   colCount: number,
   colWidths?: number[] | readonly number[],
 ) {
-  let colGroup = dom.querySelector('colgroup');
+  let colGroup = dom.querySelector<HTMLElement>(':scope > colgroup');
   if (!colWidths) {
     if (colGroup) colGroup.remove();
     return;
@@ -277,7 +277,7 @@ export class TableNode extends ElementNode {
     return super
       .getDOMSlot(element)
       .withElement(tableElement)
-      .withAfter(tableElement.querySelector('colgroup'));
+      .withAfter(tableElement.querySelector(':scope > colgroup'));
   }
 
   createDOM(config: EditorConfig, editor?: LexicalEditor): HTMLElement {

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -68,14 +68,20 @@ function $updateColgroup(
   colCount: number,
   colWidths?: number[] | readonly number[],
 ) {
-  const colGroup = dom.querySelector('colgroup');
-  if (!colGroup) {
+  let colGroup = dom.querySelector('colgroup');
+  if (!colWidths) {
+    if (colGroup) colGroup.remove();
     return;
+  }
+  if (!colGroup) {
+    colGroup = $getDocument().createElement('colgroup');
+    setDOMUnmanaged(colGroup);
+    dom.insertBefore(colGroup, dom.firstChild);
   }
   const cols = [];
   for (let i = 0; i < colCount; i++) {
     const col = $getDocument().createElement('col');
-    const width = colWidths && colWidths[i];
+    const width = colWidths[i];
     if (width) {
       col.style.width = `${width}px`;
     }

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -279,9 +279,12 @@ export class TableNode extends ElementNode {
     if (this.__style) {
       setDOMStyleFromCSS(tableElement.style, this.__style);
     }
-    const colGroup = $getDocument().createElement('colgroup');
-    tableElement.appendChild(colGroup);
-    setDOMUnmanaged(colGroup);
+    const colWidths = this.getColWidths();
+    if (colWidths) {
+      const colGroup = $getDocument().createElement('colgroup');
+      tableElement.appendChild(colGroup);
+      setDOMUnmanaged(colGroup);
+    }
     addClassNamesToElement(tableElement, config.theme.table);
     this.updateTableElement(null, tableElement, config);
     if ($isScrollableTablesActive(editor)) {

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -118,7 +118,6 @@ describe('LexicalTableCellNode tests', () => {
           `,
           html`
             <table>
-              <colgroup><col /></colgroup>
               <tbody>
                 <tr>
                   <td
@@ -150,7 +149,6 @@ describe('LexicalTableCellNode tests', () => {
           `,
           html`
             <table>
-              <colgroup><col /></colgroup>
               <tbody>
                 <tr>
                   <td
@@ -183,7 +181,6 @@ describe('LexicalTableCellNode tests', () => {
           `,
           html`
             <table>
-              <colgroup><col /></colgroup>
               <tbody>
                 <tr>
                   <td

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -126,9 +126,7 @@ describe('LexicalTableNode tests', () => {
               expectTableHtmlToBeEqual(
                 tableNode.createDOM(editorConfig).outerHTML,
                 html`
-                  <table class="${editorConfig.theme.table}">
-                    <colgroup></colgroup>
-                  </table>
+                  <table class="${editorConfig.theme.table}"></table>
                 `,
               );
             });
@@ -166,7 +164,6 @@ describe('LexicalTableNode tests', () => {
                 tables[0]!.outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
-                    <colgroup><col /></colgroup>
                     <tr dir="auto">
                       <td dir="auto">
                         <p dir="auto">
@@ -183,7 +180,6 @@ describe('LexicalTableNode tests', () => {
                   <table
                     class="${editorConfig.theme.table}"
                     style="background-color: blue">
-                    <colgroup><col /></colgroup>
                     <tr dir="auto">
                       <td dir="auto">
                         <p dir="auto">
@@ -220,7 +216,6 @@ describe('LexicalTableNode tests', () => {
                   <table
                     class="${editorConfig.theme.table}"
                     style="--table-index: 0">
-                    <colgroup><col /></colgroup>
                     <tr dir="auto">
                       <td dir="auto">
                         <p dir="auto">
@@ -237,7 +232,6 @@ describe('LexicalTableNode tests', () => {
                   <table
                     class="${editorConfig.theme.table}"
                     style="--table-index: 1">
-                    <colgroup><col /></colgroup>
                     <tr dir="auto">
                       <td dir="auto">
                         <p dir="auto">
@@ -515,10 +509,6 @@ describe('LexicalTableNode tests', () => {
               testEnv.innerHTML,
               html`
                 <table class="test-table-class">
-                  <colgroup>
-                    <col />
-                    <col />
-                  </colgroup>
                   <tr dir="auto" style="text-align: start">
                     <th dir="auto">
                       <p dir="auto">
@@ -668,11 +658,6 @@ describe('LexicalTableNode tests', () => {
               testEnv.innerHTML,
               html`
                 <table class="test-table-class">
-                  <colgroup>
-                    <col />
-                    <col />
-                    <col />
-                  </colgroup>
                   <tr dir="auto" style="text-align: start">
                     <td dir="auto" style="background-color: rgb(240, 240, 240)">
                       <p dir="auto" style="text-align: center">
@@ -985,12 +970,6 @@ describe('LexicalTableNode tests', () => {
               html`
                 <p dir="auto"><br data-lexical-managed-linebreak="true" /></p>
                 <table class="test-table-class">
-                  <colgroup>
-                    <col />
-                    <col />
-                    <col />
-                    <col />
-                  </colgroup>
                   <tr dir="auto">
                     <th dir="auto">
                       <p dir="auto">
@@ -1155,14 +1134,7 @@ describe('LexicalTableNode tests', () => {
                   <table
                     class="${editorConfig.theme.table} ${editorConfig.theme
                       .tableRowStriping}"
-                    data-lexical-row-striping="true">
-                    <colgroup>
-                      <col />
-                      <col />
-                      <col />
-                      <col />
-                    </colgroup>
-                  </table>
+                    data-lexical-row-striping="true"></table>
                 `,
               );
             });
@@ -1179,14 +1151,7 @@ describe('LexicalTableNode tests', () => {
               expectTableHtmlToBeEqual(
                 table.createDOM(editorConfig).outerHTML,
                 html`
-                  <table class="${editorConfig.theme.table}">
-                    <colgroup>
-                      <col />
-                      <col />
-                      <col />
-                      <col />
-                    </colgroup>
-                  </table>
+                  <table class="${editorConfig.theme.table}"></table>
                 `,
               );
             });
@@ -1225,14 +1190,7 @@ describe('LexicalTableNode tests', () => {
                         .tableFrozenColumn}">
                       <table
                         class="${editorConfig.theme.table}"
-                        data-lexical-frozen-column="true">
-                        <colgroup>
-                          <col />
-                          <col />
-                          <col />
-                          <col />
-                        </colgroup>
-                      </table>
+                        data-lexical-frozen-column="true"></table>
                     </div>
                   `,
                 );
@@ -1700,14 +1658,7 @@ describe('LexicalTableNode tests', () => {
                   table.createDOM(editorConfig).outerHTML,
                   html`
                     <div class="${editorConfig.theme.tableScrollableWrapper}">
-                      <table class="${editorConfig.theme.table}">
-                        <colgroup>
-                          <col />
-                          <col />
-                          <col />
-                          <col />
-                        </colgroup>
-                      </table>
+                      <table class="${editorConfig.theme.table}"></table>
                     </div>
                   `,
                 );
@@ -1737,14 +1688,7 @@ describe('LexicalTableNode tests', () => {
                 html`
                   <table
                     class="${editorConfig.theme.table} ${editorConfig.theme
-                      .tableAlignment.center}">
-                    <colgroup>
-                      <col />
-                      <col />
-                      <col />
-                      <col />
-                    </colgroup>
-                  </table>
+                      .tableAlignment.center}"></table>
                 `,
               );
             });
@@ -1761,14 +1705,7 @@ describe('LexicalTableNode tests', () => {
               expectTableHtmlToBeEqual(
                 table.createDOM(editorConfig).outerHTML,
                 html`
-                  <table class="${editorConfig.theme.table}">
-                    <colgroup>
-                      <col />
-                      <col />
-                      <col />
-                      <col />
-                    </colgroup>
-                  </table>
+                  <table class="${editorConfig.theme.table}"></table>
                 `,
               );
             });
@@ -1880,10 +1817,6 @@ describe('LexicalTableNode tests', () => {
             testEnv.innerHTML,
             html`
               <table class="test-table-class" dir="auto">
-                <colgroup>
-                  <col />
-                  <col />
-                </colgroup>
                 <tr dir="auto">
                   <th dir="auto">
                     <p dir="auto">
@@ -1922,10 +1855,6 @@ describe('LexicalTableNode tests', () => {
             html`
               <div class="table-scrollable-wrapper" dir="auto">
                 <table class="test-table-class">
-                  <colgroup>
-                    <col />
-                    <col />
-                  </colgroup>
                   <tr dir="auto">
                     <th dir="auto">
                       <p dir="auto">
@@ -1964,10 +1893,6 @@ describe('LexicalTableNode tests', () => {
             testEnv.innerHTML,
             html`
               <table class="test-table-class" dir="auto">
-                <colgroup>
-                  <col />
-                  <col />
-                </colgroup>
                 <tr dir="auto">
                   <th dir="auto">
                     <p dir="auto">

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {TableNode} from '@lexical/table';
+
 import {$insertDataTransferForRichText} from '@lexical/clipboard';
 import {$generateHtmlFromNodes} from '@lexical/html';
 import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
@@ -32,6 +34,7 @@ import {
   $selectAll,
   $setSelection,
   CUT_COMMAND,
+  isHTMLElement,
 } from 'lexical';
 import {
   $assertNodeType,
@@ -42,7 +45,7 @@ import {
   polyfillContentEditable,
 } from 'lexical/src/__tests__/utils';
 import {act, useState} from 'react';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {assert, beforeEach, describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',
@@ -66,6 +69,51 @@ function wrapTableHtml(expected: string): string {
       `<div class="table-scrollable-wrapper"$1><table`,
     )
     .replace(/<\/table>/g, '</table></div>');
+}
+
+interface TableHTMLGenerator {
+  cellTag: (col: number, row: number) => 'td' | 'th';
+  row: (children: string, row: number) => string;
+  cell: (children: string, col: number, row: number) => string;
+  body: (col: number, row: number) => string;
+}
+
+const PlainTableHTMLGenerator: TableHTMLGenerator = {
+  body: () => html`
+    <p dir="auto"><br data-lexical-managed-linebreak="true" /></p>
+  `,
+  cell: children => html`
+    <td dir="auto">${children}</td>
+  `,
+  cellTag: () => 'td',
+  row: children => html`
+    <tr dir="auto">${children}</tr>
+  `,
+};
+
+const HeadingTableHTMLGenerator: TableHTMLGenerator = {
+  ...PlainTableHTMLGenerator,
+  cellTag: (col, row) => (col === 0 || row === 0 ? 'th' : 'td'),
+};
+
+function emptyTableContentsHtml(
+  rows: number,
+  cols: number,
+  gen: TableHTMLGenerator,
+): string {
+  return html`
+    ${Array.from({length: rows}, (_a, row) =>
+      gen.row(
+        Array.from({length: cols}, (_b, col) => {
+          const rval = gen.cell(gen.body(col, row), col, row);
+          return gen.cellTag(col, row) === 'th'
+            ? rval.replace(/^\s*<td([\s\S]+)<\/td>\s*$/, '<th$1</th>')
+            : rval;
+        }).join(''),
+        row,
+      ),
+    ).join('')}
+  `;
 }
 
 polyfillContentEditable();
@@ -93,49 +141,52 @@ describe('LexicalTableNode tests', () => {
         );
       }
 
-      function stripTableContents(element: HTMLElement): HTMLElement {
-        const clone = element.cloneNode(true) as HTMLElement;
-        clone.querySelectorAll('tr').forEach(tr => tr.remove());
-        return clone;
-      }
-
       initializeUnitTest(
         testEnv => {
-          beforeEach(async () => {
+          beforeEach(() => {
             const {editor} = testEnv;
-            await editor.update(() => {
-              const root = $getRoot();
-              const paragraph = $createParagraphNode();
-              root.append(paragraph);
-              paragraph.select();
-            });
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const paragraph = $createParagraphNode();
+                root.append(paragraph);
+                paragraph.select();
+              },
+              {discrete: true},
+            );
           });
 
-          test('TableNode.constructor', async () => {
+          test('TableNode.constructor', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const tableNode = $createTableNode();
+            editor.update(
+              () => {
+                const tableNode = $createTableNode();
 
-              expect(tableNode).not.toBe(null);
-            });
+                expect(tableNode).not.toBe(null);
+              },
+              {discrete: true},
+            );
 
             expect(() => $createTableNode()).toThrow();
           });
 
-          test('TableNode.createDOM()', async () => {
+          test('TableNode.createDOM()', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const tableNode = $createTableNode();
+            editor.update(
+              () => {
+                const tableNode = $createTableNode();
 
-              expectTableHtmlToBeEqual(
-                tableNode.createDOM(editorConfig).outerHTML,
-                html`
-                  <table class="${editorConfig.theme.table}"></table>
-                `,
-              );
-            });
+                expectTableHtmlToBeEqual(
+                  tableNode.createDOM(editorConfig).outerHTML,
+                  html`
+                    <table class="${editorConfig.theme.table}"></table>
+                  `,
+                );
+              },
+              {discrete: true},
+            );
           });
 
           test('TableNode.createDOM() and updateDOM() style', () => {
@@ -170,13 +221,7 @@ describe('LexicalTableNode tests', () => {
                 tables[0]!.outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
-                    <tr dir="auto">
-                      <td dir="auto">
-                        <p dir="auto">
-                          <br data-lexical-managed-linebreak="true" />
-                        </p>
-                      </td>
-                    </tr>
+                    ${emptyTableContentsHtml(1, 1, PlainTableHTMLGenerator)}
                   </table>
                 `,
               );
@@ -186,13 +231,7 @@ describe('LexicalTableNode tests', () => {
                   <table
                     class="${editorConfig.theme.table}"
                     style="background-color: blue">
-                    <tr dir="auto">
-                      <td dir="auto">
-                        <p dir="auto">
-                          <br data-lexical-managed-linebreak="true" />
-                        </p>
-                      </td>
-                    </tr>
+                    ${emptyTableContentsHtml(1, 1, PlainTableHTMLGenerator)}
                   </table>
                 `,
               );
@@ -222,13 +261,7 @@ describe('LexicalTableNode tests', () => {
                   <table
                     class="${editorConfig.theme.table}"
                     style="--table-index: 0">
-                    <tr dir="auto">
-                      <td dir="auto">
-                        <p dir="auto">
-                          <br data-lexical-managed-linebreak="true" />
-                        </p>
-                      </td>
-                    </tr>
+                    ${emptyTableContentsHtml(1, 1, PlainTableHTMLGenerator)}
                   </table>
                 `,
               );
@@ -238,147 +271,147 @@ describe('LexicalTableNode tests', () => {
                   <table
                     class="${editorConfig.theme.table}"
                     style="--table-index: 1">
-                    <tr dir="auto">
-                      <td dir="auto">
-                        <p dir="auto">
-                          <br data-lexical-managed-linebreak="true" />
-                        </p>
-                      </td>
-                    </tr>
+                    ${emptyTableContentsHtml(1, 1, PlainTableHTMLGenerator)}
                   </table>
                 `,
               );
             }
           });
 
-          test('TableNode.exportDOM() with range selection', async () => {
+          test('TableNode.exportDOM() with range selection', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const tableNode = $createTableNodeWithDimensions(
-                2,
-                2,
-              ).setColWidths([100, 200]);
-              tableNode
-                .getAllTextNodes()
-                .forEach((node, i) => node.setTextContent(String(i)));
-              $getRoot().clear().append(tableNode);
-              expectHtmlToBeEqual(
-                $generateHtmlFromNodes(editor, $getRoot().select(0)),
-                html`
-                  <table class="${editorConfig.theme.table}">
-                    <colgroup>
-                      <col style="width: 100px" />
-                      <col style="width: 200px" />
-                    </colgroup>
-                    <tbody>
-                      <tr>
-                        <th
-                          style="
+            editor.update(
+              () => {
+                const tableNode = $createTableNodeWithDimensions(
+                  2,
+                  2,
+                ).setColWidths([100, 200]);
+                tableNode
+                  .getAllTextNodes()
+                  .forEach((node, i) => node.setTextContent(String(i)));
+                $getRoot().clear().append(tableNode);
+                expectHtmlToBeEqual(
+                  $generateHtmlFromNodes(editor, $getRoot().select(0)),
+                  html`
+                    <table class="${editorConfig.theme.table}">
+                      <colgroup>
+                        <col style="width: 100px" />
+                        <col style="width: 200px" />
+                      </colgroup>
+                      <tbody>
+                        <tr>
+                          <th
+                            style="
                             border: 1px solid black;
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
                             background-color: rgb(242, 243, 245);
                           ">
-                          <p><span style="white-space: pre-wrap">0</span></p>
-                        </th>
-                        <th
-                          style="
+                            <p><span style="white-space: pre-wrap">0</span></p>
+                          </th>
+                          <th
+                            style="
                             border: 1px solid black;
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
                             background-color: rgb(242, 243, 245);
                           ">
-                          <p><span style="white-space: pre-wrap">1</span></p>
-                        </th>
-                      </tr>
-                      <tr>
-                        <th
-                          style="
+                            <p><span style="white-space: pre-wrap">1</span></p>
+                          </th>
+                        </tr>
+                        <tr>
+                          <th
+                            style="
                             border: 1px solid black;
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
                             background-color: rgb(242, 243, 245);
                           ">
-                          <p><span style="white-space: pre-wrap">2</span></p>
-                        </th>
-                        <td
-                          style="
+                            <p><span style="white-space: pre-wrap">2</span></p>
+                          </th>
+                          <td
+                            style="
                             border: 1px solid black;
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
                           ">
-                          <p><span style="white-space: pre-wrap">3</span></p>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                `,
-              );
-            });
+                            <p><span style="white-space: pre-wrap">3</span></p>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  `,
+                );
+              },
+              {discrete: true},
+            );
           });
 
-          test('TableNode.exportDOM() with partial table selection', async () => {
+          test('TableNode.exportDOM() with partial table selection', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const tableNode = $createTableNodeWithDimensions(
-                2,
-                2,
-              ).setColWidths([100, 200]);
-              tableNode
-                .getAllTextNodes()
-                .forEach((node, i) => node.setTextContent(String(i)));
-              $getRoot().append(tableNode);
-              const tableSelection = $createTableSelection();
-              tableSelection.tableKey = tableNode.getKey();
-              const cells = $dfs(tableNode).flatMap(({node}) =>
-                $isTableCellNode(node) ? [node] : [],
-              );
-              // second column
-              tableSelection.anchor.set(cells[1].getKey(), 0, 'element');
-              tableSelection.focus.set(cells[3].getKey(), 0, 'element');
-              expectHtmlToBeEqual(
-                $generateHtmlFromNodes(editor, tableSelection),
-                html`
-                  <table class="${editorConfig.theme.table}">
-                    <colgroup><col style="width: 200px" /></colgroup>
-                    <tbody>
-                      <tr>
-                        <th
-                          style="
+            editor.update(
+              () => {
+                const tableNode = $createTableNodeWithDimensions(
+                  2,
+                  2,
+                ).setColWidths([100, 200]);
+                tableNode
+                  .getAllTextNodes()
+                  .forEach((node, i) => node.setTextContent(String(i)));
+                $getRoot().append(tableNode);
+                const tableSelection = $createTableSelection();
+                tableSelection.tableKey = tableNode.getKey();
+                const cells = $dfs(tableNode).flatMap(({node}) =>
+                  $isTableCellNode(node) ? [node] : [],
+                );
+                // second column
+                tableSelection.anchor.set(cells[1].getKey(), 0, 'element');
+                tableSelection.focus.set(cells[3].getKey(), 0, 'element');
+                expectHtmlToBeEqual(
+                  $generateHtmlFromNodes(editor, tableSelection),
+                  html`
+                    <table class="${editorConfig.theme.table}">
+                      <colgroup><col style="width: 200px" /></colgroup>
+                      <tbody>
+                        <tr>
+                          <th
+                            style="
                             border: 1px solid black;
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
                             background-color: rgb(242, 243, 245);
                           ">
-                          <p><span style="white-space: pre-wrap">1</span></p>
-                        </th>
-                      </tr>
-                      <tr>
-                        <td
-                          style="
+                            <p><span style="white-space: pre-wrap">1</span></p>
+                          </th>
+                        </tr>
+                        <tr>
+                          <td
+                            style="
                             border: 1px solid black;
                             width: 75px;
                             vertical-align: top;
                             text-align: start;
                           ">
-                          <p><span style="white-space: pre-wrap">3</span></p>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                `,
-              );
-            });
+                            <p><span style="white-space: pre-wrap">3</span></p>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  `,
+                );
+              },
+              {discrete: true},
+            );
           });
 
-          test('Copy table from an external source', async () => {
+          test('Copy table from an external source', () => {
             const {editor} = testEnv;
 
             const dataTransfer = new DataTransfer();
@@ -386,14 +419,17 @@ describe('LexicalTableNode tests', () => {
               'text/html',
               '<html><body><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-16a69100-7fff-6cb9-b829-cb1def16a58d"><div dir="ltr" style="margin-left:0pt;" align="left"><table style="border:none;border-collapse:collapse;table-layout:fixed"><colgroup><col style="width:100px"/><col style="width:200px"/></colgroup><tbody><tr style="height:22.015pt"><td style="border-left:solid #000000 1pt;border-right:solid #000000 1pt;border-bottom:solid #000000 1pt;border-top:solid #000000 1pt;vertical-align:top;padding:5pt 5pt 5pt 5pt;overflow:hidden;overflow-wrap:break-word;"><p dir="ltr" style="line-height:1.2;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Hello there</span></p></td><td style="border-left:solid #000000 1pt;border-right:solid #000000 1pt;border-bottom:solid #000000 1pt;border-top:solid #000000 1pt;vertical-align:top;padding:5pt 5pt 5pt 5pt;overflow:hidden;overflow-wrap:break-word;"><p dir="ltr" style="line-height:1.2;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">General Kenobi!</span></p></td></tr><tr style="height:22.015pt"><td style="border-left:solid #000000 1pt;border-right:solid #000000 1pt;border-bottom:solid #000000 1pt;border-top:solid #000000 1pt;vertical-align:top;padding:5pt 5pt 5pt 5pt;overflow:hidden;overflow-wrap:break-word;"><p dir="ltr" style="line-height:1.2;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Lexical is nice</span></p></td><td style="border-left:solid #000000 1pt;border-right:solid #000000 1pt;border-bottom:solid #000000 1pt;border-top:solid #000000 1pt;vertical-align:top;padding:5pt 5pt 5pt 5pt;overflow:hidden;overflow-wrap:break-word;"><br data-lexical-managed-linebreak="true"></td></tr></tbody></table></div></b><!--EndFragment--></body></html>',
             );
-            await editor.update(() => {
-              const selection = $getSelection();
-              invariant(
-                $isRangeSelection(selection),
-                'isRangeSelection(selection)',
-              );
-              $insertDataTransferForRichText(dataTransfer, selection, editor);
-            });
+            editor.update(
+              () => {
+                const selection = $getSelection();
+                invariant(
+                  $isRangeSelection(selection),
+                  'isRangeSelection(selection)',
+                );
+                $insertDataTransferForRichText(dataTransfer, selection, editor);
+              },
+              {discrete: true},
+            );
             // Make sure paragraph is inserted inside empty cells
             const emptyCell =
               '<td dir="auto"><p dir="auto"><br data-lexical-managed-linebreak="true"></p></td>';
@@ -430,7 +466,7 @@ describe('LexicalTableNode tests', () => {
             );
           });
 
-          test('Copy table with caption/tbody/thead/tfoot from an external source', async () => {
+          test('Copy table with caption/tbody/thead/tfoot from an external source', () => {
             const {editor} = testEnv;
 
             const dataTransfer = new DataTransfer();
@@ -502,14 +538,17 @@ describe('LexicalTableNode tests', () => {
                 </table>
               `,
             );
-            await editor.update(() => {
-              const selection = $getSelection();
-              invariant(
-                $isRangeSelection(selection),
-                'isRangeSelection(selection)',
-              );
-              $insertDataTransferForRichText(dataTransfer, selection, editor);
-            });
+            editor.update(
+              () => {
+                const selection = $getSelection();
+                invariant(
+                  $isRangeSelection(selection),
+                  'isRangeSelection(selection)',
+                );
+                $insertDataTransferForRichText(dataTransfer, selection, editor);
+              },
+              {discrete: true},
+            );
             // Here we are testing the createDOM, not the exportDOM, so the tbody is not there
             expectReconciledTableHtmlToBeEqual(
               testEnv.innerHTML,
@@ -570,7 +609,7 @@ describe('LexicalTableNode tests', () => {
 
           // Increased timeout to 15s as this test can be slow due to clipboard operations
           // and HTML parsing, preventing flaky test failures
-          test('Copy table with caption from an external source', async () => {
+          test('Copy table with caption from an external source', () => {
             const {editor} = testEnv;
 
             const dataTransfer = new DataTransfer();
@@ -651,14 +690,17 @@ describe('LexicalTableNode tests', () => {
                 </table>
               `,
             );
-            await editor.update(() => {
-              const selection = $getSelection();
-              invariant(
-                $isRangeSelection(selection),
-                'isRangeSelection(selection)',
-              );
-              $insertDataTransferForRichText(dataTransfer, selection, editor);
-            });
+            editor.update(
+              () => {
+                const selection = $getSelection();
+                invariant(
+                  $isRangeSelection(selection),
+                  'isRangeSelection(selection)',
+                );
+                $insertDataTransferForRichText(dataTransfer, selection, editor);
+              },
+              {discrete: true},
+            );
             // Here we are testing the createDOM, not the exportDOM, so the tbody is not there
             expectReconciledTableHtmlToBeEqual(
               testEnv.innerHTML,
@@ -737,7 +779,7 @@ describe('LexicalTableNode tests', () => {
             );
           }, 15000);
 
-          test('Copy table from an external source like gdoc with formatting', async () => {
+          test('Copy table from an external source like gdoc with formatting', () => {
             const {editor} = testEnv;
 
             const dataTransfer = new DataTransfer();
@@ -745,14 +787,17 @@ describe('LexicalTableNode tests', () => {
               'text/html',
               '<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style><table xmlns="http://www.w3.org/1999/xhtml" cellspacing="0" cellpadding="0" dir="ltr" border="1" style="table-layout:fixed;font-size:10pt;font-family:Arial;width:0px;border-collapse:collapse;border:none" data-sheets-root="1"><colgroup><col width="100"/><col width="189"/><col width="171"/></colgroup><tbody><tr style="height:21px;"><td style="overflow:hidden;padding:2px 3px 2px 3px;vertical-align:bottom;font-weight:bold;" data-sheets-value="{&quot;1&quot;:2,&quot;2&quot;:&quot;Surface&quot;}">Surface</td><td style="overflow:hidden;padding:2px 3px 2px 3px;vertical-align:bottom;font-style:italic;" data-sheets-value="{&quot;1&quot;:2,&quot;2&quot;:&quot;MWP_WORK_LS_COMPOSER&quot;}">MWP_WORK_LS_COMPOSER</td><td style="overflow:hidden;padding:2px 3px 2px 3px;vertical-align:bottom;text-decoration:underline;text-align:right;" data-sheets-value="{&quot;1&quot;:3,&quot;3&quot;:77349}">77349</td></tr><tr style="height:21px;"><td style="overflow:hidden;padding:2px 3px 2px 3px;vertical-align:bottom;" data-sheets-value="{&quot;1&quot;:2,&quot;2&quot;:&quot;Lexical&quot;}">Lexical</td><td style="overflow:hidden;padding:2px 3px 2px 3px;vertical-align:bottom;text-decoration:line-through;" data-sheets-value="{&quot;1&quot;:2,&quot;2&quot;:&quot;XDS_RICH_TEXT_AREA&quot;}">XDS_RICH_TEXT_AREA</td><td style="overflow:hidden;padding:2px 3px 2px 3px;vertical-align:bottom;" data-sheets-value="{&quot;1&quot;:2,&quot;2&quot;:&quot;sdvd sdfvsfs&quot;}" data-sheets-textstyleruns="{&quot;1&quot;:0}{&quot;1&quot;:5,&quot;2&quot;:{&quot;5&quot;:1}}"><span style="font-size:10pt;font-family:Arial;font-style:normal;">sdvd </span><span style="font-size:10pt;font-family:Arial;font-weight:bold;font-style:normal;">sdfvsfs</span></td></tr></tbody></table>',
             );
-            await editor.update(() => {
-              const selection = $getSelection();
-              invariant(
-                $isRangeSelection(selection),
-                'isRangeSelection(selection)',
-              );
-              $insertDataTransferForRichText(dataTransfer, selection, editor);
-            });
+            editor.update(
+              () => {
+                const selection = $getSelection();
+                invariant(
+                  $isRangeSelection(selection),
+                  'isRangeSelection(selection)',
+                );
+                $insertDataTransferForRichText(dataTransfer, selection, editor);
+              },
+              {discrete: true},
+            );
             expectReconciledTableHtmlToBeEqual(
               testEnv.innerHTML,
               html`
@@ -802,30 +847,39 @@ describe('LexicalTableNode tests', () => {
             );
           }, 15000);
 
-          test('Cut table in the middle of a range selection', async () => {
+          test('Cut table in the middle of a range selection', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const paragraph = $assertNodeType(
-                root.getFirstChild(),
-                $isParagraphNode,
-              );
-              const beforeText = $createTextNode('text before the table');
-              const table = $createTableNodeWithDimensions(4, 4, true);
-              const afterText = $createTextNode('text after the table');
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const paragraph = $assertNodeType(
+                  root.getFirstChild(),
+                  $isParagraphNode,
+                );
+                const beforeText = $createTextNode('text before the table');
+                const table = $createTableNodeWithDimensions(4, 4, true);
+                const afterText = $createTextNode('text after the table');
 
-              paragraph.append(beforeText);
-              paragraph.append(table);
-              paragraph.append(afterText);
-            });
-            await editor.update(() => {
-              editor.focus();
-              $selectAll();
-            });
-            await editor.update(() => {
-              editor.dispatchCommand(CUT_COMMAND, new ClipboardEvent('cut'));
-            });
+                paragraph.append(beforeText);
+                paragraph.append(table);
+                paragraph.append(afterText);
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                editor.focus();
+                $selectAll();
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                editor.dispatchCommand(CUT_COMMAND, new ClipboardEvent('cut'));
+              },
+              {discrete: true},
+            );
 
             expectHtmlToBeEqual(
               testEnv.innerHTML,
@@ -835,28 +889,37 @@ describe('LexicalTableNode tests', () => {
             );
           });
 
-          test('Cut table as last node in range selection ', async () => {
+          test('Cut table as last node in range selection ', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const paragraph = $assertNodeType(
-                root.getFirstChild(),
-                $isParagraphNode,
-              );
-              const beforeText = $createTextNode('text before the table');
-              const table = $createTableNodeWithDimensions(4, 4, true);
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const paragraph = $assertNodeType(
+                  root.getFirstChild(),
+                  $isParagraphNode,
+                );
+                const beforeText = $createTextNode('text before the table');
+                const table = $createTableNodeWithDimensions(4, 4, true);
 
-              paragraph.append(beforeText);
-              paragraph.append(table);
-            });
-            await editor.update(() => {
-              editor.focus();
-              $selectAll();
-            });
-            await editor.update(() => {
-              editor.dispatchCommand(CUT_COMMAND, new ClipboardEvent('cut'));
-            });
+                paragraph.append(beforeText);
+                paragraph.append(table);
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                editor.focus();
+                $selectAll();
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                editor.dispatchCommand(CUT_COMMAND, new ClipboardEvent('cut'));
+              },
+              {discrete: true},
+            );
 
             expectHtmlToBeEqual(
               testEnv.innerHTML,
@@ -866,28 +929,37 @@ describe('LexicalTableNode tests', () => {
             );
           });
 
-          test('Cut table as first node in range selection ', async () => {
+          test('Cut table as first node in range selection ', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const paragraph = $assertNodeType(
-                root.getFirstChild(),
-                $isParagraphNode,
-              );
-              const table = $createTableNodeWithDimensions(4, 4, true);
-              const afterText = $createTextNode('text after the table');
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const paragraph = $assertNodeType(
+                  root.getFirstChild(),
+                  $isParagraphNode,
+                );
+                const table = $createTableNodeWithDimensions(4, 4, true);
+                const afterText = $createTextNode('text after the table');
 
-              paragraph.append(table);
-              paragraph.append(afterText);
-            });
-            await editor.update(() => {
-              editor.focus();
-              $selectAll();
-            });
-            await editor.update(() => {
-              editor.dispatchCommand(CUT_COMMAND, new ClipboardEvent('cut'));
-            });
+                paragraph.append(table);
+                paragraph.append(afterText);
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                editor.focus();
+                $selectAll();
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                editor.dispatchCommand(CUT_COMMAND, new ClipboardEvent('cut'));
+              },
+              {discrete: true},
+            );
 
             expectHtmlToBeEqual(
               testEnv.innerHTML,
@@ -897,38 +969,46 @@ describe('LexicalTableNode tests', () => {
             );
           });
 
-          test('Cut table is whole selection, should remove it', async () => {
+          test('Cut table is whole selection, should remove it', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $createTableNodeWithDimensions(4, 4, true);
-              root.append(table);
-            });
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = root.getLastChild();
-              if ($isTableNode(table)) {
-                const DOMTable = $getElementForTableNode(editor, table);
-                if (DOMTable) {
-                  $assertNodeType(
-                    table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
-                    $isParagraphNode,
-                  ).append($createTextNode('some text'));
-                  const selection = $createTableSelection();
-                  selection.set(
-                    table.__key,
-                    table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                    table.getCellNodeFromCords(3, 3, DOMTable)?.__key || '',
-                  );
-                  $setSelection(selection);
-                  editor.dispatchCommand(
-                    CUT_COMMAND,
-                    new ClipboardEvent('cut'),
-                  );
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = $createTableNodeWithDimensions(4, 4, true);
+                root.append(table);
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = root.getLastChild();
+                if ($isTableNode(table)) {
+                  const DOMTable = $getElementForTableNode(editor, table);
+                  if (DOMTable) {
+                    $assertNodeType(
+                      table
+                        .getCellNodeFromCords(0, 0, DOMTable)
+                        ?.getLastChild(),
+                      $isParagraphNode,
+                    ).append($createTextNode('some text'));
+                    const selection = $createTableSelection();
+                    selection.set(
+                      table.__key,
+                      table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                      table.getCellNodeFromCords(3, 3, DOMTable)?.__key || '',
+                    );
+                    $setSelection(selection);
+                    editor.dispatchCommand(
+                      CUT_COMMAND,
+                      new ClipboardEvent('cut'),
+                    );
+                  }
                 }
-              }
-            });
+              },
+              {discrete: true},
+            );
 
             expectHtmlToBeEqual(
               testEnv.innerHTML,
@@ -938,200 +1018,139 @@ describe('LexicalTableNode tests', () => {
             );
           });
 
-          test('Cut subsection of table cells, should just clear contents', async () => {
+          test('Cut subsection of table cells, should just clear contents', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $createTableNodeWithDimensions(4, 4, true);
-              root.append(table);
-            });
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = root.getLastChild();
-              if ($isTableNode(table)) {
-                const DOMTable = $getElementForTableNode(editor, table);
-                if (DOMTable) {
-                  $assertNodeType(
-                    table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
-                    $isParagraphNode,
-                  ).append($createTextNode('some text'));
-                  const selection = $createTableSelection();
-                  selection.set(
-                    table.__key,
-                    table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                    table.getCellNodeFromCords(2, 2, DOMTable)?.__key || '',
-                  );
-                  $setSelection(selection);
-                  editor.dispatchCommand(
-                    CUT_COMMAND,
-                    new ClipboardEvent('cut'),
-                  );
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = $createTableNodeWithDimensions(4, 4, true);
+                root.append(table);
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = root.getLastChild();
+                if ($isTableNode(table)) {
+                  const DOMTable = $getElementForTableNode(editor, table);
+                  if (DOMTable) {
+                    $assertNodeType(
+                      table
+                        .getCellNodeFromCords(0, 0, DOMTable)
+                        ?.getLastChild(),
+                      $isParagraphNode,
+                    ).append($createTextNode('some text'));
+                    const selection = $createTableSelection();
+                    selection.set(
+                      table.__key,
+                      table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                      table.getCellNodeFromCords(2, 2, DOMTable)?.__key || '',
+                    );
+                    $setSelection(selection);
+                    editor.dispatchCommand(
+                      CUT_COMMAND,
+                      new ClipboardEvent('cut'),
+                    );
+                  }
                 }
-              }
-            });
+              },
+              {discrete: true},
+            );
 
             expectReconciledTableHtmlToBeEqual(
               testEnv.innerHTML,
               html`
                 <p dir="auto"><br data-lexical-managed-linebreak="true" /></p>
                 <table class="test-table-class">
-                  <tr dir="auto">
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                  </tr>
-                  <tr dir="auto">
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                  </tr>
-                  <tr dir="auto">
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                  </tr>
-                  <tr dir="auto">
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                  </tr>
+                  ${emptyTableContentsHtml(4, 4, HeadingTableHTMLGenerator)}
                 </table>
               `,
             );
           });
 
-          test('Table plain text output validation', async () => {
+          test('Table plain text output validation', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $createTableNodeWithDimensions(4, 4, true);
-              root.append(table);
-            });
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $assertNodeType(root.getLastChild(), $isTableNode);
-              const DOMTable = $getElementForTableNode(editor, table);
-              if (DOMTable) {
-                $assertNodeType(
-                  table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
-                  $isParagraphNode,
-                ).append($createTextNode('1'));
-                $assertNodeType(
-                  table.getCellNodeFromCords(1, 0, DOMTable)?.getLastChild(),
-                  $isParagraphNode,
-                ).append($createTextNode(''));
-                $assertNodeType(
-                  table.getCellNodeFromCords(2, 0, DOMTable)?.getLastChild(),
-                  $isParagraphNode,
-                ).append($createTextNode('2'));
-                $assertNodeType(
-                  table.getCellNodeFromCords(0, 1, DOMTable)?.getLastChild(),
-                  $isParagraphNode,
-                ).append($createTextNode('3'));
-                $assertNodeType(
-                  table.getCellNodeFromCords(1, 1, DOMTable)?.getLastChild(),
-                  $isParagraphNode,
-                ).append($createTextNode('4'));
-                $assertNodeType(
-                  table.getCellNodeFromCords(2, 1, DOMTable)?.getLastChild(),
-                  $isParagraphNode,
-                ).append($createTextNode(''));
-                const selection = $createTableSelection();
-                selection.set(
-                  table.__key,
-                  table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                  table.getCellNodeFromCords(2, 1, DOMTable)?.__key || '',
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = $createTableNodeWithDimensions(4, 4, true);
+                root.append(table);
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = $assertNodeType(
+                  root.getLastChild(),
+                  $isTableNode,
                 );
-                expect(selection.getTextContent()).toBe(`1\t\t2\n3\t4\t\n`);
-              }
-            });
+                const DOMTable = $getElementForTableNode(editor, table);
+                if (DOMTable) {
+                  $assertNodeType(
+                    table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
+                    $isParagraphNode,
+                  ).append($createTextNode('1'));
+                  $assertNodeType(
+                    table.getCellNodeFromCords(1, 0, DOMTable)?.getLastChild(),
+                    $isParagraphNode,
+                  ).append($createTextNode(''));
+                  $assertNodeType(
+                    table.getCellNodeFromCords(2, 0, DOMTable)?.getLastChild(),
+                    $isParagraphNode,
+                  ).append($createTextNode('2'));
+                  $assertNodeType(
+                    table.getCellNodeFromCords(0, 1, DOMTable)?.getLastChild(),
+                    $isParagraphNode,
+                  ).append($createTextNode('3'));
+                  $assertNodeType(
+                    table.getCellNodeFromCords(1, 1, DOMTable)?.getLastChild(),
+                    $isParagraphNode,
+                  ).append($createTextNode('4'));
+                  $assertNodeType(
+                    table.getCellNodeFromCords(2, 1, DOMTable)?.getLastChild(),
+                    $isParagraphNode,
+                  ).append($createTextNode(''));
+                  const selection = $createTableSelection();
+                  selection.set(
+                    table.__key,
+                    table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                    table.getCellNodeFromCords(2, 1, DOMTable)?.__key || '',
+                  );
+                  expect(selection.getTextContent()).toBe(`1\t\t2\n3\t4\t\n`);
+                }
+              },
+              {discrete: true},
+            );
           });
 
-          test('Toggle row striping ON/OFF', async () => {
+          test('Toggle row striping ON/OFF', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $createTableNodeWithDimensions(4, 4, true);
-              root.append(table);
-            });
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $assertNodeType(root.getLastChild(), $isTableNode);
-              table.setRowStriping(true);
-            });
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = $createTableNodeWithDimensions(4, 4, true);
+                root.append(table);
+              },
+              {discrete: true},
+            );
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = $assertNodeType(
+                  root.getLastChild(),
+                  $isTableNode,
+                );
+                table.setRowStriping(true);
+              },
+              {discrete: true},
+            );
 
-            await editor.update(() => {
+            editor.read('force-commit', () => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
@@ -1145,13 +1164,13 @@ describe('LexicalTableNode tests', () => {
               );
             });
 
-            await editor.update(() => {
+            editor.update(() => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
               table.setRowStriping(false);
             });
 
-            await editor.update(() => {
+            editor.read('force-commit', () => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
@@ -1164,15 +1183,18 @@ describe('LexicalTableNode tests', () => {
           });
 
           if (hasHorizontalScroll) {
-            test('Toggle frozen first column ON/OFF', async () => {
+            test('Toggle frozen first column ON/OFF', () => {
               const {editor} = testEnv;
 
-              await editor.update(() => {
-                const root = $getRoot();
-                const table = $createTableNodeWithDimensions(4, 4, true);
-                root.append(table);
-              });
-              await editor.update(() => {
+              editor.update(
+                () => {
+                  const root = $getRoot();
+                  const table = $createTableNodeWithDimensions(4, 4, true);
+                  root.append(table);
+                },
+                {discrete: true},
+              );
+              editor.update(() => {
                 const root = $getRoot();
                 const table = $assertNodeType(
                   root.getLastChild(),
@@ -1181,7 +1203,7 @@ describe('LexicalTableNode tests', () => {
                 table.setFrozenColumns(1);
               });
 
-              await editor.update(() => {
+              editor.read('force-commit', () => {
                 const root = $getRoot();
                 const table = $assertNodeType(
                   root.getLastChild(),
@@ -1645,7 +1667,7 @@ describe('LexicalTableNode tests', () => {
                 JSON.parse(expectedStringifiedEditorState),
               );
 
-              await editor.update(() => {
+              editor.update(() => {
                 const root = $getRoot();
                 const table = $assertNodeType(
                   root.getLastChild(),
@@ -1654,7 +1676,7 @@ describe('LexicalTableNode tests', () => {
                 table.setFrozenColumns(0);
               });
 
-              await editor.update(() => {
+              editor.read('force-commit', () => {
                 const root = $getRoot();
                 const table = $assertNodeType(
                   root.getLastChild(),
@@ -1672,21 +1694,24 @@ describe('LexicalTableNode tests', () => {
             });
           }
 
-          test('Change Table-level alignment', async () => {
+          test('Change Table-level alignment', () => {
             const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $createTableNodeWithDimensions(4, 4, true);
-              root.append(table);
-            });
-            await editor.update(() => {
+            editor.update(
+              () => {
+                const root = $getRoot();
+                const table = $createTableNodeWithDimensions(4, 4, true);
+                root.append(table);
+              },
+              {discrete: true},
+            );
+            editor.update(() => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
               table.setFormat('center');
             });
 
-            await editor.update(() => {
+            editor.read('force-commit', () => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
@@ -1699,13 +1724,13 @@ describe('LexicalTableNode tests', () => {
               );
             });
 
-            await editor.update(() => {
+            editor.update(() => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
               table.setFormat('left');
             });
 
-            await editor.update(() => {
+            editor.read('force-commit', () => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
               expectTableHtmlToBeEqual(
@@ -1717,36 +1742,52 @@ describe('LexicalTableNode tests', () => {
             });
           });
 
-          test('Update column widths', async () => {
+          test('Update column widths', () => {
             const {editor} = testEnv;
+            function $getTestTableNode(): TableNode {
+              return $assertNodeType($getRoot().getLastChild(), $isTableNode);
+            }
+            function $getTestTableElement(
+              table = $getTestTableNode(),
+            ): HTMLElement {
+              const element = editor.getElementByKey(table.__key);
+              assert(isHTMLElement(element));
+              return element;
+            }
 
-            await editor.update(() => {
+            editor.update(() => {
               const root = $getRoot();
               const table = $createTableNodeWithDimensions(4, 2, true);
               root.append(table);
             });
 
-            // Set widths
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $assertNodeType(root.getLastChild(), $isTableNode);
-              table.setColWidths([50, 50]);
+            editor.read('force-commit', () => {
+              expectReconciledTableHtmlToBeEqual(
+                $getTestTableElement().outerHTML,
+                html`
+                  <table class="${editorConfig.theme.table}">
+                    ${emptyTableContentsHtml(4, 2, HeadingTableHTMLGenerator)}
+                  </table>
+                `,
+              );
             });
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $assertNodeType(root.getLastChild(), $isTableNode);
-              let element = editor.getElementByKey(table.__key);
-              expect(element).toBeDefined();
-              element = stripTableContents(element!);
+            // Set widths
+            editor.update(() => {
+              $getTestTableNode().setColWidths([50, 50]);
+            });
+
+            editor.read('force-commit', () => {
+              const table = $getTestTableNode();
               expectReconciledTableHtmlToBeEqual(
-                element!.outerHTML,
+                $getTestTableElement(table).outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
                     <colgroup>
                       <col style="width: 50px;" />
                       <col style="width: 50px;" />
                     </colgroup>
+                    ${emptyTableContentsHtml(4, 2, HeadingTableHTMLGenerator)}
                   </table>
                 `,
               );
@@ -1761,9 +1802,8 @@ describe('LexicalTableNode tests', () => {
             });
 
             // Add a column
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $assertNodeType(root.getLastChild(), $isTableNode);
+            editor.update(() => {
+              const table = $getTestTableNode();
               const DOMTable = $getElementForTableNode(editor, table);
               const selection = $createTableSelection();
               selection.set(
@@ -1776,14 +1816,10 @@ describe('LexicalTableNode tests', () => {
               table.setColWidths([50, 50, 100]);
             });
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $assertNodeType(root.getLastChild(), $isTableNode);
-              let element = editor.getElementByKey(table.__key);
-              expect(element).toBeDefined();
-              element = stripTableContents(element!);
+            editor.read('force-commit', () => {
+              const table = $getTestTableNode();
               expectReconciledTableHtmlToBeEqual(
-                element!.outerHTML,
+                $getTestTableElement(table).outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
                     <colgroup>
@@ -1791,6 +1827,7 @@ describe('LexicalTableNode tests', () => {
                       <col style="width: 50px;" />
                       <col style="width: 100px;" />
                     </colgroup>
+                    ${emptyTableContentsHtml(4, 3, HeadingTableHTMLGenerator)}
                   </table>
                 `,
               );
@@ -1816,43 +1853,22 @@ describe('LexicalTableNode tests', () => {
     }
     initializeUnitTest(
       testEnv => {
-        beforeEach(async () => {
+        beforeEach(() => {
           const {editor} = testEnv;
-          await editor.update(() => {
-            const root = $getRoot();
-            root.clear().append($createTableNodeWithDimensions(2, 2, true));
-          });
+          editor.update(
+            () => {
+              const root = $getRoot();
+              root.clear().append($createTableNodeWithDimensions(2, 2, true));
+            },
+            {discrete: true},
+          );
         });
-        test('table is re-rendered when scroll changes', async () => {
-          await Promise.resolve().then();
+        test('table is re-rendered when scroll changes', () => {
           expectHtmlToBeEqual(
             testEnv.innerHTML,
             html`
               <table class="test-table-class" dir="auto">
-                <tr dir="auto">
-                  <th dir="auto">
-                    <p dir="auto">
-                      <br data-lexical-managed-linebreak="true" />
-                    </p>
-                  </th>
-                  <th dir="auto">
-                    <p dir="auto">
-                      <br data-lexical-managed-linebreak="true" />
-                    </p>
-                  </th>
-                </tr>
-                <tr dir="auto">
-                  <th dir="auto">
-                    <p dir="auto">
-                      <br data-lexical-managed-linebreak="true" />
-                    </p>
-                  </th>
-                  <td dir="auto">
-                    <p dir="auto">
-                      <br data-lexical-managed-linebreak="true" />
-                    </p>
-                  </td>
-                </tr>
+                ${emptyTableContentsHtml(2, 2, HeadingTableHTMLGenerator)}
               </table>
             `,
           );
@@ -1860,37 +1876,13 @@ describe('LexicalTableNode tests', () => {
             expect(testEnv.editor.read($isScrollableTablesActive)).toBe(false);
             setHasHorizontalScroll(true);
           });
-          await Promise.resolve().then();
           expect(testEnv.editor.read($isScrollableTablesActive)).toBe(true);
           expectHtmlToBeEqual(
             testEnv.innerHTML,
             html`
               <div class="table-scrollable-wrapper" dir="auto">
                 <table class="test-table-class">
-                  <tr dir="auto">
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                  </tr>
-                  <tr dir="auto">
-                    <th dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </th>
-                    <td dir="auto">
-                      <p dir="auto">
-                        <br data-lexical-managed-linebreak="true" />
-                      </p>
-                    </td>
-                  </tr>
+                  ${emptyTableContentsHtml(2, 2, HeadingTableHTMLGenerator)}
                 </table>
               </div>
             `,
@@ -1899,36 +1891,12 @@ describe('LexicalTableNode tests', () => {
             expect(testEnv.editor.read($isScrollableTablesActive)).toBe(true);
             setHasHorizontalScroll(false);
           });
-          await Promise.resolve().then();
           expect(testEnv.editor.read($isScrollableTablesActive)).toBe(false);
           expectHtmlToBeEqual(
             testEnv.innerHTML,
             html`
               <table class="test-table-class" dir="auto">
-                <tr dir="auto">
-                  <th dir="auto">
-                    <p dir="auto">
-                      <br data-lexical-managed-linebreak="true" />
-                    </p>
-                  </th>
-                  <th dir="auto">
-                    <p dir="auto">
-                      <br data-lexical-managed-linebreak="true" />
-                    </p>
-                  </th>
-                </tr>
-                <tr dir="auto">
-                  <th dir="auto">
-                    <p dir="auto">
-                      <br data-lexical-managed-linebreak="true" />
-                    </p>
-                  </th>
-                  <td dir="auto">
-                    <p dir="auto">
-                      <br data-lexical-managed-linebreak="true" />
-                    </p>
-                  </td>
-                </tr>
+                ${emptyTableContentsHtml(2, 2, HeadingTableHTMLGenerator)}
               </table>
             `,
           );

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -93,6 +93,12 @@ describe('LexicalTableNode tests', () => {
         );
       }
 
+      function stripTableContents(element: HTMLElement): HTMLElement {
+        const clone = element.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll('tr').forEach(tr => tr.remove());
+        return clone;
+      }
+
       initializeUnitTest(
         testEnv => {
           beforeEach(async () => {
@@ -1730,8 +1736,11 @@ describe('LexicalTableNode tests', () => {
             await editor.update(() => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
-              expectTableHtmlToBeEqual(
-                table.createDOM(editorConfig).outerHTML,
+              let element = editor.getElementByKey(table.__key);
+              expect(element).toBeDefined();
+              element = stripTableContents(element!);
+              expectReconciledTableHtmlToBeEqual(
+                element!.outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
                     <colgroup>
@@ -1770,8 +1779,11 @@ describe('LexicalTableNode tests', () => {
             await editor.update(() => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
-              expectTableHtmlToBeEqual(
-                table.createDOM(editorConfig).outerHTML,
+              let element = editor.getElementByKey(table.__key);
+              expect(element).toBeDefined();
+              element = stripTableContents(element!);
+              expectReconciledTableHtmlToBeEqual(
+                element!.outerHTML,
                 html`
                   <table class="${editorConfig.theme.table}">
                     <colgroup>


### PR DESCRIPTION

## Description

Currently, the `createDOM` method of `TableNode` always adds a `colgroup` element as a child of the table. However, if the `colWidths` property is undefined, then the `colgroup` element ends up being meaningless. This change adds a check in `createDOM` to only add the element if `colWidths` is defined.

## Test plan

Changes are covered by already existing tests; tests that verified the DOM previously checked that `colgroup` was included in the table. For cases where the column widths were not being set, those tests have been updated to remove the required `colgroup` in the expected output. For cases where the column widths were being set, those continue to pass.