### PR TITLE
[lexical-code-shiki] Bug Fix: Deduplicate async loads and merge into history

### DIFF
--- a/packages/lexical-code-shiki/src/FacadeShiki.ts
+++ b/packages/lexical-code-shiki/src/FacadeShiki.ts
@@ -25,6 +25,7 @@ import {
   $createLineBreakNode,
   $createTabNode,
   $getNodeByKey,
+  HISTORY_MERGE_TAG,
   type LexicalEditor,
   type LexicalNode,
   type NodeKey,
@@ -78,29 +79,32 @@ export function loadCodeLanguage(
 ) {
   const diffedLanguage = getDiffedLanguage(language);
   const langId = diffedLanguage ? diffedLanguage : language;
-  if (!isCodeLanguageLoaded(langId)) {
-    const languageInfo = bundledLanguagesInfo.find(
-      desc =>
-        desc.id === langId || (desc.aliases && desc.aliases.includes(langId)),
-    );
-    if (languageInfo) {
-      // in case we arrive here concurrently (not yet loaded language is loaded twice)
-      // shiki's synchronous checks make sure to load it only once
-      return shiki.loadLanguage(languageInfo.import()).then(() => {
-        // here we know that the language is loaded
-        // make sure the code is highlighed with the correct language
-        if (editor && codeNodeKey) {
-          editor.update(() => {
-            const codeNode = $getNodeByKey(codeNodeKey);
-            if ($isCodeNode(codeNode) && codeNode.getLanguage() === language) {
-              codeNode.setIsSyntaxHighlightSupported(true);
-              codeNode.markDirty();
-            }
-          });
-        }
-      });
-    }
+  if (isCodeLanguageLoaded(langId)) {
+    return undefined;
   }
+
+  const languageInfo = bundledLanguagesInfo.find(
+    desc =>
+      desc.id === langId || (desc.aliases && desc.aliases.includes(langId)),
+  );
+  if (!languageInfo) {
+    return undefined;
+  }
+
+  return shiki.loadLanguage(languageInfo.import()).then(() => {
+    if (editor && codeNodeKey) {
+      editor.update(
+        () => {
+          const codeNode = $getNodeByKey(codeNodeKey);
+          if ($isCodeNode(codeNode) && codeNode.getLanguage() === language) {
+            codeNode.setIsSyntaxHighlightSupported(true);
+            codeNode.markDirty();
+          }
+        },
+        {tag: HISTORY_MERGE_TAG},
+      );
+    }
+  });
 }
 
 export function isCodeThemeLoaded(theme: string) {
@@ -119,21 +123,28 @@ export function loadCodeTheme(
   editor?: LexicalEditor,
   codeNodeKey?: NodeKey,
 ) {
-  if (!isCodeThemeLoaded(theme)) {
-    const themeInfo = bundledThemesInfo.find(info => info.id === theme);
-    if (themeInfo) {
-      return shiki.loadTheme(themeInfo.import()).then(() => {
-        if (editor && codeNodeKey) {
-          editor.update(() => {
-            const codeNode = $getNodeByKey(codeNodeKey);
-            if ($isCodeNode(codeNode)) {
-              codeNode.markDirty();
-            }
-          });
-        }
-      });
-    }
+  if (isCodeThemeLoaded(theme)) {
+    return undefined;
   }
+
+  const themeInfo = bundledThemesInfo.find(info => info.id === theme);
+  if (!themeInfo) {
+    return undefined;
+  }
+
+  return shiki.loadTheme(themeInfo.import()).then(() => {
+    if (editor && codeNodeKey) {
+      editor.update(
+        () => {
+          const codeNode = $getNodeByKey(codeNodeKey);
+          if ($isCodeNode(codeNode)) {
+            codeNode.markDirty();
+          }
+        },
+        {tag: HISTORY_MERGE_TAG},
+      );
+    }
+  });
 }
 
 export function getCodeLanguageOptions(): [string, string][] {

--- a/packages/lexical-code-shiki/src/__tests__/unit/CodeShikiHistory.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/CodeShikiHistory.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createCodeNode} from '@lexical/code';
+import {
+  CodeShikiExtension,
+  loadCodeLanguage,
+  loadCodeTheme,
+} from '@lexical/code-shiki';
+import {
+  buildEditorFromExtensions,
+  getExtensionDependencyFromEditor,
+} from '@lexical/extension';
+import {HistoryExtension} from '@lexical/history';
+import {RichTextExtension} from '@lexical/rich-text';
+import {$createTextNode, $getRoot, defineExtension} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+function createEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [RichTextExtension, HistoryExtension, CodeShikiExtension],
+      name: 'code-shiki-history-test',
+    }),
+  );
+}
+
+/**
+ * @lexical/code-shiki triggers async `editor.update()` calls while loading
+ * grammar (loadCodeLanguage) and theme (loadCodeTheme) via Shiki. Before the
+ * fix, each concurrent transform fired its own Promise `.then()`, producing
+ * isolated `HISTORY_PUSH` entries that polluted the undo stack. After the
+ * fix, async updates are tagged with `HISTORY_MERGE_TAG` so they fold into
+ * the preceding history entry.
+ */
+describe('CodeShiki async loads do not pollute history stack', () => {
+  test('creating a CodeNode with an unloaded language does not push to the undo stack', async () => {
+    using editor = createEditor();
+
+    // typescript is not loaded yet at this point
+    editor.update(
+      () => {
+        const codeNode = $createCodeNode('typescript');
+        codeNode.append($createTextNode('const x = 1;'));
+        $getRoot().append(codeNode);
+      },
+      {discrete: true},
+    );
+
+    // Wait for the async language/theme loads that the transform triggered.
+    // Because of in-flight Map deduplication, these calls return the same
+    // Promise that is already in flight.
+    await loadCodeLanguage('typescript');
+    await loadCodeTheme('poimandres');
+
+    const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+
+    // The merge-tag should have prevented any PUSH into the stack
+    expect(output.canUndo.peek()).toBe(false);
+  });
+});


### PR DESCRIPTION
Current behavior :
When multiple `CodeNode` transforms race to load the same unloaded language/theme via `loadCodeLanguage`/`loadCodeTheme`, each concurrent `.then()` chain fires its own `editor.update()`. Since these async updates lack tags, they produce isolated `HISTORY_PUSH` entries that pollute the undo stack. In practice, creating a single `CodeNode` with an unloaded language generates 3-6 spurious undo states.

Changes :
- Tagged async `editor.update()` calls with `HISTORY_MERGE_TAG` so they fold into the preceding history entry instead of pushing new ones

Test plan :

**Before**
Creating a `CodeNode` with language: `'typescript'` (not yet loaded) results in multiple `canUndo() === true` states. The history stack shows 3–6 entries before settling.

**After**
Added `CodeShikiHistory.test.ts`: after awaiting the async load, `output.canUndo.peek()` remains `false`. The merge tag successfully folds all async updates into the initial `editor.update()` history entry.