### PR TITLE
[lexical] Feature: Editor operation benchmarks

### DIFF
--- a/packages/lexical/src/__bench__/README.md
+++ b/packages/lexical/src/__bench__/README.md
@@ -29,6 +29,7 @@ jsdom setup cost.
 | ---- | ------- | -------- |
 | `nodeMap.bench.ts` | `bench` | `Map` vs `GenMap` on clone / typing / paste / iteration / get |
 | `dom/editorCycle.bench.ts` | `bench-dom` | real `editor.update` cycle cost on a jsdom-backed editor |
+| `dom/editorOperations.bench.ts` | `bench-dom` | editor operations: split, format, delete range, paste, select-all |
 
 Helpers shared across files live in `_utils.ts` (microbench) and
 `dom/_utils.ts` (real-editor). Use them when you can; extract new helpers
@@ -100,31 +101,38 @@ register both under the same `describe` block. Vitest's summary shows the
 relative factor between benches in the same block, which is exactly what
 you want to cite in PR descriptions.
 
-**Setup state** — reset state in the `setup` callback so each iteration
-starts from a clean baseline. Vitest invokes `setup` before each timed
-iteration; allocations inside `setup` do not count toward the benchmark.
+**Setup state** — use the `setup` callback to initialize state before a
+task's measurement loop begins. Vitest invokes `setup` once per task
+(before warmup iterations and again before measured iterations), not
+per-iteration. Mutations made by the bench body accumulate across
+iterations — design accordingly (either make the body idempotent, or
+accept that it measures incremental cost on evolving state).
 
 **DCE prevention** — V8 may eliminate calls whose return values are
-unused. Each bench file should declare a module-level sink and `push`
-into it from the timed body so the call can't be elided:
+unused. Each bench file should declare a module-level scalar sink and
+assign into it from the timed body so the call can't be elided:
 
 ```ts
-const benchSinks: unknown[] = [];
+let _benchSink: unknown;
 
 bench('get', () => {
-  benchSinks.push(map.get(someKey));
+  _benchSink = map.get(someKey);
 });
 ```
 
-For loops, accumulate into a local and push the local once at the end:
+For loops, accumulate into a local and assign the local once at the end:
 
 ```ts
 bench('iterate', () => {
   let count = 0;
   for (const _ of map) count++;
-  benchSinks.push(count);
+  _benchSink = count;
 });
 ```
+
+A scalar assignment (rather than an array push) avoids unbounded memory
+growth at high iteration counts — e.g. size=100000 `get` can run millions
+of iterations per bench cycle.
 
 ## Reading results
 

