### PR TITLE
[lexical][lexical-website] Bug Fix: Homepage crash from optimized dev build

### DIFF
--- a/.github/workflows/call-core-tests.yml
+++ b/.github/workflows/call-core-tests.yml
@@ -18,10 +18,17 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ matrix.node-version }}
+      - uses: ./.github/actions/setup-playwright
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: pnpm run ci-check
       - run: pnpm run build
       - run: pnpm run build-www
       - run: pnpm run --filter @lexical/website build
+      # Loads the built homepage in a browser and fails if an embedded example
+      # throws at runtime (a green `build` alone does not catch this — see
+      # #8860).
+      - run: pnpm run --filter @lexical/website test-examples
       - run: pnpm run --filter lexical-playground build-vercel
 
   unit:

--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -138,7 +138,7 @@ test.describe('History', () => {
         focusPath: [1],
       });
     } else {
-      assertHTML(
+      await assertHTML(
         page,
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
@@ -301,7 +301,7 @@ test.describe('History', () => {
         focusPath: [1, 0, 0],
       });
     } else {
-      assertHTML(
+      await assertHTML(
         page,
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
@@ -322,7 +322,7 @@ test.describe('History', () => {
     await redo(page);
 
     if (isRichText) {
-      assertHTML(
+      await assertHTML(
         page,
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
@@ -340,7 +340,7 @@ test.describe('History', () => {
         focusPath: [1, 0, 0],
       });
     } else {
-      assertHTML(
+      await assertHTML(
         page,
         html`
           <p class="PlaygroundEditorTheme__paragraph" dir="auto">
@@ -939,7 +939,7 @@ test.describe('History - IME', () => {
 
     await undo(page);
 
-    assertHTML(
+    await assertHTML(
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph" dir="auto">

--- a/packages/lexical-playground/__tests__/regression/1055-fast-typing-undo.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/1055-fast-typing-undo.spec.mjs
@@ -24,6 +24,19 @@ test.describe('Regression test #1055', () => {
     test.skip(isCollab);
     await focusEditor(page);
     await page.keyboard.type('hello');
+    // Wait for the typed text to settle before undoing. On WebKit the input
+    // events dispatched by keyboard.type() can be applied after the call
+    // resolves; without this barrier the undo below races ahead of the typing
+    // and the still-queued input then re-applies the text, so the editor is
+    // not empty when we assert (flaky on the mac-plain/webkit suite).
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">hello</span>
+        </p>
+      `,
+    );
     await undo(page);
     await assertHTML(
       page,

--- a/packages/lexical-website/package.json
+++ b/packages/lexical-website/package.json
@@ -7,6 +7,7 @@
     "start": "pnpm -C ../.. run build && cross-env IGNORE_PEER_DEPENDENCIES=react TYPEDOC_WATCH=true docusaurus start",
     "build": "pnpm run tsc && pnpm -C ../.. run build && pnpm -C ../.. run build:dev-examples && cross-env IGNORE_PEER_DEPENDENCIES=react docusaurus build",
     "tsc": "tsc -p tsconfig.json",
+    "test-examples": "node scripts/check-homepage-examples.mjs",
     "swizzle": "cross-env IGNORE_PEER_DEPENDENCIES=react docusaurus swizzle",
     "deploy": "cross-env IGNORE_PEER_DEPENDENCIES=react docusaurus deploy",
     "clear": "cross-env IGNORE_PEER_DEPENDENCIES=react docusaurus clear",

--- a/packages/lexical-website/scripts/check-homepage-examples.mjs
+++ b/packages/lexical-website/scripts/check-homepage-examples.mjs
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// Smoke test for the built website homepage. A successful `docusaurus build`
+// does not catch *runtime* failures in the embedded editor examples — e.g.
+// #8860, where a Lexical node-registration invariant crashed an example in the
+// optimized dev build. This loads the built homepage in a real browser and
+// fails if any embedded example throws while mounting.
+//
+// Usage: node scripts/check-homepage-examples.mjs
+// Assumes `build/` already exists (run the docusaurus build first).
+
+import {createReadStream, existsSync, statSync} from 'node:fs';
+import {createServer} from 'node:http';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {chromium} from 'playwright';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BUILD_DIR = path.resolve(__dirname, '..', 'build');
+
+// The homepage editor examples, keyed by the `data-example-error` marker that
+// ExampleErrorBoundary renders on failure (matches `stackblitzPath`).
+const EXPECTED_EXAMPLES = [
+  'website-notion',
+  'website-chat',
+  'website-rich-input',
+  'agent-example',
+];
+
+// External resources (analytics) that may be network-blocked in CI. Errors
+// from these are unrelated to the examples and must not fail the check.
+const IGNORED_ERROR_PATTERNS = [
+  /googletagmanager\.com/,
+  /_vercel\//,
+  /vercel-insights/,
+  /ERR_TUNNEL_CONNECTION_FAILED/,
+  /Failed to load resource/,
+];
+
+const CONTENT_TYPES = {
+  '.css': 'text/css',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.mjs': 'text/javascript',
+  '.svg': 'image/svg+xml',
+  '.wasm': 'application/wasm',
+};
+
+function startServer() {
+  const server = createServer((req, res) => {
+    const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    let filePath = path.join(BUILD_DIR, urlPath);
+    if (existsSync(filePath) && statSync(filePath).isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+    }
+    if (!existsSync(filePath)) {
+      // Only fall back to the SPA shell for extension-less client routes;
+      // a missing asset must 404 so it surfaces as a real failure.
+      if (path.extname(urlPath) === '') {
+        filePath = path.join(BUILD_DIR, 'index.html');
+      } else {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+    }
+    res.writeHead(200, {
+      'Content-Type':
+        CONTENT_TYPES[path.extname(filePath)] || 'application/octet-stream',
+    });
+    createReadStream(filePath).pipe(res);
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+async function main() {
+  if (!existsSync(path.join(BUILD_DIR, 'index.html'))) {
+    throw new Error(
+      `Missing ${BUILD_DIR}/index.html. Run the website build first ` +
+        `(pnpm run --filter @lexical/website build).`,
+    );
+  }
+
+  const server = await startServer();
+  const {port} = server.address();
+  const baseURL = `http://127.0.0.1:${port}/`;
+
+  // In CI, Playwright resolves its own browser from the default cache. Allow
+  // an explicit override (e.g. for sandboxes with a shared browser install).
+  const executablePath = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+  const browser = await chromium.launch(executablePath ? {executablePath} : {});
+  const page = await browser.newPage();
+
+  const errors = [];
+  const keep = source => text => {
+    if (!IGNORED_ERROR_PATTERNS.some(re => re.test(text))) {
+      errors.push(`[${source}] ${text}`);
+    }
+  };
+  page.on('pageerror', err => keep('pageerror')(err.stack || err.message));
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      keep('console.error')(msg.text());
+    }
+  });
+
+  let brokenExamples = [];
+  let renderedEditors = 0;
+  try {
+    await page.goto(baseURL, {timeout: 60000, waitUntil: 'load'});
+    // The examples are below the fold; some are lazy-loaded on scroll.
+    for (let i = 0; i < 10; i++) {
+      await page.mouse.wheel(0, 1500);
+      await page.waitForTimeout(800);
+    }
+    await page.waitForTimeout(2000);
+
+    brokenExamples = await page.$$eval('[data-example-error]', nodes =>
+      nodes.map(n => n.getAttribute('data-example-error')),
+    );
+    renderedEditors = await page.$$eval(
+      '[data-lexical-editor]',
+      nodes => nodes.length,
+    );
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  const problems = [];
+  if (brokenExamples.length > 0) {
+    problems.push(
+      `Example error boundaries triggered: ${brokenExamples.join(', ')}`,
+    );
+  }
+  if (errors.length > 0) {
+    problems.push(`Runtime errors on the homepage:\n  ${errors.join('\n  ')}`);
+  }
+  // At minimum the three synchronous editors must mount. The agent example is
+  // lazy/browser-only and may not finish mounting its heavy worker in CI, so we
+  // do not require all four editors here — a crash in it still surfaces via the
+  // error boundary marker above.
+  if (renderedEditors < EXPECTED_EXAMPLES.length - 1) {
+    problems.push(
+      `Only ${renderedEditors} editor(s) mounted, expected at least ` +
+        `${EXPECTED_EXAMPLES.length - 1}.`,
+    );
+  }
+
+  if (problems.length > 0) {
+    console.error('\n❌ Homepage examples check FAILED:\n');
+    for (const p of problems) {
+      console.error(`  • ${p}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `✅ Homepage examples OK (${renderedEditors} editors mounted, no ` +
+      `runtime errors, no broken examples).\n`,
+  );
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/lexical-website/src/components/ExampleErrorBoundary.tsx
+++ b/packages/lexical-website/src/components/ExampleErrorBoundary.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
+import React from 'react';
+
+interface Props {
+  /** Human-readable label for the example, used in the fallback message. */
+  name: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Isolates a single embedded homepage example. If the example throws while
+ * rendering (for example, a Lexical node registration invariant firing in an
+ * optimized dev build, see #8860) the failure is contained here instead of
+ * taking down the entire homepage.
+ *
+ * The boundary mechanics are delegated to `@lexical/react`'s
+ * {@link LexicalErrorBoundary}. The fallback renders a `data-example-error`
+ * marker so automated checks can detect a broken example even though the error
+ * itself is caught (see scripts/check-homepage-examples.mjs).
+ */
+export default function ExampleErrorBoundary({
+  name,
+  children,
+}: Props): React.ReactNode {
+  return (
+    <LexicalErrorBoundary
+      onError={error => {
+        // Surface the failure on the console so it is visible in the browser
+        // and to CI, while keeping the rest of the page interactive.
+        console.error(`Homepage example "${name}" crashed:`, error);
+      }}
+      fallback={
+        <div
+          data-example-error={name}
+          role="alert"
+          className="rounded-lg border border-red-300 bg-red-50 p-6 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">
+          <p className="font-semibold">This example failed to load.</p>
+          <p className="mt-1 opacity-80">
+            Something went wrong rendering this demo. The rest of the page is
+            unaffected.
+          </p>
+        </div>
+      }>
+      <>{children}</>
+    </LexicalErrorBoundary>
+  );
+}

--- a/packages/lexical-website/src/components/HomepageExamples.tsx
+++ b/packages/lexical-website/src/components/HomepageExamples.tsx
@@ -12,6 +12,7 @@ import NotionEditor from '@examples/website-notion/Editor';
 import RichInputEditor from '@examples/website-rich-input/Editor';
 import React from 'react';
 
+import ExampleErrorBoundary from './ExampleErrorBoundary';
 import StackBlitzButton from './StackBlitzButton';
 
 const AgentEditor = React.lazy(() =>
@@ -125,7 +126,9 @@ export default function HomepageExamples() {
           title={section.title}
           description={section.description}
           stackblitzPath={section.stackblitzPath}>
-          {section.editor}
+          <ExampleErrorBoundary name={section.stackblitzPath}>
+            {section.editor}
+          </ExampleErrorBoundary>
         </ExampleSection>
       ))}
     </div>

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -3190,6 +3190,14 @@ const STATIC_NODE_CONFIG_CACHE = new WeakMap<
   OwnStaticNodeConfig
 >();
 
+// TextNode.length > 0 will only be true if the compiler output
+// is not ES6 compliant, in which case we can not provide this
+// warning. We also can't reliably provide this warning if the output
+// has been optimized because `arg=undefined` parameter defaults can
+// be stripped.
+const IS_UNOPTIMIZED_DEV_BUILD =
+  __DEV__ && TextNode.length === 0 && TextNode.name === 'TextNode';
+
 /** @internal */
 export function getStaticNodeConfig(
   klass: Klass<LexicalNode>,
@@ -3244,8 +3252,9 @@ export function getStaticNodeConfig(
     if (!hasOwnStaticMethod(klass, 'clone')) {
       // TextNode.length > 0 will only be true if the compiler output
       // is not ES6 compliant, in which case we can not provide this
-      // warning
-      if (__DEV__ && TextNode.length === 0) {
+      // warning. We also can't reliably provide this warning if the output
+      // has been optimized.
+      if (__DEV__ && IS_UNOPTIMIZED_DEV_BUILD) {
         invariant(
           klass.length === 0,
           '%s (type %s) must implement a static clone method since its constructor has %s required arguments (expecting 0). Use an explicit default in the first argument of your constructor(prop: T=X, nodeKey?: NodeKey).',
@@ -3260,7 +3269,7 @@ export function getStaticNodeConfig(
       };
     }
     if (!hasOwnStaticMethod(klass, 'importJSON')) {
-      if (__DEV__ && TextNode.length === 0) {
+      if (__DEV__ && IS_UNOPTIMIZED_DEV_BUILD) {
         invariant(
           klass.length === 0,
           '%s (type %s) must implement a static importJSON method since its constructor has %s required arguments (expecting 0). Use an explicit default in the first argument of your constructor(prop: T=X, nodeKey?: NodeKey).',

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -104,6 +104,7 @@ import {
   isCurrentlyReadOnlyMode,
   triggerCommandListeners,
 } from './LexicalUpdates';
+import {TabNode} from './nodes/LexicalTabNode';
 import {type TextFormatType, TextNode} from './nodes/LexicalTextNode';
 
 const __DEV__ = process.env.NODE_ENV !== 'production';
@@ -3196,7 +3197,13 @@ const STATIC_NODE_CONFIG_CACHE = new WeakMap<
 // has been optimized because `arg=undefined` parameter defaults can
 // be stripped.
 const IS_UNOPTIMIZED_DEV_BUILD =
-  __DEV__ && TextNode.length === 0 && TextNode.name === 'TextNode';
+  __DEV__ &&
+  // constructor(key=undefined)
+  TabNode.length === 0 &&
+  // constructor(text='', key?: NodeKey)
+  TextNode.length === 0 &&
+  // Class name mangling is another signal that this may be unreliable
+  TextNode.name === 'TextNode';
 
 /** @internal */
 export function getStaticNodeConfig(


### PR DESCRIPTION
## Description

The website homepage crashed entirely with
`nV (type tab) must implement a static clone method since its constructor has 1 required arguments (expecting 0)`, taking down every embedded example.

Root cause: the website bundles the dev build of `lexical` (so the node registration invariants are live) but minifies it for production. The minifier strips `arg = undefined` default-parameter assignments, which inflates `Function.length` for node constructors. The existing `TextNode.length === 0` guard detects non-ES6 compiler output but not a minified build — `TextNode`'s own `text = ''` default survives minification (`''` is not `undefined`) — so the clone/`importJSON` `klass.length === 0` invariants false-fired at runtime and crashed the first example to mount.

This PR:

- **lexical**: only run the clone/`importJSON` length invariants when the build is unoptimized, detected via `TextNode.name === 'TextNode'` (class names are mangled once the output is minified).
- **lexical-website**: wrap each embedded homepage example in its own error boundary (built on `@lexical/react`'s `LexicalErrorBoundary`) so a single failing example no longer takes down the whole page. The fallback renders a `data-example-error` marker.
- **lexical-website**: add a homepage smoke test that loads the built site in a browser and fails if an embedded example throws at runtime, wired into the core CI job. A green `build` alone does not catch this class of failure.

Closes #8860

## Test plan

### Before

- Built the website (`pnpm --filter @lexical/website build`) and loaded the homepage in Chromium: the first example threw the clone invariant and the page failed to render.
- Injected a client-only render crash into one example and ran the new `test-examples` check *without* the error boundary: the entire homepage went down.

### After

- `pnpm --filter @lexical/website build` succeeds and the new `pnpm --filter @lexical/website test-examples` smoke check passes (7 editors mounted, no runtime errors, no broken examples).
- Negative test: injected a client-only crash into one example — the build still succeeded, the error boundary isolated the failure (the other examples kept working), and `test-examples` failed with exit 1 naming the broken example. Reverted after verifying.
- Unit tests pass for `LexicalUtils`, `LexicalNode`, `LexicalNodeState`, and `DecoratorTextExtension` (263 tests); eslint and prettier are clean.
