### PR TITLE
[lexical] Bug Fix: Scope bench vitest projects to exclude regular test files

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -169,6 +169,7 @@ export default defineConfig({
             include: ['packages/*/src/__bench__/*.bench.ts'],
           },
           environment: 'node',
+          include: [],
           name: 'bench',
         },
       },
@@ -189,6 +190,7 @@ export default defineConfig({
             ),
           },
           environment: 'jsdom',
+          include: [],
           name: 'bench-dom',
           setupFiles: ['./vitest.setup.mts'],
           typecheck: {


### PR DESCRIPTION
## Description

The `bench` and `bench-dom` vitest projects define `benchmark.include` patterns but have no `test.include`, so running `pnpm vitest run` (without `--project`) causes them to match regular test files via the default include glob. `bench` (node env) then fails with `DOMParser is not defined` on unit tests, and `bench-dom` (jsdom env) fails with `Selection.modify is not a function` on browser tests.

Adding `include: []` to both projects ensures they only activate for `vitest bench` and never claim regular test files.

## Test plan

- [x] `pnpm vitest run --project bench` — "No test files found" (previously ran all unit tests in node env)
- [x] `pnpm vitest run --project bench-dom` — "No test files found" (previously ran all browser tests in jsdom)
- [x] `pnpm vitest bench --run --project bench` — nodeMap benchmarks pass
- [x] `pnpm vitest bench --run --project bench-dom` — editorCycle benchmarks pass
- [x] `pnpm vitest run --project unit` — 213 passed (unaffected)