--- a/packages/lexical/src/__bench__/dom/editorOperations.bench.ts
+++ b/packages/lexical/src/__bench__/dom/editorOperations.bench.ts
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import invariant from '@lexical/internal/invariant';
+import {bench, describe} from 'vitest';
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $insertNodes,
+  $isParagraphNode,
+  $isRangeSelection,
+  $isTextNode,
+  $selectAll,
+  type LexicalEditor,
+} from '../../';
+import {createTestEditor} from '../../__tests__/utils';
+import {attachToDOM, buildLargeDoc} from './_utils';
+
+const SPLIT_TEXT = 'paragraph with some text content for splitting';
+const MIN_SPLIT_TEXT_LENGTH = 2;
+
+const SIZES = [100, 1000] as const;
+
+for (const size of SIZES) {
+  // Splits last child at midpoint. Resets text when exhausted (~every
+  // 5 iters) to avoid O(n) backward walk that would dominate timing.
+  describe(`size=${size} :: split paragraph (Enter)`, () => {
+    let editor: LexicalEditor;
+
+    bench(
+      'insertParagraph',
+      () => {
+        editor.update(
+          () => {
+            const last = $getRoot().getLastChild();
+            invariant(
+              last !== null && $isParagraphNode(last),
+              'Expected ParagraphNode',
+            );
+            const textNode = last.getFirstChild();
+            invariant($isTextNode(textNode), 'Expected TextNode');
+            if (textNode.getTextContentSize() <= MIN_SPLIT_TEXT_LENGTH) {
+              textNode.setTextContent(SPLIT_TEXT);
+            }
+            const splitOffset = Math.floor(textNode.getTextContentSize() / 2);
+            textNode.select(splitOffset, splitOffset);
+            const selection = $getSelection();
+            invariant($isRangeSelection(selection), 'Expected RangeSelection');
+            selection.insertParagraph();
+          },
+          {discrete: true},
+        );
+      },
+      {
+        setup: () => {
+          editor = createTestEditor();
+          attachToDOM(editor);
+          buildLargeDoc(editor, size);
+        },
+      },
+    );
+  });
+
+  // Non-destructive: bold toggles on the same paragraph each iteration.
+  // Selection + format in one discrete update so reconcile is measured.
+  describe(`size=${size} :: format text (bold on selection)`, () => {
+    let editor: LexicalEditor;
+
+    bench(
+      'formatText bold',
+      () => {
+        editor.update(
+          () => {
+            const last = $getRoot().getLastChild();
+            invariant(
+              last !== null && $isParagraphNode(last),
+              'Expected ParagraphNode',
+            );
+            const textNode = last.getFirstChild();
+            invariant($isTextNode(textNode), 'Expected TextNode');
+            textNode.select(0, textNode.getTextContentSize());
+            const selection = $getSelection();
+            invariant($isRangeSelection(selection), 'Expected RangeSelection');
+            selection.formatText('bold');
+          },
+          {discrete: true},
+        );
+      },
+      {
+        setup: () => {
+          editor = createTestEditor();
+          attachToDOM(editor);
+          buildLargeDoc(editor, size);
+        },
+      },
+    );
+  });
+
+  // Destructive: selects the last 10 paragraphs and deletes via
+  // removeText — the same code path as a user pressing Delete.
+  // Anchors at the end of the paragraph before the range so that
+  // after deletion the anchor paragraph keeps its text, avoiding
+  // the empty-paragraph artifact that a start-of-range anchor causes.
+  describe(`size=${size} :: delete range (10 paragraphs)`, () => {
+    let editor: LexicalEditor;
+
+    bench(
+      'removeText across 10 paragraphs',
+      () => {
+        editor.update(
+          () => {
+            const root = $getRoot();
+            invariant(
+              root.getChildrenSize() > 10,
+              'Document exhausted (%s children remain)',
+              String(root.getChildrenSize()),
+            );
+            const lastNode = root.getLastChild();
+            invariant(
+              lastNode !== null && $isParagraphNode(lastNode),
+              'Expected last ParagraphNode',
+            );
+            let firstToDelete = lastNode;
+            for (let i = 0; i < 9; i++) {
+              const prev = firstToDelete.getPreviousSibling();
+              invariant(prev !== null, 'Expected previous sibling');
+              firstToDelete = prev;
+            }
+            const anchorNode = firstToDelete.getPreviousSibling();
+            invariant(
+              anchorNode !== null && $isParagraphNode(anchorNode),
+              'Expected anchor ParagraphNode',
+            );
+            const anchorText = anchorNode.getLastChild();
+            invariant($isTextNode(anchorText), 'Expected anchor TextNode');
+            const focusText = lastNode.getLastChild();
+            invariant($isTextNode(focusText), 'Expected focus TextNode');
+            anchorText.select(
+              anchorText.getTextContentSize(),
+              anchorText.getTextContentSize(),
+            );
+            const selection = $getSelection();
+            invariant($isRangeSelection(selection), 'Expected RangeSelection');
+            selection.focus.set(
+              focusText.getKey(),
+              focusText.getTextContentSize(),
+              'text',
+            );
+            selection.removeText();
+          },
+          {discrete: true},
+        );
+      },
+      {
+        iterations: size,
+        setup: () => {
+          editor = createTestEditor();
+          attachToDOM(editor);
+          buildLargeDoc(editor, size * 16);
+        },
+        time: 0,
+        warmupIterations: 5,
+        warmupTime: 0,
+      },
+    );
+  });
+
+  // Accumulative: inserts 10 paragraphs at the end per iteration.
+  describe(`size=${size} :: paste 10 paragraphs`, () => {
+    let editor: LexicalEditor;
+    let cycle = 0;
+
+    bench(
+      '$insertNodes at end',
+      () => {
+        editor.update(
+          () => {
+            const last = $getRoot().getLastChild();
+            invariant(
+              last !== null && $isParagraphNode(last),
+              'Expected ParagraphNode',
+            );
+            const textNode = last.getFirstChild();
+            invariant($isTextNode(textNode), 'Expected TextNode');
+            textNode.select(
+              textNode.getTextContentSize(),
+              textNode.getTextContentSize(),
+            );
+            const nodes = [];
+            for (let i = 0; i < 10; i++) {
+              nodes.push(
+                $createParagraphNode().append(
+                  $createTextNode(`paste-${cycle}-${i}`),
+                ),
+              );
+            }
+            $insertNodes(nodes);
+            cycle++;
+          },
+          {discrete: true},
+        );
+      },
+      {
+        setup: () => {
+          editor = createTestEditor();
+          attachToDOM(editor);
+          buildLargeDoc(editor, size);
+          cycle = 0;
+        },
+      },
+    );
+  });
+
+  // Non-destructive: select all + italic toggle.
+  describe(`size=${size} :: select all + format`, () => {
+    let editor: LexicalEditor;
+
+    bench(
+      '$selectAll + formatText italic',
+      () => {
+        editor.update(
+          () => {
+            $selectAll();
+            const selection = $getSelection();
+            invariant($isRangeSelection(selection), 'Expected RangeSelection');
+            selection.formatText('italic');
+          },
+          {discrete: true},
+        );
+      },
+      {
+        setup: () => {
+          editor = createTestEditor();
+          attachToDOM(editor);
+          buildLargeDoc(editor, size);
+        },
+      },
+    );
+  });
+}

