### PR TITLE
[lexical-table][lexical-playground] Chore: Deprecate getShape() and migrate playground

### DIFF
--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -9,6 +9,8 @@
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {
+  $computeTableCellRectBoundary,
+  $computeTableMap,
   $deleteTableColumnAtSelection,
   $deleteTableRowAtSelection,
   $getNodeTriplet,
@@ -64,14 +66,29 @@ import useModal from '../../hooks/useModal';
 import ColorPicker from '../../ui/ColorPicker';
 import DropDown, {DropDownItem} from '../../ui/DropDown';
 
-function computeSelectionCount(selection: TableSelection): {
+function $computeSelectionCounts(selection: TableSelection): {
   columns: number;
   rows: number;
 } {
-  const selectionShape = selection.getShape();
+  const anchorCell = selection.anchor.getNode();
+  const focusCell = selection.focus.getNode();
+  if (!$isTableCellNode(anchorCell) || !$isTableCellNode(focusCell)) {
+    return {columns: 1, rows: 1};
+  }
+  const tableNode = $getTableNodeFromLexicalNodeOrThrow(anchorCell);
+  const [map, cellAMap, cellBMap] = $computeTableMap(
+    tableNode,
+    anchorCell,
+    focusCell,
+  );
+  const {minColumn, maxColumn, minRow, maxRow} = $computeTableCellRectBoundary(
+    map,
+    cellAMap,
+    cellBMap,
+  );
   return {
-    columns: selectionShape.toX - selectionShape.fromX + 1,
-    rows: selectionShape.toY - selectionShape.fromY + 1,
+    columns: maxColumn - minColumn + 1,
+    rows: maxRow - minRow + 1,
   };
 }
 
@@ -168,8 +185,8 @@ function TableActionMenu({
       const selection = $getSelection();
       // Merge cells
       if ($isTableSelection(selection)) {
-        const currentSelectionCounts = computeSelectionCount(selection);
-        updateSelectionCounts(computeSelectionCount(selection));
+        const currentSelectionCounts = $computeSelectionCounts(selection);
+        updateSelectionCounts($computeSelectionCounts(selection));
         const isCollapsedTableSelection = selection.anchor.is(selection.focus);
         setCanMergeCells(
           !isCollapsedTableSelection &&

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -288,6 +288,7 @@ export class TableSelection implements BaseSelection {
     selection.insertNodes(nodes);
   }
 
+  /** @deprecated Use {@link $computeTableMap} and {@link $computeTableCellRectBoundary} directly. */
   getShape(): TableSelectionShape {
     const {anchorTable, anchorCell, focusCell} = $getCellNodes(this);
     const [map, cellAMap, cellBMap] = $computeTableMap(

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -48,6 +48,7 @@ import {$findTableNode} from './LexicalTableSelectionHelpers';
 import {
   $computeTableCellRectBoundary,
   $computeTableMap,
+  $getTableCellNodeRect,
   $insertTableIntoGrid,
 } from './LexicalTableUtils';
 
@@ -290,19 +291,41 @@ export class TableSelection implements BaseSelection {
 
   /** @deprecated Use {@link $computeTableMap} and {@link $computeTableCellRectBoundary} directly. */
   getShape(): TableSelectionShape {
-    const {anchorTable, anchorCell, focusCell} = $getCellNodes(this);
-    const [map, cellAMap, cellBMap] = $computeTableMap(
-      anchorTable,
-      anchorCell,
-      focusCell,
+    const {anchorCell, focusCell} = $getCellNodes(this);
+    const anchorCellNodeRect = $getTableCellNodeRect(anchorCell);
+    invariant(
+      anchorCellNodeRect !== null,
+      'getCellRect: expected to find AnchorNode',
     );
-    const {minColumn, maxColumn, minRow, maxRow} =
-      $computeTableCellRectBoundary(map, cellAMap, cellBMap);
+    const focusCellNodeRect = $getTableCellNodeRect(focusCell);
+    invariant(
+      focusCellNodeRect !== null,
+      'getCellRect: expected to find focusCellNode',
+    );
+
+    const startX = Math.min(
+      anchorCellNodeRect.columnIndex,
+      focusCellNodeRect.columnIndex,
+    );
+    const stopX = Math.max(
+      anchorCellNodeRect.columnIndex + anchorCellNodeRect.colSpan - 1,
+      focusCellNodeRect.columnIndex + focusCellNodeRect.colSpan - 1,
+    );
+
+    const startY = Math.min(
+      anchorCellNodeRect.rowIndex,
+      focusCellNodeRect.rowIndex,
+    );
+    const stopY = Math.max(
+      anchorCellNodeRect.rowIndex + anchorCellNodeRect.rowSpan - 1,
+      focusCellNodeRect.rowIndex + focusCellNodeRect.rowSpan - 1,
+    );
+
     return {
-      fromX: minColumn,
-      fromY: minRow,
-      toX: maxColumn,
-      toY: maxRow,
+      fromX: Math.min(startX, stopX),
+      fromY: Math.min(startY, stopY),
+      toX: Math.max(startX, stopX),
+      toY: Math.max(startY, stopY),
     };
   }
 

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -48,7 +48,6 @@ import {$findTableNode} from './LexicalTableSelectionHelpers';
 import {
   $computeTableCellRectBoundary,
   $computeTableMap,
-  $getTableCellNodeRect,
   $insertTableIntoGrid,
 } from './LexicalTableUtils';
 
@@ -289,43 +288,20 @@ export class TableSelection implements BaseSelection {
     selection.insertNodes(nodes);
   }
 
-  // TODO Deprecate this method. It's confusing when used with colspan|rowspan
   getShape(): TableSelectionShape {
-    const {anchorCell, focusCell} = $getCellNodes(this);
-    const anchorCellNodeRect = $getTableCellNodeRect(anchorCell);
-    invariant(
-      anchorCellNodeRect !== null,
-      'getCellRect: expected to find AnchorNode',
+    const {anchorTable, anchorCell, focusCell} = $getCellNodes(this);
+    const [map, cellAMap, cellBMap] = $computeTableMap(
+      anchorTable,
+      anchorCell,
+      focusCell,
     );
-    const focusCellNodeRect = $getTableCellNodeRect(focusCell);
-    invariant(
-      focusCellNodeRect !== null,
-      'getCellRect: expected to find focusCellNode',
-    );
-
-    const startX = Math.min(
-      anchorCellNodeRect.columnIndex,
-      focusCellNodeRect.columnIndex,
-    );
-    const stopX = Math.max(
-      anchorCellNodeRect.columnIndex + anchorCellNodeRect.colSpan - 1,
-      focusCellNodeRect.columnIndex + focusCellNodeRect.colSpan - 1,
-    );
-
-    const startY = Math.min(
-      anchorCellNodeRect.rowIndex,
-      focusCellNodeRect.rowIndex,
-    );
-    const stopY = Math.max(
-      anchorCellNodeRect.rowIndex + anchorCellNodeRect.rowSpan - 1,
-      focusCellNodeRect.rowIndex + focusCellNodeRect.rowSpan - 1,
-    );
-
+    const {minColumn, maxColumn, minRow, maxRow} =
+      $computeTableCellRectBoundary(map, cellAMap, cellBMap);
     return {
-      fromX: Math.min(startX, stopX),
-      fromY: Math.min(startY, stopY),
-      toX: Math.max(startX, stopX),
-      toY: Math.max(startY, stopY),
+      fromX: minColumn,
+      fromY: minRow,
+      toX: maxColumn,
+      toY: maxRow,
     };
   }
 

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -1197,6 +1197,10 @@ export function $computeTableCellRectSpans(
   return {bottomSpan, leftSpan, rightSpan, topSpan};
 }
 
+/**
+ * Compute the bounding rectangle of two table cells in a table map,
+ * expanding iteratively to include any merged cells that overlap the boundary.
+ */
 export function $computeTableCellRectBoundary(
   map: TableMapType,
   cellAMap: TableMapValueType,

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -11,7 +11,6 @@ import {
   $computeTableMapSkipCellCheck,
   $createTableCellNode,
   $createTableNode,
-  $createTableNodeWithDimensions,
   $createTableRowNode,
   $createTableSelectionFrom,
   $deleteTableRowAtSelection,
@@ -306,38 +305,7 @@ describe('table selection', () => {
       });
     });
 
-    describe('getShape with merged cells', () => {
-      test('expands boundary when a non-anchor/focus cell spans beyond the initial rectangle', () => {
-        testEnv.editor.update(
-          () => {
-            const table = $createTableNodeWithDimensions(3, 3, false);
-            $getRoot().clear().append(table);
-
-            // Merge row 1, cols 1-2 by setting colSpan and removing
-            // the extra cell
-            const map0 = $computeTableMapSkipCellCheck(table, null, null)[0];
-            const mergeTarget = map0[1][1].cell;
-            mergeTarget.setColSpan(2);
-            map0[1][2].cell.remove();
-
-            // Select (0,0) to (2,1) — the merged cell at row 1 spans
-            // to col 2, so getShape must expand toX to 2
-            const map1 = $computeTableMapSkipCellCheck(table, null, null)[0];
-            const sel = $createTableSelectionFrom(
-              table,
-              map1[0][0].cell,
-              map1[2][1].cell,
-            );
-            const shape = sel.getShape();
-            expect(shape.fromX).toBe(0);
-            expect(shape.fromY).toBe(0);
-            expect(shape.toX).toBe(2);
-            expect(shape.toY).toBe(2);
-          },
-          {discrete: true},
-        );
-      });
-
+    describe('getShape', () => {
       test('returns correct shape for non-merged table', () => {
         testEnv.editor.update(
           () => {

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -11,6 +11,7 @@ import {
   $computeTableMapSkipCellCheck,
   $createTableCellNode,
   $createTableNode,
+  $createTableNodeWithDimensions,
   $createTableRowNode,
   $createTableSelectionFrom,
   $deleteTableRowAtSelection,
@@ -299,6 +300,52 @@ describe('table selection', () => {
               ['0,0', '1,0'],
               ['0,1', '1,1'],
             ]);
+          },
+          {discrete: true},
+        );
+      });
+    });
+
+    describe('getShape with merged cells', () => {
+      test('expands boundary when a non-anchor/focus cell spans beyond the initial rectangle', () => {
+        testEnv.editor.update(
+          () => {
+            const table = $createTableNodeWithDimensions(3, 3, false);
+            $getRoot().clear().append(table);
+
+            // Merge row 1, cols 1-2 by setting colSpan and removing
+            // the extra cell
+            const map0 = $computeTableMapSkipCellCheck(table, null, null)[0];
+            const mergeTarget = map0[1][1].cell;
+            mergeTarget.__colSpan = 2;
+            map0[1][2].cell.remove();
+
+            // Select (0,0) to (2,1) — the merged cell at row 1 spans
+            // to col 2, so getShape must expand toX to 2
+            const map1 = $computeTableMapSkipCellCheck(table, null, null)[0];
+            const sel = $createTableSelectionFrom(
+              table,
+              map1[0][0].cell,
+              map1[2][1].cell,
+            );
+            const shape = sel.getShape();
+            expect(shape.fromX).toBe(0);
+            expect(shape.fromY).toBe(0);
+            expect(shape.toX).toBe(2);
+            expect(shape.toY).toBe(2);
+          },
+          {discrete: true},
+        );
+      });
+
+      test('returns correct shape for non-merged table', () => {
+        testEnv.editor.update(
+          () => {
+            const shape = tableSelection.getShape();
+            expect(shape.fromX).toBe(0);
+            expect(shape.fromY).toBe(0);
+            expect(shape.toX).toBe(1);
+            expect(shape.toY).toBe(1);
           },
           {discrete: true},
         );

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -317,7 +317,7 @@ describe('table selection', () => {
             // the extra cell
             const map0 = $computeTableMapSkipCellCheck(table, null, null)[0];
             const mergeTarget = map0[1][1].cell;
-            mergeTarget.__colSpan = 2;
+            mergeTarget.setColSpan(2);
             map0[1][2].cell.remove();
 
             // Select (0,0) to (2,1) — the merged cell at row 1 spans

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -65,6 +65,7 @@ export {
   getTableElement,
   getTableObserverFromTableElement,
 } from './LexicalTableSelectionHelpers';
+export type {TableCellRectBoundary} from './LexicalTableUtils';
 export {
   $computeTableCellRectBoundary,
   $computeTableMap,

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -66,6 +66,7 @@ export {
   getTableObserverFromTableElement,
 } from './LexicalTableSelectionHelpers';
 export {
+  $computeTableCellRectBoundary,
   $computeTableMap,
   $computeTableMapSkipCellCheck,
   $createTableNodeWithDimensions,


### PR DESCRIPTION
## Description

`TableSelection.getShape()` only considers the colSpan/rowSpan of the anchor and focus cells, producing incorrect results when a third merged cell spans beyond the initial boundary. Rather than fix the implementation and risk breaking consumers that depend on the current behavior, this PR marks `getShape()` as `@deprecated` and migrates the only internal caller — `computeSelectionCount` in `TableActionMenuPlugin` — to use `$computeTableMap` + `$computeTableCellRectBoundary` directly (renamed to `$computeSelectionCounts`).

`$computeTableCellRectBoundary` and its return type `TableCellRectBoundary` are now exported from `@lexical/table`.

## Test plan

- [x] `pnpm test-unit --project unit -- LexicalTableSelection` — 14 passed
  - `getShape` baseline: non-merged 2×2 table returns correct shape
- [x] Manual playground: create 3×3 table → merge row 1 cols 1-2 → select cells → context menu shows correct row/column count
- [x] tsc / flow / prettier / eslint clean