### PR TITLE
[Breaking Changes][lexical] BC: allow importJSON() overrides to return null (regressed by #8640 $config port)

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -487,7 +487,7 @@ declare export class LexicalNode {
   static getType(): string;
   static clone(data: $FlowFixMe): LexicalNode;
   static importDOM(): DOMConversionMap | null;
-  static importJSON(serializedNode: $FlowFixMe): LexicalNode;
+  static importJSON(serializedNode: $FlowFixMe): LexicalNode | null;
   constructor(key?: NodeKey): void;
   exportDOM(editor: LexicalEditor): DOMExportOutput;
   exportJSON(): SerializedLexicalNode;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -145,8 +145,12 @@ export interface StaticNodeConfigValue<
   /**
    * An alternative to the static importJSON() method
    * that provides better type inference.
+   *
+   * May return `null` to signal that the node type has no JSON
+   * representation and should be skipped during deserialization,
+   * mirroring the nullable static importJSON() contract.
    */
-  readonly $importJSON?: (serializedNode: SerializedLexicalNode) => T;
+  readonly $importJSON?: (serializedNode: SerializedLexicalNode) => T | null;
   /**
    * An alternative to the static importDOM() method
    */
@@ -1547,10 +1551,16 @@ export class LexicalNode {
    * be important if you ever make breaking changes to a node schema (by adding or removing properties).
    * See [Serialization & Deserialization](https://lexical.dev/docs/concepts/serialization#lexical---html).
    *
+   * A subclass may override this to return `null` to signal that the node type
+   * has no JSON representation and should be skipped during deserialization
+   * (e.g. an ephemeral/decorative node that is never serialized). The return
+   * type is intentionally nullable so that such opt-out overrides remain
+   * assignable to the base contract.
+   *
    * */
   static importJSON(
     _serializedNode: SerializedLexicalNode & Record<string, unknown>,
-  ): LexicalNode {
+  ): LexicalNode | null {
     invariant(
       false,
       'LexicalNode: Node %s does not implement .importJSON().',

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -431,6 +431,13 @@ function $parseSerializedNodeImpl<
   }
 
   const node = nodeClass.importJSON(serializedNode);
+  invariant(
+    node !== null,
+    'LexicalNode: Node %s returned null from importJSON. A node that opts ' +
+      'out of JSON import (by overriding importJSON to return null) must not ' +
+      'be serialized into the EditorState it is being parsed from.',
+    nodeClass.name,
+  );
   const children = serializedNode.children;
 
   if ($isElementNode(node) && Array.isArray(children)) {

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -31,6 +31,7 @@ import {
   type NodeKey,
   ParagraphNode,
   type RangeSelection,
+  type SerializedElementNode,
   type TabNode,
   TextNode,
 } from 'lexical';
@@ -1546,6 +1547,7 @@ describe('LexicalNode tests', () => {
                 version: 1,
               });
               expect(node).toBeInstanceOf(CustomTextNode);
+              invariant(node !== null);
               expect(node.getType()).toBe('custom-text');
               expect(node.getTextContent()).toBe('codegen!');
             },
@@ -1760,6 +1762,54 @@ describe('LexicalNode tests', () => {
               // The reentrant direct clone must have copied inner's tag.
               expect(clonedOuter.__reentrantClone).not.toBeNull();
               expect(clonedOuter.__reentrantClone!.__tag).toBe('custom');
+            },
+            {discrete: true},
+          );
+        });
+        test('importJSON() override may return null to opt out of JSON import (BC #8640)', () => {
+          // Backward-compatibility: before the $config() port (#8640) the base
+          // static importJSON contract was nullable, which let a subclass mark
+          // a node type as non-JSON-importable by returning null. This test
+          // pins that contract so the override typechecks and, when such a
+          // node is never serialized, deserialization of the rest of the tree
+          // is unaffected.
+          class NonImportableNode extends ElementNode {
+            static getType(): string {
+              return 'non-importable';
+            }
+            static clone(node: NonImportableNode): NonImportableNode {
+              return new NonImportableNode(node.__key);
+            }
+            static importJSON(
+              _serializedNode: SerializedElementNode,
+            ): NonImportableNode | null {
+              return null;
+            }
+            createDOM(): HTMLElement {
+              return document.createElement('div');
+            }
+            updateDOM(): boolean {
+              return false;
+            }
+          }
+          const editor = createEditor({
+            nodes: [NonImportableNode],
+            onError(err) {
+              throw err;
+            },
+          });
+          editor.update(
+            () => {
+              // The override is honored and returns null without throwing.
+              const node = NonImportableNode.importJSON({
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'non-importable',
+                version: 1,
+              });
+              expect(node).toBeNull();
             },
             {discrete: true},
           );

--- a/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
@@ -255,7 +255,7 @@ describe('LexicalNode state', () => {
           expect(json2[NODE_STATE_KEY]).toStrictEqual({
             numberState: 1,
           });
-          const paragraph2 = ParagraphNode.importJSON(json2);
+          const paragraph2 = ParagraphNode.importJSON(json2)!;
           const json3 = paragraph2.exportJSON();
           expect(json3[NODE_STATE_KEY]).toStrictEqual({
             numberState: 1,
@@ -271,7 +271,7 @@ describe('LexicalNode state', () => {
           const malicious = JSON.parse(
             `{"type":"paragraph","version":1,"${NODE_STATE_KEY}":{"__proto__":{"injectedKey":"evil"}}}`,
           );
-          const paragraph = ParagraphNode.importJSON(malicious);
+          const paragraph = ParagraphNode.importJSON(malicious)!;
           // The global prototype is untouched.
           expect(({} as Record<string, unknown>).injectedKey).toBeUndefined();
           expect(Object.prototype).not.toHaveProperty('injectedKey');
@@ -348,7 +348,7 @@ describe('LexicalNode state', () => {
             version: 1,
           };
           for (const doc of [flatJSON, nestedJSON, bothJSON]) {
-            const node = StateNode.importJSON(doc);
+            const node = StateNode.importJSON(doc)!;
             expect(node.exportJSON()).toEqual(flatJSON);
             expect($getState(node, boolState)).toBe(true);
             expect($getState(node, numberState)).toBe(2);


### PR DESCRIPTION
## The problem this solves

A Lexical node can be **non-JSON-serializable** — an ephemeral or decorative node that exists in the editor tree but has no meaningful JSON representation. The established way to express that, since well before the `$config()` protocol, is to override `importJSON()` to return `null`:

```js
// "This node type has no JSON representation."
static importJSON(_serializedNode: SerializedElementNode): ?MyNode {
  return null;
}
```

**#8640 (the `$config()` port) broke this pattern.** It made the base contract non-nullable — the base/auto-synthesized `importJSON` is now typed `(): LexicalNode`, and the generated Flow stub declares `static importJSON(serializedNode: $FlowFixMe): LexicalNode`. A subclass that returns `null` no longer typechecks against the stricter base, in both TS and Flow. There is no BC shim and no documented alternative.

### Concrete breakage (real consumer)

In Meta's `www`, `CaaSLexicalInsertLineNode` (`@flow strict-local`, extends `ElementNode`) is exactly this kind of node — an insert-line marker that renders as `<hr>` and is intentionally never serialized:

```js
static importJSON(_serializedNode: SerializedElementNode): ?CaaSLexicalInsertLineNode {
  return null;
}
```

Once #8640's non-nullable contract reaches the vendored Flow stub, this override fails `flow`:

```
Cannot extend ElementNode with CaaSLexicalInsertLineNode because in property
importJSON the return value: null or undefined is incompatible with LexicalNode.
```

`@flow strict-local` has no `$FlowFixMe` escape hatch, so the node cannot be patched locally without weakening its type mode. This is a backward-compatibility regression in Lexical's public API, and the pre-#8640 pattern needs to keep working (or have a sanctioned replacement).

## The fix

Restore the pre-#8640 contract: `importJSON()` overrides may return `null` again.

- `LexicalNode.importJSON(...)` return type widened back to `LexicalNode | null`.
- `StaticNodeConfigValue.$importJSON` helper widened to `=> T | null` to mirror it.
- Hand-written Flow stub (`flow/Lexical.js.flow`) base declaration widened to `static importJSON(serializedNode: $FlowFixMe): LexicalNode | null` — this is the declaration `www` Flow consumers actually resolve against.
- Internal deserializer (`$parseSerializedNodeImpl`) now `invariant`s that a **registered** node's `importJSON` did not return `null`, with a clear message. A node that opts out of JSON import is, by definition, never serialized into the `EditorState` being parsed — so that path is unreachable for such nodes at runtime, and the internal caller stays non-null and fully type-safe.

This is a pure widening of the return type: existing overrides that return a concrete node remain assignable; only code that immediately dereferences a direct `Node.importJSON(json)` call must now account for `| null` (the pre-#8640 contract already required this).

## Tradeoff / note for maintainers

Widening the base return does make the common path slightly stricter for callers that call `SomeNode.importJSON(json)` directly and dereference the result immediately. If you'd prefer not to loosen the common path, the alternative is a sanctioned "non-importable node" API/pattern with a documented migration — happy to reshape this PR that way. Either way, the public API currently offers neither a BC shim nor a documented path for opting a node out of JSON import.

## Test plan

- Added a regression test in `LexicalNode.test.ts` (`importJSON() override may return null to opt out of JSON import (BC #8640)`): a node overriding `importJSON` to return `null` typechecks and returns `null` at runtime without throwing.
- `tsc -p ./tsconfig.json --noEmit` — clean.
- `check-flow-types` — `No errors!`.
- `vitest --project unit` for `LexicalNode.test` + `LexicalNodeState.test` — 220/220 pass.

## References

- #8640 — `$config()` port (the regressing change)
- #8864 — `clone()` BC fix (landed)
- #8867 — `getType()` collision fix (landed)

## Scope

`importJSON` nullability BC only. The separate `getType()` recursion regressed by #8867 under compiled output is fixed independently in its own follow-up PR (#8869) (touches disjoint code — the `$config()` synthesis runtime, not the importJSON contract).