### PR TITLE
fix: $config() auto-synthesized clone() loses properties when called directly (#8640)

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -122,6 +122,29 @@ export function getPendingNodeToClone(): null | LexicalNode {
   return node;
 }
 
+// Internal, module-private sentinel passed as the second argument to an
+// auto-synthesized clone (see getStaticNodeConfig) by the internal clone
+// wrappers ($cloneWithProperties / $copyNode). Those wrappers are contractually
+// responsible for calling `afterCloneFrom(node)` on the result exactly once, so
+// they pass this sentinel to tell the synthesized clone NOT to call it too.
+//
+// An auto-synthesized clone has no explicit body, so when it is called *without*
+// this sentinel — i.e. directly as `NodeClass.clone(node)`, a documented and
+// idiomatic pattern before the $config() port — it must copy the source node's
+// properties itself, otherwise callers silently get a default-constructed node
+// with lost state (e.g. HeadingNode's tag reverting to 'h1').
+//
+// The signal is per-call rather than a module global, so it is unaffected by
+// reentrancy: a clone (or afterCloneFrom) that happens to clone another node,
+// even in another editor, does not accidentally suppress that node's own
+// afterCloneFrom. It is also un-spoofable by external callers because the
+// sentinel is not exported. afterCloneFrom is not guaranteed idempotent (some
+// nodes accumulate state there, e.g. a version counter), so it is critical that
+// it runs exactly once per clone regardless of call path.
+const INTERNAL_SKIP_AFTER_CLONE_FROM: unique symbol = Symbol(
+  'INTERNAL_SKIP_AFTER_CLONE_FROM',
+);
+
 let keyCounter = 1;
 
 export function resetRandomKey(): void {
@@ -1800,7 +1823,12 @@ export function $copyNode<T extends LexicalNode>(
   node: T,
   skipReset = false,
 ): T {
-  const copy = node.constructor.clone(node) as T;
+  const copy = (
+    node.constructor.clone as (
+      data: LexicalNode,
+      internalSkipAfterCloneFrom?: typeof INTERNAL_SKIP_AFTER_CLONE_FROM,
+    ) => T
+  )(node, INTERNAL_SKIP_AFTER_CLONE_FROM);
   $setNodeKey(copy, null);
   copy.afterCloneFrom(node);
   if (!skipReset) {
@@ -2889,7 +2917,12 @@ function computeTypeToNodeMap(editorState: EditorState): TypeToNodeMap {
  */
 export function $cloneWithProperties<T extends LexicalNode>(latestNode: T): T {
   const constructor = latestNode.constructor;
-  const mutableNode = constructor.clone(latestNode) as T;
+  const mutableNode = (
+    constructor.clone as (
+      data: LexicalNode,
+      internalSkipAfterCloneFrom?: typeof INTERNAL_SKIP_AFTER_CLONE_FROM,
+    ) => T
+  )(latestNode, INTERNAL_SKIP_AFTER_CLONE_FROM);
   mutableNode.afterCloneFrom(latestNode);
   if (__DEV__) {
     invariant(
@@ -3263,9 +3296,25 @@ export function getStaticNodeConfig(
           String(klass.length),
         );
       }
-      klass.clone = (prevNode: LexicalNode) => {
+      klass.clone = (
+        prevNode: LexicalNode,
+        internalSkipAfterCloneFrom?: typeof INTERNAL_SKIP_AFTER_CLONE_FROM,
+      ) => {
         setPendingNodeToClone(prevNode);
-        return new klass();
+        const node = new klass();
+        // The internal clone wrappers ($cloneWithProperties / $copyNode) pass
+        // the module-private INTERNAL_SKIP_AFTER_CLONE_FROM sentinel because
+        // they call afterCloneFrom themselves. When this synthesized clone is
+        // instead called directly — e.g. `NodeClass.clone(node)`, an idiomatic
+        // pre-$config() pattern — the sentinel is absent, so we call
+        // afterCloneFrom here to preserve the documented clone() contract and
+        // avoid silent property loss. afterCloneFrom is not guaranteed
+        // idempotent, so this must run exactly once (see the sentinel
+        // definition for the full rationale).
+        if (internalSkipAfterCloneFrom !== INTERNAL_SKIP_AFTER_CLONE_FROM) {
+          node.afterCloneFrom(prevNode);
+        }
+        return node;
       };
     }
     if (!hasOwnStaticMethod(klass, 'importJSON')) {

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -7,6 +7,7 @@
  */
 import invariant from '@lexical/internal/invariant';
 import {
+  $cloneWithProperties,
   $create,
   $createLineBreakNode,
   $createParagraphNode,
@@ -1616,6 +1617,149 @@ describe('LexicalNode tests', () => {
               expect(versionedTextNode.__mode).toEqual(0);
               expect(versionedTextNode.getLatest().__mode).toEqual(1);
               expect(versionedTextNode.getMode()).toEqual('token');
+            },
+            {discrete: true},
+          );
+        });
+        // Regression test for the $config() clone auto-synthesis BC break:
+        // a node that drops its explicit static clone() in favor of $config()
+        // gets a zero-arg auto-clone. When that auto-clone is invoked directly
+        // (NodeClass.clone(node) / node.constructor.clone(node)) rather than
+        // through $cloneWithProperties, it must still copy the source node's
+        // properties via afterCloneFrom, otherwise callers silently get a
+        // default-constructed node with lost state.
+        test('direct clone() of an auto-synthesized node preserves properties', () => {
+          class ConfigTagNode extends ElementNode {
+            __tag: string = 'default';
+            $config() {
+              return this.config('config-tag', {extends: ElementNode});
+            }
+            afterCloneFrom(node: this): void {
+              super.afterCloneFrom(node);
+              this.__tag = node.__tag;
+            }
+            setTag(tag: string): this {
+              const self = this.getWritable();
+              self.__tag = tag;
+              return self;
+            }
+          }
+          const editor = createEditor({
+            nodes: [ConfigTagNode],
+            onError(err) {
+              throw err;
+            },
+          });
+          editor.update(
+            () => {
+              const source = $create(ConfigTagNode).setTag('custom');
+              $getRoot().append(source);
+              expect(source.__tag).toBe('custom');
+              // Direct call to the auto-synthesized clone (the idiomatic,
+              // pre-#8640 pattern) must not lose __tag.
+              const directClone = ConfigTagNode.clone(source) as ConfigTagNode;
+              expect(directClone.__tag).toBe('custom');
+              // Going through $cloneWithProperties must remain correct too.
+              const wrapperClone = $cloneWithProperties(source);
+              expect(wrapperClone.__tag).toBe('custom');
+            },
+            {discrete: true},
+          );
+        });
+        // afterCloneFrom is not guaranteed idempotent — some nodes accumulate
+        // state there (e.g. incrementing a version counter). It must therefore
+        // run exactly once per clone regardless of call path, so the direct-call
+        // fix above must NOT cause $cloneWithProperties to double-apply it.
+        test('afterCloneFrom runs exactly once for auto-synthesized clone', () => {
+          class ConfigVersionNode extends ElementNode {
+            __version: number = 0;
+            $config() {
+              return this.config('config-version', {extends: ElementNode});
+            }
+            afterCloneFrom(node: this): void {
+              super.afterCloneFrom(node);
+              this.__version = node.__version + 1;
+            }
+          }
+          const editor = createEditor({
+            nodes: [ConfigVersionNode],
+            onError(err) {
+              throw err;
+            },
+          });
+          editor.update(
+            () => {
+              const source = $create(ConfigVersionNode);
+              $getRoot().append(source);
+              expect(source.__version).toBe(0);
+              // One clone => exactly one afterCloneFrom => version + 1.
+              const cloned = $cloneWithProperties(source);
+              expect(cloned.__version).toBe(1);
+            },
+            {discrete: true},
+          );
+        });
+        // Guards the reentrancy concern with the auto-clone fix: a direct
+        // clone of one auto-synthesized node performed from within another
+        // node's clone/afterCloneFrom logic must still copy its own source
+        // properties. The signal that suppresses the wrapper-driven
+        // afterCloneFrom must be per-call (not a shared/module-global flag),
+        // otherwise a nested direct clone would wrongly inherit the outer
+        // node's "skip" state and silently drop its properties.
+        test('reentrant direct clone during another clone preserves properties', () => {
+          class InnerTagNode extends ElementNode {
+            __tag: string = 'default';
+            $config() {
+              return this.config('inner-tag', {extends: ElementNode});
+            }
+            afterCloneFrom(node: this): void {
+              super.afterCloneFrom(node);
+              this.__tag = node.__tag;
+            }
+            setTag(tag: string): this {
+              const self = this.getWritable();
+              self.__tag = tag;
+              return self;
+            }
+          }
+          class OuterNode extends ElementNode {
+            // Populated during clone by directly cloning `__templateSource`.
+            __reentrantClone: InnerTagNode | null = null;
+            __templateSource: InnerTagNode | null = null;
+            $config() {
+              return this.config('outer-reentrant', {extends: ElementNode});
+            }
+            afterCloneFrom(node: this): void {
+              super.afterCloneFrom(node);
+              // Reentrant DIRECT clone of a different auto-synthesized node,
+              // performed while this OuterNode is itself being cloned.
+              if (node.__templateSource) {
+                this.__reentrantClone = InnerTagNode.clone(
+                  node.__templateSource,
+                ) as InnerTagNode;
+              }
+            }
+            setTemplateSource(source: InnerTagNode): this {
+              const self = this.getWritable();
+              self.__templateSource = source;
+              return self;
+            }
+          }
+          const editor = createEditor({
+            nodes: [InnerTagNode, OuterNode],
+            onError(err) {
+              throw err;
+            },
+          });
+          editor.update(
+            () => {
+              const inner = $create(InnerTagNode).setTag('custom');
+              const outer = $create(OuterNode).setTemplateSource(inner);
+              $getRoot().append(inner, outer);
+              const clonedOuter = $cloneWithProperties(outer);
+              // The reentrant direct clone must have copied inner's tag.
+              expect(clonedOuter.__reentrantClone).not.toBeNull();
+              expect(clonedOuter.__reentrantClone!.__tag).toBe('custom');
             },
             {discrete: true},
           );


### PR DESCRIPTION
## Bug

[#8640](https://github.com/facebook/lexical/pull/8640) ("Port node classes to the `$config()` protocol") introduced a silent backwards-compatibility break in the `LexicalNode` clone contract, found while syncing the change into Meta's internal `www` codebase (D112781184).

### What breaks

When a node drops its explicit `static clone()` in favor of `$config()` (e.g. `HeadingNode`), `getStaticNodeConfig` auto-synthesizes a zero-arg clone:

```ts
klass.clone = (prevNode) => {
  setPendingNodeToClone(prevNode);
  return new klass();
};
```

That synthesized clone only produces a correct instance when it is driven through the internal `$cloneWithProperties` / `$copyNode` wrappers, because **those wrappers** are what call `afterCloneFrom(prevNode)` afterwards (which is where subclasses copy their own state). The synthesized clone itself only preserves `__key` (via `setPendingNodeToClone`), not properties.

Any caller that invokes `NodeClass.clone(node)` / `node.constructor.clone(node)` **directly** — a documented, idiomatic pattern before #8640 — now silently gets a default-constructed node with lost properties. For `HeadingNode`, `__tag` is copied only in `afterCloneFrom`, so a direct clone of an `h2` returns a node whose tag has reverted to the constructor default `'h1'`.

This is a **silent data-correctness bug, not a throw**, so it's easy to miss in review. It affects the 25+ core nodes that rely on auto-synthesized clone (`ParagraphNode`, `TextNode`, `ListNode`, `TableNode`, `HeadingNode`, `LinkNode`, …).

## Fix

Close the gap at the source rather than relying on every caller using the "right" entry point: the synthesized clone now calls `afterCloneFrom()` itself **when it is not being driven by an internal wrapper**, so it is correct regardless of call path.

The subtlety is that `afterCloneFrom` is **not guaranteed idempotent** — some nodes deliberately accumulate state there (the existing `clone() with no boilerplate` unit test uses a node that increments a `__version` counter in `afterCloneFrom`). So `afterCloneFrom` must run **exactly once** per clone. A `cloneWrapperDepth` guard achieves this:

- `$cloneWithProperties` and `$copyNode` wrap their `constructor.clone(node)` call in `runInCloneWrapper(...)` and remain solely responsible for calling `afterCloneFrom` (unchanged behavior for them).
- The synthesized clone checks `isInCloneWrapper()`: inside a wrapper it does **not** self-apply (the wrapper will); called directly it self-applies.

This preserves the existing contract for explicit `static clone()` implementations (they still must not call `afterCloneFrom`; the wrappers do) and fixes direct callers without any double-application.

## Tests

Added two regression tests in `LexicalNode.test.ts`:

1. `direct clone() of an auto-synthesized node preserves properties` — asserts a direct `NodeClass.clone(node)` on a `$config()`-based node keeps its custom property (fails before this change, passes after), and that `$cloneWithProperties` still works.
2. `afterCloneFrom runs exactly once for auto-synthesized clone` — a node that increments a version counter in `afterCloneFrom` ends at version `1` (not `2`) after one clone, guarding against double-application from this change.

Verified locally:
- `LexicalNode.test.ts`: 96 passed
- full `packages/lexical` unit suite: **1204 passed** (no regressions from double-`afterCloneFrom`)
- `packages/lexical-rich-text` (incl. 19 `HeadingNode` tests): 112 passed
- `prettier --check` and `tsc --noEmit` clean on the changed files

## Follow-up (not in this PR): stricter `importJSON` base signature

While syncing, a second BC break was found: #8640 also tightened the base `LexicalNode.importJSON` return type to non-nullable `LexicalNode`. Subclasses that intentionally return `null` from `importJSON` (signaling "this node type does not support JSON import") now fail type-checking.

I deliberately left this out of this PR. Naively relaxing the base return type to `LexicalNode | null` ripples into the deserializer (`$parseSerializedNodeImpl` in `LexicalUpdates.ts`) and its recursive child-append path, forcing every `importJSON` consumer to handle `null` and changing deserialization semantics — a larger API decision than a clone-correctness fix should carry. The cleaner alternative is an explicit `$config()` opt-out (e.g. `importable: false`) with matching deserializer support. Happy to open a separate PR / discussion once maintainers weigh in on the preferred shape. In the meantime the `www`-side flow break can be unblocked with a local flow annotation on the specific non-importable subclass.

## Context

Reported by the Lexical → fbsource sync oncall. Concrete internal regressions that surfaced this (Meta-internal): `CaaSLexicalInsertLineNode.js` flow break and an `MLCNestingEnforcementPlugin` heading-nesting test failure (`h1>h2>text` unwrapping `h2` to `h1`) — both explained by the direct-clone property loss above. See D112781184 for the full internal analysis.