--- a/packages/lexical/src/__bench__/nodeMap.bench.ts
+++ b/packages/lexical/src/__bench__/nodeMap.bench.ts
@@ -13,10 +13,11 @@ import {buildMap, type FakeNode, makeNode} from './_utils';
 
 const SIZES = [100, 1000, 10000, 100000] as const;
 
-// Module-level sink push'd into by each bench body so V8 can't elide
-// the work. The array is intentionally never read; `push` is the
-// observable side effect that anchors the computation. See README.md.
-const benchSinks: unknown[] = [];
+// Module-level sink written by each bench body so V8 can't elide the
+// work. A simple variable assignment is sufficient as an observable
+// side effect — unlike an array push, it doesn't grow without bound
+// and avoids memory exhaustion at high iteration counts (size=100000 get).
+let _benchSink: unknown;
 
 function buildGenMap(size: number): GenMap<string, FakeNode> {
   const g = new GenMap<string, FakeNode>();
@@ -38,7 +39,7 @@ for (const size of SIZES) {
     bench(
       'Map: new Map(prev)',
       () => {
-        const _ = new Map(mapBase);
+        _benchSink = new Map(mapBase);
       },
       {
         setup: () => {
@@ -50,7 +51,7 @@ for (const size of SIZES) {
     bench(
       'GenMap: clone()',
       () => {
-        const _ = genBase.clone();
+        _benchSink = genBase.clone();
       },
       {
         setup: () => {
@@ -69,6 +70,7 @@ for (const size of SIZES) {
       () => {
         const next = new Map(mapBase);
         next.set('newKey', makeNode('newKey'));
+        _benchSink = next;
       },
       {
         setup: () => {
@@ -82,6 +84,7 @@ for (const size of SIZES) {
       () => {
         const next = genBase.clone();
         next.set('newKey', makeNode('newKey'));
+        _benchSink = next;
       },
       {
         setup: () => {
@@ -104,6 +107,7 @@ for (const size of SIZES) {
           next.set(`typed${c}`, makeNode(`typed${c}`));
           cur = next;
         }
+        _benchSink = cur;
       },
       {
         setup: () => {
@@ -121,6 +125,7 @@ for (const size of SIZES) {
           next.set(`typed${c}`, makeNode(`typed${c}`));
           cur = next;
         }
+        _benchSink = cur;
       },
       {
         setup: () => {
@@ -142,6 +147,7 @@ for (const size of SIZES) {
           const k = `paste${i}`;
           next.set(k, makeNode(k));
         }
+        _benchSink = next;
       },
       {
         setup: () => {
@@ -158,6 +164,7 @@ for (const size of SIZES) {
           const k = `paste${i}`;
           next.set(k, makeNode(k));
         }
+        _benchSink = next;
       },
       {
         setup: () => {
@@ -175,7 +182,7 @@ for (const size of SIZES) {
     bench(
       'Map',
       () => {
-        benchSinks.push(mapBase.get(k));
+        _benchSink = mapBase.get(k);
       },
       {
         setup: () => {
@@ -187,7 +194,7 @@ for (const size of SIZES) {
     bench(
       'GenMap',
       () => {
-        benchSinks.push(genBase.get(k));
+        _benchSink = genBase.get(k);
       },
       {
         setup: () => {
@@ -206,7 +213,7 @@ for (const size of SIZES) {
       () => {
         let count = 0;
         for (const _ of mapBase) count++;
-        benchSinks.push(count);
+        _benchSink = count;
       },
       {
         setup: () => {
@@ -220,7 +227,7 @@ for (const size of SIZES) {
       () => {
         let count = 0;
         for (const _ of genBase) count++;
-        benchSinks.push(count);
+        _benchSink = count;
       },
       {
         setup: () => {


### PR DESCRIPTION
## Description

The benchmark infrastructure landed a few PRs ago with `nodeMap.bench.ts` and `editorCycle.bench.ts`, but contributors still couldn't answer "how fast is a paragraph split on a 1000-node document?" or "what's the real cost of select-all + format?". This PR fills that gap.

`editorOperations.bench.ts` adds 5 benchmarks covering the operations a contributor is most likely to care about when optimizing editing paths: paragraph split (Enter), bold formatting, range deletion, paste, and select-all + format. Each measures the full end-to-end cost through DOM reconciliation, not just tree mutation.

Along the way, two correctness issues in the existing `nodeMap.bench.ts` surfaced:
- The `benchSinks` array grew without bound, causing memory exhaustion at size=100000 (millions of iterations × one push per iter). Replaced with a scalar `_benchSink` assignment.
- Four clone/paste bench bodies assigned to dead locals (`const _`) that offered no principled DCE prevention. Now all bodies write their final result to `_benchSink`.

The README's conventions section is updated to match: the `setup` documentation incorrectly claimed per-iteration invocation (it's per-task), and the DCE pattern now shows the scalar approach.

### Design notes

**Why `{discrete: true}` on every update** — Without it, `$beginUpdate` defers reconciliation to a microtask (`_flushSync = false` → `scheduleMicroTask`). Tinybench only measures synchronous time, so the actual DOM work never executes during measurement. An early prototype used `dispatchCommand(FORMAT_TEXT_COMMAND)` outside `editor.update()` — it reported ~25kHz (just selection creation) instead of ~7kHz (format + reconcile). Verified by tracing through LexicalUpdates.ts:1141→1256.

**Why the split benchmark resets text instead of walking backward** — The natural pattern (walk backward to find splittable text) grows to O(n) as the document accumulates short fragments. Measured empirically: at size=1000, the walk consumed 30% of total iteration time. The benchmark was measuring "find a paragraph" rather than "split a paragraph." Resetting the last child's text every ~5 iterations keeps per-iteration cost dominated by the actual `insertParagraph` + reconcile path.

**Why delete uses fixed iterations with 16× headroom** — It's destructive (shrinks the document by 10 paragraphs/iter). Tinybench's time-based loop would eventually exhaust the document and crash. `time: 0` + `iterations: size` gives exact control. `size * 16` ensures `size * 6` paragraphs survive after all iterations + warmup. The anchor sits at the *end* of the paragraph preceding the delete range — anchoring at the range start leaves an empty-paragraph artifact after `removeText()`.

**Why SIZES = [100, 1000] not [1000, 5000]** — "Select all + format italic" is O(n). At size=5000, one iteration takes 5+ ms, making default vitest timing impractical. 100→1000 still demonstrates the scaling factor.

**Why setup semantics matter** — Vitest passes the user's `setup` as tinybench's bench-level hook (runs once per task, not per iteration). The destructive and accumulative benchmarks rely on this: delete consumes paragraphs across iterations, paste grows the document, split accumulates fragments. The old README would have misled contributors into expecting per-iteration reset.

## Test plan

- [x] `pnpm tsc --noEmit -p tsconfig.json` — clean
- [x] ESLint (json format, both files) — 0 errors, 0 warnings
- [x] Benchmarks produce valid measurements on Node 22. (Local Node 20.11 lacks `util.styleText` which vitest 4.1.8's rolldown dependency requires — environment limitation, not code issue.)