### PR TITLE
[lexical] Bug Fix: Create selection when clicking between block decorators on Firefox

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -756,6 +756,73 @@ test.describe('HorizontalRule', () => {
     expect(isNodeSel).toBe(true);
   });
 
+  test('Clicking between consecutive block decorators creates selection (#6775)', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+    await waitForSelector(page, 'hr');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+    await getPageOrFrame(page).waitForFunction(() => {
+      const editor = document.querySelector('[contenteditable="true"]');
+      return editor && editor.querySelectorAll('hr').length === 2;
+    });
+
+    // Remove all non-decorator children so the HRs are directly adjacent
+    await getPageOrFrame(page).evaluate(() => {
+      const editor = window.lexicalEditor;
+      editor.update(
+        () => {
+          const root = editor.getEditorState()._nodeMap.get('root');
+          for (const child of root.getChildren()) {
+            if (!('decorate' in child)) {
+              child.remove();
+            }
+          }
+        },
+        {discrete: true},
+      );
+    });
+
+    // Click between the two HR elements
+    const clickPos = await getPageOrFrame(page).evaluate(() => {
+      const editor = document.querySelector('[contenteditable="true"]');
+      const hrs = editor.querySelectorAll('hr');
+      const rect1 = hrs[0].getBoundingClientRect();
+      const rect2 = hrs[1].getBoundingClientRect();
+      return {
+        x: Math.round(rect1.left + rect1.width / 2),
+        y: Math.round((rect1.bottom + rect2.top) / 2),
+      };
+    });
+    await page.mouse.click(clickPos.x, clickPos.y);
+
+    // Without the fix, Firefox leaves selection as null (rangeCount === 0).
+    // The fix computes the correct child offset from click coordinates.
+    const selState = await getPageOrFrame(page).evaluate(() => {
+      const sel = window.lexicalEditor.getEditorState()._selection;
+      if (sel === null) {
+        return null;
+      }
+      if ('anchor' in sel) {
+        return {
+          anchorKey: sel.anchor.key,
+          anchorType: sel.anchor.type,
+          type: 'range',
+        };
+      }
+      return {type: 'node'};
+    });
+    expect(selState).not.toBeNull();
+    expect(selState.type).toBe('range');
+    expect(selState.anchorKey).toBe('root');
+    expect(selState.anchorType).toBe('element');
+  });
+
   test('ArrowDown from block cursor between shadow root and decorator selects the decorator', async ({
     page,
     isPlainText,

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -575,10 +575,11 @@ function onClick(event: PointerEvent, editor: LexicalEditor): void {
 
     // Firefox produces no DOM range when clicking between block-level
     // decorators (rangeCount === 0). Use click coordinates to compute
-    // the correct child offset.
+    // the correct child offset. Only act when the click landed directly
+    // on the root element (not inside a child like a table cell).
     if (IS_FIREFOX && domSelection !== null && domSelection.rangeCount === 0) {
       const rootElement = editor._rootElement;
-      if (rootElement !== null) {
+      if (rootElement !== null && event.target === rootElement) {
         const clientY = event.clientY;
         let offset = rootElement.childNodes.length;
         for (let i = 0; i < rootElement.childNodes.length; i++) {

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -573,6 +573,44 @@ function onClick(event: PointerEvent, editor: LexicalEditor): void {
       }
     }
 
+    // Firefox produces no DOM range when clicking between block-level
+    // decorators (rangeCount === 0). Use click coordinates to compute
+    // the correct child offset.
+    if (
+      IS_FIREFOX &&
+      selection === null &&
+      domSelection !== null &&
+      domSelection.rangeCount === 0
+    ) {
+      const rootElement = editor._rootElement;
+      if (rootElement !== null) {
+        const clientY = event.clientY;
+        let offset = rootElement.childNodes.length;
+        for (let i = 0; i < rootElement.childNodes.length; i++) {
+          const child = rootElement.childNodes[i];
+          if (isHTMLElement(child)) {
+            const rect = child.getBoundingClientRect();
+            if (clientY <= (rect.top + rect.bottom) / 2) {
+              offset = i;
+              break;
+            }
+          }
+        }
+        domSelection.setBaseAndExtent(rootElement, offset, rootElement, offset);
+        const newSelection = $internalCreateRangeSelection(
+          lastSelection,
+          domSelection,
+          editor,
+          event,
+        );
+        if (newSelection !== null) {
+          $setSelection(newSelection);
+        } else {
+          domSelection.removeAllRanges();
+        }
+      }
+    }
+
     dispatchCommand(editor, CLICK_COMMAND, event);
   });
 }
@@ -1816,6 +1854,12 @@ function onDocumentSelectionChange(event: Event): void {
           event,
         );
         $setSelection(newSelection);
+      } else if (IS_FIREFOX && domAnchorNode === null) {
+        // Firefox leaves the DOM selection empty (rangeCount === 0) when
+        // clicking between block-level decorators. Clear Lexical's
+        // selection so it can be recomputed from click coordinates in
+        // the click event.
+        $setSelection(null);
       }
     });
   }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -576,12 +576,7 @@ function onClick(event: PointerEvent, editor: LexicalEditor): void {
     // Firefox produces no DOM range when clicking between block-level
     // decorators (rangeCount === 0). Use click coordinates to compute
     // the correct child offset.
-    if (
-      IS_FIREFOX &&
-      selection === null &&
-      domSelection !== null &&
-      domSelection.rangeCount === 0
-    ) {
+    if (IS_FIREFOX && domSelection !== null && domSelection.rangeCount === 0) {
       const rootElement = editor._rootElement;
       if (rootElement !== null) {
         const clientY = event.clientY;
@@ -1854,12 +1849,6 @@ function onDocumentSelectionChange(event: Event): void {
           event,
         );
         $setSelection(newSelection);
-      } else if (IS_FIREFOX && domAnchorNode === null) {
-        // Firefox leaves the DOM selection empty (rangeCount === 0) when
-        // clicking between block-level decorators. Clear Lexical's
-        // selection so it can be recomputed from click coordinates in
-        // the click event.
-        $setSelection(null);
       }
     });
   }


