### PR TITLE
[lexical-table] Bug Fix: Enable DELETE_LINE_COMMAND in table cells

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -713,7 +713,11 @@ export function applyTableHandlers(
 
   for (const command of DELETE_TEXT_COMMANDS) {
     tableObserver.listenersToRemove.add(
-      editor.registerCommand(command, $deleteTextHandler, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(
+        command,
+        $deleteTextHandler,
+        COMMAND_PRIORITY_HIGH,
+      ),
     );
   }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -72,7 +72,6 @@ import {
   KEY_DELETE_COMMAND,
   KEY_ESCAPE_COMMAND,
   KEY_TAB_COMMAND,
-  type LexicalCommand,
   type LexicalEditor,
   type LexicalNode,
   type NodeKey,
@@ -673,7 +672,7 @@ export function applyTableHandlers(
     ),
   );
 
-  const deleteTextHandler = (command: LexicalCommand<boolean>) => () => {
+  const $deleteTextHandler = () => {
     const selection = $getSelection();
 
     if (!$isSelectionInTable(selection, tableNode)) {
@@ -707,33 +706,6 @@ export function applyTableHandlers(
         tableObserver.$clearText();
         return true;
       }
-
-      const nearestElementNode = $findMatchingParent(
-        selection.anchor.getNode(),
-        n => $isElementNode(n),
-      );
-
-      const topLevelCellElementNode =
-        nearestElementNode &&
-        $findMatchingParent(
-          nearestElementNode,
-          n => $isElementNode(n) && $isTableCellNode(n.getParent()),
-        );
-
-      if (
-        !$isElementNode(topLevelCellElementNode) ||
-        !$isElementNode(nearestElementNode)
-      ) {
-        return false;
-      }
-
-      if (
-        command === DELETE_LINE_COMMAND &&
-        topLevelCellElementNode.getPreviousSibling() === null
-      ) {
-        // TODO: Fix Delete Line in Table Cells.
-        return true;
-      }
     }
 
     return false;
@@ -741,11 +713,7 @@ export function applyTableHandlers(
 
   for (const command of DELETE_TEXT_COMMANDS) {
     tableObserver.listenersToRemove.add(
-      editor.registerCommand(
-        command,
-        deleteTextHandler(command),
-        COMMAND_PRIORITY_HIGH,
-      ),
+      editor.registerCommand(command, $deleteTextHandler, COMMAND_PRIORITY_HIGH),
     );
   }
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
@@ -11,17 +11,22 @@ import {
   $computeTableMapSkipCellCheck,
   $createTableNodeWithDimensions,
   $createTableSelectionFrom,
+  $isTableCellNode,
   $isTableNode,
+  $isTableRowNode,
   TableExtension,
 } from '@lexical/table';
 import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $isParagraphNode,
   $setSelection,
   COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_EDITOR,
   COPY_COMMAND,
   defineExtension,
+  DELETE_LINE_COMMAND,
   KEY_ARROW_DOWN_COMMAND,
   type LexicalEditorWithDispose,
   SELECTION_CHANGE_COMMAND,
@@ -294,6 +299,70 @@ describe('LexicalTableSelectionHelpers', () => {
       expect(received).toBe(false);
       unregister();
       document.body.removeChild(sibling);
+    });
+  });
+
+  describe('DELETE_LINE_COMMAND in table cells', () => {
+    let editor: LexicalEditorWithDispose;
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      editor = buildEditorFromExtensions(
+        defineExtension({
+          dependencies: [TableExtension],
+          name: 'delete-line-test',
+        }),
+      );
+      editor.setRootElement(container);
+    });
+
+    afterEach(() => {
+      editor.dispose();
+      document.body.removeChild(container);
+    });
+
+    test('DELETE_LINE_COMMAND propagates past the table handler in the first cell paragraph', () => {
+      editor.update(
+        () => {
+          const table = $createTableNodeWithDimensions(2, 2, false);
+          $getRoot().clear().append(table);
+          const firstRow = table.getFirstChildOrThrow();
+          if (!$isTableRowNode(firstRow)) {
+            throw new Error('Expected TableRowNode');
+          }
+          const firstCell = firstRow.getFirstChildOrThrow();
+          if (!$isTableCellNode(firstCell)) {
+            throw new Error('Expected TableCellNode');
+          }
+          const paragraph = firstCell.getFirstChildOrThrow();
+          if (!$isParagraphNode(paragraph)) {
+            throw new Error('Expected ParagraphNode');
+          }
+          paragraph.clear().append($createTextNode('hello world'));
+          paragraph.selectEnd();
+        },
+        {discrete: true},
+      );
+
+      let propagated = false;
+      const unregister = editor.registerCommand(
+        DELETE_LINE_COMMAND,
+        () => {
+          propagated = true;
+          return true;
+        },
+        COMMAND_PRIORITY_EDITOR,
+      );
+
+      editor.dispatchCommand(DELETE_LINE_COMMAND, true);
+      expect(propagated).toBe(true);
+
+      propagated = false;
+      editor.dispatchCommand(DELETE_LINE_COMMAND, false);
+      expect(propagated).toBe(true);
+      unregister();
     });
   });
 });

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
@@ -31,6 +31,7 @@ import {
   type LexicalEditorWithDispose,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 
 describe('LexicalTableSelectionHelpers', () => {
@@ -328,18 +329,18 @@ describe('LexicalTableSelectionHelpers', () => {
         () => {
           const table = $createTableNodeWithDimensions(2, 2, false);
           $getRoot().clear().append(table);
-          const firstRow = table.getFirstChildOrThrow();
-          if (!$isTableRowNode(firstRow)) {
-            throw new Error('Expected TableRowNode');
-          }
-          const firstCell = firstRow.getFirstChildOrThrow();
-          if (!$isTableCellNode(firstCell)) {
-            throw new Error('Expected TableCellNode');
-          }
-          const paragraph = firstCell.getFirstChildOrThrow();
-          if (!$isParagraphNode(paragraph)) {
-            throw new Error('Expected ParagraphNode');
-          }
+          const firstRow = $assertNodeType(
+            table.getFirstChildOrThrow(),
+            $isTableRowNode,
+          );
+          const firstCell = $assertNodeType(
+            firstRow.getFirstChildOrThrow(),
+            $isTableCellNode,
+          );
+          const paragraph = $assertNodeType(
+            firstCell.getFirstChildOrThrow(),
+            $isParagraphNode,
+          );
           paragraph.clear().append($createTextNode('hello world'));
           paragraph.selectEnd();
         },


### PR DESCRIPTION
## Description

`DELETE_LINE_COMMAND` (Cmd+Backspace on macOS, Ctrl+Shift+K on Linux) was silently swallowed in the first paragraph of a table cell. The table's `deleteTextHandler` returned `true` without doing anything, with a TODO comment acknowledging the gap.

This is no longer needed. `deleteLine` calls `$extendSelectionForDeletion` with `lineboundary`, and `$shrinkSelectionToRoot` already clamps the result at `TableCellNode`'s shadow root boundary. `deleteCharacter` (the fallback for collapsed-at-boundary cases) also stops at shadow roots via `iterNodeCarets('shadowRoot')`. These are the same mechanisms that `DELETE_WORD_COMMAND` and `DELETE_CHARACTER_COMMAND` rely on — neither has ever needed special-case handling here.

The swallowing block, the dead code it guarded (`nearestElementNode` / `topLevelCellElementNode` computation, which resolved to `return false` for all three commands), and the now-unused closure factory parameter are all removed.

## Test plan

- [x] Unit: `pnpm test-unit -- packages/lexical-table` — passes
  - New test verifies `DELETE_LINE_COMMAND` propagates past the table handler to `COMMAND_PRIORITY_EDITOR` for both `isBackward=true` and `isBackward=false`
- [x] Manual playground (Chrome, Safari, Firefox):
  - "hello world" in first cell → cursor at end → Cmd+Backspace: text deleted within cell
  - Cursor at cell start → Cmd+Backspace: no-op (correct, already at line start)
  - Cursor at start → Ctrl+K: forward delete-line works
  - Multi-paragraph cell: second paragraph → Cmd+Backspace: deletes within paragraph
  - Adjacent cell text unaffected in all scenarios
- [x] tsc clean