### PR TITLE
[lexical] Bug Fix: run editor updates dispatched from a read-only context in a fresh writable update

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -1284,7 +1284,30 @@ export function updateEditorSync(
   options?: EditorUpdateOptions,
 ): void {
   if (activeEditor === editor && options === undefined) {
-    updateFn();
+    if (isCurrentlyReadOnlyMode()) {
+      // We are nominally "inside an update" for this editor, but the active
+      // context is read-only (e.g. a command dispatched from inside
+      // editor.read(), or a force-commit read on the stack). Running updateFn
+      // inline here would mutate the frozen active editor state and throw
+      // "Cannot call set() on a frozen Lexical node map" — an error that gets
+      // routed to editor._onError rather than rethrown, so the mutation is
+      // silently dropped. Route through $beginUpdate instead, which starts a
+      // fresh writable update, so the work actually applies.
+      if (__DEV__) {
+        console.warn(
+          `updateEditorSync: an editor update (e.g. a command listener that ` +
+            `mutates the editor) ran while a read-only context was on the ` +
+            `stack. This most commonly happens when a command is dispatched ` +
+            `from inside editor.read(). The update has been deferred to a ` +
+            `fresh writable update so it still applies, but dispatching ` +
+            `mutations from a read-only context is an anti-pattern — dispatch ` +
+            `after editor.read() returns, or via queueMicrotask.`,
+        );
+      }
+      $beginUpdate(editor, updateFn, options);
+    } else {
+      updateFn();
+    }
   } else {
     $beginUpdate(editor, updateFn, options);
   }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1478,6 +1478,54 @@ describe('LexicalEditor tests', () => {
     expect(errorListener).toHaveBeenCalledTimes(0);
   });
 
+  it('applies (and warns in DEV) when a command dispatched from a read-only context mutates the editor', async () => {
+    init();
+
+    const READONLY_MUTATE_COMMAND = createCommand<void>(
+      'READONLY_MUTATE_COMMAND',
+    );
+    // A listener that mutates the editor state, mirroring the real-world case
+    // (e.g. CLEAR_EDITOR_COMMAND building a fresh paragraph).
+    const unregister = editor.registerCommand(
+      READONLY_MUTATE_COMMAND,
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('mutated')));
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      // Dispatching from inside editor.read() (a read-only context) is the
+      // application anti-pattern. Previously the mutating listener ran inline
+      // against the frozen node map and threw (caught by _onError, silently
+      // dropping the mutation). It should now be deferred to a writable update
+      // so the mutation actually applies, and warn in DEV.
+      editor.read(() => {
+        editor.dispatchCommand(READONLY_MUTATE_COMMAND, undefined);
+      });
+      // Deferred update flushes on the next tick.
+      await Promise.resolve();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/read-only context/);
+      editor.read(() => {
+        expect($getRoot().getTextContent()).toBe('mutated');
+      });
+
+      // A top-level (writable) dispatch must NOT warn and applies inline.
+      warnSpy.mockClear();
+      editor.dispatchCommand(READONLY_MUTATE_COMMAND, undefined);
+      expect(warnSpy).toHaveBeenCalledTimes(0);
+    } finally {
+      warnSpy.mockRestore();
+      unregister();
+    }
+  });
+
   it('Should be able to update an editor state without a root element', () => {
     const ref = createRef<HTMLDivElement>();
 


### PR DESCRIPTION
## Summary

Makes editor updates that are dispatched from a **read-only context** actually apply (instead of throwing on the frozen node map), by running them in a fresh writable update — and warns in DEV that this is an anti-pattern.

> Reworked per review (@etrepum). Earlier revisions of this PR only guarded `CLEAR_EDITOR_COMMAND`, then only warned. As pointed out, a warning alone still leaves the operation broken. This revision fixes the behavior generally in `updateEditorSync` (where command listeners run) so any command dispatched from a read-only context works, and keeps a DEV warning so the root-cause anti-pattern is surfaced.

## The failure

A command listener that mutates the editor state — e.g. `CLEAR_EDITOR_COMMAND` building a fresh paragraph — throws:

```
Cannot call set() on a frozen Lexical node map
```

...when the command is dispatched while a **read-only context is on the stack** (most commonly a command dispatched from inside `editor.read()`, or a nested force-commit read). Command listeners run via `updateEditorSync`, which runs `updateFn` **inline** when `activeEditor === editor`. If that active context is read-only, the inline mutation hits the frozen active editor state and throws. The error is routed to `editor._onError` rather than rethrown, so the dispatch appears to succeed while the mutation is silently dropped.

(As discussed: a *plain* nested dispatch from another command listener runs writable via `updateEditorSync`, so this is not a general problem for dispatch-based composers — it only occurs when a read-only context is live on the stack. That app pattern is the root cause; the DEV warning makes it visible.)

## What this does

In `updateEditorSync`, when the inline fast-path would run but `isCurrentlyReadOnlyMode()` is true, route through `$beginUpdate` (a fresh writable update) instead of running inline:

```ts
if (activeEditor === editor && options === undefined) {
  if (isCurrentlyReadOnlyMode()) {
    if (__DEV__) { console.warn(/* dispatched from read-only context; the update was deferred to a writable update; dispatch after editor.read() or via queueMicrotask */); }
    $beginUpdate(editor, updateFn, options);   // deferred, writable — mutation applies
  } else {
    updateFn();                                 // unchanged writable fast-path
  }
} else {
  $beginUpdate(editor, updateFn, options);
}
```

- Only changes a path that previously **threw** (frozen map). No currently-working path is affected.
- General across all commands, not clear-specific.
- DEV-only warning; no extra prod logging and no new throw.

## Test plan

- Added a unit test in `LexicalEditor.test.tsx`: a mutating command dispatched from inside `editor.read()` now (a) warns once in DEV and (b) **actually applies** the mutation (asserts the resulting text content), while a top-level writable dispatch does not warn. Verified it **fails** without the fix (mutation dropped) and **passes** with it.
- `ClearEditorExtension.test.ts`: 3/3 still pass (the inline document-replacement behavior from #8826 is preserved for the writable case).
- Full `packages/lexical` unit suite: **807/807 passing**. Prettier + eslint clean.