### PR DESCRIPTION
## Description

Firefox does not produce a DOM selection when clicking in the gap between block-level decorator elements (e.g. consecutive `<hr>` nodes). Chrome and Safari handle this by placing the selection on `rootElement` at the appropriate child offset, but Firefox leaves `rangeCount === 0` and does not fire a `selectionchange` event (since from its perspective nothing changed). This means Lexical never creates a selection, and the block cursor that normally appears between decorators is never shown.

The fix adds two coordinating branches in `LexicalEvents.ts`:

1. In `onDocumentSelectionChange` (mousedown path): when Firefox reports an empty DOM selection (`domAnchorNode === null`), clear Lexical's selection so the committed state reflects the empty DOM.

2. In `onClick`: when `selection === null` and `domSelection.rangeCount === 0`, iterate `rootElement.childNodes` comparing `event.clientY` against each child's vertical midpoint to compute the correct offset, then call `setBaseAndExtent` to establish the DOM selection. `$internalCreateRangeSelection` picks it up from there, and the existing block cursor mechanism (`$updateDOMBlockCursorElement`) renders the cursor at the gap.

Closes #6775

### Design notes

**Why two sites instead of onClick alone?** — For click events with `detail !== 3`, `$internalCreateRangeSelection` clones the committed RangeSelection without re-reading the DOM. If a selection already exists when the user clicks between decorators, the clone makes `$getSelection()` return non-null, preventing the onClick branch from entering. The selectionchange branch nulls the committed selection first, so the subsequent onClick sees `null` and fires.

**`caretPositionFromPoint`** — Tested on Firefox; it returns the decorator element itself (`{offsetNode: hr, offset: 0}`) rather than a root-level child offset. It can't distinguish "between child 1 and child 2 of rootElement," so the manual midpoint loop is necessary.

**Why core, not an extension?** — The block cursor mechanism itself lives in `LexicalUtils.ts` (core). This fix establishes the selection that the block cursor relies on — it's event-layer plumbing, not a feature-specific behavior.

## Test plan

- [x] Manual (Firefox): playground with 3 consecutive horizontal rules — clicking in each gap shows the block cursor at the correct position
- [x] Manual (Firefox): existing selection in a paragraph, then click between decorators — cursor moves to the gap
- [x] Manual (Chrome/Safari): same scenarios unchanged (the `IS_FIREFOX` guard prevents the new code from running)
- [x] `pnpm tsc --noEmit` — clean