### PR TITLE
[lexical-table] Chore: Remove dead code in table command handlers

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -856,15 +856,6 @@ export function applyTableHandlers(
           tableObserver.$formatCells(payload);
 
           return true;
-        } else if ($isRangeSelection(selection)) {
-          const tableCellNode = $findMatchingParent(
-            selection.anchor.getNode(),
-            n => $isTableCellNode(n),
-          );
-
-          if (!$isTableCellNode(tableCellNode)) {
-            return false;
-          }
         }
 
         return false;

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -683,29 +683,6 @@ export function applyTableHandlers(
       tableObserver.$clearText();
 
       return true;
-    } else if ($isRangeSelection(selection)) {
-      const tableCellNode = $findParentTableCellNodeInTable(
-        tableNode,
-        selection.anchor.getNode(),
-      );
-
-      if (!$isTableCellNode(tableCellNode)) {
-        return false;
-      }
-
-      const anchorNode = selection.anchor.getNode();
-      const focusNode = selection.focus.getNode();
-      const isAnchorInside = tableNode.isParentOf(anchorNode);
-      const isFocusInside = tableNode.isParentOf(focusNode);
-
-      const selectionContainsPartialTable =
-        (isAnchorInside && !isFocusInside) ||
-        (isFocusInside && !isAnchorInside);
-
-      if (selectionContainsPartialTable) {
-        tableObserver.$clearText();
-        return true;
-      }
     }
 
     return false;


### PR DESCRIPTION
## Description

Two unreachable branches in `LexicalTableSelectionHelpers.ts` left over from past refactors:

1. `$deleteTextHandler` checked `selectionContainsPartialTable` (one endpoint inside the table, one outside) — but the `$isSelectionInTable` guard above it already guarantees *both* anchor and focus are inside, so the partial check was always false. Introduced as dead code by PR #4689 when it added `$isSelectionInTable` as a top-level guard without removing the now-redundant inner check.

2. `FORMAT_TEXT_COMMAND` handler had an `else if ($isRangeSelection)` branch that looked up the parent table cell but returned `false` regardless of whether it found one — both paths fell through to `return false`. Pure no-op.

Neither branch has ever been exercised (no test covers them, consistent with being unreachable). The `$deleteCellHandler` for `KEY_BACKSPACE`/`KEY_DELETE` handles the partial-table case correctly and is unaffected.

## Test plan

- [x] `pnpm test-unit -- packages/lexical-table` — 3968 tests pass, 0 regressions
- [x] e2e (chromium) — 770 pass
- [x] tsc clean