### PR TITLE
[lexical] Chore: Migrate LexicalSelection tests to buildEditorFromExtensions

### DIFF
--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -401,11 +401,11 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingText.getKey(), 0, 'text');
-            sel.focus.set(
-              trailingTokenText.getKey(),
+            sel.setTextNodeRange(
+              leadingText,
+              0,
+              trailingTokenText,
               trailingTokenText.getTextContentSize(),
-              'text',
             );
             $setSelection(sel);
             sel.removeText();
@@ -423,14 +423,7 @@ describe('LexicalSelection tests', () => {
       test('remove initial TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.anchor.set(leadingText.getKey(), 0, 'text');
-            sel.focus.set(
-              leadingText.getKey(),
-              leadingText.getTextContentSize(),
-              'text',
-            );
-            $setSelection(sel);
+            const sel = leadingText.select(0, leadingText.getTextContentSize());
             sel.removeText();
             expect(leadingText.isAttached()).toBe(false);
             expect(trailingTokenText.isAttached()).toBe(true);
@@ -446,14 +439,10 @@ describe('LexicalSelection tests', () => {
       test('remove trailing token TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.anchor.set(trailingTokenText.getKey(), 0, 'text');
-            sel.focus.set(
-              trailingTokenText.getKey(),
+            const sel = trailingTokenText.select(
+              0,
               trailingTokenText.getTextContentSize(),
-              'text',
             );
-            $setSelection(sel);
             sel.removeText();
             expect(leadingText.isAttached()).toBe(true);
             expect(trailingTokenText.isAttached()).toBe(false);
@@ -472,8 +461,12 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingText.getKey(), 0, 'text');
-            sel.focus.set(trailingTokenText.getKey(), 'token '.length, 'text');
+            sel.setTextNodeRange(
+              leadingText,
+              0,
+              trailingTokenText,
+              'token '.length,
+            );
             $setSelection(sel);
             sel.removeText();
             expect(leadingText.isAttached()).toBe(false);
@@ -493,8 +486,12 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingText.getKey(), 'lead'.length, 'text');
-            sel.focus.set(trailingTokenText.getKey(), 'token '.length, 'text');
+            sel.setTextNodeRange(
+              leadingText,
+              'lead'.length,
+              trailingTokenText,
+              'token '.length,
+            );
             $setSelection(sel);
             sel.removeText();
             expect(leadingText.isAttached()).toBe(true);
@@ -535,11 +532,11 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingTokenText.getKey(), 0, 'text');
-            sel.focus.set(
-              trailingText.getKey(),
+            sel.setTextNodeRange(
+              leadingTokenText,
+              0,
+              trailingText,
               trailingText.getTextContentSize(),
-              'text',
             );
             $setSelection(sel);
             sel.removeText();
@@ -557,14 +554,10 @@ describe('LexicalSelection tests', () => {
       test('remove trailing TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.anchor.set(trailingText.getKey(), 0, 'text');
-            sel.focus.set(
-              trailingText.getKey(),
+            const sel = trailingText.select(
+              0,
               trailingText.getTextContentSize(),
-              'text',
             );
-            $setSelection(sel);
             sel.removeText();
             expect(leadingTokenText.isAttached()).toBe(true);
             expect(trailingText.isAttached()).toBe(false);
@@ -582,14 +575,10 @@ describe('LexicalSelection tests', () => {
       test('remove leading token TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.anchor.set(leadingTokenText.getKey(), 0, 'text');
-            sel.focus.set(
-              leadingTokenText.getKey(),
+            const sel = leadingTokenText.select(
+              0,
               leadingTokenText.getTextContentSize(),
-              'text',
             );
-            $setSelection(sel);
             sel.removeText();
             expect(leadingTokenText.isAttached()).toBe(false);
             expect(trailingText.isAttached()).toBe(true);
@@ -606,11 +595,11 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingTokenText.getKey(), 'token '.length, 'text');
-            sel.focus.set(
-              trailingText.getKey(),
+            sel.setTextNodeRange(
+              leadingTokenText,
+              'token '.length,
+              trailingText,
               trailingText.getTextContentSize(),
-              'text',
             );
             $setSelection(sel);
             sel.removeText();
@@ -631,8 +620,12 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingTokenText.getKey(), 'token '.length, 'text');
-            sel.focus.set(trailingText.getKey(), 'trail'.length, 'text');
+            sel.setTextNodeRange(
+              leadingTokenText,
+              'token '.length,
+              trailingText,
+              'trail'.length,
+            );
             $setSelection(sel);
             sel.removeText();
             expect(leadingTokenText.isAttached()).toBe(false);
@@ -674,11 +667,11 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingText.getKey(), 0, 'text');
-            sel.focus.set(
-              trailingSegmentedText.getKey(),
+            sel.setTextNodeRange(
+              leadingText,
+              0,
+              trailingSegmentedText,
               trailingSegmentedText.getTextContentSize(),
-              'text',
             );
             $setSelection(sel);
             sel.removeText();
@@ -696,14 +689,7 @@ describe('LexicalSelection tests', () => {
       test('remove initial TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.anchor.set(leadingText.getKey(), 0, 'text');
-            sel.focus.set(
-              leadingText.getKey(),
-              leadingText.getTextContentSize(),
-              'text',
-            );
-            $setSelection(sel);
+            const sel = leadingText.select(0, leadingText.getTextContentSize());
             sel.removeText();
             expect(leadingText.isAttached()).toBe(false);
             expect(trailingSegmentedText.isAttached()).toBe(true);
@@ -719,14 +705,10 @@ describe('LexicalSelection tests', () => {
       test('remove trailing segmented TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.anchor.set(trailingSegmentedText.getKey(), 0, 'text');
-            sel.focus.set(
-              trailingSegmentedText.getKey(),
+            const sel = trailingSegmentedText.select(
+              0,
               trailingSegmentedText.getTextContentSize(),
-              'text',
             );
-            $setSelection(sel);
             sel.removeText();
             expect(leadingText.isAttached()).toBe(true);
             expect(trailingSegmentedText.isAttached()).toBe(false);
@@ -745,11 +727,11 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingText.getKey(), 0, 'text');
-            sel.focus.set(
-              trailingSegmentedText.getKey(),
+            sel.setTextNodeRange(
+              leadingText,
+              0,
+              trailingSegmentedText,
               'segmented '.length,
-              'text',
             );
             $setSelection(sel);
             sel.removeText();
@@ -772,11 +754,11 @@ describe('LexicalSelection tests', () => {
         editor.update(
           () => {
             const sel = $createRangeSelection();
-            sel.anchor.set(leadingText.getKey(), 'lead'.length, 'text');
-            sel.focus.set(
-              trailingSegmentedText.getKey(),
+            sel.setTextNodeRange(
+              leadingText,
+              'lead'.length,
+              trailingSegmentedText,
               'segmented '.length,
-              'text',
             );
             $setSelection(sel);
             expect($getSelection()).toBe(sel);
@@ -1021,7 +1003,7 @@ describe('Regression tests for #8707', () => {
       invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
       const children = shadow.getChildren();
       expect(children).toHaveLength(1);
-      expect($isDecoratorNode(children[0])).toBe(true);
+      assert($isDecoratorNode(children[0]));
     });
   });
 
@@ -1053,8 +1035,8 @@ describe('Regression tests for #8707', () => {
       invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
       const children = shadow.getChildren();
       expect(children).toHaveLength(2);
-      expect($isDecoratorNode(children[0])).toBe(true);
-      expect($isParagraphNode(children[1])).toBe(true);
+      assert($isDecoratorNode(children[0]));
+      assert($isParagraphNode(children[1]));
       expect(children[1].getTextContent()).toBe('inserted');
     });
   });
@@ -1090,7 +1072,7 @@ describe('Regression tests for #8707', () => {
       const shadow = root.getFirstChildOrThrow();
       invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
       expect(shadow.getChildrenSize()).toBe(2);
-      expect($isParagraphNode(shadow.getLastChild())).toBe(true);
+      assert($isParagraphNode(shadow.getLastChild()));
     });
   });
 
@@ -1121,8 +1103,8 @@ describe('Regression tests for #8707', () => {
       // The decorator is a direct child of root; no empty paragraph wrapper
       // was created for it.
       expect(children).toHaveLength(2);
-      expect($isParagraphNode(children[0])).toBe(true);
-      expect($isDecoratorNode(children[1])).toBe(true);
+      assert($isParagraphNode(children[0]));
+      assert($isDecoratorNode(children[1]));
     });
   });
 });
@@ -1714,9 +1696,7 @@ describe('extract()', () => {
   test('select partial TextNode extracts paragraph text', () => {
     editor.update(
       () => {
-        const selection = $createRangeSelection();
-        selection.anchor.set(paragraphText.getKey(), 2, 'text');
-        selection.focus.set(paragraphText.getKey(), 8, 'text');
+        const selection = paragraphText.select(2, 8);
         const extracted = selection.extract();
         expect(extracted).toEqual([
           expect.objectContaining({__text: 'ragrap'}),
@@ -1729,9 +1709,7 @@ describe('extract()', () => {
   test('select partial TextNode extracts link text', () => {
     editor.update(
       () => {
-        const selection = $createRangeSelection();
-        selection.anchor.set(linkText.getKey(), 1, 'text');
-        selection.focus.set(linkText.getKey(), 4, 'text');
+        const selection = linkText.select(1, 4);
         const extracted = selection.extract();
         expect(extracted).toEqual([expect.objectContaining({__text: 'ink'})]);
         expect(selection.getNodes()).toEqual(extracted);
@@ -1743,8 +1721,7 @@ describe('extract()', () => {
     editor.update(
       () => {
         const selection = $createRangeSelection();
-        selection.anchor.set(paragraphText.getKey(), 10, 'text');
-        selection.focus.set(linkText.getKey(), 4, 'text');
+        selection.setTextNodeRange(paragraphText, 10, linkText, 4);
         const extracted = selection.extract();
         expect(mapLatest(extracted)).toEqual([
           expect.objectContaining({__text: 'text'}),
@@ -1760,12 +1737,12 @@ describe('extract()', () => {
     editor.update(
       () => {
         const selection = $createRangeSelection();
-        selection.anchor.set(
-          paragraphText.getKey(),
+        selection.setTextNodeRange(
+          paragraphText,
           paragraphText.getTextContentSize(),
-          'text',
+          linkText,
+          4,
         );
-        selection.focus.set(linkText.getKey(), 4, 'text');
         const beforeNodes = selection.getNodes();
         const extracted = selection.extract();
         expect(mapLatest(extracted)).toEqual([
@@ -1783,8 +1760,7 @@ describe('extract()', () => {
     editor.update(
       () => {
         const selection = $createRangeSelection();
-        selection.anchor.set(paragraphText.getKey(), 4, 'text');
-        selection.focus.set(linkText.getKey(), 0, 'text');
+        selection.setTextNodeRange(paragraphText, 4, linkText, 0);
         const beforeNodes = selection.getNodes();
         expect(mapLatest(selection.extract())).toEqual([
           expect.objectContaining({__text: 'graph text'}),

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -5,10 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {$createLinkNode, $isLinkNode, type LinkNode} from '@lexical/link';
+import {
+  buildEditorFromExtensions,
+  defineExtension,
+  type LexicalEditorWithDispose,
+} from '@lexical/extension';
+import {
+  $createLinkNode,
+  $isLinkNode,
+  LinkExtension,
+  type LinkNode,
+} from '@lexical/link';
 import {
   $createListItemNode,
   $createListNode,
+  ListExtension,
   type ListItemNode,
   type ListNode,
 } from '@lexical/list';
@@ -41,7 +52,15 @@ import {
   type RangeSelection,
   type TextNode,
 } from 'lexical';
-import {assert, beforeEach, describe, expect, test} from 'vitest';
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  onTestFinished,
+  test,
+} from 'vitest';
 
 import {$internalCreateRangeSelection} from '../../LexicalSelection';
 import {
@@ -51,794 +70,740 @@ import {
   $createTestInlineElementNode,
   $createTestShadowRootNode,
   $isTestShadowRootNode,
-  initializeUnitTest,
   invariant,
+  TestDecoratorNode,
+  TestInlineElementNode,
+  TestShadowRootNode,
 } from '../utils';
+
+const selectionTestExtension = defineExtension({
+  dependencies: [LinkExtension, ListExtension],
+  name: '@test/selection',
+  nodes: [TestDecoratorNode, TestInlineElementNode, TestShadowRootNode],
+});
 
 function mapLatest<T extends LexicalNode>(nodes: T[]): T[] {
   return nodes.map(node => node.getLatest());
 }
 
 describe('LexicalSelection tests', () => {
-  initializeUnitTest(testEnv => {
-    describe('Inserting text either side of inline elements', () => {
-      const setup = async (
-        mode: 'start-of-paragraph' | 'mid-paragraph' | 'end-of-paragraph',
-      ) => {
-        const {container, editor} = testEnv;
+  let editor: LexicalEditor;
+  let container: HTMLDivElement;
 
-        if (!container) {
-          throw new Error('Expected container to be truthy');
-        }
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.setRootElement(container);
+  });
 
-        await editor.update(() => {
-          const root = $getRoot();
-          if (root.getFirstChild() !== null) {
-            throw new Error('Expected root to be childless');
-          }
+  afterEach(() => {
+    editor.setRootElement(null);
+    container.remove();
+  });
 
-          const paragraph = $createParagraphNode();
-          if (mode === 'start-of-paragraph') {
-            paragraph.append(
-              $createLinkNode('https://', {}).append($createTextNode('a')),
-              $createTextNode('b'),
-            );
-          } else if (mode === 'mid-paragraph') {
-            paragraph.append(
-              $createTextNode('a'),
-              $createLinkNode('https://', {}).append($createTextNode('b')),
-              $createTextNode('c'),
-            );
-          } else {
-            paragraph.append(
-              $createTextNode('a'),
-              $createLinkNode('https://', {}).append($createTextNode('b')),
-            );
-          }
+  describe('Inserting text either side of inline elements', () => {
+    const setup = async (
+      mode: 'start-of-paragraph' | 'mid-paragraph' | 'end-of-paragraph',
+    ) => {
+      await editor.update(() => {
+        const root = $getRoot();
+        root.clear();
 
-          root.append(paragraph);
-        });
-
-        const expectation =
-          mode === 'start-of-paragraph'
-            ? '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><a href="https://"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">b</span></p></div>'
-            : mode === 'mid-paragraph'
-              ? '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">c</span></p></div>'
-              : '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a></p></div>';
-
-        expect(container.innerHTML).toBe(expectation);
-
-        return {container, editor};
-      };
-
-      const $insertTextOrNodes = (
-        selection: RangeSelection,
-        method: 'insertText' | 'insertNodes',
-      ) => {
-        if (method === 'insertText') {
-          // Insert text (mirroring what LexicalClipboard does when pasting
-          // inline plain text)
-          selection.insertText('x');
+        const paragraph = $createParagraphNode();
+        if (mode === 'start-of-paragraph') {
+          paragraph.append(
+            $createLinkNode('https://', {}).append($createTextNode('a')),
+            $createTextNode('b'),
+          );
+        } else if (mode === 'mid-paragraph') {
+          paragraph.append(
+            $createTextNode('a'),
+            $createLinkNode('https://', {}).append($createTextNode('b')),
+            $createTextNode('c'),
+          );
         } else {
-          // Insert a paragraph bearing a single text node (mirroring what
-          // LexicalClipboard does when pasting inline rich text)
-          selection.insertNodes([
-            $createParagraphNode().append($createTextNode('x')),
-          ]);
+          paragraph.append(
+            $createTextNode('a'),
+            $createLinkNode('https://', {}).append($createTextNode('b')),
+          );
         }
-      };
 
-      describe('Inserting text before inline elements', () => {
-        describe('Start-of-paragraph inline elements', () => {
-          const insertText = async ({
-            container,
-            editor,
-            method,
-          }: {
-            container: HTMLDivElement;
-            editor: LexicalEditor;
-            method: 'insertText' | 'insertNodes';
-          }) => {
-            await editor.update(() => {
-              const paragraph = $getRoot().getFirstChildOrThrow();
-              invariant($isParagraphNode(paragraph));
-              const linkNode = paragraph.getFirstChildOrThrow();
-              invariant($isLinkNode(linkNode));
+        root.append(paragraph);
+      });
 
-              // Place the cursor at the start of the link node
-              // For review: is there a way to select "outside" of the link
-              // node?
-              const selection = linkNode.select(0, 0);
-              $insertTextOrNodes(selection, method);
-            });
+      const expectation =
+        mode === 'start-of-paragraph'
+          ? '<p dir="auto"><a href="https://"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">b</span></p>'
+          : mode === 'mid-paragraph'
+            ? '<p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">c</span></p>'
+            : '<p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a></p>';
 
-            expect(container.innerHTML).toBe(
-              '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">x</span><a href="https://"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">b</span></p></div>',
-            );
-          };
+      expect(container.innerHTML).toBe(expectation);
+    };
 
-          test('Can insert text before a start-of-paragraph inline element, using insertText', async () => {
-            const {container, editor} = await setup('start-of-paragraph');
+    const $insertTextOrNodes = (
+      selection: RangeSelection,
+      method: 'insertText' | 'insertNodes',
+    ) => {
+      if (method === 'insertText') {
+        // Insert text (mirroring what LexicalClipboard does when pasting
+        // inline plain text)
+        selection.insertText('x');
+      } else {
+        // Insert a paragraph bearing a single text node (mirroring what
+        // LexicalClipboard does when pasting inline rich text)
+        selection.insertNodes([
+          $createParagraphNode().append($createTextNode('x')),
+        ]);
+      }
+    };
 
-            await insertText({container, editor, method: 'insertText'});
+    describe('Inserting text before inline elements', () => {
+      describe('Start-of-paragraph inline elements', () => {
+        const insertText = async (method: 'insertText' | 'insertNodes') => {
+          await editor.update(() => {
+            const paragraph = $getRoot().getFirstChildOrThrow();
+            invariant($isParagraphNode(paragraph));
+            const linkNode = paragraph.getFirstChildOrThrow();
+            invariant($isLinkNode(linkNode));
+
+            // Place the cursor at the start of the link node
+            // For review: is there a way to select "outside" of the link
+            // node?
+            const selection = linkNode.select(0, 0);
+            $insertTextOrNodes(selection, method);
           });
 
-          test('Can insert text before a start-of-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('start-of-paragraph');
+          expect(container.innerHTML).toBe(
+            '<p dir="auto"><span data-lexical-text="true">x</span><a href="https://"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">b</span></p>',
+          );
+        };
 
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+        test('Can insert text before a start-of-paragraph inline element, using insertText', async () => {
+          await setup('start-of-paragraph');
+
+          await insertText('insertText');
         });
 
-        describe('Mid-paragraph inline elements', () => {
-          const insertText = async ({
-            container,
-            editor,
-            method,
-          }: {
-            container: HTMLDivElement;
-            editor: LexicalEditor;
-            method: 'insertText' | 'insertNodes';
-          }) => {
-            await editor.update(() => {
-              const paragraph = $getRoot().getFirstChildOrThrow();
-              invariant($isParagraphNode(paragraph));
-              const textNode = paragraph.getFirstChildOrThrow();
-              invariant($isTextNode(textNode));
+        test('Can insert text before a start-of-paragraph inline element, using insertNodes', async () => {
+          await setup('start-of-paragraph');
 
-              // Place the cursor between the link and the first text node by
-              // selecting the end of the text node
-              const selection = textNode.select(1, 1);
-              $insertTextOrNodes(selection, method);
-            });
-
-            expect(container.innerHTML).toBe(
-              '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">ax</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">c</span></p></div>',
-            );
-          };
-
-          test('Can insert text before a mid-paragraph inline element, using insertText', async () => {
-            const {container, editor} = await setup('mid-paragraph');
-
-            await insertText({container, editor, method: 'insertText'});
-          });
-
-          test('Can insert text before a mid-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('mid-paragraph');
-
-            await insertText({container, editor, method: 'insertNodes'});
-          });
-        });
-
-        describe('End-of-paragraph inline elements', () => {
-          const insertText = async ({
-            container,
-            editor,
-            method,
-          }: {
-            container: HTMLDivElement;
-            editor: LexicalEditor;
-            method: 'insertText' | 'insertNodes';
-          }) => {
-            await editor.update(() => {
-              const paragraph = $getRoot().getFirstChildOrThrow();
-              invariant($isParagraphNode(paragraph));
-              const textNode = paragraph.getFirstChildOrThrow();
-              invariant($isTextNode(textNode));
-
-              // Place the cursor before the link element by selecting the end
-              // of the text node
-              const selection = textNode.select(1, 1);
-              $insertTextOrNodes(selection, method);
-            });
-
-            expect(container.innerHTML).toBe(
-              '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">ax</span><a href="https://"><span data-lexical-text="true">b</span></a></p></div>',
-            );
-          };
-
-          test('Can insert text before an end-of-paragraph inline element, using insertText', async () => {
-            const {container, editor} = await setup('end-of-paragraph');
-
-            await insertText({container, editor, method: 'insertText'});
-          });
-
-          test('Can insert text before an end-of-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('end-of-paragraph');
-
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+          await insertText('insertNodes');
         });
       });
 
-      describe('Inserting text after inline elements', () => {
-        describe('Start-of-paragraph inline elements', () => {
-          const insertText = async ({
-            container,
-            editor,
-            method,
-          }: {
-            container: HTMLDivElement;
-            editor: LexicalEditor;
-            method: 'insertText' | 'insertNodes';
-          }) => {
-            await editor.update(() => {
-              const paragraph = $getRoot().getFirstChildOrThrow();
-              invariant($isParagraphNode(paragraph));
-              const textNode = paragraph.getLastChildOrThrow();
-              invariant($isTextNode(textNode));
+      describe('Mid-paragraph inline elements', () => {
+        const insertText = async (method: 'insertText' | 'insertNodes') => {
+          await editor.update(() => {
+            const paragraph = $getRoot().getFirstChildOrThrow();
+            invariant($isParagraphNode(paragraph));
+            const textNode = paragraph.getFirstChildOrThrow();
+            invariant($isTextNode(textNode));
 
-              // Place the cursor between the link and the last text node by
-              // selecting the start of the text node
-              const selection = textNode.select(0, 0);
-              $insertTextOrNodes(selection, method);
-            });
-
-            expect(container.innerHTML).toBe(
-              '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><a href="https://"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">xb</span></p></div>',
-            );
-          };
-
-          test('Can insert text after a start-of-paragraph inline element, using insertText', async () => {
-            const {container, editor} = await setup('start-of-paragraph');
-
-            await insertText({container, editor, method: 'insertText'});
+            // Place the cursor between the link and the first text node by
+            // selecting the end of the text node
+            const selection = textNode.select(1, 1);
+            $insertTextOrNodes(selection, method);
           });
 
-          test('Can insert text after a start-of-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('start-of-paragraph');
+          expect(container.innerHTML).toBe(
+            '<p dir="auto"><span data-lexical-text="true">ax</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">c</span></p>',
+          );
+        };
 
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+        test('Can insert text before a mid-paragraph inline element, using insertText', async () => {
+          await setup('mid-paragraph');
+
+          await insertText('insertText');
         });
 
-        describe('Mid-paragraph inline elements', () => {
-          const insertText = async ({
-            container,
-            editor,
-            method,
-          }: {
-            container: HTMLDivElement;
-            editor: LexicalEditor;
-            method: 'insertText' | 'insertNodes';
-          }) => {
-            await editor.update(() => {
-              const paragraph = $getRoot().getFirstChildOrThrow();
-              invariant($isParagraphNode(paragraph));
-              const textNode = paragraph.getLastChildOrThrow();
-              invariant($isTextNode(textNode));
+        test('Can insert text before a mid-paragraph inline element, using insertNodes', async () => {
+          await setup('mid-paragraph');
 
-              // Place the cursor between the link and the last text node by
-              // selecting the start of the text node
-              const selection = textNode.select(0, 0);
-              $insertTextOrNodes(selection, method);
-            });
+          await insertText('insertNodes');
+        });
+      });
 
-            expect(container.innerHTML).toBe(
-              '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">xc</span></p></div>',
-            );
-          };
+      describe('End-of-paragraph inline elements', () => {
+        const insertText = async (method: 'insertText' | 'insertNodes') => {
+          await editor.update(() => {
+            const paragraph = $getRoot().getFirstChildOrThrow();
+            invariant($isParagraphNode(paragraph));
+            const textNode = paragraph.getFirstChildOrThrow();
+            invariant($isTextNode(textNode));
 
-          test('Can insert text after a mid-paragraph inline element, using insertText', async () => {
-            const {container, editor} = await setup('mid-paragraph');
-
-            await insertText({container, editor, method: 'insertText'});
+            // Place the cursor before the link element by selecting the end
+            // of the text node
+            const selection = textNode.select(1, 1);
+            $insertTextOrNodes(selection, method);
           });
 
-          test('Can insert text after a mid-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('mid-paragraph');
+          expect(container.innerHTML).toBe(
+            '<p dir="auto"><span data-lexical-text="true">ax</span><a href="https://"><span data-lexical-text="true">b</span></a></p>',
+          );
+        };
 
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+        test('Can insert text before an end-of-paragraph inline element, using insertText', async () => {
+          await setup('end-of-paragraph');
+
+          await insertText('insertText');
         });
 
-        describe('End-of-paragraph inline elements', () => {
-          const insertText = async ({
-            container,
-            editor,
-            method,
-          }: {
-            container: HTMLDivElement;
-            editor: LexicalEditor;
-            method: 'insertText' | 'insertNodes';
-          }) => {
-            await editor.update(() => {
-              const paragraph = $getRoot().getFirstChildOrThrow();
-              invariant($isParagraphNode(paragraph));
-              const linkNode = paragraph.getLastChildOrThrow();
-              invariant($isLinkNode(linkNode));
+        test('Can insert text before an end-of-paragraph inline element, using insertNodes', async () => {
+          await setup('end-of-paragraph');
 
-              // Place the cursor at the end of the link element
-              // For review: not sure if there's a better way to select
-              // "outside" of the link element.
-              const selection = linkNode.select(1, 1);
-              $insertTextOrNodes(selection, method);
-            });
-
-            expect(container.innerHTML).toBe(
-              '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">x</span></p></div>',
-            );
-          };
-
-          test('Can insert text after an end-of-paragraph inline element, using insertText', async () => {
-            const {container, editor} = await setup('end-of-paragraph');
-
-            await insertText({container, editor, method: 'insertText'});
-          });
-
-          test('Can insert text after an end-of-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('end-of-paragraph');
-
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+          await insertText('insertNodes');
         });
       });
     });
 
-    describe('insertText()', () => {
-      test('inserts into existing paragraph node when selection is on parent of paragraph', () => {
-        const {editor} = testEnv;
-        editor.update(() => {
-          const root = $getRoot();
-          const paragraph = $createParagraphNode();
-          root.clear().append(paragraph);
+    describe('Inserting text after inline elements', () => {
+      describe('Start-of-paragraph inline elements', () => {
+        const insertText = async (method: 'insertText' | 'insertNodes') => {
+          await editor.update(() => {
+            const paragraph = $getRoot().getFirstChildOrThrow();
+            invariant($isParagraphNode(paragraph));
+            const textNode = paragraph.getLastChildOrThrow();
+            invariant($isTextNode(textNode));
 
-          const selection = $createRangeSelection();
-          selection.anchor.set('root', 0, 'element');
-          selection.focus.set('root', 0, 'element');
-          $setSelection(selection);
+            // Place the cursor between the link and the last text node by
+            // selecting the start of the text node
+            const selection = textNode.select(0, 0);
+            $insertTextOrNodes(selection, method);
+          });
 
-          selection.insertText('text');
-          expect(root.getChildrenSize()).toBe(1);
-          expect(root.getTextContent()).toBe('text');
+          expect(container.innerHTML).toBe(
+            '<p dir="auto"><a href="https://"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">xb</span></p>',
+          );
+        };
+
+        test('Can insert text after a start-of-paragraph inline element, using insertText', async () => {
+          await setup('start-of-paragraph');
+
+          await insertText('insertText');
+        });
+
+        test('Can insert text after a start-of-paragraph inline element, using insertNodes', async () => {
+          await setup('start-of-paragraph');
+
+          await insertText('insertNodes');
+        });
+      });
+
+      describe('Mid-paragraph inline elements', () => {
+        const insertText = async (method: 'insertText' | 'insertNodes') => {
+          await editor.update(() => {
+            const paragraph = $getRoot().getFirstChildOrThrow();
+            invariant($isParagraphNode(paragraph));
+            const textNode = paragraph.getLastChildOrThrow();
+            invariant($isTextNode(textNode));
+
+            // Place the cursor between the link and the last text node by
+            // selecting the start of the text node
+            const selection = textNode.select(0, 0);
+            $insertTextOrNodes(selection, method);
+          });
+
+          expect(container.innerHTML).toBe(
+            '<p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">xc</span></p>',
+          );
+        };
+
+        test('Can insert text after a mid-paragraph inline element, using insertText', async () => {
+          await setup('mid-paragraph');
+
+          await insertText('insertText');
+        });
+
+        test('Can insert text after a mid-paragraph inline element, using insertNodes', async () => {
+          await setup('mid-paragraph');
+
+          await insertText('insertNodes');
+        });
+      });
+
+      describe('End-of-paragraph inline elements', () => {
+        const insertText = async (method: 'insertText' | 'insertNodes') => {
+          await editor.update(() => {
+            const paragraph = $getRoot().getFirstChildOrThrow();
+            invariant($isParagraphNode(paragraph));
+            const linkNode = paragraph.getLastChildOrThrow();
+            invariant($isLinkNode(linkNode));
+
+            // Place the cursor at the end of the link element
+            // For review: not sure if there's a better way to select
+            // "outside" of the link element.
+            const selection = linkNode.select(1, 1);
+            $insertTextOrNodes(selection, method);
+          });
+
+          expect(container.innerHTML).toBe(
+            '<p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">x</span></p>',
+          );
+        };
+
+        test('Can insert text after an end-of-paragraph inline element, using insertText', async () => {
+          await setup('end-of-paragraph');
+
+          await insertText('insertText');
+        });
+
+        test('Can insert text after an end-of-paragraph inline element, using insertNodes', async () => {
+          await setup('end-of-paragraph');
+
+          await insertText('insertNodes');
         });
       });
     });
+  });
 
-    describe('removeText', () => {
-      describe('with a leading TextNode and a trailing token TextNode', () => {
-        let leadingText: TextNode;
-        let trailingTokenText: TextNode;
-        let paragraph: ParagraphNode;
-        beforeEach(() => {
-          testEnv.editor.update(
-            () => {
-              leadingText = $createTextNode('leading text');
-              trailingTokenText =
-                $createTextNode('token text').setMode('token');
-              paragraph = $createParagraphNode().append(
-                leadingText,
-                trailingTokenText,
-              );
-              $getRoot().clear().append(paragraph);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove all text', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingText.getKey(), 0, 'text');
-              sel.focus.set(
-                trailingTokenText.getKey(),
-                trailingTokenText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(false);
-              expect(trailingTokenText.isAttached()).toBe(false);
-              expect($getRoot().getAllTextNodes()).toHaveLength(0);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(paragraph.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove initial TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingText.getKey(), 0, 'text');
-              sel.focus.set(
-                leadingText.getKey(),
-                leadingText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(false);
-              expect(trailingTokenText.isAttached()).toBe(true);
-              expect($getRoot().getAllTextNodes()).toHaveLength(1);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(trailingTokenText.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove trailing token TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(trailingTokenText.getKey(), 0, 'text');
-              sel.focus.set(
-                trailingTokenText.getKey(),
-                trailingTokenText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(true);
-              expect(trailingTokenText.isAttached()).toBe(false);
-              expect($getRoot().getAllTextNodes()).toHaveLength(1);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(leadingText.getKey());
-              expect(selection.anchor.offset).toBe(
-                leadingText.getTextContentSize(),
-              );
-            },
-            {discrete: true},
-          );
-        });
-        test('remove initial TextNode and partial token TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingText.getKey(), 0, 'text');
-              sel.focus.set(
-                trailingTokenText.getKey(),
-                'token '.length,
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(false);
-              // expecting no node since it was token
-              expect(trailingTokenText.isAttached()).toBe(false);
-              const allTextNodes = $getRoot().getAllTextNodes();
-              expect(allTextNodes).toHaveLength(0);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(paragraph.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove partial initial TextNode and partial token TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingText.getKey(), 'lead'.length, 'text');
-              sel.focus.set(
-                trailingTokenText.getKey(),
-                'token '.length,
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(true);
-              expect(trailingTokenText.isAttached()).toBe(false);
-              const allTextNodes = $getRoot().getAllTextNodes();
-              // The token node will be completely removed
-              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
-                'lead',
-              ]);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(leadingText.getKey());
-              expect(selection.anchor.offset).toBe('lead'.length);
-            },
-            {discrete: true},
-          );
-        });
+  describe('insertText()', () => {
+    test('inserts into existing paragraph node when selection is on parent of paragraph', () => {
+      editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.clear().append(paragraph);
+
+        const selection = $createRangeSelection();
+        selection.anchor.set('root', 0, 'element');
+        selection.focus.set('root', 0, 'element');
+        $setSelection(selection);
+
+        selection.insertText('text');
+        expect(root.getChildrenSize()).toBe(1);
+        expect(root.getTextContent()).toBe('text');
       });
-      describe('with a leading token TextNode and a trailing TextNode', () => {
-        let leadingTokenText: TextNode;
-        let trailingText: TextNode;
-        let paragraph: ParagraphNode;
-        beforeEach(() => {
-          testEnv.editor.update(
-            () => {
-              leadingTokenText = $createTextNode('token text').setMode('token');
-              trailingText = $createTextNode('trailing text');
-              paragraph = $createParagraphNode().append(
-                leadingTokenText,
-                trailingText,
-              );
-              $getRoot().clear().append(paragraph);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove all text', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingTokenText.getKey(), 0, 'text');
-              sel.focus.set(
-                trailingText.getKey(),
-                trailingText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingTokenText.isAttached()).toBe(false);
-              expect(trailingText.isAttached()).toBe(false);
-              expect($getRoot().getAllTextNodes()).toHaveLength(0);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(paragraph.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove trailing TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(trailingText.getKey(), 0, 'text');
-              sel.focus.set(
-                trailingText.getKey(),
-                trailingText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingTokenText.isAttached()).toBe(true);
-              expect(trailingText.isAttached()).toBe(false);
-              expect($getRoot().getAllTextNodes()).toHaveLength(1);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(leadingTokenText.getKey());
-              expect(selection.anchor.offset).toBe(
-                leadingTokenText.getTextContentSize(),
-              );
-            },
-            {discrete: true},
-          );
-        });
-        test('remove leading token TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingTokenText.getKey(), 0, 'text');
-              sel.focus.set(
-                leadingTokenText.getKey(),
-                leadingTokenText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingTokenText.isAttached()).toBe(false);
-              expect(trailingText.isAttached()).toBe(true);
-              expect($getRoot().getAllTextNodes()).toHaveLength(1);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(trailingText.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove partial leading token TextNode and trailing TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(
-                leadingTokenText.getKey(),
-                'token '.length,
-                'text',
-              );
-              sel.focus.set(
-                trailingText.getKey(),
-                trailingText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(trailingText.isAttached()).toBe(false);
-              // expecting no node since it was token
-              expect(leadingTokenText.isAttached()).toBe(false);
-              const allTextNodes = $getRoot().getAllTextNodes();
-              expect(allTextNodes).toHaveLength(0);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(paragraph.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove partial token TextNode and partial trailing TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(
-                leadingTokenText.getKey(),
-                'token '.length,
-                'text',
-              );
-              sel.focus.set(trailingText.getKey(), 'trail'.length, 'text');
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingTokenText.isAttached()).toBe(false);
-              expect(trailingText.isAttached()).toBe(true);
-              const allTextNodes = $getRoot().getAllTextNodes();
-              // The token node will be completely removed
-              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
-                'ing text',
-              ]);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(trailingText.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
+    });
+  });
+
+  describe('removeText', () => {
+    describe('with a leading TextNode and a trailing token TextNode', () => {
+      let leadingText: TextNode;
+      let trailingTokenText: TextNode;
+      let paragraph: ParagraphNode;
+      beforeEach(() => {
+        editor.update(
+          () => {
+            leadingText = $createTextNode('leading text');
+            trailingTokenText = $createTextNode('token text').setMode('token');
+            paragraph = $createParagraphNode().append(
+              leadingText,
+              trailingTokenText,
+            );
+            $getRoot().clear().append(paragraph);
+          },
+          {discrete: true},
+        );
       });
-      describe('with a leading TextNode and a trailing segmented TextNode', () => {
-        let leadingText: TextNode;
-        let trailingSegmentedText: TextNode;
-        let paragraph: ParagraphNode;
-        beforeEach(() => {
-          testEnv.editor.update(
-            () => {
-              leadingText = $createTextNode('leading text');
-              trailingSegmentedText =
-                $createTextNode('segmented text').setMode('segmented');
-              paragraph = $createParagraphNode().append(
-                leadingText,
-                trailingSegmentedText,
-              );
-              $getRoot().clear().append(paragraph);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove all text', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingText.getKey(), 0, 'text');
-              sel.focus.set(
-                trailingSegmentedText.getKey(),
-                trailingSegmentedText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(false);
-              expect(trailingSegmentedText.isAttached()).toBe(false);
-              expect($getRoot().getAllTextNodes()).toHaveLength(0);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(paragraph.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove initial TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingText.getKey(), 0, 'text');
-              sel.focus.set(
-                leadingText.getKey(),
-                leadingText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(false);
-              expect(trailingSegmentedText.isAttached()).toBe(true);
-              expect($getRoot().getAllTextNodes()).toHaveLength(1);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(trailingSegmentedText.getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove trailing segmented TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(trailingSegmentedText.getKey(), 0, 'text');
-              sel.focus.set(
-                trailingSegmentedText.getKey(),
-                trailingSegmentedText.getTextContentSize(),
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(true);
-              expect(trailingSegmentedText.isAttached()).toBe(false);
-              expect($getRoot().getAllTextNodes()).toHaveLength(1);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(leadingText.getKey());
-              expect(selection.anchor.offset).toBe(
-                leadingText.getTextContentSize(),
-              );
-            },
-            {discrete: true},
-          );
-        });
-        test('remove initial TextNode and partial segmented TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingText.getKey(), 0, 'text');
-              sel.focus.set(
-                trailingSegmentedText.getKey(),
-                'segmented '.length,
-                'text',
-              );
-              $setSelection(sel);
-              sel.removeText();
-              expect(leadingText.isAttached()).toBe(false);
-              // expecting a new node since it was segmented
-              expect(trailingSegmentedText.isAttached()).toBe(false);
-              const allTextNodes = $getRoot().getAllTextNodes();
-              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
-                'text',
-              ]);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(allTextNodes[0].getKey());
-              expect(selection.anchor.offset).toBe(0);
-            },
-            {discrete: true},
-          );
-        });
-        test('remove partial initial TextNode and partial segmented TextNode', () => {
-          testEnv.editor.update(
-            () => {
-              const sel = $createRangeSelection();
-              sel.anchor.set(leadingText.getKey(), 'lead'.length, 'text');
-              sel.focus.set(
-                trailingSegmentedText.getKey(),
-                'segmented '.length,
-                'text',
-              );
-              $setSelection(sel);
-              expect($getSelection()).toBe(sel);
-              sel.removeText();
-              expect($getSelection()).toBe(sel);
-              expect(leadingText.isAttached()).toBe(true);
-              expect(trailingSegmentedText.isAttached()).toBe(false);
-              const allTextNodes = $getRoot().getAllTextNodes();
-              // These should get merged in reconciliation
-              expect(allTextNodes.map(node => node.getTextContent())).toEqual([
-                'lead',
-                'text',
-              ]);
-              const selection = $assertRangeSelection($getSelection());
-              expect(selection.isCollapsed()).toBe(true);
-              expect(selection.anchor.key).toBe(leadingText.getKey());
-              expect(selection.anchor.offset).toBe('lead'.length);
-            },
-            {discrete: true},
-          );
-          testEnv.editor.read('latest', () => {
+      test('remove all text', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingText.getKey(), 0, 'text');
+            sel.focus.set(
+              trailingTokenText.getKey(),
+              trailingTokenText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(false);
+            expect(trailingTokenText.isAttached()).toBe(false);
+            expect($getRoot().getAllTextNodes()).toHaveLength(0);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(paragraph.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove initial TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingText.getKey(), 0, 'text');
+            sel.focus.set(
+              leadingText.getKey(),
+              leadingText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(false);
+            expect(trailingTokenText.isAttached()).toBe(true);
+            expect($getRoot().getAllTextNodes()).toHaveLength(1);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(trailingTokenText.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove trailing token TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(trailingTokenText.getKey(), 0, 'text');
+            sel.focus.set(
+              trailingTokenText.getKey(),
+              trailingTokenText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(true);
+            expect(trailingTokenText.isAttached()).toBe(false);
+            expect($getRoot().getAllTextNodes()).toHaveLength(1);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(leadingText.getKey());
+            expect(selection.anchor.offset).toBe(
+              leadingText.getTextContentSize(),
+            );
+          },
+          {discrete: true},
+        );
+      });
+      test('remove initial TextNode and partial token TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingText.getKey(), 0, 'text');
+            sel.focus.set(trailingTokenText.getKey(), 'token '.length, 'text');
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(false);
+            // expecting no node since it was token
+            expect(trailingTokenText.isAttached()).toBe(false);
+            const allTextNodes = $getRoot().getAllTextNodes();
+            expect(allTextNodes).toHaveLength(0);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(paragraph.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove partial initial TextNode and partial token TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingText.getKey(), 'lead'.length, 'text');
+            sel.focus.set(trailingTokenText.getKey(), 'token '.length, 'text');
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(true);
+            expect(trailingTokenText.isAttached()).toBe(false);
+            const allTextNodes = $getRoot().getAllTextNodes();
+            // The token node will be completely removed
+            expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+              'lead',
+            ]);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(leadingText.getKey());
+            expect(selection.anchor.offset).toBe('lead'.length);
+          },
+          {discrete: true},
+        );
+      });
+    });
+    describe('with a leading token TextNode and a trailing TextNode', () => {
+      let leadingTokenText: TextNode;
+      let trailingText: TextNode;
+      let paragraph: ParagraphNode;
+      beforeEach(() => {
+        editor.update(
+          () => {
+            leadingTokenText = $createTextNode('token text').setMode('token');
+            trailingText = $createTextNode('trailing text');
+            paragraph = $createParagraphNode().append(
+              leadingTokenText,
+              trailingText,
+            );
+            $getRoot().clear().append(paragraph);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove all text', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingTokenText.getKey(), 0, 'text');
+            sel.focus.set(
+              trailingText.getKey(),
+              trailingText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingTokenText.isAttached()).toBe(false);
+            expect(trailingText.isAttached()).toBe(false);
+            expect($getRoot().getAllTextNodes()).toHaveLength(0);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(paragraph.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove trailing TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(trailingText.getKey(), 0, 'text');
+            sel.focus.set(
+              trailingText.getKey(),
+              trailingText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingTokenText.isAttached()).toBe(true);
+            expect(trailingText.isAttached()).toBe(false);
+            expect($getRoot().getAllTextNodes()).toHaveLength(1);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(leadingTokenText.getKey());
+            expect(selection.anchor.offset).toBe(
+              leadingTokenText.getTextContentSize(),
+            );
+          },
+          {discrete: true},
+        );
+      });
+      test('remove leading token TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingTokenText.getKey(), 0, 'text');
+            sel.focus.set(
+              leadingTokenText.getKey(),
+              leadingTokenText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingTokenText.isAttached()).toBe(false);
+            expect(trailingText.isAttached()).toBe(true);
+            expect($getRoot().getAllTextNodes()).toHaveLength(1);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(trailingText.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove partial leading token TextNode and trailing TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingTokenText.getKey(), 'token '.length, 'text');
+            sel.focus.set(
+              trailingText.getKey(),
+              trailingText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(trailingText.isAttached()).toBe(false);
+            // expecting no node since it was token
+            expect(leadingTokenText.isAttached()).toBe(false);
+            const allTextNodes = $getRoot().getAllTextNodes();
+            expect(allTextNodes).toHaveLength(0);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(paragraph.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove partial token TextNode and partial trailing TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingTokenText.getKey(), 'token '.length, 'text');
+            sel.focus.set(trailingText.getKey(), 'trail'.length, 'text');
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingTokenText.isAttached()).toBe(false);
+            expect(trailingText.isAttached()).toBe(true);
+            const allTextNodes = $getRoot().getAllTextNodes();
+            // The token node will be completely removed
+            expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+              'ing text',
+            ]);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(trailingText.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+    });
+    describe('with a leading TextNode and a trailing segmented TextNode', () => {
+      let leadingText: TextNode;
+      let trailingSegmentedText: TextNode;
+      let paragraph: ParagraphNode;
+      beforeEach(() => {
+        editor.update(
+          () => {
+            leadingText = $createTextNode('leading text');
+            trailingSegmentedText =
+              $createTextNode('segmented text').setMode('segmented');
+            paragraph = $createParagraphNode().append(
+              leadingText,
+              trailingSegmentedText,
+            );
+            $getRoot().clear().append(paragraph);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove all text', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingText.getKey(), 0, 'text');
+            sel.focus.set(
+              trailingSegmentedText.getKey(),
+              trailingSegmentedText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(false);
+            expect(trailingSegmentedText.isAttached()).toBe(false);
+            expect($getRoot().getAllTextNodes()).toHaveLength(0);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(paragraph.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove initial TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingText.getKey(), 0, 'text');
+            sel.focus.set(
+              leadingText.getKey(),
+              leadingText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(false);
+            expect(trailingSegmentedText.isAttached()).toBe(true);
+            expect($getRoot().getAllTextNodes()).toHaveLength(1);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(trailingSegmentedText.getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove trailing segmented TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(trailingSegmentedText.getKey(), 0, 'text');
+            sel.focus.set(
+              trailingSegmentedText.getKey(),
+              trailingSegmentedText.getTextContentSize(),
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(true);
+            expect(trailingSegmentedText.isAttached()).toBe(false);
+            expect($getRoot().getAllTextNodes()).toHaveLength(1);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(leadingText.getKey());
+            expect(selection.anchor.offset).toBe(
+              leadingText.getTextContentSize(),
+            );
+          },
+          {discrete: true},
+        );
+      });
+      test('remove initial TextNode and partial segmented TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingText.getKey(), 0, 'text');
+            sel.focus.set(
+              trailingSegmentedText.getKey(),
+              'segmented '.length,
+              'text',
+            );
+            $setSelection(sel);
+            sel.removeText();
+            expect(leadingText.isAttached()).toBe(false);
+            // expecting a new node since it was segmented
+            expect(trailingSegmentedText.isAttached()).toBe(false);
+            const allTextNodes = $getRoot().getAllTextNodes();
+            expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+              'text',
+            ]);
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(allTextNodes[0].getKey());
+            expect(selection.anchor.offset).toBe(0);
+          },
+          {discrete: true},
+        );
+      });
+      test('remove partial initial TextNode and partial segmented TextNode', () => {
+        editor.update(
+          () => {
+            const sel = $createRangeSelection();
+            sel.anchor.set(leadingText.getKey(), 'lead'.length, 'text');
+            sel.focus.set(
+              trailingSegmentedText.getKey(),
+              'segmented '.length,
+              'text',
+            );
+            $setSelection(sel);
+            expect($getSelection()).toBe(sel);
+            sel.removeText();
+            expect($getSelection()).toBe(sel);
+            expect(leadingText.isAttached()).toBe(true);
+            expect(trailingSegmentedText.isAttached()).toBe(false);
             const allTextNodes = $getRoot().getAllTextNodes();
             // These should get merged in reconciliation
             expect(allTextNodes.map(node => node.getTextContent())).toEqual([
-              'leadtext',
+              'lead',
+              'text',
             ]);
-            expect(leadingText.isAttached()).toBe(true);
-          });
+            const selection = $assertRangeSelection($getSelection());
+            expect(selection.isCollapsed()).toBe(true);
+            expect(selection.anchor.key).toBe(leadingText.getKey());
+            expect(selection.anchor.offset).toBe('lead'.length);
+          },
+          {discrete: true},
+        );
+        editor.read('latest', () => {
+          const allTextNodes = $getRoot().getAllTextNodes();
+          // These should get merged in reconciliation
+          expect(allTextNodes.map(node => node.getTextContent())).toEqual([
+            'leadtext',
+          ]);
+          expect(leadingText.isAttached()).toBe(true);
         });
       });
     });
@@ -846,68 +811,69 @@ describe('LexicalSelection tests', () => {
 });
 
 describe('Segmented node composition (#5065)', () => {
-  initializeUnitTest(testEnv => {
-    test('insertText during composition preserves node key', () => {
-      testEnv.editor.update(
-        () => {
-          const segmented = $createTextNode('JohnSmith').setMode('segmented');
-          $getRoot().clear().append($createParagraphNode().append(segmented));
-          const key = segmented.getKey();
+  test('insertText during composition preserves node key', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const segmented = $createTextNode('JohnSmith').setMode('segmented');
+        $getRoot().clear().append($createParagraphNode().append(segmented));
+        const key = segmented.getKey();
 
-          $setCompositionKey(key);
-          const sel = segmented.select(4, 4);
-          sel.insertText('');
+        $setCompositionKey(key);
+        const sel = segmented.select(4, 4);
+        sel.insertText('');
 
-          const latest = segmented.getLatest();
-          expect(latest.getKey()).toBe(key);
-          expect(latest.isSegmented()).toBe(false);
-          expect(latest.getTextContent()).toBe('JohnSmith');
-        },
-        {discrete: true},
-      );
-    });
+        const latest = segmented.getLatest();
+        expect(latest.getKey()).toBe(key);
+        expect(latest.isSegmented()).toBe(false);
+        expect(latest.getTextContent()).toBe('JohnSmith');
+      },
+      {discrete: true},
+    );
+  });
 
-    test('insertText without composition replaces segmented node', () => {
-      testEnv.editor.update(
-        () => {
-          const segmented = $createTextNode('JohnSmith').setMode('segmented');
-          $getRoot().clear().append($createParagraphNode().append(segmented));
+  test('insertText without composition replaces segmented node', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const segmented = $createTextNode('JohnSmith').setMode('segmented');
+        $getRoot().clear().append($createParagraphNode().append(segmented));
 
-          const sel = segmented.select(4, 4);
-          sel.insertText('');
+        const sel = segmented.select(4, 4);
+        sel.insertText('');
 
-          expect(segmented.isAttached()).toBe(false);
-          const allText = $getRoot().getAllTextNodes();
-          expect(allText).toHaveLength(1);
-          expect(allText[0].getKey()).not.toBe(segmented.getKey());
-          expect(allText[0].getTextContent()).toBe('JohnSmith');
-        },
-        {discrete: true},
-      );
-    });
+        expect(segmented.isAttached()).toBe(false);
+        const allText = $getRoot().getAllTextNodes();
+        expect(allText).toHaveLength(1);
+        expect(allText[0].getKey()).not.toBe(segmented.getKey());
+        expect(allText[0].getTextContent()).toBe('JohnSmith');
+      },
+      {discrete: true},
+    );
+  });
 
-    test('insertText during composition preserves format and style', () => {
-      testEnv.editor.update(
-        () => {
-          const segmented = $createTextNode('JohnSmith')
-            .setMode('segmented')
-            .setFormat('bold');
-          $getRoot().clear().append($createParagraphNode().append(segmented));
-          const key = segmented.getKey();
+  test('insertText during composition preserves format and style', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const segmented = $createTextNode('JohnSmith')
+          .setMode('segmented')
+          .setFormat('bold');
+        $getRoot().clear().append($createParagraphNode().append(segmented));
+        const key = segmented.getKey();
 
-          $setCompositionKey(key);
-          const sel = segmented.select(4, 4);
-          sel.format = 1; // bold
-          sel.insertText('');
+        $setCompositionKey(key);
+        const sel = segmented.select(4, 4);
+        sel.format = 1; // bold
+        sel.insertText('');
 
-          const latest = segmented.getLatest();
-          expect(latest.isAttached()).toBe(true);
-          expect(latest.getKey()).toBe(key);
-          expect(latest.getFormat()).toBe(1);
-        },
-        {discrete: true},
-      );
-    });
+        const latest = segmented.getLatest();
+        expect(latest.isAttached()).toBe(true);
+        expect(latest.getKey()).toBe(key);
+        expect(latest.getFormat()).toBe(1);
+      },
+      {discrete: true},
+    );
   });
 });
 
@@ -956,269 +922,294 @@ describe('Regression tests for #8707', () => {
   // pasting a copied decorator) used to throw because a shadow root has no
   // block ancestor to split. Roots and shadow roots hold blocks directly, so
   // the block goes straight in at the anchor offset with no paragraph wrapper.
-  initializeUnitTest(testEnv => {
-    test('inserts a block decorator after the block cursor at the end of a shadow root', () => {
-      const {editor} = testEnv;
-      let shadowKey = '';
-      editor.update(
-        () => {
-          const shadow = $createTestShadowRootNode();
-          shadow.append($createTestDecoratorNode().setIsInline(false));
-          $getRoot().clear().append(shadow);
-          shadowKey = shadow.getKey();
-          // Block cursor: collapsed element point after the decorator.
-          shadow.select(1, 1);
-        },
-        {discrete: true},
-      );
+  test('inserts a block decorator after the block cursor at the end of a shadow root', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    let shadowKey = '';
+    editor.update(
+      () => {
+        const shadow = $createTestShadowRootNode();
+        shadow.append($createTestDecoratorNode().setIsInline(false));
+        $getRoot().clear().append(shadow);
+        shadowKey = shadow.getKey();
+        // Block cursor: collapsed element point after the decorator.
+        shadow.select(1, 1);
+      },
+      {discrete: true},
+    );
 
-      editor.update(
-        () => {
-          const selection = $getSelection();
-          invariant($isRangeSelection(selection), 'Expected RangeSelection');
-          selection.insertNodes([
-            $createTestDecoratorNode().setIsInline(false),
-          ]);
-        },
-        {discrete: true},
-      );
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
+      },
+      {discrete: true},
+    );
 
-      editor.read(() => {
-        const root = $getRoot();
-        // The decorator landed in the same shadow root as the block cursor,
-        // not the outer document root.
-        expect(root.getChildrenSize()).toBe(1);
-        const shadow = root.getFirstChildOrThrow();
-        invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
-        expect(shadow.getKey()).toBe(shadowKey);
-        const children = shadow.getChildren();
-        expect(children).toHaveLength(2);
-        expect(children.every($isDecoratorNode)).toBe(true);
-      });
+    editor.read(() => {
+      const root = $getRoot();
+      // The decorator landed in the same shadow root as the block cursor,
+      // not the outer document root.
+      expect(root.getChildrenSize()).toBe(1);
+      const shadow = root.getFirstChildOrThrow();
+      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      expect(shadow.getKey()).toBe(shadowKey);
+      const children = shadow.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every($isDecoratorNode)).toBe(true);
     });
+  });
 
-    test('inserts a block decorator before the block cursor at the start of a shadow root', () => {
-      const {editor} = testEnv;
-      let existingKey = '';
-      editor.update(
-        () => {
-          const shadow = $createTestShadowRootNode();
-          const existing = $createTestDecoratorNode().setIsInline(false);
-          shadow.append(existing);
-          $getRoot().clear().append(shadow);
-          existingKey = existing.getKey();
-          // Block cursor: collapsed element point before the decorator.
-          shadow.select(0, 0);
-        },
-        {discrete: true},
-      );
+  test('inserts a block decorator before the block cursor at the start of a shadow root', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    let existingKey = '';
+    editor.update(
+      () => {
+        const shadow = $createTestShadowRootNode();
+        const existing = $createTestDecoratorNode().setIsInline(false);
+        shadow.append(existing);
+        $getRoot().clear().append(shadow);
+        existingKey = existing.getKey();
+        // Block cursor: collapsed element point before the decorator.
+        shadow.select(0, 0);
+      },
+      {discrete: true},
+    );
 
-      editor.update(
-        () => {
-          const selection = $getSelection();
-          invariant($isRangeSelection(selection), 'Expected RangeSelection');
-          selection.insertNodes([
-            $createTestDecoratorNode().setIsInline(false),
-          ]);
-        },
-        {discrete: true},
-      );
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
+      },
+      {discrete: true},
+    );
 
-      editor.read(() => {
-        const shadow = $getRoot().getFirstChildOrThrow();
-        invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
-        const children = shadow.getChildren();
-        expect(children).toHaveLength(2);
-        expect(children.every($isDecoratorNode)).toBe(true);
-        // Inserted before the pre-existing decorator.
-        expect(children[1].getKey()).toBe(existingKey);
-      });
+    editor.read(() => {
+      const shadow = $getRoot().getFirstChildOrThrow();
+      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      const children = shadow.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every($isDecoratorNode)).toBe(true);
+      // Inserted before the pre-existing decorator.
+      expect(children[1].getKey()).toBe(existingKey);
     });
+  });
 
-    test('inserts a block decorator into an empty shadow root', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const shadow = $createTestShadowRootNode();
-          $getRoot().clear().append(shadow);
-          shadow.select(0, 0);
-        },
-        {discrete: true},
-      );
+  test('inserts a block decorator into an empty shadow root', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const shadow = $createTestShadowRootNode();
+        $getRoot().clear().append(shadow);
+        shadow.select(0, 0);
+      },
+      {discrete: true},
+    );
 
-      editor.update(
-        () => {
-          const selection = $getSelection();
-          invariant($isRangeSelection(selection), 'Expected RangeSelection');
-          selection.insertNodes([
-            $createTestDecoratorNode().setIsInline(false),
-          ]);
-        },
-        {discrete: true},
-      );
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
+      },
+      {discrete: true},
+    );
 
-      editor.read(() => {
-        const shadow = $getRoot().getFirstChildOrThrow();
-        invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
-        const children = shadow.getChildren();
-        expect(children).toHaveLength(1);
-        expect($isDecoratorNode(children[0])).toBe(true);
-      });
+    editor.read(() => {
+      const shadow = $getRoot().getFirstChildOrThrow();
+      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      const children = shadow.getChildren();
+      expect(children).toHaveLength(1);
+      expect($isDecoratorNode(children[0])).toBe(true);
     });
+  });
 
-    test('inserts a block element at the block cursor inside a shadow root', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const shadow = $createTestShadowRootNode();
-          shadow.append($createTestDecoratorNode().setIsInline(false));
-          $getRoot().clear().append(shadow);
-          shadow.select(1, 1);
-        },
-        {discrete: true},
-      );
+  test('inserts a block element at the block cursor inside a shadow root', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const shadow = $createTestShadowRootNode();
+        shadow.append($createTestDecoratorNode().setIsInline(false));
+        $getRoot().clear().append(shadow);
+        shadow.select(1, 1);
+      },
+      {discrete: true},
+    );
 
-      editor.update(
-        () => {
-          const selection = $getSelection();
-          invariant($isRangeSelection(selection), 'Expected RangeSelection');
-          selection.insertNodes([
-            $createParagraphNode().append($createTextNode('inserted')),
-          ]);
-        },
-        {discrete: true},
-      );
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertNodes([
+          $createParagraphNode().append($createTextNode('inserted')),
+        ]);
+      },
+      {discrete: true},
+    );
 
-      editor.read(() => {
-        const shadow = $getRoot().getFirstChildOrThrow();
-        invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
-        const children = shadow.getChildren();
-        expect(children).toHaveLength(2);
-        expect($isDecoratorNode(children[0])).toBe(true);
-        expect($isParagraphNode(children[1])).toBe(true);
-        expect(children[1].getTextContent()).toBe('inserted');
-      });
+    editor.read(() => {
+      const shadow = $getRoot().getFirstChildOrThrow();
+      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      const children = shadow.getChildren();
+      expect(children).toHaveLength(2);
+      expect($isDecoratorNode(children[0])).toBe(true);
+      expect($isParagraphNode(children[1])).toBe(true);
+      expect(children[1].getTextContent()).toBe('inserted');
     });
+  });
 
-    test('insertParagraph at an element point on a shadow root seeds into that shadow root', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const shadow = $createTestShadowRootNode();
-          shadow.append($createTestDecoratorNode().setIsInline(false));
-          $getRoot().clear().append(shadow);
-          shadow.select(1, 1);
-        },
-        {discrete: true},
-      );
+  test('insertParagraph at an element point on a shadow root seeds into that shadow root', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const shadow = $createTestShadowRootNode();
+        shadow.append($createTestDecoratorNode().setIsInline(false));
+        $getRoot().clear().append(shadow);
+        shadow.select(1, 1);
+      },
+      {discrete: true},
+    );
 
-      editor.update(
-        () => {
-          const selection = $getSelection();
-          invariant($isRangeSelection(selection), 'Expected RangeSelection');
-          const paragraph = selection.insertParagraph();
-          invariant(paragraph !== null, 'Expected a paragraph to be inserted');
-          expect(paragraph.getParent()!.is($getRoot().getFirstChild())).toBe(
-            true,
-          );
-        },
-        {discrete: true},
-      );
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        const paragraph = selection.insertParagraph();
+        invariant(paragraph !== null, 'Expected a paragraph to be inserted');
+        expect(paragraph.getParent()!.is($getRoot().getFirstChild())).toBe(
+          true,
+        );
+      },
+      {discrete: true},
+    );
 
-      editor.read(() => {
-        const root = $getRoot();
-        expect(root.getChildrenSize()).toBe(1);
-        const shadow = root.getFirstChildOrThrow();
-        invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
-        expect(shadow.getChildrenSize()).toBe(2);
-        expect($isParagraphNode(shadow.getLastChild())).toBe(true);
-      });
+    editor.read(() => {
+      const root = $getRoot();
+      expect(root.getChildrenSize()).toBe(1);
+      const shadow = root.getFirstChildOrThrow();
+      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      expect(shadow.getChildrenSize()).toBe(2);
+      expect($isParagraphNode(shadow.getLastChild())).toBe(true);
     });
+  });
 
-    test('inserts a block decorator at a root element point without wrapping it in a paragraph', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          $getRoot()
-            .clear()
-            .append($createParagraphNode().append($createTextNode('existing')));
-          // Element point directly on the root, after the paragraph.
-          $getRoot().select(1, 1);
-        },
-        {discrete: true},
-      );
+  test('inserts a block decorator at a root element point without wrapping it in a paragraph', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('existing')));
+        // Element point directly on the root, after the paragraph.
+        $getRoot().select(1, 1);
+      },
+      {discrete: true},
+    );
 
-      editor.update(
-        () => {
-          const selection = $getSelection();
-          invariant($isRangeSelection(selection), 'Expected RangeSelection');
-          selection.insertNodes([
-            $createTestDecoratorNode().setIsInline(false),
-          ]);
-        },
-        {discrete: true},
-      );
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
+      },
+      {discrete: true},
+    );
 
-      editor.read(() => {
-        const children = $getRoot().getChildren();
-        // The decorator is a direct child of root; no empty paragraph wrapper
-        // was created for it.
-        expect(children).toHaveLength(2);
-        expect($isParagraphNode(children[0])).toBe(true);
-        expect($isDecoratorNode(children[1])).toBe(true);
-      });
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      // The decorator is a direct child of root; no empty paragraph wrapper
+      // was created for it.
+      expect(children).toHaveLength(2);
+      expect($isParagraphNode(children[0])).toBe(true);
+      expect($isDecoratorNode(children[1])).toBe(true);
     });
   });
 });
 
 describe('getNodes()', () => {
-  initializeUnitTest(testEnv => {
-    let paragraphNode: ParagraphNode;
-    let paragraphText: TextNode;
-    let linkNode: LinkNode;
-    let linkText: TextNode;
-    let listNode: ListNode;
-    let listItemText1: TextNode;
-    let listItemText2: TextNode;
-    let listItem1: ListItemNode;
-    let listItem2: ListItemNode;
-    let emptyParagraph: ParagraphNode;
+  let editor: LexicalEditorWithDispose;
+  let paragraphNode: ParagraphNode;
+  let paragraphText: TextNode;
+  let linkNode: LinkNode;
+  let linkText: TextNode;
+  let listNode: ListNode;
+  let listItemText1: TextNode;
+  let listItemText2: TextNode;
+  let listItem1: ListItemNode;
+  let listItem2: ListItemNode;
+  let emptyParagraph: ParagraphNode;
 
-    beforeEach(() => {
-      testEnv.editor.update(() => {
-        paragraphText = $createTextNode('paragraph text');
-        linkText = $createTextNode('link text');
-        linkNode = $createLinkNode();
-        paragraphNode = $createParagraphNode();
-        listItemText1 = $createTextNode('item 1');
-        listItemText2 = $createTextNode('item 2');
-        listItem1 = $createListItemNode();
-        listItem2 = $createListItemNode();
-        listNode = $createListNode('bullet');
-        emptyParagraph = $createParagraphNode();
-        $getRoot()
-          .clear()
-          .append(
-            paragraphNode.append(paragraphText, linkNode.append(linkText)),
-            listNode.append(
-              listItem1.append(listItemText1),
-              listItem2.append(listItemText2),
-            ),
-            emptyParagraph,
-          );
-      });
+  beforeEach(() => {
+    editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(() => {
+      paragraphText = $createTextNode('paragraph text');
+      linkText = $createTextNode('link text');
+      linkNode = $createLinkNode();
+      paragraphNode = $createParagraphNode();
+      listItemText1 = $createTextNode('item 1');
+      listItemText2 = $createTextNode('item 2');
+      listItem1 = $createListItemNode();
+      listItem2 = $createListItemNode();
+      listNode = $createListNode('bullet');
+      emptyParagraph = $createParagraphNode();
+      $getRoot()
+        .clear()
+        .append(
+          paragraphNode.append(paragraphText, linkNode.append(linkText)),
+          listNode.append(
+            listItem1.append(listItemText1),
+            listItem2.append(listItemText2),
+          ),
+          emptyParagraph,
+        );
     });
-    describe('$selectAll()', () => {
-      test('with test document', () => {
-        testEnv.editor.update(
-          () => {
-            const selection = $selectAll();
-            // Normalized to the text nodes
-            expect(selection).toMatchObject({
-              anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-              focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
-            });
-            expect(selection.getNodes()).toEqual([
+  });
+  afterEach(() => {
+    editor[Symbol.dispose]();
+  });
+  describe('$selectAll()', () => {
+    test('with test document', () => {
+      editor.update(
+        () => {
+          const selection = $selectAll();
+          // Normalized to the text nodes
+          expect(selection).toMatchObject({
+            anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
+            focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
+          });
+          expect(selection.getNodes()).toEqual([
+            paragraphText,
+            linkNode,
+            linkText,
+            // The parent paragraphNode comes after its children because the
+            // selection started inside of it at paragraphText
+            paragraphNode,
+            listNode,
+            listItem1,
+            listItemText1,
+            listItem2,
+            listItemText2,
+            emptyParagraph,
+          ]);
+        },
+        {discrete: true},
+      );
+    });
+    test('with leading inline decorator', () => {
+      editor.update(
+        () => {
+          const inlineDecoratorLeading = $createTestDecoratorNode();
+          paragraphNode.splice(0, 0, [inlineDecoratorLeading]);
+          const selection = $selectAll();
+          // Normalized to the text nodes
+          expect(selection).toMatchObject({
+            anchor: {key: paragraphNode.getKey(), offset: 0, type: 'element'},
+            focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
+          });
+          expect(selection.getNodes()).toEqual(
+            [
+              inlineDecoratorLeading,
               paragraphText,
               linkNode,
               linkText,
@@ -1231,322 +1222,94 @@ describe('getNodes()', () => {
               listItem2,
               listItemText2,
               emptyParagraph,
-            ]);
-          },
-          {discrete: true},
-        );
-      });
-      test('with leading inline decorator', () => {
-        testEnv.editor.update(
-          () => {
-            const inlineDecoratorLeading = $createTestDecoratorNode();
-            paragraphNode.splice(0, 0, [inlineDecoratorLeading]);
-            const selection = $selectAll();
-            // Normalized to the text nodes
-            expect(selection).toMatchObject({
-              anchor: {key: paragraphNode.getKey(), offset: 0, type: 'element'},
-              focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
-            });
-            expect(selection.getNodes()).toEqual(
-              [
-                inlineDecoratorLeading,
-                paragraphText,
-                linkNode,
-                linkText,
-                // The parent paragraphNode comes after its children because the
-                // selection started inside of it at paragraphText
-                paragraphNode,
-                listNode,
-                listItem1,
-                listItemText1,
-                listItem2,
-                listItemText2,
-                emptyParagraph,
-              ].map(node => node.getLatest()),
-            );
-          },
-          {discrete: true},
-        );
-      });
-      test('with trailing inline decorator', () => {
-        testEnv.editor.update(
-          () => {
-            const inlineDecoratorTrailing = $createTestDecoratorNode();
-            const noLongerEmptyParagraph = emptyParagraph;
-            noLongerEmptyParagraph.splice(0, 0, [inlineDecoratorTrailing]);
-            const selection = $selectAll();
-            // Normalized to the text nodes
-            expect(selection).toMatchObject({
-              anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-              focus: {key: emptyParagraph.getKey(), offset: 1, type: 'element'},
-            });
-            expect(selection.getNodes()).toEqual(
-              [
-                paragraphText,
-                linkNode,
-                linkText,
-                // The parent paragraphNode comes after its children because the
-                // selection started inside of it at paragraphText
-                paragraphNode,
-                listNode,
-                listItem1,
-                listItemText1,
-                listItem2,
-                listItemText2,
-                noLongerEmptyParagraph,
-                inlineDecoratorTrailing,
-              ].map(node => node.getLatest()),
-            );
-          },
-          {discrete: true},
-        );
-      });
-      test('with leading empty inline element', () => {
-        testEnv.editor.update(
-          () => {
-            const inlineElementLeading = $createTestInlineElementNode();
-            paragraphNode.splice(0, 0, [inlineElementLeading]);
-            const selection = $selectAll();
-            // Normalized to the text nodes
-            expect(selection).toMatchObject({
-              anchor: {
-                key: inlineElementLeading.getKey(),
-                offset: 0,
-                type: 'element',
-              },
-              focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
-            });
-            expect(selection.getNodes()).toEqual(
-              [
-                inlineElementLeading,
-                paragraphText,
-                linkNode,
-                linkText,
-                // The parent paragraphNode comes after its children because the
-                // selection started inside of it at paragraphText
-                paragraphNode,
-                listNode,
-                listItem1,
-                listItemText1,
-                listItem2,
-                listItemText2,
-                emptyParagraph,
-              ].map(node => node.getLatest()),
-            );
-          },
-          {discrete: true},
-        );
-      });
-      test('with trailing empty inline element', () => {
-        testEnv.editor.update(
-          () => {
-            const inlineElementTrailing = $createTestInlineElementNode();
-            const noLongerEmptyParagraph = emptyParagraph;
-            noLongerEmptyParagraph.splice(0, 0, [inlineElementTrailing]);
-            const selection = $selectAll();
-            // Normalized to the text nodes
-            expect(selection).toMatchObject({
-              anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-              focus: {
-                key: inlineElementTrailing.getKey(),
-                offset: 0,
-                type: 'element',
-              },
-            });
-            expect(selection.getNodes()).toEqual(
-              [
-                paragraphText,
-                linkNode,
-                linkText,
-                // The parent paragraphNode comes after its children because the
-                // selection started inside of it at paragraphText
-                paragraphNode,
-                listNode,
-                listItem1,
-                listItemText1,
-                listItem2,
-                listItemText2,
-                noLongerEmptyParagraph,
-                inlineElementTrailing,
-              ].map(node => node.getLatest()),
-            );
-          },
-          {discrete: true},
-        );
-      });
-      test('after removing empty paragraph', () => {
-        testEnv.editor.update(
-          () => {
-            emptyParagraph.remove();
-            const selection = $selectAll();
-            // Normalized to the text nodes
-            expect(selection).toMatchObject({
-              anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-              focus: {
-                key: listItemText2.getKey(),
-                offset: listItemText2.getTextContentSize(),
-                type: 'text',
-              },
-            });
-            expect(selection.getNodes()).toEqual(
-              [
-                paragraphText,
-                linkNode,
-                linkText,
-                // The parent paragraphNode comes after its children because the
-                // selection started inside of it at paragraphText
-                paragraphNode,
-                listNode,
-                listItem1,
-                listItemText1,
-                listItem2,
-                listItemText2,
-              ].map(n => n.getLatest()),
-            );
-          },
-          {discrete: true},
-        );
-      });
-    });
-    test('Manual select all without normalization', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set('root', 0, 'element');
-          selection.focus.set('root', $getRoot().getChildrenSize(), 'element');
-          expect(selection.getNodes()).toEqual([
-            paragraphText,
-            linkNode,
-            linkText,
-            // The parent paragraphNode comes later because there is
-            // an implicit normalization in the beginning of getNodes
-            // to work around… something? See the getDescendantByIndex usage.
-            paragraphNode,
-            listNode,
-            listItem1,
-            listItemText1,
-            listItem2,
-            listItemText2,
-            emptyParagraph,
-          ]);
-        },
-        {discrete: true},
-      );
-    });
-    test('Manual select all from first text to last empty paragraph', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(paragraphText.getKey(), 0, 'text');
-          selection.focus.set(emptyParagraph.getKey(), 0, 'element');
-          expect(selection.getNodes()).toEqual([
-            paragraphText,
-            linkNode,
-            linkText,
-            // The parent paragraphNode comes later because there is
-            // an implicit normalization in the beginning of getNodes
-            // to work around… something? See the getDescendantByIndex usage.
-            paragraphNode,
-            listNode,
-            listItem1,
-            listItemText1,
-            listItem2,
-            listItemText2,
-            emptyParagraph,
-          ]);
-        },
-        {discrete: true},
-      );
-    });
-    test('Manual select with focus collapsed between inline decorators', () => {
-      testEnv.editor.update(
-        () => {
-          const inlineDecoratorLeading = $createTestDecoratorNode();
-          const inlineDecoratorTrailing = $createTestDecoratorNode();
-          const noLongerEmptyParagraph = emptyParagraph;
-          noLongerEmptyParagraph.splice(0, 0, [
-            inlineDecoratorLeading,
-            inlineDecoratorTrailing,
-          ]);
-          const selection = $createRangeSelection();
-          // Collapsed between decorators
-          selection.anchor.set(noLongerEmptyParagraph.getKey(), 1, 'element');
-          selection.focus.set(noLongerEmptyParagraph.getKey(), 1, 'element');
-          expect(selection.isCollapsed()).toBe(true);
-          expect(selection).toMatchObject({
-            anchor: {
-              key: noLongerEmptyParagraph.getKey(),
-              offset: 1,
-              type: 'element',
-            },
-            focus: {
-              key: noLongerEmptyParagraph.getKey(),
-              offset: 1,
-              type: 'element',
-            },
-          });
-          expect(selection.getNodes()).toEqual(
-            // The bias is towards the right
-            [inlineDecoratorTrailing].map(node => node.getLatest()),
+            ].map(node => node.getLatest()),
           );
         },
         {discrete: true},
       );
     });
-    test('Manual select with focus collapsed after inline decorator', () => {
-      testEnv.editor.update(
+    test('with trailing inline decorator', () => {
+      editor.update(
         () => {
-          const inlineDecoratorLeading = $createTestDecoratorNode();
           const inlineDecoratorTrailing = $createTestDecoratorNode();
           const noLongerEmptyParagraph = emptyParagraph;
-          noLongerEmptyParagraph.splice(0, 0, [
-            inlineDecoratorLeading,
-            inlineDecoratorTrailing,
-          ]);
-          const selection = $createRangeSelection();
-          // Collapsed after decorators
-          selection.anchor.set(noLongerEmptyParagraph.getKey(), 2, 'element');
-          selection.focus.set(noLongerEmptyParagraph.getKey(), 2, 'element');
-          expect(selection.isCollapsed()).toBe(true);
+          noLongerEmptyParagraph.splice(0, 0, [inlineDecoratorTrailing]);
+          const selection = $selectAll();
+          // Normalized to the text nodes
           expect(selection).toMatchObject({
-            anchor: {
-              key: noLongerEmptyParagraph.getKey(),
-              offset: 2,
-              type: 'element',
-            },
-            focus: {
-              key: noLongerEmptyParagraph.getKey(),
-              offset: 2,
-              type: 'element',
-            },
+            anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
+            focus: {key: emptyParagraph.getKey(), offset: 1, type: 'element'},
           });
           expect(selection.getNodes()).toEqual(
-            // The bias is towards the last descendant since no
-            // nodes exist to the right
-            [inlineDecoratorTrailing].map(node => node.getLatest()),
+            [
+              paragraphText,
+              linkNode,
+              linkText,
+              // The parent paragraphNode comes after its children because the
+              // selection started inside of it at paragraphText
+              paragraphNode,
+              listNode,
+              listItem1,
+              listItemText1,
+              listItem2,
+              listItemText2,
+              noLongerEmptyParagraph,
+              inlineDecoratorTrailing,
+            ].map(node => node.getLatest()),
           );
         },
         {discrete: true},
       );
     });
-    test('Manual select with focus between inline decorators', () => {
-      testEnv.editor.update(
+    test('with leading empty inline element', () => {
+      editor.update(
         () => {
-          const inlineDecoratorLeading = $createTestDecoratorNode();
-          const inlineDecoratorTrailing = $createTestDecoratorNode();
+          const inlineElementLeading = $createTestInlineElementNode();
+          paragraphNode.splice(0, 0, [inlineElementLeading]);
+          const selection = $selectAll();
+          // Normalized to the text nodes
+          expect(selection).toMatchObject({
+            anchor: {
+              key: inlineElementLeading.getKey(),
+              offset: 0,
+              type: 'element',
+            },
+            focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
+          });
+          expect(selection.getNodes()).toEqual(
+            [
+              inlineElementLeading,
+              paragraphText,
+              linkNode,
+              linkText,
+              // The parent paragraphNode comes after its children because the
+              // selection started inside of it at paragraphText
+              paragraphNode,
+              listNode,
+              listItem1,
+              listItemText1,
+              listItem2,
+              listItemText2,
+              emptyParagraph,
+            ].map(node => node.getLatest()),
+          );
+        },
+        {discrete: true},
+      );
+    });
+    test('with trailing empty inline element', () => {
+      editor.update(
+        () => {
+          const inlineElementTrailing = $createTestInlineElementNode();
           const noLongerEmptyParagraph = emptyParagraph;
-          noLongerEmptyParagraph.splice(0, 0, [
-            inlineDecoratorLeading,
-            inlineDecoratorTrailing,
-          ]);
-          const selection = $createRangeSelection();
-          selection.anchor.set(paragraphText.getKey(), 0, 'text');
-          selection.focus.set(noLongerEmptyParagraph.getKey(), 1, 'element');
+          noLongerEmptyParagraph.splice(0, 0, [inlineElementTrailing]);
+          const selection = $selectAll();
+          // Normalized to the text nodes
           expect(selection).toMatchObject({
             anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
             focus: {
-              key: noLongerEmptyParagraph.getKey(),
-              offset: 1,
+              key: inlineElementTrailing.getKey(),
+              offset: 0,
               type: 'element',
             },
           });
@@ -1564,868 +1327,1061 @@ describe('getNodes()', () => {
               listItem2,
               listItemText2,
               noLongerEmptyParagraph,
-              inlineDecoratorLeading,
+              inlineElementTrailing,
             ].map(node => node.getLatest()),
           );
         },
         {discrete: true},
       );
     });
-    test('select only the paragraph (not normalized)', () => {
-      testEnv.editor.update(
+    test('after removing empty paragraph', () => {
+      editor.update(
         () => {
-          const selection = paragraphNode.select(
-            0,
-            paragraphNode.getChildrenSize(),
-          );
+          emptyParagraph.remove();
+          const selection = $selectAll();
+          // Normalized to the text nodes
           expect(selection).toMatchObject({
-            anchor: {key: paragraphNode.getKey(), offset: 0, type: 'element'},
+            anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
             focus: {
-              key: paragraphNode.getKey(),
-              offset: paragraphNode.getChildrenSize(),
-              type: 'element',
+              key: listItemText2.getKey(),
+              offset: listItemText2.getTextContentSize(),
+              type: 'text',
             },
           });
-          // The selection doesn't visit outside of the paragraph
-          expect(selection.getNodes()).toEqual([
-            paragraphText,
-            linkNode,
-            linkText,
-          ]);
+          expect(selection.getNodes()).toEqual(
+            [
+              paragraphText,
+              linkNode,
+              linkText,
+              // The parent paragraphNode comes after its children because the
+              // selection started inside of it at paragraphText
+              paragraphNode,
+              listNode,
+              listItem1,
+              listItemText1,
+              listItem2,
+              listItemText2,
+            ].map(n => n.getLatest()),
+          );
         },
         {discrete: true},
       );
     });
-    test('select around the paragraph (not normalized)', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(
-            'root',
-            paragraphNode.getIndexWithinParent(),
-            'element',
-          );
-          selection.focus.set(
-            'root',
-            paragraphNode.getIndexWithinParent() + 1,
-            'element',
-          );
-          expect(selection).toMatchObject({
-            anchor: {key: 'root', offset: 0, type: 'element'},
-            focus: {key: 'root', offset: 1, type: 'element'},
-          });
-          // The selection shouldn't visit outside of the paragraph
-          expect(selection.getNodes()).toEqual([
+  });
+  test('Manual select all without normalization', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set('root', 0, 'element');
+        selection.focus.set('root', $getRoot().getChildrenSize(), 'element');
+        expect(selection.getNodes()).toEqual([
+          paragraphText,
+          linkNode,
+          linkText,
+          // The parent paragraphNode comes later because there is
+          // an implicit normalization in the beginning of getNodes
+          // to work around… something? See the getDescendantByIndex usage.
+          paragraphNode,
+          listNode,
+          listItem1,
+          listItemText1,
+          listItem2,
+          listItemText2,
+          emptyParagraph,
+        ]);
+      },
+      {discrete: true},
+    );
+  });
+  test('Manual select all from first text to last empty paragraph', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(paragraphText.getKey(), 0, 'text');
+        selection.focus.set(emptyParagraph.getKey(), 0, 'element');
+        expect(selection.getNodes()).toEqual([
+          paragraphText,
+          linkNode,
+          linkText,
+          // The parent paragraphNode comes later because there is
+          // an implicit normalization in the beginning of getNodes
+          // to work around… something? See the getDescendantByIndex usage.
+          paragraphNode,
+          listNode,
+          listItem1,
+          listItemText1,
+          listItem2,
+          listItemText2,
+          emptyParagraph,
+        ]);
+      },
+      {discrete: true},
+    );
+  });
+  test('Manual select with focus collapsed between inline decorators', () => {
+    editor.update(
+      () => {
+        const inlineDecoratorLeading = $createTestDecoratorNode();
+        const inlineDecoratorTrailing = $createTestDecoratorNode();
+        const noLongerEmptyParagraph = emptyParagraph;
+        noLongerEmptyParagraph.splice(0, 0, [
+          inlineDecoratorLeading,
+          inlineDecoratorTrailing,
+        ]);
+        const selection = $createRangeSelection();
+        // Collapsed between decorators
+        selection.anchor.set(noLongerEmptyParagraph.getKey(), 1, 'element');
+        selection.focus.set(noLongerEmptyParagraph.getKey(), 1, 'element');
+        expect(selection.isCollapsed()).toBe(true);
+        expect(selection).toMatchObject({
+          anchor: {
+            key: noLongerEmptyParagraph.getKey(),
+            offset: 1,
+            type: 'element',
+          },
+          focus: {
+            key: noLongerEmptyParagraph.getKey(),
+            offset: 1,
+            type: 'element',
+          },
+        });
+        expect(selection.getNodes()).toEqual(
+          // The bias is towards the right
+          [inlineDecoratorTrailing].map(node => node.getLatest()),
+        );
+      },
+      {discrete: true},
+    );
+  });
+  test('Manual select with focus collapsed after inline decorator', () => {
+    editor.update(
+      () => {
+        const inlineDecoratorLeading = $createTestDecoratorNode();
+        const inlineDecoratorTrailing = $createTestDecoratorNode();
+        const noLongerEmptyParagraph = emptyParagraph;
+        noLongerEmptyParagraph.splice(0, 0, [
+          inlineDecoratorLeading,
+          inlineDecoratorTrailing,
+        ]);
+        const selection = $createRangeSelection();
+        // Collapsed after decorators
+        selection.anchor.set(noLongerEmptyParagraph.getKey(), 2, 'element');
+        selection.focus.set(noLongerEmptyParagraph.getKey(), 2, 'element');
+        expect(selection.isCollapsed()).toBe(true);
+        expect(selection).toMatchObject({
+          anchor: {
+            key: noLongerEmptyParagraph.getKey(),
+            offset: 2,
+            type: 'element',
+          },
+          focus: {
+            key: noLongerEmptyParagraph.getKey(),
+            offset: 2,
+            type: 'element',
+          },
+        });
+        expect(selection.getNodes()).toEqual(
+          // The bias is towards the last descendant since no
+          // nodes exist to the right
+          [inlineDecoratorTrailing].map(node => node.getLatest()),
+        );
+      },
+      {discrete: true},
+    );
+  });
+  test('Manual select with focus between inline decorators', () => {
+    editor.update(
+      () => {
+        const inlineDecoratorLeading = $createTestDecoratorNode();
+        const inlineDecoratorTrailing = $createTestDecoratorNode();
+        const noLongerEmptyParagraph = emptyParagraph;
+        noLongerEmptyParagraph.splice(0, 0, [
+          inlineDecoratorLeading,
+          inlineDecoratorTrailing,
+        ]);
+        const selection = $createRangeSelection();
+        selection.anchor.set(paragraphText.getKey(), 0, 'text');
+        selection.focus.set(noLongerEmptyParagraph.getKey(), 1, 'element');
+        expect(selection).toMatchObject({
+          anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
+          focus: {
+            key: noLongerEmptyParagraph.getKey(),
+            offset: 1,
+            type: 'element',
+          },
+        });
+        expect(selection.getNodes()).toEqual(
+          [
             paragraphText,
             linkNode,
             linkText,
+            // The parent paragraphNode comes after its children because the
+            // selection started inside of it at paragraphText
             paragraphNode,
-          ]);
-        },
-        {discrete: true},
-      );
-    });
-    test('selection collapsed inside an empty element', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(emptyParagraph.getKey(), 0, 'element');
-          selection.focus.set(emptyParagraph.getKey(), 0, 'element');
-          // The selection should include the node it is collapsed inside
-          expect(selection.getNodes()).toEqual([emptyParagraph]);
-        },
-        {discrete: true},
-      );
-    });
-    test('select an empty ListItemNode (collapsed)', () => {
-      testEnv.editor.update(
-        () => {
-          const emptyListItem = $createListItemNode();
-          listItem2.insertBefore(emptyListItem);
-          const selection = $createRangeSelection();
-          selection.anchor.set(emptyListItem.getKey(), 0, 'element');
-          selection.focus.set(emptyListItem.getKey(), 0, 'element');
-          expect(selection).toMatchObject({
-            anchor: {key: emptyListItem.getKey(), offset: 0, type: 'element'},
-            focus: {key: emptyListItem.getKey(), offset: 0, type: 'element'},
-          });
-          expect(selection.getNodes()).toEqual([emptyListItem]);
-        },
-        {discrete: true},
-      );
-    });
+            listNode,
+            listItem1,
+            listItemText1,
+            listItem2,
+            listItemText2,
+            noLongerEmptyParagraph,
+            inlineDecoratorLeading,
+          ].map(node => node.getLatest()),
+        );
+      },
+      {discrete: true},
+    );
+  });
+  test('select only the paragraph (not normalized)', () => {
+    editor.update(
+      () => {
+        const selection = paragraphNode.select(
+          0,
+          paragraphNode.getChildrenSize(),
+        );
+        expect(selection).toMatchObject({
+          anchor: {key: paragraphNode.getKey(), offset: 0, type: 'element'},
+          focus: {
+            key: paragraphNode.getKey(),
+            offset: paragraphNode.getChildrenSize(),
+            type: 'element',
+          },
+        });
+        // The selection doesn't visit outside of the paragraph
+        expect(selection.getNodes()).toEqual([
+          paragraphText,
+          linkNode,
+          linkText,
+        ]);
+      },
+      {discrete: true},
+    );
+  });
+  test('select around the paragraph (not normalized)', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(
+          'root',
+          paragraphNode.getIndexWithinParent(),
+          'element',
+        );
+        selection.focus.set(
+          'root',
+          paragraphNode.getIndexWithinParent() + 1,
+          'element',
+        );
+        expect(selection).toMatchObject({
+          anchor: {key: 'root', offset: 0, type: 'element'},
+          focus: {key: 'root', offset: 1, type: 'element'},
+        });
+        // The selection shouldn't visit outside of the paragraph
+        expect(selection.getNodes()).toEqual([
+          paragraphText,
+          linkNode,
+          linkText,
+          paragraphNode,
+        ]);
+      },
+      {discrete: true},
+    );
+  });
+  test('selection collapsed inside an empty element', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(emptyParagraph.getKey(), 0, 'element');
+        selection.focus.set(emptyParagraph.getKey(), 0, 'element');
+        // The selection should include the node it is collapsed inside
+        expect(selection.getNodes()).toEqual([emptyParagraph]);
+      },
+      {discrete: true},
+    );
+  });
+  test('select an empty ListItemNode (collapsed)', () => {
+    editor.update(
+      () => {
+        const emptyListItem = $createListItemNode();
+        listItem2.insertBefore(emptyListItem);
+        const selection = $createRangeSelection();
+        selection.anchor.set(emptyListItem.getKey(), 0, 'element');
+        selection.focus.set(emptyListItem.getKey(), 0, 'element');
+        expect(selection).toMatchObject({
+          anchor: {key: emptyListItem.getKey(), offset: 0, type: 'element'},
+          focus: {key: emptyListItem.getKey(), offset: 0, type: 'element'},
+        });
+        expect(selection.getNodes()).toEqual([emptyListItem]);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('extract()', () => {
-  initializeUnitTest(testEnv => {
-    let paragraphNode: ParagraphNode;
-    let paragraphText: TextNode;
-    let linkNode: LinkNode;
-    let linkText: TextNode;
-    let listNode: ListNode;
-    let listItemText1: TextNode;
-    let listItemText2: TextNode;
-    let listItem1: ListItemNode;
-    let listItem2: ListItemNode;
-    let emptyParagraph: ParagraphNode;
+  let editor: LexicalEditorWithDispose;
+  let paragraphNode: ParagraphNode;
+  let paragraphText: TextNode;
+  let linkNode: LinkNode;
+  let linkText: TextNode;
+  let listNode: ListNode;
+  let listItemText1: TextNode;
+  let listItemText2: TextNode;
+  let listItem1: ListItemNode;
+  let listItem2: ListItemNode;
+  let emptyParagraph: ParagraphNode;
 
-    beforeEach(() => {
-      testEnv.editor.update(() => {
-        paragraphText = $createTextNode('paragraph text');
-        linkText = $createTextNode('link text');
-        linkNode = $createLinkNode();
-        paragraphNode = $createParagraphNode();
-        listItemText1 = $createTextNode('item 1');
-        listItemText2 = $createTextNode('item 2');
-        listItem1 = $createListItemNode();
-        listItem2 = $createListItemNode();
-        listNode = $createListNode('bullet');
-        emptyParagraph = $createParagraphNode();
-        $getRoot()
-          .clear()
-          .append(
-            paragraphNode.append(paragraphText, linkNode.append(linkText)),
-            listNode.append(
-              listItem1.append(listItemText1),
-              listItem2.append(listItemText2),
-            ),
-            emptyParagraph,
-          );
-      });
+  beforeEach(() => {
+    editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(() => {
+      paragraphText = $createTextNode('paragraph text');
+      linkText = $createTextNode('link text');
+      linkNode = $createLinkNode();
+      paragraphNode = $createParagraphNode();
+      listItemText1 = $createTextNode('item 1');
+      listItemText2 = $createTextNode('item 2');
+      listItem1 = $createListItemNode();
+      listItem2 = $createListItemNode();
+      listNode = $createListNode('bullet');
+      emptyParagraph = $createParagraphNode();
+      $getRoot()
+        .clear()
+        .append(
+          paragraphNode.append(paragraphText, linkNode.append(linkText)),
+          listNode.append(
+            listItem1.append(listItemText1),
+            listItem2.append(listItemText2),
+          ),
+          emptyParagraph,
+        );
     });
-    test('Manual select all without normalization', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set('root', 0, 'element');
-          selection.focus.set('root', $getRoot().getChildrenSize(), 'element');
-          const extracted = selection.extract();
-          expect(extracted).toEqual([
-            paragraphText,
-            linkNode,
-            linkText,
-            // The parent paragraphNode comes later because there is
-            // an implicit normalization in the beginning of getNodes
-            // to work around… something? See the getDescendantByIndex usage.
-            paragraphNode,
-            listNode,
-            listItem1,
-            listItemText1,
-            listItem2,
-            listItemText2,
-            emptyParagraph,
-          ]);
-          expect(selection.getNodes()).toEqual(extracted);
-        },
-        {discrete: true},
-      );
-    });
-    test('Manual select all from first text to last empty paragraph', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(paragraphText.getKey(), 0, 'text');
-          selection.focus.set(emptyParagraph.getKey(), 0, 'element');
-          const extracted = selection.extract();
-          expect(extracted).toEqual([
-            paragraphText,
-            linkNode,
-            linkText,
-            // The parent paragraphNode comes later because there is
-            // an implicit normalization in the beginning of getNodes
-            // to work around… something? See the getDescendantByIndex usage.
-            paragraphNode,
-            listNode,
-            listItem1,
-            listItemText1,
-            listItem2,
-            listItemText2,
-            emptyParagraph,
-          ]);
-          expect(selection.getNodes()).toEqual(extracted);
-        },
-        {discrete: true},
-      );
-    });
-    test('select partial TextNode extracts paragraph text', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(paragraphText.getKey(), 2, 'text');
-          selection.focus.set(paragraphText.getKey(), 8, 'text');
-          const extracted = selection.extract();
-          expect(extracted).toEqual([
-            expect.objectContaining({__text: 'ragrap'}),
-          ]);
-          expect(selection.getNodes()).toEqual(extracted);
-        },
-        {discrete: true},
-      );
-    });
-    test('select partial TextNode extracts link text', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(linkText.getKey(), 1, 'text');
-          selection.focus.set(linkText.getKey(), 4, 'text');
-          const extracted = selection.extract();
-          expect(extracted).toEqual([expect.objectContaining({__text: 'ink'})]);
-          expect(selection.getNodes()).toEqual(extracted);
-        },
-        {discrete: true},
-      );
-    });
-    test('select multiple partial TextNode extracts text', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(paragraphText.getKey(), 10, 'text');
-          selection.focus.set(linkText.getKey(), 4, 'text');
-          const extracted = selection.extract();
-          expect(mapLatest(extracted)).toEqual([
-            expect.objectContaining({__text: 'text'}),
-            linkNode.getLatest(),
-            expect.objectContaining({__text: 'link'}),
-          ]);
-          expect(mapLatest(selection.getNodes())).toEqual(mapLatest(extracted));
-        },
-        {discrete: true},
-      );
-    });
-    test('select last offset TextNode as first node removes node', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(
-            paragraphText.getKey(),
-            paragraphText.getTextContentSize(),
-            'text',
-          );
-          selection.focus.set(linkText.getKey(), 4, 'text');
-          const beforeNodes = selection.getNodes();
-          const extracted = selection.extract();
-          expect(mapLatest(extracted)).toEqual([
-            linkNode.getLatest(),
-            expect.objectContaining({__text: 'link'}),
-          ]);
-          // The identity of the linkText does not change
-          // since the first node is re-used
-          expect(mapLatest(selection.getNodes())).toEqual(
-            mapLatest(beforeNodes),
-          );
-        },
-        {discrete: true},
-      );
-    });
-    test('select 0 offset TextNode as last node removes node', () => {
-      testEnv.editor.update(
-        () => {
-          const selection = $createRangeSelection();
-          selection.anchor.set(paragraphText.getKey(), 4, 'text');
-          selection.focus.set(linkText.getKey(), 0, 'text');
-          const beforeNodes = selection.getNodes();
-          expect(mapLatest(selection.extract())).toEqual([
-            expect.objectContaining({__text: 'graph text'}),
-            linkNode.getLatest(),
-          ]);
-          // The identity is not paragraphText anymore because
-          // that is the left side outside of the extraction
-          expect(mapLatest(selection.getNodes())).toEqual([
-            paragraphText.getNextSibling(),
-            ...mapLatest(beforeNodes.slice(1)),
-          ]);
-        },
-        {discrete: true},
-      );
-    });
+  });
+  afterEach(() => {
+    editor[Symbol.dispose]();
+  });
+  test('Manual select all without normalization', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set('root', 0, 'element');
+        selection.focus.set('root', $getRoot().getChildrenSize(), 'element');
+        const extracted = selection.extract();
+        expect(extracted).toEqual([
+          paragraphText,
+          linkNode,
+          linkText,
+          // The parent paragraphNode comes later because there is
+          // an implicit normalization in the beginning of getNodes
+          // to work around… something? See the getDescendantByIndex usage.
+          paragraphNode,
+          listNode,
+          listItem1,
+          listItemText1,
+          listItem2,
+          listItemText2,
+          emptyParagraph,
+        ]);
+        expect(selection.getNodes()).toEqual(extracted);
+      },
+      {discrete: true},
+    );
+  });
+  test('Manual select all from first text to last empty paragraph', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(paragraphText.getKey(), 0, 'text');
+        selection.focus.set(emptyParagraph.getKey(), 0, 'element');
+        const extracted = selection.extract();
+        expect(extracted).toEqual([
+          paragraphText,
+          linkNode,
+          linkText,
+          // The parent paragraphNode comes later because there is
+          // an implicit normalization in the beginning of getNodes
+          // to work around… something? See the getDescendantByIndex usage.
+          paragraphNode,
+          listNode,
+          listItem1,
+          listItemText1,
+          listItem2,
+          listItemText2,
+          emptyParagraph,
+        ]);
+        expect(selection.getNodes()).toEqual(extracted);
+      },
+      {discrete: true},
+    );
+  });
+  test('select partial TextNode extracts paragraph text', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(paragraphText.getKey(), 2, 'text');
+        selection.focus.set(paragraphText.getKey(), 8, 'text');
+        const extracted = selection.extract();
+        expect(extracted).toEqual([
+          expect.objectContaining({__text: 'ragrap'}),
+        ]);
+        expect(selection.getNodes()).toEqual(extracted);
+      },
+      {discrete: true},
+    );
+  });
+  test('select partial TextNode extracts link text', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(linkText.getKey(), 1, 'text');
+        selection.focus.set(linkText.getKey(), 4, 'text');
+        const extracted = selection.extract();
+        expect(extracted).toEqual([expect.objectContaining({__text: 'ink'})]);
+        expect(selection.getNodes()).toEqual(extracted);
+      },
+      {discrete: true},
+    );
+  });
+  test('select multiple partial TextNode extracts text', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(paragraphText.getKey(), 10, 'text');
+        selection.focus.set(linkText.getKey(), 4, 'text');
+        const extracted = selection.extract();
+        expect(mapLatest(extracted)).toEqual([
+          expect.objectContaining({__text: 'text'}),
+          linkNode.getLatest(),
+          expect.objectContaining({__text: 'link'}),
+        ]);
+        expect(mapLatest(selection.getNodes())).toEqual(mapLatest(extracted));
+      },
+      {discrete: true},
+    );
+  });
+  test('select last offset TextNode as first node removes node', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(
+          paragraphText.getKey(),
+          paragraphText.getTextContentSize(),
+          'text',
+        );
+        selection.focus.set(linkText.getKey(), 4, 'text');
+        const beforeNodes = selection.getNodes();
+        const extracted = selection.extract();
+        expect(mapLatest(extracted)).toEqual([
+          linkNode.getLatest(),
+          expect.objectContaining({__text: 'link'}),
+        ]);
+        // The identity of the linkText does not change
+        // since the first node is re-used
+        expect(mapLatest(selection.getNodes())).toEqual(mapLatest(beforeNodes));
+      },
+      {discrete: true},
+    );
+  });
+  test('select 0 offset TextNode as last node removes node', () => {
+    editor.update(
+      () => {
+        const selection = $createRangeSelection();
+        selection.anchor.set(paragraphText.getKey(), 4, 'text');
+        selection.focus.set(linkText.getKey(), 0, 'text');
+        const beforeNodes = selection.getNodes();
+        expect(mapLatest(selection.extract())).toEqual([
+          expect.objectContaining({__text: 'graph text'}),
+          linkNode.getLatest(),
+        ]);
+        // The identity is not paragraphText anymore because
+        // that is the left side outside of the extraction
+        expect(mapLatest(selection.getNodes())).toEqual([
+          paragraphText.getNextSibling(),
+          ...mapLatest(beforeNodes.slice(1)),
+        ]);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('Regression #7081', () => {
-  initializeUnitTest(testEnv => {
-    test('Firefox selection & paste before linebreak', () => {
-      testEnv.editor.update(
-        () => {
-          const textNode =
-            $createTextNode('XXXX').setStyle(`color: --color-test`);
-          const paragraphNode = $createParagraphNode();
-          $getRoot()
-            .clear()
-            .append(
-              paragraphNode.append(
-                $createTextNode('ID: '),
-                textNode,
-                $createLineBreakNode(),
-                $createTextNode('aa'),
-              ),
-            );
-          const selection = textNode.select(0);
-          selection.focus.set(
-            paragraphNode.getKey(),
-            1 + textNode.getIndexWithinParent(),
-            'element',
+  test('Firefox selection & paste before linebreak', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const textNode =
+          $createTextNode('XXXX').setStyle(`color: --color-test`);
+        const paragraphNode = $createParagraphNode();
+        $getRoot()
+          .clear()
+          .append(
+            paragraphNode.append(
+              $createTextNode('ID: '),
+              textNode,
+              $createLineBreakNode(),
+              $createTextNode('aa'),
+            ),
           );
-          selection.insertText('123');
-          expect(textNode.isAttached()).toBe(true);
-          expect(textNode.getTextContent()).toBe('123');
-        },
-        {discrete: true},
-      );
-    });
+        const selection = textNode.select(0);
+        selection.focus.set(
+          paragraphNode.getKey(),
+          1 + textNode.getIndexWithinParent(),
+          'element',
+        );
+        selection.insertText('123');
+        expect(textNode.isAttached()).toBe(true);
+        expect(textNode.getTextContent()).toBe('123');
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('Regression #7173', () => {
-  initializeUnitTest(testEnv => {
-    test('Can insertNodes of multiple blocks with a target of an initial empty block and the entire next block', () => {
-      testEnv.editor.update(
-        () => {
-          const emptyParagraph = $createParagraphNode();
-          const replacedParagraph = $createParagraphNode().append(
-            $createTextNode('replaced!'),
-          );
-          $getRoot().clear().append(emptyParagraph, replacedParagraph);
-          const selection = $selectAll();
-          const insertedNodes = [
-            $createParagraphNode().append($createTextNode('p1')),
-            $createParagraphNode().append($createTextNode('p2')),
-          ];
-          selection.insertNodes(insertedNodes);
-          const children = $getRoot().getChildren();
-          expect(children).toHaveLength(2);
-          expect(children).toEqual(insertedNodes);
-        },
-        {discrete: true},
-      );
-    });
+  test('Can insertNodes of multiple blocks with a target of an initial empty block and the entire next block', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const emptyParagraph = $createParagraphNode();
+        const replacedParagraph = $createParagraphNode().append(
+          $createTextNode('replaced!'),
+        );
+        $getRoot().clear().append(emptyParagraph, replacedParagraph);
+        const selection = $selectAll();
+        const insertedNodes = [
+          $createParagraphNode().append($createTextNode('p1')),
+          $createParagraphNode().append($createTextNode('p2')),
+        ];
+        selection.insertNodes(insertedNodes);
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(2);
+        expect(children).toEqual(insertedNodes);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('Regression #3181', () => {
-  initializeUnitTest(testEnv => {
-    test('Point.isBefore edge case with mixed TextNode & ElementNode and matching descendants', () => {
-      testEnv.editor.update(
-        () => {
-          const paragraph = $createParagraphNode();
-          const targetText = $createTextNode('target').setMode('token');
-          $getRoot()
-            .clear()
-            .append(
-              paragraph.append(
-                $createTextNode('a').setMode('token'),
-                $createTextNode('b').setMode('token'),
-                targetText,
-              ),
-            );
-          const selection = paragraph.select(2, 2);
-          selection.focus.set(targetText.getKey(), 1, 'text');
-          expect(selection).toMatchObject({
-            anchor: {key: paragraph.getKey(), offset: 2, type: 'element'},
-            focus: {key: targetText.getKey(), offset: 1, type: 'text'},
-          });
-          const caretRange = $caretRangeFromSelection(selection);
-          expect(
-            $comparePointCaretNext(
-              // These are no-op when isBefore is correct
-              $getCaretInDirection(caretRange.anchor, 'next'),
-              $getCaretInDirection(caretRange.focus, 'next'),
+  test('Point.isBefore edge case with mixed TextNode & ElementNode and matching descendants', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const targetText = $createTextNode('target').setMode('token');
+        $getRoot()
+          .clear()
+          .append(
+            paragraph.append(
+              $createTextNode('a').setMode('token'),
+              $createTextNode('b').setMode('token'),
+              targetText,
             ),
-          ).toBe(-1);
-          expect(selection.anchor.isBefore(selection.focus)).toBe(true);
-          expect(selection.focus.isBefore(selection.anchor)).toBe(false);
-        },
-        {discrete: true},
-      );
-    });
+          );
+        const selection = paragraph.select(2, 2);
+        selection.focus.set(targetText.getKey(), 1, 'text');
+        expect(selection).toMatchObject({
+          anchor: {key: paragraph.getKey(), offset: 2, type: 'element'},
+          focus: {key: targetText.getKey(), offset: 1, type: 'text'},
+        });
+        const caretRange = $caretRangeFromSelection(selection);
+        expect(
+          $comparePointCaretNext(
+            $getCaretInDirection(caretRange.anchor, 'next'),
+            $getCaretInDirection(caretRange.focus, 'next'),
+          ),
+        ).toBe(-1);
+        expect(selection.anchor.isBefore(selection.focus)).toBe(true);
+        expect(selection.focus.isBefore(selection.anchor)).toBe(false);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('Regression #8067', () => {
-  initializeUnitTest(testEnv => {
-    test('Formatting issue when replacing text with format', () => {
-      testEnv.editor.update(
-        () => {
-          const root = $getRoot();
-          const paragraph = $createParagraphNode();
-          const firstNode = $createTextNode('hello');
-          firstNode.toggleFormat('bold');
-          const lastNode = $createTextNode(' world!');
-          paragraph.append(firstNode, lastNode);
-          root.clear().append(paragraph);
-          const selection = $selectAll();
-          selection.insertText('hello');
-          const children = $assertNodeType(
-            paragraph.getChildren()[0],
-            $isTextNode,
-          );
-          expect(children.getTextContent()).toBe('hello');
-          expect(children.hasFormat('bold')).toBe(true);
-        },
-        {discrete: true},
-      );
-    });
+  test('Formatting issue when replacing text with format', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const firstNode = $createTextNode('hello');
+        firstNode.toggleFormat('bold');
+        const lastNode = $createTextNode(' world!');
+        paragraph.append(firstNode, lastNode);
+        root.clear().append(paragraph);
+        const selection = $selectAll();
+        selection.insertText('hello');
+        const children = $assertNodeType(
+          paragraph.getChildren()[0],
+          $isTextNode,
+        );
+        expect(children.getTextContent()).toBe('hello');
+        expect(children.hasFormat('bold')).toBe(true);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('RangeSelection.isBackward() caching (#5825)', () => {
-  initializeUnitTest(testEnv => {
-    test('caches the result and invalidates on Point mutations', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode();
-          const text = $createTextNode('hello');
-          paragraph.append(text);
-          root.append(paragraph);
+  test('caches the result and invalidates on Point mutations', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('hello');
+        paragraph.append(text);
+        root.append(paragraph);
 
-          const selection = text.select(0, 5);
-          expect(selection._cachedIsBackward).toBeNull();
+        const selection = text.select(0, 5);
+        expect(selection._cachedIsBackward).toBeNull();
 
-          // First call computes and caches.
-          expect(selection.isBackward()).toBe(false);
-          expect(selection._cachedIsBackward).toBe(false);
+        // First call computes and caches.
+        expect(selection.isBackward()).toBe(false);
+        expect(selection._cachedIsBackward).toBe(false);
 
-          // Hits the cache without recomputing.
-          expect(selection.isBackward()).toBe(false);
+        // Hits the cache without recomputing.
+        expect(selection.isBackward()).toBe(false);
 
-          // setTextNodeRange routes through anchor.set + focus.set,
-          // invalidating the cache.
-          selection.setTextNodeRange(text, 5, text, 0);
-          expect(selection._cachedIsBackward).toBeNull();
+        // setTextNodeRange routes through anchor.set + focus.set,
+        // invalidating the cache.
+        selection.setTextNodeRange(text, 5, text, 0);
+        expect(selection._cachedIsBackward).toBeNull();
 
-          // anchor=5, focus=0 → now backward, recomputed and re-cached.
-          expect(selection.isBackward()).toBe(true);
-          expect(selection._cachedIsBackward).toBe(true);
-        },
-        {discrete: true},
-      );
-    });
+        // anchor=5, focus=0 → now backward, recomputed and re-cached.
+        expect(selection.isBackward()).toBe(true);
+        expect(selection._cachedIsBackward).toBe(true);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('Regression #8098', () => {
-  initializeUnitTest(testEnv => {
-    test('Do not apply format and style when moving to different node', async () => {
-      const {editor} = testEnv;
-      let normalTextKey: string;
+  test('Do not apply format and style when moving to different node', async () => {
+    const container = document.createElement('div');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    onTestFinished(() => container.remove());
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.setRootElement(container);
+    let normalTextKey: string;
 
-      await editor.update(
-        () => {
-          const root = $getRoot();
-          const paragraph = $createParagraphNode();
-          const firstNode = $createTextNode('가다');
-          firstNode.toggleFormat('bold');
-          const lastNode = $createTextNode('라바');
-          paragraph.append(firstNode, lastNode);
-          root.clear().append(paragraph);
-          firstNode.select(0, 0).format = 1;
-          normalTextKey = lastNode.getKey();
-        },
-        {discrete: true},
-      );
+    await editor.update(
+      () => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const firstNode = $createTextNode('가다');
+        firstNode.toggleFormat('bold');
+        const lastNode = $createTextNode('라바');
+        paragraph.append(firstNode, lastNode);
+        root.clear().append(paragraph);
+        firstNode.select(0, 0).format = 1;
+        normalTextKey = lastNode.getKey();
+      },
+      {discrete: true},
+    );
 
-      const domSelection = getDOMSelection(editor._window ?? window);
-      const range = document.createRange();
-      range.setStart(editor.getElementByKey(normalTextKey!)!.firstChild!, 1);
-      range.collapse(true);
-      domSelection?.removeAllRanges();
-      domSelection?.addRange(range);
+    const domSelection = getDOMSelection(editor._window ?? window);
+    const range = document.createRange();
+    range.setStart(editor.getElementByKey(normalTextKey!)!.firstChild!, 1);
+    range.collapse(true);
+    domSelection?.removeAllRanges();
+    domSelection?.addRange(range);
 
-      await editor.update(
-        () => {
-          const selection = $internalCreateRangeSelection(
-            $getSelection(),
-            domSelection,
-            editor,
-            {type: 'selectionchange'} as Event,
-          );
-          expect(selection).not.toBeNull();
-          expect(selection!.format).toBe(0);
-          expect(selection!.style).toBe('');
-        },
-        {discrete: true},
-      );
-    });
+    await editor.update(
+      () => {
+        const selection = $internalCreateRangeSelection(
+          $getSelection(),
+          domSelection,
+          editor,
+          {type: 'selectionchange'} as Event,
+        );
+        expect(selection).not.toBeNull();
+        expect(selection!.format).toBe(0);
+        expect(selection!.style).toBe('');
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('$wrapInlineNodes regression', () => {
-  initializeUnitTest(testEnv => {
-    test('Wraps all inline nodes, preserving first linebreak if contain a block element', () => {
-      testEnv.editor.update(
-        () => {
-          $getRoot().clear();
-          const selection = $selectAll();
+  test('Wraps all inline nodes, preserving first linebreak if contain a block element', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        $getRoot().clear();
+        const selection = $selectAll();
 
-          const inlineNodes = [
+        const inlineNodes = [
+          $createLineBreakNode(),
+          $createTextNode('p1'),
+          $createTextNode('p1').setFormat('bold'),
+        ];
+        selection.insertNodes([...inlineNodes, $createParagraphNode()]);
+
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(2);
+        assert($isParagraphNode(children[0]));
+        expect(children[0].getChildren()).toEqual(inlineNodes);
+      },
+      {discrete: true},
+    );
+  });
+
+  test('Collapses a lone linebreak run into an empty paragraph at the end of a non-empty paragraph', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode().append($createTextNode('abc'));
+        root.append(paragraph);
+
+        paragraph
+          .selectEnd()
+          .insertNodes([
             $createLineBreakNode(),
-            $createTextNode('p1'),
-            $createTextNode('p1').setFormat('bold'),
-          ];
-          selection.insertNodes([...inlineNodes, $createParagraphNode()]);
+            $createParagraphNode().append($createTextNode('x')),
+          ]);
 
-          const children = $getRoot().getChildren();
-          expect(children).toHaveLength(2);
-          assert($isParagraphNode(children[0]));
-          expect(children[0].getChildren()).toEqual(inlineNodes);
-        },
-        {discrete: true},
-      );
-    });
+        const children = root.getChildren();
+        expect(children).toHaveLength(3);
+        assert($isParagraphNode(children[0]));
+        expect(children[0].getTextContent()).toBe('abc');
+        assert($isParagraphNode(children[1]));
+        expect(children[1].getChildrenSize()).toBe(0);
+        assert($isParagraphNode(children[2]));
+        expect(children[2].getTextContent()).toBe('x');
+      },
+      {discrete: true},
+    );
+  });
 
-    test('Collapses a lone linebreak run into an empty paragraph at the end of a non-empty paragraph', () => {
-      testEnv.editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode().append(
-            $createTextNode('abc'),
-          );
-          root.append(paragraph);
+  test('Preserves a linebreak followed by inline content when merging into a non-empty paragraph', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode().append($createTextNode('abc'));
+        root.append(paragraph);
 
-          paragraph
-            .selectEnd()
-            .insertNodes([
-              $createLineBreakNode(),
-              $createParagraphNode().append($createTextNode('x')),
-            ]);
+        paragraph
+          .selectEnd()
+          .insertNodes([
+            $createLineBreakNode(),
+            $createTextNode('tail'),
+            $createParagraphNode().append($createTextNode('x')),
+          ]);
 
-          const children = root.getChildren();
-          expect(children).toHaveLength(3);
-          assert($isParagraphNode(children[0]));
-          expect(children[0].getTextContent()).toBe('abc');
-          assert($isParagraphNode(children[1]));
-          expect(children[1].getChildrenSize()).toBe(0);
-          assert($isParagraphNode(children[2]));
-          expect(children[2].getTextContent()).toBe('x');
-        },
-        {discrete: true},
-      );
-    });
+        const children = root.getChildren();
+        expect(children).toHaveLength(2);
+        assert($isParagraphNode(children[0]));
+        expect(children[0].getChildren().map(child => child.getType())).toEqual(
+          ['text', 'linebreak', 'text'],
+        );
+        expect(children[0].getTextContent()).toBe('abc\ntail');
+        assert($isParagraphNode(children[1]));
+        expect(children[1].getTextContent()).toBe('x');
+      },
+      {discrete: true},
+    );
+  });
 
-    test('Preserves a linebreak followed by inline content when merging into a non-empty paragraph', () => {
-      testEnv.editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode().append(
-            $createTextNode('abc'),
-          );
-          root.append(paragraph);
+  test('Collapses a lone trailing linebreak after a block into an empty paragraph', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
 
-          paragraph
-            .selectEnd()
-            .insertNodes([
-              $createLineBreakNode(),
-              $createTextNode('tail'),
-              $createParagraphNode().append($createTextNode('x')),
-            ]);
+        paragraph
+          .selectEnd()
+          .insertNodes([
+            $createParagraphNode().append($createTextNode('x')),
+            $createLineBreakNode(),
+          ]);
 
-          const children = root.getChildren();
-          expect(children).toHaveLength(2);
-          assert($isParagraphNode(children[0]));
-          expect(
-            children[0].getChildren().map(child => child.getType()),
-          ).toEqual(['text', 'linebreak', 'text']);
-          expect(children[0].getTextContent()).toBe('abc\ntail');
-          assert($isParagraphNode(children[1]));
-          expect(children[1].getTextContent()).toBe('x');
-        },
-        {discrete: true},
-      );
-    });
-
-    test('Collapses a lone trailing linebreak after a block into an empty paragraph', () => {
-      testEnv.editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode();
-          root.append(paragraph);
-
-          paragraph
-            .selectEnd()
-            .insertNodes([
-              $createParagraphNode().append($createTextNode('x')),
-              $createLineBreakNode(),
-            ]);
-
-          const children = root.getChildren();
-          expect(children).toHaveLength(2);
-          assert($isParagraphNode(children[0]));
-          expect(children[0].getTextContent()).toBe('x');
-          assert($isParagraphNode(children[1]));
-          expect(children[1].getChildrenSize()).toBe(0);
-        },
-        {discrete: true},
-      );
-    });
+        const children = root.getChildren();
+        expect(children).toHaveLength(2);
+        assert($isParagraphNode(children[0]));
+        expect(children[0].getTextContent()).toBe('x');
+        assert($isParagraphNode(children[1]));
+        expect(children[1].getChildrenSize()).toBe(0);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('Regression #7551 - Selection boundary normalization for single-child inline elements', () => {
-  initializeUnitTest(testEnv => {
-    test('collapsed selection at end of single-child inline element stays inside', async () => {
-      const {editor} = testEnv;
-      let linkTextKey: string;
+  test('collapsed selection at end of single-child inline element stays inside', async () => {
+    const container = document.createElement('div');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    onTestFinished(() => container.remove());
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.setRootElement(container);
+    let linkTextKey: string;
 
-      await editor.update(() => {
-        const root = $getRoot();
-        root.clear();
-        const paragraph = $createParagraphNode();
-        const before = $createTextNode('hello ');
-        const linkText = $createTextNode('A');
-        const link = $createLinkNode('https://example.com', {}).append(
-          linkText,
-        );
-        const after = $createTextNode(' world');
-        paragraph.append(before, link, after);
-        root.append(paragraph);
-        linkTextKey = linkText.__key;
-      });
-
-      editor.update(
-        () => {
-          const domSelection = getDOMSelection(editor._window ?? window);
-          const linkTextDOM = editor.getElementByKey(linkTextKey)!.firstChild!;
-          const range = document.createRange();
-          range.setStart(linkTextDOM, 1);
-          range.collapse(true);
-          domSelection?.removeAllRanges();
-          domSelection?.addRange(range);
-
-          const selection = $internalCreateRangeSelection(
-            $getSelection(),
-            domSelection,
-            editor,
-            {type: 'selectionchange'} as Event,
-          );
-          invariant(selection !== null);
-          const {anchor} = selection;
-          const anchorNode = anchor.getNode();
-          invariant($isTextNode(anchorNode));
-          const parent = anchorNode.getParent();
-          invariant($isLinkNode(parent));
-          expect(anchor.offset).toBe(1);
-        },
-        {discrete: true},
-      );
+    await editor.update(() => {
+      const root = $getRoot();
+      root.clear();
+      const paragraph = $createParagraphNode();
+      const before = $createTextNode('hello ');
+      const linkText = $createTextNode('A');
+      const link = $createLinkNode('https://example.com', {}).append(linkText);
+      const after = $createTextNode(' world');
+      paragraph.append(before, link, after);
+      root.append(paragraph);
+      linkTextKey = linkText.__key;
     });
 
-    test('collapsed selection at end of multi-child inline element normalizes to next sibling', async () => {
-      const {editor} = testEnv;
-      let boldBKey: string;
+    editor.update(
+      () => {
+        const domSelection = getDOMSelection(editor._window ?? window);
+        const linkTextDOM = editor.getElementByKey(linkTextKey)!.firstChild!;
+        const range = document.createRange();
+        range.setStart(linkTextDOM, 1);
+        range.collapse(true);
+        domSelection?.removeAllRanges();
+        domSelection?.addRange(range);
 
-      await editor.update(() => {
-        const root = $getRoot();
-        root.clear();
-        const paragraph = $createParagraphNode();
-        const before = $createTextNode('hello ');
-        const boldB = $createTextNode('B').toggleFormat('bold');
-        const link = $createLinkNode('https://example.com', {}).append(
-          $createTextNode('A'),
-          boldB,
+        const selection = $internalCreateRangeSelection(
+          $getSelection(),
+          domSelection,
+          editor,
+          {type: 'selectionchange'} as Event,
         );
-        const after = $createTextNode(' world');
-        paragraph.append(before, link, after);
-        root.append(paragraph);
-        boldBKey = boldB.__key;
-      });
+        invariant(selection !== null);
+        const {anchor} = selection;
+        const anchorNode = anchor.getNode();
+        invariant($isTextNode(anchorNode));
+        const parent = anchorNode.getParent();
+        invariant($isLinkNode(parent));
+        expect(anchor.offset).toBe(1);
+      },
+      {discrete: true},
+    );
+  });
 
-      editor.update(
-        () => {
-          const domSelection = getDOMSelection(editor._window ?? window);
-          const boldBDOM = editor.getElementByKey(boldBKey)!.firstChild!;
-          const range = document.createRange();
-          range.setStart(boldBDOM, 1);
-          range.collapse(true);
-          domSelection?.removeAllRanges();
-          domSelection?.addRange(range);
+  test('collapsed selection at end of multi-child inline element normalizes to next sibling', async () => {
+    const container = document.createElement('div');
+    container.contentEditable = 'true';
+    document.body.appendChild(container);
+    onTestFinished(() => container.remove());
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.setRootElement(container);
+    let boldBKey: string;
 
-          const selection = $internalCreateRangeSelection(
-            $getSelection(),
-            domSelection,
-            editor,
-            {type: 'selectionchange'} as Event,
-          );
-          invariant(selection !== null);
-          const {anchor} = selection;
-          const anchorNode = anchor.getNode();
-          invariant($isTextNode(anchorNode));
-          expect(anchorNode.getTextContent()).toBe(' world');
-          expect(anchor.offset).toBe(0);
-        },
-        {discrete: true},
+    await editor.update(() => {
+      const root = $getRoot();
+      root.clear();
+      const paragraph = $createParagraphNode();
+      const before = $createTextNode('hello ');
+      const boldB = $createTextNode('B').toggleFormat('bold');
+      const link = $createLinkNode('https://example.com', {}).append(
+        $createTextNode('A'),
+        boldB,
       );
+      const after = $createTextNode(' world');
+      paragraph.append(before, link, after);
+      root.append(paragraph);
+      boldBKey = boldB.__key;
     });
+
+    editor.update(
+      () => {
+        const domSelection = getDOMSelection(editor._window ?? window);
+        const boldBDOM = editor.getElementByKey(boldBKey)!.firstChild!;
+        const range = document.createRange();
+        range.setStart(boldBDOM, 1);
+        range.collapse(true);
+        domSelection?.removeAllRanges();
+        domSelection?.addRange(range);
+
+        const selection = $internalCreateRangeSelection(
+          $getSelection(),
+          domSelection,
+          editor,
+          {type: 'selectionchange'} as Event,
+        );
+        invariant(selection !== null);
+        const {anchor} = selection;
+        const anchorNode = anchor.getNode();
+        invariant($isTextNode(anchorNode));
+        expect(anchorNode.getTextContent()).toBe(' world');
+        expect(anchor.offset).toBe(0);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('$formatText toggle direction (#6935)', () => {
-  initializeUnitTest(testEnv => {
-    test('uses selection.format (AND) instead of first node for toggle direction', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode();
-          const boldText = $createTextNode('bold');
-          boldText.setFormat(IS_BOLD);
-          const plainText = $createTextNode('plain');
-          paragraph.append(boldText, plainText);
-          root.append(paragraph);
+  test('uses selection.format (AND) instead of first node for toggle direction', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const boldText = $createTextNode('bold');
+        boldText.setFormat(IS_BOLD);
+        const plainText = $createTextNode('plain');
+        paragraph.append(boldText, plainText);
+        root.append(paragraph);
 
-          const selection = $selectAll();
-          expect(selection.hasFormat('bold')).toBe(false);
+        const selection = $selectAll();
+        expect(selection.hasFormat('bold')).toBe(false);
 
-          $formatText(selection, 'bold');
-          const children = paragraph.getChildren();
-          const first = $assertNodeType(children[0], $isTextNode);
-          const second = $assertNodeType(children[1], $isTextNode);
-          expect(first.hasFormat('bold')).toBe(true);
-          expect(second.hasFormat('bold')).toBe(true);
-        },
-        {discrete: true},
-      );
-    });
+        $formatText(selection, 'bold');
+        const children = paragraph.getChildren();
+        const first = $assertNodeType(children[0], $isTextNode);
+        const second = $assertNodeType(children[1], $isTextNode);
+        expect(first.hasFormat('bold')).toBe(true);
+        expect(second.hasFormat('bold')).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
 
-    test('toggling off works when all nodes share the format', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode();
-          const bold1 = $createTextNode('aaa');
-          bold1.setFormat(IS_BOLD);
-          const bold2 = $createTextNode('bbb');
-          bold2.setFormat(IS_BOLD);
-          paragraph.append(bold1, bold2);
-          root.append(paragraph);
+  test('toggling off works when all nodes share the format', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const bold1 = $createTextNode('aaa');
+        bold1.setFormat(IS_BOLD);
+        const bold2 = $createTextNode('bbb');
+        bold2.setFormat(IS_BOLD);
+        paragraph.append(bold1, bold2);
+        root.append(paragraph);
 
-          const selection = $selectAll();
-          // onSelectionChange computes this as AND of all text nodes;
-          // unit tests bypass the event handler so we set it manually.
-          selection.format = IS_BOLD;
-          expect(selection.hasFormat('bold')).toBe(true);
+        const selection = $selectAll();
+        // onSelectionChange computes this as AND of all text nodes;
+        // unit tests bypass the event handler so we set it manually.
+        selection.format = IS_BOLD;
+        expect(selection.hasFormat('bold')).toBe(true);
 
-          $formatText(selection, 'bold');
-          const children = paragraph.getChildren();
-          const first = $assertNodeType(children[0], $isTextNode);
-          const second = $assertNodeType(children[1], $isTextNode);
-          expect(first.hasFormat('bold')).toBe(false);
-          expect(second.hasFormat('bold')).toBe(false);
-        },
-        {discrete: true},
-      );
-    });
+        $formatText(selection, 'bold');
+        const children = paragraph.getChildren();
+        const first = $assertNodeType(children[0], $isTextNode);
+        const second = $assertNodeType(children[1], $isTextNode);
+        expect(first.hasFormat('bold')).toBe(false);
+        expect(second.hasFormat('bold')).toBe(false);
+      },
+      {discrete: true},
+    );
+  });
 
-    test('explicit alignWithFormat bypasses selection.format reference', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode();
-          const boldText = $createTextNode('bold');
-          boldText.setFormat(IS_BOLD);
-          const plainText = $createTextNode('plain');
-          paragraph.append(boldText, plainText);
-          root.append(paragraph);
+  test('explicit alignWithFormat bypasses selection.format reference', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const boldText = $createTextNode('bold');
+        boldText.setFormat(IS_BOLD);
+        const plainText = $createTextNode('plain');
+        paragraph.append(boldText, plainText);
+        root.append(paragraph);
 
-          const selection = $selectAll();
-          $formatText(selection, 'bold', IS_BOLD);
-          const children = paragraph.getChildren();
-          const first = $assertNodeType(children[0], $isTextNode);
-          const second = $assertNodeType(children[1], $isTextNode);
-          expect(first.hasFormat('bold')).toBe(true);
-          expect(second.hasFormat('bold')).toBe(true);
-        },
-        {discrete: true},
-      );
-    });
+        const selection = $selectAll();
+        $formatText(selection, 'bold', IS_BOLD);
+        const children = paragraph.getChildren();
+        const first = $assertNodeType(children[0], $isTextNode);
+        const second = $assertNodeType(children[1], $isTextNode);
+        expect(first.hasFormat('bold')).toBe(true);
+        expect(second.hasFormat('bold')).toBe(true);
+      },
+      {discrete: true},
+    );
   });
 });
 
 describe('$setTextFormat (#5518)', () => {
-  initializeUnitTest(testEnv => {
-    test('sets bold to true on mixed formatting', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode();
-          const boldText = $createTextNode('bold');
-          boldText.setFormat(IS_BOLD);
-          const plainText = $createTextNode('plain');
-          paragraph.append(boldText, plainText);
-          root.append(paragraph);
+  test('sets bold to true on mixed formatting', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const boldText = $createTextNode('bold');
+        boldText.setFormat(IS_BOLD);
+        const plainText = $createTextNode('plain');
+        paragraph.append(boldText, plainText);
+        root.append(paragraph);
 
-          const selection = $selectAll();
-          $setTextFormat(selection, {bold: true});
-          const children = paragraph.getChildren();
-          const first = $assertNodeType(children[0], $isTextNode);
-          const second = $assertNodeType(children[1], $isTextNode);
-          expect(first.hasFormat('bold')).toBe(true);
-          expect(second.hasFormat('bold')).toBe(true);
-        },
-        {discrete: true},
-      );
-    });
+        const selection = $selectAll();
+        $setTextFormat(selection, {bold: true});
+        const children = paragraph.getChildren();
+        const first = $assertNodeType(children[0], $isTextNode);
+        const second = $assertNodeType(children[1], $isTextNode);
+        expect(first.hasFormat('bold')).toBe(true);
+        expect(second.hasFormat('bold')).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
 
-    test('sets bold to false on all-bold text', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode();
-          const bold1 = $createTextNode('aaa');
-          bold1.setFormat(IS_BOLD);
-          const bold2 = $createTextNode('bbb');
-          bold2.setFormat(IS_BOLD);
-          paragraph.append(bold1, bold2);
-          root.append(paragraph);
+  test('sets bold to false on all-bold text', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const bold1 = $createTextNode('aaa');
+        bold1.setFormat(IS_BOLD);
+        const bold2 = $createTextNode('bbb');
+        bold2.setFormat(IS_BOLD);
+        paragraph.append(bold1, bold2);
+        root.append(paragraph);
 
-          const selection = $selectAll();
-          // $setTextFormat uses explicit alignWithFormat, so selection.format
-          // doesn't matter here — but we set it for realism.
-          selection.format = IS_BOLD;
-          $setTextFormat(selection, {bold: false});
-          const children = paragraph.getChildren();
-          const first = $assertNodeType(children[0], $isTextNode);
-          const second = $assertNodeType(children[1], $isTextNode);
-          expect(first.hasFormat('bold')).toBe(false);
-          expect(second.hasFormat('bold')).toBe(false);
-        },
-        {discrete: true},
-      );
-    });
+        const selection = $selectAll();
+        // $setTextFormat uses explicit alignWithFormat, so selection.format
+        // doesn't matter here — but we set it for realism.
+        selection.format = IS_BOLD;
+        $setTextFormat(selection, {bold: false});
+        const children = paragraph.getChildren();
+        const first = $assertNodeType(children[0], $isTextNode);
+        const second = $assertNodeType(children[1], $isTextNode);
+        expect(first.hasFormat('bold')).toBe(false);
+        expect(second.hasFormat('bold')).toBe(false);
+      },
+      {discrete: true},
+    );
+  });
 
-    test('sets multiple formats at once', () => {
-      const {editor} = testEnv;
-      editor.update(
-        () => {
-          const root = $getRoot();
-          root.clear();
-          const paragraph = $createParagraphNode();
-          const text = $createTextNode('hello');
-          paragraph.append(text);
-          root.append(paragraph);
+  test('sets multiple formats at once', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('hello');
+        paragraph.append(text);
+        root.append(paragraph);
 
-          const selection = $selectAll();
-          $setTextFormat(selection, {bold: true, italic: true});
-          const node = $assertNodeType(paragraph.getFirstChild(), $isTextNode);
-          expect(node.hasFormat('bold')).toBe(true);
-          expect(node.hasFormat('italic')).toBe(true);
-        },
-        {discrete: true},
-      );
-    });
+        const selection = $selectAll();
+        $setTextFormat(selection, {bold: true, italic: true});
+        const node = $assertNodeType(paragraph.getFirstChild(), $isTextNode);
+        expect(node.hasFormat('bold')).toBe(true);
+        expect(node.hasFormat('italic')).toBe(true);
+      },
+      {discrete: true},
+    );
   });
 });

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -42,11 +42,9 @@ import {
   $setCompositionKey,
   $setSelection,
   $setTextFormat,
-  createEditor,
   ElementNode,
   getDOMSelection,
   IS_BOLD,
-  type LexicalEditor,
   type LexicalNode,
   type ParagraphNode,
   type RangeSelection,
@@ -65,12 +63,10 @@ import {
 import {$internalCreateRangeSelection} from '../../LexicalSelection';
 import {
   $assertNodeType,
-  $assertRangeSelection,
   $createTestDecoratorNode,
   $createTestInlineElementNode,
   $createTestShadowRootNode,
   $isTestShadowRootNode,
-  invariant,
   TestDecoratorNode,
   TestInlineElementNode,
   TestShadowRootNode,
@@ -87,7 +83,7 @@ function mapLatest<T extends LexicalNode>(nodes: T[]): T[] {
 }
 
 describe('LexicalSelection tests', () => {
-  let editor: LexicalEditor;
+  let editor: LexicalEditorWithDispose;
   let container: HTMLDivElement;
 
   beforeEach(() => {
@@ -99,7 +95,7 @@ describe('LexicalSelection tests', () => {
   });
 
   afterEach(() => {
-    editor.setRootElement(null);
+    editor[Symbol.dispose]();
     container.remove();
   });
 
@@ -133,14 +129,16 @@ describe('LexicalSelection tests', () => {
         root.append(paragraph);
       });
 
-      const expectation =
-        mode === 'start-of-paragraph'
-          ? '<p dir="auto"><a href="https://"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">b</span></p>'
-          : mode === 'mid-paragraph'
-            ? '<p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">c</span></p>'
-            : '<p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a></p>';
+      const expectations = {
+        'end-of-paragraph':
+          '<p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a></p>',
+        'mid-paragraph':
+          '<p dir="auto"><span data-lexical-text="true">a</span><a href="https://"><span data-lexical-text="true">b</span></a><span data-lexical-text="true">c</span></p>',
+        'start-of-paragraph':
+          '<p dir="auto"><a href="https://"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">b</span></p>',
+      };
 
-      expect(container.innerHTML).toBe(expectation);
+      expect(container.innerHTML).toBe(expectations[mode]);
     };
 
     const $insertTextOrNodes = (
@@ -165,9 +163,9 @@ describe('LexicalSelection tests', () => {
         const insertText = async (method: 'insertText' | 'insertNodes') => {
           await editor.update(() => {
             const paragraph = $getRoot().getFirstChildOrThrow();
-            invariant($isParagraphNode(paragraph));
+            assert($isParagraphNode(paragraph));
             const linkNode = paragraph.getFirstChildOrThrow();
-            invariant($isLinkNode(linkNode));
+            assert($isLinkNode(linkNode));
 
             // Place the cursor at the start of the link node
             // For review: is there a way to select "outside" of the link
@@ -198,9 +196,9 @@ describe('LexicalSelection tests', () => {
         const insertText = async (method: 'insertText' | 'insertNodes') => {
           await editor.update(() => {
             const paragraph = $getRoot().getFirstChildOrThrow();
-            invariant($isParagraphNode(paragraph));
+            assert($isParagraphNode(paragraph));
             const textNode = paragraph.getFirstChildOrThrow();
-            invariant($isTextNode(textNode));
+            assert($isTextNode(textNode));
 
             // Place the cursor between the link and the first text node by
             // selecting the end of the text node
@@ -230,9 +228,9 @@ describe('LexicalSelection tests', () => {
         const insertText = async (method: 'insertText' | 'insertNodes') => {
           await editor.update(() => {
             const paragraph = $getRoot().getFirstChildOrThrow();
-            invariant($isParagraphNode(paragraph));
+            assert($isParagraphNode(paragraph));
             const textNode = paragraph.getFirstChildOrThrow();
-            invariant($isTextNode(textNode));
+            assert($isTextNode(textNode));
 
             // Place the cursor before the link element by selecting the end
             // of the text node
@@ -264,9 +262,9 @@ describe('LexicalSelection tests', () => {
         const insertText = async (method: 'insertText' | 'insertNodes') => {
           await editor.update(() => {
             const paragraph = $getRoot().getFirstChildOrThrow();
-            invariant($isParagraphNode(paragraph));
+            assert($isParagraphNode(paragraph));
             const textNode = paragraph.getLastChildOrThrow();
-            invariant($isTextNode(textNode));
+            assert($isTextNode(textNode));
 
             // Place the cursor between the link and the last text node by
             // selecting the start of the text node
@@ -296,9 +294,9 @@ describe('LexicalSelection tests', () => {
         const insertText = async (method: 'insertText' | 'insertNodes') => {
           await editor.update(() => {
             const paragraph = $getRoot().getFirstChildOrThrow();
-            invariant($isParagraphNode(paragraph));
+            assert($isParagraphNode(paragraph));
             const textNode = paragraph.getLastChildOrThrow();
-            invariant($isTextNode(textNode));
+            assert($isTextNode(textNode));
 
             // Place the cursor between the link and the last text node by
             // selecting the start of the text node
@@ -328,9 +326,9 @@ describe('LexicalSelection tests', () => {
         const insertText = async (method: 'insertText' | 'insertNodes') => {
           await editor.update(() => {
             const paragraph = $getRoot().getFirstChildOrThrow();
-            invariant($isParagraphNode(paragraph));
+            assert($isParagraphNode(paragraph));
             const linkNode = paragraph.getLastChildOrThrow();
-            invariant($isLinkNode(linkNode));
+            assert($isLinkNode(linkNode));
 
             // Place the cursor at the end of the link element
             // For review: not sure if there's a better way to select
@@ -361,20 +359,23 @@ describe('LexicalSelection tests', () => {
 
   describe('insertText()', () => {
     test('inserts into existing paragraph node when selection is on parent of paragraph', () => {
-      editor.update(() => {
-        const root = $getRoot();
-        const paragraph = $createParagraphNode();
-        root.clear().append(paragraph);
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const paragraph = $createParagraphNode();
+          root.clear().append(paragraph);
 
-        const selection = $createRangeSelection();
-        selection.anchor.set('root', 0, 'element');
-        selection.focus.set('root', 0, 'element');
-        $setSelection(selection);
+          const selection = $createRangeSelection();
+          selection.anchor.set('root', 0, 'element');
+          selection.focus.set('root', 0, 'element');
+          $setSelection(selection);
 
-        selection.insertText('text');
-        expect(root.getChildrenSize()).toBe(1);
-        expect(root.getTextContent()).toBe('text');
-      });
+          selection.insertText('text');
+          expect(root.getChildrenSize()).toBe(1);
+          expect(root.getTextContent()).toBe('text');
+        },
+        {discrete: true},
+      );
     });
   });
 
@@ -400,19 +401,20 @@ describe('LexicalSelection tests', () => {
       test('remove all text', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingText,
-              0,
-              trailingTokenText,
-              trailingTokenText.getTextContentSize(),
-            );
-            $setSelection(sel);
+            const sel = leadingText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingText,
+                0,
+                trailingTokenText,
+                trailingTokenText.getTextContentSize(),
+              );
             sel.removeText();
             expect(leadingText.isAttached()).toBe(false);
             expect(trailingTokenText.isAttached()).toBe(false);
             expect($getRoot().getAllTextNodes()).toHaveLength(0);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(paragraph.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -428,7 +430,8 @@ describe('LexicalSelection tests', () => {
             expect(leadingText.isAttached()).toBe(false);
             expect(trailingTokenText.isAttached()).toBe(true);
             expect($getRoot().getAllTextNodes()).toHaveLength(1);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(trailingTokenText.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -447,7 +450,8 @@ describe('LexicalSelection tests', () => {
             expect(leadingText.isAttached()).toBe(true);
             expect(trailingTokenText.isAttached()).toBe(false);
             expect($getRoot().getAllTextNodes()).toHaveLength(1);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(leadingText.getKey());
             expect(selection.anchor.offset).toBe(
@@ -460,21 +464,22 @@ describe('LexicalSelection tests', () => {
       test('remove initial TextNode and partial token TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingText,
-              0,
-              trailingTokenText,
-              'token '.length,
-            );
-            $setSelection(sel);
+            const sel = leadingText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingText,
+                0,
+                trailingTokenText,
+                'token '.length,
+              );
             sel.removeText();
             expect(leadingText.isAttached()).toBe(false);
             // expecting no node since it was token
             expect(trailingTokenText.isAttached()).toBe(false);
             const allTextNodes = $getRoot().getAllTextNodes();
             expect(allTextNodes).toHaveLength(0);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(paragraph.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -485,14 +490,14 @@ describe('LexicalSelection tests', () => {
       test('remove partial initial TextNode and partial token TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingText,
-              'lead'.length,
-              trailingTokenText,
-              'token '.length,
-            );
-            $setSelection(sel);
+            const sel = leadingText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingText,
+                'lead'.length,
+                trailingTokenText,
+                'token '.length,
+              );
             sel.removeText();
             expect(leadingText.isAttached()).toBe(true);
             expect(trailingTokenText.isAttached()).toBe(false);
@@ -501,7 +506,8 @@ describe('LexicalSelection tests', () => {
             expect(allTextNodes.map(node => node.getTextContent())).toEqual([
               'lead',
             ]);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(leadingText.getKey());
             expect(selection.anchor.offset).toBe('lead'.length);
@@ -531,19 +537,20 @@ describe('LexicalSelection tests', () => {
       test('remove all text', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingTokenText,
-              0,
-              trailingText,
-              trailingText.getTextContentSize(),
-            );
-            $setSelection(sel);
+            const sel = leadingTokenText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingTokenText,
+                0,
+                trailingText,
+                trailingText.getTextContentSize(),
+              );
             sel.removeText();
             expect(leadingTokenText.isAttached()).toBe(false);
             expect(trailingText.isAttached()).toBe(false);
             expect($getRoot().getAllTextNodes()).toHaveLength(0);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(paragraph.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -562,7 +569,8 @@ describe('LexicalSelection tests', () => {
             expect(leadingTokenText.isAttached()).toBe(true);
             expect(trailingText.isAttached()).toBe(false);
             expect($getRoot().getAllTextNodes()).toHaveLength(1);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(leadingTokenText.getKey());
             expect(selection.anchor.offset).toBe(
@@ -583,7 +591,8 @@ describe('LexicalSelection tests', () => {
             expect(leadingTokenText.isAttached()).toBe(false);
             expect(trailingText.isAttached()).toBe(true);
             expect($getRoot().getAllTextNodes()).toHaveLength(1);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(trailingText.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -594,21 +603,22 @@ describe('LexicalSelection tests', () => {
       test('remove partial leading token TextNode and trailing TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingTokenText,
-              'token '.length,
-              trailingText,
-              trailingText.getTextContentSize(),
-            );
-            $setSelection(sel);
+            const sel = leadingTokenText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingTokenText,
+                'token '.length,
+                trailingText,
+                trailingText.getTextContentSize(),
+              );
             sel.removeText();
             expect(trailingText.isAttached()).toBe(false);
             // expecting no node since it was token
             expect(leadingTokenText.isAttached()).toBe(false);
             const allTextNodes = $getRoot().getAllTextNodes();
             expect(allTextNodes).toHaveLength(0);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(paragraph.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -619,14 +629,14 @@ describe('LexicalSelection tests', () => {
       test('remove partial token TextNode and partial trailing TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingTokenText,
-              'token '.length,
-              trailingText,
-              'trail'.length,
-            );
-            $setSelection(sel);
+            const sel = leadingTokenText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingTokenText,
+                'token '.length,
+                trailingText,
+                'trail'.length,
+              );
             sel.removeText();
             expect(leadingTokenText.isAttached()).toBe(false);
             expect(trailingText.isAttached()).toBe(true);
@@ -635,7 +645,8 @@ describe('LexicalSelection tests', () => {
             expect(allTextNodes.map(node => node.getTextContent())).toEqual([
               'ing text',
             ]);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(trailingText.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -666,19 +677,20 @@ describe('LexicalSelection tests', () => {
       test('remove all text', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingText,
-              0,
-              trailingSegmentedText,
-              trailingSegmentedText.getTextContentSize(),
-            );
-            $setSelection(sel);
+            const sel = leadingText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingText,
+                0,
+                trailingSegmentedText,
+                trailingSegmentedText.getTextContentSize(),
+              );
             sel.removeText();
             expect(leadingText.isAttached()).toBe(false);
             expect(trailingSegmentedText.isAttached()).toBe(false);
             expect($getRoot().getAllTextNodes()).toHaveLength(0);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(paragraph.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -694,7 +706,8 @@ describe('LexicalSelection tests', () => {
             expect(leadingText.isAttached()).toBe(false);
             expect(trailingSegmentedText.isAttached()).toBe(true);
             expect($getRoot().getAllTextNodes()).toHaveLength(1);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(trailingSegmentedText.getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -713,7 +726,8 @@ describe('LexicalSelection tests', () => {
             expect(leadingText.isAttached()).toBe(true);
             expect(trailingSegmentedText.isAttached()).toBe(false);
             expect($getRoot().getAllTextNodes()).toHaveLength(1);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(leadingText.getKey());
             expect(selection.anchor.offset).toBe(
@@ -726,14 +740,14 @@ describe('LexicalSelection tests', () => {
       test('remove initial TextNode and partial segmented TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingText,
-              0,
-              trailingSegmentedText,
-              'segmented '.length,
-            );
-            $setSelection(sel);
+            const sel = leadingText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingText,
+                0,
+                trailingSegmentedText,
+                'segmented '.length,
+              );
             sel.removeText();
             expect(leadingText.isAttached()).toBe(false);
             // expecting a new node since it was segmented
@@ -742,7 +756,8 @@ describe('LexicalSelection tests', () => {
             expect(allTextNodes.map(node => node.getTextContent())).toEqual([
               'text',
             ]);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(allTextNodes[0].getKey());
             expect(selection.anchor.offset).toBe(0);
@@ -753,14 +768,14 @@ describe('LexicalSelection tests', () => {
       test('remove partial initial TextNode and partial segmented TextNode', () => {
         editor.update(
           () => {
-            const sel = $createRangeSelection();
-            sel.setTextNodeRange(
-              leadingText,
-              'lead'.length,
-              trailingSegmentedText,
-              'segmented '.length,
-            );
-            $setSelection(sel);
+            const sel = leadingText
+              .select(0, 0)
+              .setTextNodeRange(
+                leadingText,
+                'lead'.length,
+                trailingSegmentedText,
+                'segmented '.length,
+              );
             expect($getSelection()).toBe(sel);
             sel.removeText();
             expect($getSelection()).toBe(sel);
@@ -772,7 +787,8 @@ describe('LexicalSelection tests', () => {
               'lead',
               'text',
             ]);
-            const selection = $assertRangeSelection($getSelection());
+            const selection = $getSelection();
+            assert($isRangeSelection(selection));
             expect(selection.isCollapsed()).toBe(true);
             expect(selection.anchor.key).toBe(leadingText.getKey());
             expect(selection.anchor.offset).toBe('lead'.length);
@@ -875,12 +891,9 @@ describe('Regression tests for #6701', () => {
         return false;
       }
     }
-    const editor = createEditor({
-      nodes: [InlineElementNode],
-      onError: err => {
-        throw err;
-      },
-    });
+    using editor = buildEditorFromExtensions(
+      defineExtension({name: '@test/6701', nodes: [InlineElementNode]}),
+    );
     expect(() =>
       editor.update(
         () => {
@@ -922,7 +935,7 @@ describe('Regression tests for #8707', () => {
     editor.update(
       () => {
         const selection = $getSelection();
-        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
         selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
       },
       {discrete: true},
@@ -934,7 +947,7 @@ describe('Regression tests for #8707', () => {
       // not the outer document root.
       expect(root.getChildrenSize()).toBe(1);
       const shadow = root.getFirstChildOrThrow();
-      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      assert($isTestShadowRootNode(shadow), 'Expected shadow root');
       expect(shadow.getKey()).toBe(shadowKey);
       const children = shadow.getChildren();
       expect(children).toHaveLength(2);
@@ -961,7 +974,7 @@ describe('Regression tests for #8707', () => {
     editor.update(
       () => {
         const selection = $getSelection();
-        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
         selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
       },
       {discrete: true},
@@ -969,7 +982,7 @@ describe('Regression tests for #8707', () => {
 
     editor.read(() => {
       const shadow = $getRoot().getFirstChildOrThrow();
-      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      assert($isTestShadowRootNode(shadow), 'Expected shadow root');
       const children = shadow.getChildren();
       expect(children).toHaveLength(2);
       expect(children.every($isDecoratorNode)).toBe(true);
@@ -992,7 +1005,7 @@ describe('Regression tests for #8707', () => {
     editor.update(
       () => {
         const selection = $getSelection();
-        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
         selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
       },
       {discrete: true},
@@ -1000,7 +1013,7 @@ describe('Regression tests for #8707', () => {
 
     editor.read(() => {
       const shadow = $getRoot().getFirstChildOrThrow();
-      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      assert($isTestShadowRootNode(shadow), 'Expected shadow root');
       const children = shadow.getChildren();
       expect(children).toHaveLength(1);
       assert($isDecoratorNode(children[0]));
@@ -1022,7 +1035,7 @@ describe('Regression tests for #8707', () => {
     editor.update(
       () => {
         const selection = $getSelection();
-        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
         selection.insertNodes([
           $createParagraphNode().append($createTextNode('inserted')),
         ]);
@@ -1032,7 +1045,7 @@ describe('Regression tests for #8707', () => {
 
     editor.read(() => {
       const shadow = $getRoot().getFirstChildOrThrow();
-      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      assert($isTestShadowRootNode(shadow), 'Expected shadow root');
       const children = shadow.getChildren();
       expect(children).toHaveLength(2);
       assert($isDecoratorNode(children[0]));
@@ -1056,9 +1069,9 @@ describe('Regression tests for #8707', () => {
     editor.update(
       () => {
         const selection = $getSelection();
-        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
         const paragraph = selection.insertParagraph();
-        invariant(paragraph !== null, 'Expected a paragraph to be inserted');
+        assert(paragraph !== null, 'Expected a paragraph to be inserted');
         expect(paragraph.getParent()!.is($getRoot().getFirstChild())).toBe(
           true,
         );
@@ -1070,7 +1083,7 @@ describe('Regression tests for #8707', () => {
       const root = $getRoot();
       expect(root.getChildrenSize()).toBe(1);
       const shadow = root.getFirstChildOrThrow();
-      invariant($isTestShadowRootNode(shadow), 'Expected shadow root');
+      assert($isTestShadowRootNode(shadow), 'Expected shadow root');
       expect(shadow.getChildrenSize()).toBe(2);
       assert($isParagraphNode(shadow.getLastChild()));
     });
@@ -1092,7 +1105,7 @@ describe('Regression tests for #8707', () => {
     editor.update(
       () => {
         const selection = $getSelection();
-        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
         selection.insertNodes([$createTestDecoratorNode().setIsInline(false)]);
       },
       {discrete: true},
@@ -1109,7 +1122,7 @@ describe('Regression tests for #8707', () => {
   });
 });
 
-describe('getNodes()', () => {
+describe('getNodes() and extract()', () => {
   let editor: LexicalEditorWithDispose;
   let paragraphNode: ParagraphNode;
   let paragraphText: TextNode;
@@ -1150,22 +1163,220 @@ describe('getNodes()', () => {
   afterEach(() => {
     editor[Symbol.dispose]();
   });
-  describe('$selectAll()', () => {
-    test('with test document', () => {
+  describe('getNodes()', () => {
+    describe('$selectAll()', () => {
+      test('with test document', () => {
+        editor.update(
+          () => {
+            const selection = $selectAll();
+            // Normalized to the text nodes
+            expect(selection).toMatchObject({
+              anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
+              focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
+            });
+            expect(selection.getNodes()).toEqual([
+              paragraphText,
+              linkNode,
+              linkText,
+              // The parent paragraphNode comes after its children because the
+              // selection started inside of it at paragraphText
+              paragraphNode,
+              listNode,
+              listItem1,
+              listItemText1,
+              listItem2,
+              listItemText2,
+              emptyParagraph,
+            ]);
+          },
+          {discrete: true},
+        );
+      });
+      test('with leading inline decorator', () => {
+        editor.update(
+          () => {
+            const inlineDecoratorLeading = $createTestDecoratorNode();
+            paragraphNode.splice(0, 0, [inlineDecoratorLeading]);
+            const selection = $selectAll();
+            // Normalized to the text nodes
+            expect(selection).toMatchObject({
+              anchor: {key: paragraphNode.getKey(), offset: 0, type: 'element'},
+              focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
+            });
+            expect(selection.getNodes()).toEqual(
+              [
+                inlineDecoratorLeading,
+                paragraphText,
+                linkNode,
+                linkText,
+                // The parent paragraphNode comes after its children because the
+                // selection started inside of it at paragraphText
+                paragraphNode,
+                listNode,
+                listItem1,
+                listItemText1,
+                listItem2,
+                listItemText2,
+                emptyParagraph,
+              ].map(node => node.getLatest()),
+            );
+          },
+          {discrete: true},
+        );
+      });
+      test('with trailing inline decorator', () => {
+        editor.update(
+          () => {
+            const inlineDecoratorTrailing = $createTestDecoratorNode();
+            const noLongerEmptyParagraph = emptyParagraph;
+            noLongerEmptyParagraph.splice(0, 0, [inlineDecoratorTrailing]);
+            const selection = $selectAll();
+            // Normalized to the text nodes
+            expect(selection).toMatchObject({
+              anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
+              focus: {key: emptyParagraph.getKey(), offset: 1, type: 'element'},
+            });
+            expect(selection.getNodes()).toEqual(
+              [
+                paragraphText,
+                linkNode,
+                linkText,
+                // The parent paragraphNode comes after its children because the
+                // selection started inside of it at paragraphText
+                paragraphNode,
+                listNode,
+                listItem1,
+                listItemText1,
+                listItem2,
+                listItemText2,
+                noLongerEmptyParagraph,
+                inlineDecoratorTrailing,
+              ].map(node => node.getLatest()),
+            );
+          },
+          {discrete: true},
+        );
+      });
+      test('with leading empty inline element', () => {
+        editor.update(
+          () => {
+            const inlineElementLeading = $createTestInlineElementNode();
+            paragraphNode.splice(0, 0, [inlineElementLeading]);
+            const selection = $selectAll();
+            // Normalized to the text nodes
+            expect(selection).toMatchObject({
+              anchor: {
+                key: inlineElementLeading.getKey(),
+                offset: 0,
+                type: 'element',
+              },
+              focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
+            });
+            expect(selection.getNodes()).toEqual(
+              [
+                inlineElementLeading,
+                paragraphText,
+                linkNode,
+                linkText,
+                // The parent paragraphNode comes after its children because the
+                // selection started inside of it at paragraphText
+                paragraphNode,
+                listNode,
+                listItem1,
+                listItemText1,
+                listItem2,
+                listItemText2,
+                emptyParagraph,
+              ].map(node => node.getLatest()),
+            );
+          },
+          {discrete: true},
+        );
+      });
+      test('with trailing empty inline element', () => {
+        editor.update(
+          () => {
+            const inlineElementTrailing = $createTestInlineElementNode();
+            const noLongerEmptyParagraph = emptyParagraph;
+            noLongerEmptyParagraph.splice(0, 0, [inlineElementTrailing]);
+            const selection = $selectAll();
+            // Normalized to the text nodes
+            expect(selection).toMatchObject({
+              anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
+              focus: {
+                key: inlineElementTrailing.getKey(),
+                offset: 0,
+                type: 'element',
+              },
+            });
+            expect(selection.getNodes()).toEqual(
+              [
+                paragraphText,
+                linkNode,
+                linkText,
+                // The parent paragraphNode comes after its children because the
+                // selection started inside of it at paragraphText
+                paragraphNode,
+                listNode,
+                listItem1,
+                listItemText1,
+                listItem2,
+                listItemText2,
+                noLongerEmptyParagraph,
+                inlineElementTrailing,
+              ].map(node => node.getLatest()),
+            );
+          },
+          {discrete: true},
+        );
+      });
+      test('after removing empty paragraph', () => {
+        editor.update(
+          () => {
+            emptyParagraph.remove();
+            const selection = $selectAll();
+            // Normalized to the text nodes
+            expect(selection).toMatchObject({
+              anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
+              focus: {
+                key: listItemText2.getKey(),
+                offset: listItemText2.getTextContentSize(),
+                type: 'text',
+              },
+            });
+            expect(selection.getNodes()).toEqual(
+              [
+                paragraphText,
+                linkNode,
+                linkText,
+                // The parent paragraphNode comes after its children because the
+                // selection started inside of it at paragraphText
+                paragraphNode,
+                listNode,
+                listItem1,
+                listItemText1,
+                listItem2,
+                listItemText2,
+              ].map(n => n.getLatest()),
+            );
+          },
+          {discrete: true},
+        );
+      });
+    });
+    test('Manual select all without normalization', () => {
       editor.update(
         () => {
-          const selection = $selectAll();
-          // Normalized to the text nodes
-          expect(selection).toMatchObject({
-            anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-            focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
-          });
+          const selection = $createRangeSelection();
+          selection.anchor.set('root', 0, 'element');
+          selection.focus.set('root', $getRoot().getChildrenSize(), 'element');
           expect(selection.getNodes()).toEqual([
             paragraphText,
             linkNode,
             linkText,
-            // The parent paragraphNode comes after its children because the
-            // selection started inside of it at paragraphText
+            // The parent paragraphNode comes later because there is
+            // an implicit normalization in the beginning of getNodes
+            // to work around… something? See the getDescendantByIndex usage.
             paragraphNode,
             listNode,
             listItem1,
@@ -1178,603 +1389,368 @@ describe('getNodes()', () => {
         {discrete: true},
       );
     });
-    test('with leading inline decorator', () => {
+    test('Manual select all from first text to last empty paragraph', () => {
       editor.update(
         () => {
-          const inlineDecoratorLeading = $createTestDecoratorNode();
-          paragraphNode.splice(0, 0, [inlineDecoratorLeading]);
-          const selection = $selectAll();
-          // Normalized to the text nodes
-          expect(selection).toMatchObject({
-            anchor: {key: paragraphNode.getKey(), offset: 0, type: 'element'},
-            focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
-          });
-          expect(selection.getNodes()).toEqual(
-            [
-              inlineDecoratorLeading,
-              paragraphText,
-              linkNode,
-              linkText,
-              // The parent paragraphNode comes after its children because the
-              // selection started inside of it at paragraphText
-              paragraphNode,
-              listNode,
-              listItem1,
-              listItemText1,
-              listItem2,
-              listItemText2,
-              emptyParagraph,
-            ].map(node => node.getLatest()),
-          );
-        },
-        {discrete: true},
-      );
-    });
-    test('with trailing inline decorator', () => {
-      editor.update(
-        () => {
-          const inlineDecoratorTrailing = $createTestDecoratorNode();
-          const noLongerEmptyParagraph = emptyParagraph;
-          noLongerEmptyParagraph.splice(0, 0, [inlineDecoratorTrailing]);
-          const selection = $selectAll();
-          // Normalized to the text nodes
-          expect(selection).toMatchObject({
-            anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-            focus: {key: emptyParagraph.getKey(), offset: 1, type: 'element'},
-          });
-          expect(selection.getNodes()).toEqual(
-            [
-              paragraphText,
-              linkNode,
-              linkText,
-              // The parent paragraphNode comes after its children because the
-              // selection started inside of it at paragraphText
-              paragraphNode,
-              listNode,
-              listItem1,
-              listItemText1,
-              listItem2,
-              listItemText2,
-              noLongerEmptyParagraph,
-              inlineDecoratorTrailing,
-            ].map(node => node.getLatest()),
-          );
-        },
-        {discrete: true},
-      );
-    });
-    test('with leading empty inline element', () => {
-      editor.update(
-        () => {
-          const inlineElementLeading = $createTestInlineElementNode();
-          paragraphNode.splice(0, 0, [inlineElementLeading]);
-          const selection = $selectAll();
-          // Normalized to the text nodes
-          expect(selection).toMatchObject({
-            anchor: {
-              key: inlineElementLeading.getKey(),
-              offset: 0,
-              type: 'element',
-            },
-            focus: {key: emptyParagraph.getKey(), offset: 0, type: 'element'},
-          });
-          expect(selection.getNodes()).toEqual(
-            [
-              inlineElementLeading,
-              paragraphText,
-              linkNode,
-              linkText,
-              // The parent paragraphNode comes after its children because the
-              // selection started inside of it at paragraphText
-              paragraphNode,
-              listNode,
-              listItem1,
-              listItemText1,
-              listItem2,
-              listItemText2,
-              emptyParagraph,
-            ].map(node => node.getLatest()),
-          );
-        },
-        {discrete: true},
-      );
-    });
-    test('with trailing empty inline element', () => {
-      editor.update(
-        () => {
-          const inlineElementTrailing = $createTestInlineElementNode();
-          const noLongerEmptyParagraph = emptyParagraph;
-          noLongerEmptyParagraph.splice(0, 0, [inlineElementTrailing]);
-          const selection = $selectAll();
-          // Normalized to the text nodes
-          expect(selection).toMatchObject({
-            anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-            focus: {
-              key: inlineElementTrailing.getKey(),
-              offset: 0,
-              type: 'element',
-            },
-          });
-          expect(selection.getNodes()).toEqual(
-            [
-              paragraphText,
-              linkNode,
-              linkText,
-              // The parent paragraphNode comes after its children because the
-              // selection started inside of it at paragraphText
-              paragraphNode,
-              listNode,
-              listItem1,
-              listItemText1,
-              listItem2,
-              listItemText2,
-              noLongerEmptyParagraph,
-              inlineElementTrailing,
-            ].map(node => node.getLatest()),
-          );
-        },
-        {discrete: true},
-      );
-    });
-    test('after removing empty paragraph', () => {
-      editor.update(
-        () => {
-          emptyParagraph.remove();
-          const selection = $selectAll();
-          // Normalized to the text nodes
-          expect(selection).toMatchObject({
-            anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-            focus: {
-              key: listItemText2.getKey(),
-              offset: listItemText2.getTextContentSize(),
-              type: 'text',
-            },
-          });
-          expect(selection.getNodes()).toEqual(
-            [
-              paragraphText,
-              linkNode,
-              linkText,
-              // The parent paragraphNode comes after its children because the
-              // selection started inside of it at paragraphText
-              paragraphNode,
-              listNode,
-              listItem1,
-              listItemText1,
-              listItem2,
-              listItemText2,
-            ].map(n => n.getLatest()),
-          );
-        },
-        {discrete: true},
-      );
-    });
-  });
-  test('Manual select all without normalization', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.anchor.set('root', 0, 'element');
-        selection.focus.set('root', $getRoot().getChildrenSize(), 'element');
-        expect(selection.getNodes()).toEqual([
-          paragraphText,
-          linkNode,
-          linkText,
-          // The parent paragraphNode comes later because there is
-          // an implicit normalization in the beginning of getNodes
-          // to work around… something? See the getDescendantByIndex usage.
-          paragraphNode,
-          listNode,
-          listItem1,
-          listItemText1,
-          listItem2,
-          listItemText2,
-          emptyParagraph,
-        ]);
-      },
-      {discrete: true},
-    );
-  });
-  test('Manual select all from first text to last empty paragraph', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.anchor.set(paragraphText.getKey(), 0, 'text');
-        selection.focus.set(emptyParagraph.getKey(), 0, 'element');
-        expect(selection.getNodes()).toEqual([
-          paragraphText,
-          linkNode,
-          linkText,
-          // The parent paragraphNode comes later because there is
-          // an implicit normalization in the beginning of getNodes
-          // to work around… something? See the getDescendantByIndex usage.
-          paragraphNode,
-          listNode,
-          listItem1,
-          listItemText1,
-          listItem2,
-          listItemText2,
-          emptyParagraph,
-        ]);
-      },
-      {discrete: true},
-    );
-  });
-  test('Manual select with focus collapsed between inline decorators', () => {
-    editor.update(
-      () => {
-        const inlineDecoratorLeading = $createTestDecoratorNode();
-        const inlineDecoratorTrailing = $createTestDecoratorNode();
-        const noLongerEmptyParagraph = emptyParagraph;
-        noLongerEmptyParagraph.splice(0, 0, [
-          inlineDecoratorLeading,
-          inlineDecoratorTrailing,
-        ]);
-        const selection = $createRangeSelection();
-        // Collapsed between decorators
-        selection.anchor.set(noLongerEmptyParagraph.getKey(), 1, 'element');
-        selection.focus.set(noLongerEmptyParagraph.getKey(), 1, 'element');
-        expect(selection.isCollapsed()).toBe(true);
-        expect(selection).toMatchObject({
-          anchor: {
-            key: noLongerEmptyParagraph.getKey(),
-            offset: 1,
-            type: 'element',
-          },
-          focus: {
-            key: noLongerEmptyParagraph.getKey(),
-            offset: 1,
-            type: 'element',
-          },
-        });
-        expect(selection.getNodes()).toEqual(
-          // The bias is towards the right
-          [inlineDecoratorTrailing].map(node => node.getLatest()),
-        );
-      },
-      {discrete: true},
-    );
-  });
-  test('Manual select with focus collapsed after inline decorator', () => {
-    editor.update(
-      () => {
-        const inlineDecoratorLeading = $createTestDecoratorNode();
-        const inlineDecoratorTrailing = $createTestDecoratorNode();
-        const noLongerEmptyParagraph = emptyParagraph;
-        noLongerEmptyParagraph.splice(0, 0, [
-          inlineDecoratorLeading,
-          inlineDecoratorTrailing,
-        ]);
-        const selection = $createRangeSelection();
-        // Collapsed after decorators
-        selection.anchor.set(noLongerEmptyParagraph.getKey(), 2, 'element');
-        selection.focus.set(noLongerEmptyParagraph.getKey(), 2, 'element');
-        expect(selection.isCollapsed()).toBe(true);
-        expect(selection).toMatchObject({
-          anchor: {
-            key: noLongerEmptyParagraph.getKey(),
-            offset: 2,
-            type: 'element',
-          },
-          focus: {
-            key: noLongerEmptyParagraph.getKey(),
-            offset: 2,
-            type: 'element',
-          },
-        });
-        expect(selection.getNodes()).toEqual(
-          // The bias is towards the last descendant since no
-          // nodes exist to the right
-          [inlineDecoratorTrailing].map(node => node.getLatest()),
-        );
-      },
-      {discrete: true},
-    );
-  });
-  test('Manual select with focus between inline decorators', () => {
-    editor.update(
-      () => {
-        const inlineDecoratorLeading = $createTestDecoratorNode();
-        const inlineDecoratorTrailing = $createTestDecoratorNode();
-        const noLongerEmptyParagraph = emptyParagraph;
-        noLongerEmptyParagraph.splice(0, 0, [
-          inlineDecoratorLeading,
-          inlineDecoratorTrailing,
-        ]);
-        const selection = $createRangeSelection();
-        selection.anchor.set(paragraphText.getKey(), 0, 'text');
-        selection.focus.set(noLongerEmptyParagraph.getKey(), 1, 'element');
-        expect(selection).toMatchObject({
-          anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
-          focus: {
-            key: noLongerEmptyParagraph.getKey(),
-            offset: 1,
-            type: 'element',
-          },
-        });
-        expect(selection.getNodes()).toEqual(
-          [
+          const selection = $createRangeSelection();
+          selection.anchor.set(paragraphText.getKey(), 0, 'text');
+          selection.focus.set(emptyParagraph.getKey(), 0, 'element');
+          expect(selection.getNodes()).toEqual([
             paragraphText,
             linkNode,
             linkText,
-            // The parent paragraphNode comes after its children because the
-            // selection started inside of it at paragraphText
+            // The parent paragraphNode comes later because there is
+            // an implicit normalization in the beginning of getNodes
+            // to work around… something? See the getDescendantByIndex usage.
             paragraphNode,
             listNode,
             listItem1,
             listItemText1,
             listItem2,
             listItemText2,
-            noLongerEmptyParagraph,
+            emptyParagraph,
+          ]);
+        },
+        {discrete: true},
+      );
+    });
+    test('Manual select with focus collapsed between inline decorators', () => {
+      editor.update(
+        () => {
+          const inlineDecoratorLeading = $createTestDecoratorNode();
+          const inlineDecoratorTrailing = $createTestDecoratorNode();
+          const noLongerEmptyParagraph = emptyParagraph;
+          noLongerEmptyParagraph.splice(0, 0, [
             inlineDecoratorLeading,
-          ].map(node => node.getLatest()),
-        );
-      },
-      {discrete: true},
-    );
-  });
-  test('select only the paragraph (not normalized)', () => {
-    editor.update(
-      () => {
-        const selection = paragraphNode.select(
-          0,
-          paragraphNode.getChildrenSize(),
-        );
-        expect(selection).toMatchObject({
-          anchor: {key: paragraphNode.getKey(), offset: 0, type: 'element'},
-          focus: {
-            key: paragraphNode.getKey(),
-            offset: paragraphNode.getChildrenSize(),
-            type: 'element',
-          },
-        });
-        // The selection doesn't visit outside of the paragraph
-        expect(selection.getNodes()).toEqual([
-          paragraphText,
-          linkNode,
-          linkText,
-        ]);
-      },
-      {discrete: true},
-    );
-  });
-  test('select around the paragraph (not normalized)', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.anchor.set(
-          'root',
-          paragraphNode.getIndexWithinParent(),
-          'element',
-        );
-        selection.focus.set(
-          'root',
-          paragraphNode.getIndexWithinParent() + 1,
-          'element',
-        );
-        expect(selection).toMatchObject({
-          anchor: {key: 'root', offset: 0, type: 'element'},
-          focus: {key: 'root', offset: 1, type: 'element'},
-        });
-        // The selection shouldn't visit outside of the paragraph
-        expect(selection.getNodes()).toEqual([
-          paragraphText,
-          linkNode,
-          linkText,
-          paragraphNode,
-        ]);
-      },
-      {discrete: true},
-    );
-  });
-  test('selection collapsed inside an empty element', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.anchor.set(emptyParagraph.getKey(), 0, 'element');
-        selection.focus.set(emptyParagraph.getKey(), 0, 'element');
-        // The selection should include the node it is collapsed inside
-        expect(selection.getNodes()).toEqual([emptyParagraph]);
-      },
-      {discrete: true},
-    );
-  });
-  test('select an empty ListItemNode (collapsed)', () => {
-    editor.update(
-      () => {
-        const emptyListItem = $createListItemNode();
-        listItem2.insertBefore(emptyListItem);
-        const selection = $createRangeSelection();
-        selection.anchor.set(emptyListItem.getKey(), 0, 'element');
-        selection.focus.set(emptyListItem.getKey(), 0, 'element');
-        expect(selection).toMatchObject({
-          anchor: {key: emptyListItem.getKey(), offset: 0, type: 'element'},
-          focus: {key: emptyListItem.getKey(), offset: 0, type: 'element'},
-        });
-        expect(selection.getNodes()).toEqual([emptyListItem]);
-      },
-      {discrete: true},
-    );
-  });
-});
-
-describe('extract()', () => {
-  let editor: LexicalEditorWithDispose;
-  let paragraphNode: ParagraphNode;
-  let paragraphText: TextNode;
-  let linkNode: LinkNode;
-  let linkText: TextNode;
-  let listNode: ListNode;
-  let listItemText1: TextNode;
-  let listItemText2: TextNode;
-  let listItem1: ListItemNode;
-  let listItem2: ListItemNode;
-  let emptyParagraph: ParagraphNode;
-
-  beforeEach(() => {
-    editor = buildEditorFromExtensions(selectionTestExtension);
-    editor.update(() => {
-      paragraphText = $createTextNode('paragraph text');
-      linkText = $createTextNode('link text');
-      linkNode = $createLinkNode();
-      paragraphNode = $createParagraphNode();
-      listItemText1 = $createTextNode('item 1');
-      listItemText2 = $createTextNode('item 2');
-      listItem1 = $createListItemNode();
-      listItem2 = $createListItemNode();
-      listNode = $createListNode('bullet');
-      emptyParagraph = $createParagraphNode();
-      $getRoot()
-        .clear()
-        .append(
-          paragraphNode.append(paragraphText, linkNode.append(linkText)),
-          listNode.append(
-            listItem1.append(listItemText1),
-            listItem2.append(listItemText2),
-          ),
-          emptyParagraph,
-        );
+            inlineDecoratorTrailing,
+          ]);
+          const selection = $createRangeSelection();
+          // Collapsed between decorators
+          selection.anchor.set(noLongerEmptyParagraph.getKey(), 1, 'element');
+          selection.focus.set(noLongerEmptyParagraph.getKey(), 1, 'element');
+          expect(selection.isCollapsed()).toBe(true);
+          expect(selection).toMatchObject({
+            anchor: {
+              key: noLongerEmptyParagraph.getKey(),
+              offset: 1,
+              type: 'element',
+            },
+            focus: {
+              key: noLongerEmptyParagraph.getKey(),
+              offset: 1,
+              type: 'element',
+            },
+          });
+          expect(selection.getNodes()).toEqual(
+            // The bias is towards the right
+            [inlineDecoratorTrailing].map(node => node.getLatest()),
+          );
+        },
+        {discrete: true},
+      );
+    });
+    test('Manual select with focus collapsed after inline decorator', () => {
+      editor.update(
+        () => {
+          const inlineDecoratorLeading = $createTestDecoratorNode();
+          const inlineDecoratorTrailing = $createTestDecoratorNode();
+          const noLongerEmptyParagraph = emptyParagraph;
+          noLongerEmptyParagraph.splice(0, 0, [
+            inlineDecoratorLeading,
+            inlineDecoratorTrailing,
+          ]);
+          const selection = $createRangeSelection();
+          // Collapsed after decorators
+          selection.anchor.set(noLongerEmptyParagraph.getKey(), 2, 'element');
+          selection.focus.set(noLongerEmptyParagraph.getKey(), 2, 'element');
+          expect(selection.isCollapsed()).toBe(true);
+          expect(selection).toMatchObject({
+            anchor: {
+              key: noLongerEmptyParagraph.getKey(),
+              offset: 2,
+              type: 'element',
+            },
+            focus: {
+              key: noLongerEmptyParagraph.getKey(),
+              offset: 2,
+              type: 'element',
+            },
+          });
+          expect(selection.getNodes()).toEqual(
+            // The bias is towards the last descendant since no
+            // nodes exist to the right
+            [inlineDecoratorTrailing].map(node => node.getLatest()),
+          );
+        },
+        {discrete: true},
+      );
+    });
+    test('Manual select with focus between inline decorators', () => {
+      editor.update(
+        () => {
+          const inlineDecoratorLeading = $createTestDecoratorNode();
+          const inlineDecoratorTrailing = $createTestDecoratorNode();
+          const noLongerEmptyParagraph = emptyParagraph;
+          noLongerEmptyParagraph.splice(0, 0, [
+            inlineDecoratorLeading,
+            inlineDecoratorTrailing,
+          ]);
+          const selection = $createRangeSelection();
+          selection.anchor.set(paragraphText.getKey(), 0, 'text');
+          selection.focus.set(noLongerEmptyParagraph.getKey(), 1, 'element');
+          expect(selection).toMatchObject({
+            anchor: {key: paragraphText.getKey(), offset: 0, type: 'text'},
+            focus: {
+              key: noLongerEmptyParagraph.getKey(),
+              offset: 1,
+              type: 'element',
+            },
+          });
+          expect(selection.getNodes()).toEqual(
+            [
+              paragraphText,
+              linkNode,
+              linkText,
+              // The parent paragraphNode comes after its children because the
+              // selection started inside of it at paragraphText
+              paragraphNode,
+              listNode,
+              listItem1,
+              listItemText1,
+              listItem2,
+              listItemText2,
+              noLongerEmptyParagraph,
+              inlineDecoratorLeading,
+            ].map(node => node.getLatest()),
+          );
+        },
+        {discrete: true},
+      );
+    });
+    test('select only the paragraph (not normalized)', () => {
+      editor.update(
+        () => {
+          const selection = paragraphNode.select(
+            0,
+            paragraphNode.getChildrenSize(),
+          );
+          expect(selection).toMatchObject({
+            anchor: {key: paragraphNode.getKey(), offset: 0, type: 'element'},
+            focus: {
+              key: paragraphNode.getKey(),
+              offset: paragraphNode.getChildrenSize(),
+              type: 'element',
+            },
+          });
+          // The selection doesn't visit outside of the paragraph
+          expect(selection.getNodes()).toEqual([
+            paragraphText,
+            linkNode,
+            linkText,
+          ]);
+        },
+        {discrete: true},
+      );
+    });
+    test('select around the paragraph (not normalized)', () => {
+      editor.update(
+        () => {
+          const selection = $createRangeSelection();
+          selection.anchor.set(
+            'root',
+            paragraphNode.getIndexWithinParent(),
+            'element',
+          );
+          selection.focus.set(
+            'root',
+            paragraphNode.getIndexWithinParent() + 1,
+            'element',
+          );
+          expect(selection).toMatchObject({
+            anchor: {key: 'root', offset: 0, type: 'element'},
+            focus: {key: 'root', offset: 1, type: 'element'},
+          });
+          // The selection shouldn't visit outside of the paragraph
+          expect(selection.getNodes()).toEqual([
+            paragraphText,
+            linkNode,
+            linkText,
+            paragraphNode,
+          ]);
+        },
+        {discrete: true},
+      );
+    });
+    test('selection collapsed inside an empty element', () => {
+      editor.update(
+        () => {
+          const selection = $createRangeSelection();
+          selection.anchor.set(emptyParagraph.getKey(), 0, 'element');
+          selection.focus.set(emptyParagraph.getKey(), 0, 'element');
+          // The selection should include the node it is collapsed inside
+          expect(selection.getNodes()).toEqual([emptyParagraph]);
+        },
+        {discrete: true},
+      );
+    });
+    test('select an empty ListItemNode (collapsed)', () => {
+      editor.update(
+        () => {
+          const emptyListItem = $createListItemNode();
+          listItem2.insertBefore(emptyListItem);
+          const selection = $createRangeSelection();
+          selection.anchor.set(emptyListItem.getKey(), 0, 'element');
+          selection.focus.set(emptyListItem.getKey(), 0, 'element');
+          expect(selection).toMatchObject({
+            anchor: {key: emptyListItem.getKey(), offset: 0, type: 'element'},
+            focus: {key: emptyListItem.getKey(), offset: 0, type: 'element'},
+          });
+          expect(selection.getNodes()).toEqual([emptyListItem]);
+        },
+        {discrete: true},
+      );
     });
   });
-  afterEach(() => {
-    editor[Symbol.dispose]();
-  });
-  test('Manual select all without normalization', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.anchor.set('root', 0, 'element');
-        selection.focus.set('root', $getRoot().getChildrenSize(), 'element');
-        const extracted = selection.extract();
-        expect(extracted).toEqual([
-          paragraphText,
-          linkNode,
-          linkText,
-          // The parent paragraphNode comes later because there is
-          // an implicit normalization in the beginning of getNodes
-          // to work around… something? See the getDescendantByIndex usage.
-          paragraphNode,
-          listNode,
-          listItem1,
-          listItemText1,
-          listItem2,
-          listItemText2,
-          emptyParagraph,
-        ]);
-        expect(selection.getNodes()).toEqual(extracted);
-      },
-      {discrete: true},
-    );
-  });
-  test('Manual select all from first text to last empty paragraph', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.anchor.set(paragraphText.getKey(), 0, 'text');
-        selection.focus.set(emptyParagraph.getKey(), 0, 'element');
-        const extracted = selection.extract();
-        expect(extracted).toEqual([
-          paragraphText,
-          linkNode,
-          linkText,
-          // The parent paragraphNode comes later because there is
-          // an implicit normalization in the beginning of getNodes
-          // to work around… something? See the getDescendantByIndex usage.
-          paragraphNode,
-          listNode,
-          listItem1,
-          listItemText1,
-          listItem2,
-          listItemText2,
-          emptyParagraph,
-        ]);
-        expect(selection.getNodes()).toEqual(extracted);
-      },
-      {discrete: true},
-    );
-  });
-  test('select partial TextNode extracts paragraph text', () => {
-    editor.update(
-      () => {
-        const selection = paragraphText.select(2, 8);
-        const extracted = selection.extract();
-        expect(extracted).toEqual([
-          expect.objectContaining({__text: 'ragrap'}),
-        ]);
-        expect(selection.getNodes()).toEqual(extracted);
-      },
-      {discrete: true},
-    );
-  });
-  test('select partial TextNode extracts link text', () => {
-    editor.update(
-      () => {
-        const selection = linkText.select(1, 4);
-        const extracted = selection.extract();
-        expect(extracted).toEqual([expect.objectContaining({__text: 'ink'})]);
-        expect(selection.getNodes()).toEqual(extracted);
-      },
-      {discrete: true},
-    );
-  });
-  test('select multiple partial TextNode extracts text', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.setTextNodeRange(paragraphText, 10, linkText, 4);
-        const extracted = selection.extract();
-        expect(mapLatest(extracted)).toEqual([
-          expect.objectContaining({__text: 'text'}),
-          linkNode.getLatest(),
-          expect.objectContaining({__text: 'link'}),
-        ]);
-        expect(mapLatest(selection.getNodes())).toEqual(mapLatest(extracted));
-      },
-      {discrete: true},
-    );
-  });
-  test('select last offset TextNode as first node removes node', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.setTextNodeRange(
-          paragraphText,
-          paragraphText.getTextContentSize(),
-          linkText,
-          4,
-        );
-        const beforeNodes = selection.getNodes();
-        const extracted = selection.extract();
-        expect(mapLatest(extracted)).toEqual([
-          linkNode.getLatest(),
-          expect.objectContaining({__text: 'link'}),
-        ]);
-        // The identity of the linkText does not change
-        // since the first node is re-used
-        expect(mapLatest(selection.getNodes())).toEqual(mapLatest(beforeNodes));
-      },
-      {discrete: true},
-    );
-  });
-  test('select 0 offset TextNode as last node removes node', () => {
-    editor.update(
-      () => {
-        const selection = $createRangeSelection();
-        selection.setTextNodeRange(paragraphText, 4, linkText, 0);
-        const beforeNodes = selection.getNodes();
-        expect(mapLatest(selection.extract())).toEqual([
-          expect.objectContaining({__text: 'graph text'}),
-          linkNode.getLatest(),
-        ]);
-        // The identity is not paragraphText anymore because
-        // that is the left side outside of the extraction
-        expect(mapLatest(selection.getNodes())).toEqual([
-          paragraphText.getNextSibling(),
-          ...mapLatest(beforeNodes.slice(1)),
-        ]);
-      },
-      {discrete: true},
-    );
+  describe('extract()', () => {
+    test('Manual select all without normalization', () => {
+      editor.update(
+        () => {
+          const selection = $createRangeSelection();
+          selection.anchor.set('root', 0, 'element');
+          selection.focus.set('root', $getRoot().getChildrenSize(), 'element');
+          const extracted = selection.extract();
+          expect(extracted).toEqual([
+            paragraphText,
+            linkNode,
+            linkText,
+            // The parent paragraphNode comes later because there is
+            // an implicit normalization in the beginning of getNodes
+            // to work around… something? See the getDescendantByIndex usage.
+            paragraphNode,
+            listNode,
+            listItem1,
+            listItemText1,
+            listItem2,
+            listItemText2,
+            emptyParagraph,
+          ]);
+          expect(selection.getNodes()).toEqual(extracted);
+        },
+        {discrete: true},
+      );
+    });
+    test('Manual select all from first text to last empty paragraph', () => {
+      editor.update(
+        () => {
+          const selection = $createRangeSelection();
+          selection.anchor.set(paragraphText.getKey(), 0, 'text');
+          selection.focus.set(emptyParagraph.getKey(), 0, 'element');
+          const extracted = selection.extract();
+          expect(extracted).toEqual([
+            paragraphText,
+            linkNode,
+            linkText,
+            // The parent paragraphNode comes later because there is
+            // an implicit normalization in the beginning of getNodes
+            // to work around… something? See the getDescendantByIndex usage.
+            paragraphNode,
+            listNode,
+            listItem1,
+            listItemText1,
+            listItem2,
+            listItemText2,
+            emptyParagraph,
+          ]);
+          expect(selection.getNodes()).toEqual(extracted);
+        },
+        {discrete: true},
+      );
+    });
+    test('select partial TextNode extracts paragraph text', () => {
+      editor.update(
+        () => {
+          const selection = paragraphText.select(2, 8);
+          const extracted = selection.extract();
+          expect(extracted).toEqual([
+            expect.objectContaining({__text: 'ragrap'}),
+          ]);
+          expect(selection.getNodes()).toEqual(extracted);
+        },
+        {discrete: true},
+      );
+    });
+    test('select partial TextNode extracts link text', () => {
+      editor.update(
+        () => {
+          const selection = linkText.select(1, 4);
+          const extracted = selection.extract();
+          expect(extracted).toEqual([expect.objectContaining({__text: 'ink'})]);
+          expect(selection.getNodes()).toEqual(extracted);
+        },
+        {discrete: true},
+      );
+    });
+    test('select multiple partial TextNode extracts text', () => {
+      editor.update(
+        () => {
+          const selection = $createRangeSelection();
+          selection.setTextNodeRange(paragraphText, 10, linkText, 4);
+          const extracted = selection.extract();
+          expect(mapLatest(extracted)).toEqual([
+            expect.objectContaining({__text: 'text'}),
+            linkNode.getLatest(),
+            expect.objectContaining({__text: 'link'}),
+          ]);
+          expect(mapLatest(selection.getNodes())).toEqual(mapLatest(extracted));
+        },
+        {discrete: true},
+      );
+    });
+    test('select last offset TextNode as first node removes node', () => {
+      editor.update(
+        () => {
+          const selection = $createRangeSelection();
+          selection.setTextNodeRange(
+            paragraphText,
+            paragraphText.getTextContentSize(),
+            linkText,
+            4,
+          );
+          const beforeNodes = selection.getNodes();
+          const extracted = selection.extract();
+          expect(mapLatest(extracted)).toEqual([
+            linkNode.getLatest(),
+            expect.objectContaining({__text: 'link'}),
+          ]);
+          // The identity of the linkText does not change
+          // since the first node is re-used
+          expect(mapLatest(selection.getNodes())).toEqual(
+            mapLatest(beforeNodes),
+          );
+        },
+        {discrete: true},
+      );
+    });
+    test('select 0 offset TextNode as last node removes node', () => {
+      editor.update(
+        () => {
+          const selection = $createRangeSelection();
+          selection.setTextNodeRange(paragraphText, 4, linkText, 0);
+          const beforeNodes = selection.getNodes();
+          expect(mapLatest(selection.extract())).toEqual([
+            expect.objectContaining({__text: 'graph text'}),
+            linkNode.getLatest(),
+          ]);
+          // The identity is not paragraphText anymore because
+          // that is the left side outside of the extraction
+          expect(mapLatest(selection.getNodes())).toEqual([
+            paragraphText.getNextSibling(),
+            ...mapLatest(beforeNodes.slice(1)),
+          ]);
+        },
+        {discrete: true},
+      );
+    });
   });
 });
 
@@ -1936,7 +1912,7 @@ describe('RangeSelection.isBackward() caching (#5825)', () => {
 });
 
 describe('Regression #8098', () => {
-  test('Do not apply format and style when moving to different node', async () => {
+  test('Do not apply format and style when moving to different node', () => {
     const container = document.createElement('div');
     container.contentEditable = 'true';
     document.body.appendChild(container);
@@ -1945,7 +1921,7 @@ describe('Regression #8098', () => {
     editor.setRootElement(container);
     let normalTextKey: string;
 
-    await editor.update(
+    editor.update(
       () => {
         const root = $getRoot();
         const paragraph = $createParagraphNode();
@@ -1967,7 +1943,7 @@ describe('Regression #8098', () => {
     domSelection?.removeAllRanges();
     domSelection?.addRange(range);
 
-    await editor.update(
+    editor.update(
       () => {
         const selection = $internalCreateRangeSelection(
           $getSelection(),
@@ -2135,12 +2111,12 @@ describe('Regression #7551 - Selection boundary normalization for single-child i
           editor,
           {type: 'selectionchange'} as Event,
         );
-        invariant(selection !== null);
+        assert(selection !== null);
         const {anchor} = selection;
         const anchorNode = anchor.getNode();
-        invariant($isTextNode(anchorNode));
+        assert($isTextNode(anchorNode));
         const parent = anchorNode.getParent();
-        invariant($isLinkNode(parent));
+        assert($isLinkNode(parent));
         expect(anchor.offset).toBe(1);
       },
       {discrete: true},
@@ -2188,10 +2164,10 @@ describe('Regression #7551 - Selection boundary normalization for single-child i
           editor,
           {type: 'selectionchange'} as Event,
         );
-        invariant(selection !== null);
+        assert(selection !== null);
         const {anchor} = selection;
         const anchorNode = anchor.getNode();
-        invariant($isTextNode(anchorNode));
+        assert($isTextNode(anchorNode));
         expect(anchorNode.getTextContent()).toBe(' world');
         expect(anchor.offset).toBe(0);
       },


### PR DESCRIPTION
## Description

`LexicalSelection.test.ts` still used the legacy `initializeUnitTest` pattern — a React-rendering harness with `testEnv.editor`, a wrapper `<div>`, and implicit `beforeEach`/`afterEach`. This PR replaces all 15 `initializeUnitTest` blocks with the headless `buildEditorFromExtensions` + `using` pattern (or shared `let editor` + `beforeEach`/`afterEach` where tests need common state).

Along the way, several stale patterns got cleaned up:

- `expect($isFoo(x)).toBe(true)` → `assert($isFoo(x))` (vitest type-narrowing assert)
- Manual `anchor.set` / `focus.set` pairs → `setTextNodeRange()` or `node.select()`
- `$assertRangeSelection($getSelection())` → `assert($isRangeSelection(selection))`
- 3-line `$createRangeSelection()` + `setTextNodeRange()` + `$setSelection()` → `node.select(0, 0).setTextNodeRange()`
- Duplicate `beforeEach` setup between `getNodes()` and `extract()` → shared parent describe
- `createEditor` in the #6701 regression test → `buildEditorFromExtensions`
- Nested ternary in inline-element setup → object lookup
- Redundant `await` on `{discrete: true}` updates

Net −92 lines. All 78 tests pass unchanged.

## Test plan

- [x] `pnpm test-unit -- LexicalSelection.test.ts` — 78 pass
- [x] Full unit suite — 3971 pass
- [x] e2e (chromium) — 770 pass
- [x] tsc / prettier / eslint clean