### PR TITLE
[lexical-table] Chore: Deprecate $createTableSelection in favor of $createTableSelectionFrom

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -421,12 +421,8 @@ export function $isTableSelection(x: unknown): x is TableSelection {
   return x instanceof TableSelection;
 }
 
+/** @deprecated Use {@link $createTableSelectionFrom} instead. */
 export function $createTableSelection(): TableSelection {
-  // TODO this is a suboptimal design, it doesn't make sense to have
-  // a table selection that isn't associated with a table. This
-  // constructor should have required arguments and in __DEV__ we
-  // should check that they point to a table and are element points to
-  // cell nodes of that table.
   const anchor = $createPoint('root', 0, 'element');
   const focus = $createPoint('root', 0, 'element');
   return new TableSelection('root', anchor, focus);
@@ -463,7 +459,11 @@ export function $createTableSelectionFrom(
   const prevSelection = $getSelection();
   const nextSelection = $isTableSelection(prevSelection)
     ? prevSelection.clone()
-    : $createTableSelection();
+    : new TableSelection(
+        'root',
+        $createPoint('root', 0, 'element'),
+        $createPoint('root', 0, 'element'),
+      );
   nextSelection.set(
     tableNode.getKey(),
     anchorCell.getKey(),

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -417,6 +417,7 @@ export class TableSelection implements BaseSelection {
   }
 }
 
+/** Type guard for {@link TableSelection}. */
 export function $isTableSelection(x: unknown): x is TableSelection {
   return x instanceof TableSelection;
 }
@@ -428,6 +429,15 @@ export function $createTableSelection(): TableSelection {
   return new TableSelection('root', anchor, focus);
 }
 
+/**
+ * Creates a {@link TableSelection} spanning from `anchorCell` to `focusCell`
+ * within `tableNode`. In `__DEV__` mode, validates that both cells belong to
+ * the given table and that the table is attached to the editor state.
+ *
+ * If the current selection is already a TableSelection, it clones and
+ * re-targets it (preserving identity for dirty-checking); otherwise it
+ * constructs a fresh one.
+ */
 export function $createTableSelectionFrom(
   tableNode: TableNode,
   anchorCell: TableCellNode,

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -14,7 +14,7 @@ import {
   $createTableNode,
   $createTableNodeWithDimensions,
   $createTableRowNode,
-  $createTableSelection,
+  $createTableSelectionFrom,
   $getElementForTableNode,
   $insertTableColumnAtSelection,
   $isScrollableTablesActive,
@@ -334,14 +334,15 @@ describe('LexicalTableNode tests', () => {
                 .getAllTextNodes()
                 .forEach((node, i) => node.setTextContent(String(i)));
               $getRoot().append(tableNode);
-              const tableSelection = $createTableSelection();
-              tableSelection.tableKey = tableNode.getKey();
               const cells = $dfs(tableNode).flatMap(({node}) =>
                 $isTableCellNode(node) ? [node] : [],
               );
               // second column
-              tableSelection.anchor.set(cells[1].getKey(), 0, 'element');
-              tableSelection.focus.set(cells[3].getKey(), 0, 'element');
+              const tableSelection = $createTableSelectionFrom(
+                tableNode,
+                cells[1],
+                cells[3],
+              );
               expectHtmlToBeEqual(
                 $generateHtmlFromNodes(editor, tableSelection),
                 html`
@@ -924,11 +925,16 @@ describe('LexicalTableNode tests', () => {
                     table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
                     $isParagraphNode,
                   ).append($createTextNode('some text'));
-                  const selection = $createTableSelection();
-                  selection.set(
-                    table.__key,
-                    table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                    table.getCellNodeFromCords(3, 3, DOMTable)?.__key || '',
+                  const anchorCell = table.getCellNodeFromCords(
+                    0,
+                    0,
+                    DOMTable,
+                  )!;
+                  const focusCell = table.getCellNodeFromCords(3, 3, DOMTable)!;
+                  const selection = $createTableSelectionFrom(
+                    table,
+                    anchorCell,
+                    focusCell,
                   );
                   $setSelection(selection);
                   editor.dispatchCommand(
@@ -965,11 +971,16 @@ describe('LexicalTableNode tests', () => {
                     table.getCellNodeFromCords(0, 0, DOMTable)?.getLastChild(),
                     $isParagraphNode,
                   ).append($createTextNode('some text'));
-                  const selection = $createTableSelection();
-                  selection.set(
-                    table.__key,
-                    table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                    table.getCellNodeFromCords(2, 2, DOMTable)?.__key || '',
+                  const anchorCell = table.getCellNodeFromCords(
+                    0,
+                    0,
+                    DOMTable,
+                  )!;
+                  const focusCell = table.getCellNodeFromCords(2, 2, DOMTable)!;
+                  const selection = $createTableSelectionFrom(
+                    table,
+                    anchorCell,
+                    focusCell,
                   );
                   $setSelection(selection);
                   editor.dispatchCommand(
@@ -1121,11 +1132,12 @@ describe('LexicalTableNode tests', () => {
                   table.getCellNodeFromCords(2, 1, DOMTable)?.getLastChild(),
                   $isParagraphNode,
                 ).append($createTextNode(''));
-                const selection = $createTableSelection();
-                selection.set(
-                  table.__key,
-                  table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                  table.getCellNodeFromCords(2, 1, DOMTable)?.__key || '',
+                const anchorCell = table.getCellNodeFromCords(0, 0, DOMTable)!;
+                const focusCell = table.getCellNodeFromCords(2, 1, DOMTable)!;
+                const selection = $createTableSelectionFrom(
+                  table,
+                  anchorCell,
+                  focusCell,
                 );
                 expect(selection.getTextContent()).toBe(`1\t\t2\n3\t4\t\n`);
               }
@@ -1819,12 +1831,8 @@ describe('LexicalTableNode tests', () => {
               const root = $getRoot();
               const table = $assertNodeType(root.getLastChild(), $isTableNode);
               const DOMTable = $getElementForTableNode(editor, table);
-              const selection = $createTableSelection();
-              selection.set(
-                table.__key,
-                table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-                table.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
-              );
+              const cell = table.getCellNodeFromCords(0, 0, DOMTable)!;
+              const selection = $createTableSelectionFrom(table, cell, cell);
               $setSelection(selection);
               $insertTableColumnAtSelection();
               table.setColWidths([50, 50, 100]);


### PR DESCRIPTION
## Description

`$createTableSelection()` creates a blank `TableSelection` with meaningless `'root'` keys that must be immediately overwritten via `.set()` — the source itself had a TODO calling this "a suboptimal design." This PR deprecates it in favor of `$createTableSelectionFrom()`, which takes a table node and anchor/focus cells and validates them in `__DEV__`.

The only internal caller (`$createTableSelectionFrom` itself) now constructs `TableSelection` directly. All five test usages in `LexicalTableNode.test.tsx` are migrated to `$createTableSelectionFrom()`. The deprecated function remains exported for backwards compatibility.

## Test plan

- [x] `pnpm test-unit --project unit -- LexicalTableNode` — 38 passed
- [x] `pnpm test-unit --project unit -- LexicalTableSelection` — 13 passed
- [x] All table package tests (140 passed)
- [x] tsc / prettier / eslint clean