### PR TITLE
fix: $config() synthesized getType() recurses infinitely when inherited as own static (#8867 follow-up)

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -3222,6 +3222,13 @@ const STATIC_NODE_CONFIG_CACHE = new WeakMap<
   Klass<LexicalNode>,
   OwnStaticNodeConfig
 >();
+// Brands a getType() closure that Lexical synthesized (as opposed to a
+// user-defined static getType()). getStaticNodeConfig uses this to avoid
+// re-entering a synthesized closure while deriving a node's type, which would
+// otherwise recurse infinitely for subclasses under compiled class output.
+const SYNTHESIZED_GET_TYPE: unique symbol = Symbol(
+  'lexical.synthesizedGetType',
+);
 
 // TextNode.length > 0 will only be true if the compiler output
 // is not ES6 compliant, in which case we can not provide this
@@ -3244,9 +3251,21 @@ export function getStaticNodeConfig(
       ? klass.prototype[PROTOTYPE_CONFIG_METHOD]()
       : undefined;
   const isAbstract = isAbstractNodeClass(klass);
-  const nodeType =
+  // Only trust a *user-defined* own static getType() to derive the node type.
+  // A getType() that we synthesized (branded with SYNTHESIZED_GET_TYPE) must
+  // not be called here: the synthesized closure defers to
+  // LexicalNode.getType.call(this) for a foreign `this`, which re-enters
+  // getStaticNodeConfig and — when the closure is inherited/own-copied onto a
+  // subclass by the compiled class output — causes infinite recursion
+  // (RangeError: Maximum call stack size exceeded). For such a class the type
+  // is derived from the $config record below instead. (#8867 follow-up.)
+  const ownGetType =
     !isAbstract && hasOwnStaticMethod(klass, 'getType')
-      ? klass.getType()
+      ? klass.getType
+      : undefined;
+  const nodeType =
+    ownGetType && !(SYNTHESIZED_GET_TYPE in ownGetType)
+      ? ownGetType.call(klass)
       : undefined;
   let ownNodeConfig:
     | undefined
@@ -3290,12 +3309,19 @@ export function getStaticNodeConfig(
       // the exact class it was synthesized for; otherwise defer to the base
       // LexicalNode.getType(), which resolves the correct type for `this`.
       const synthesizedForKlass = klass;
-      klass.getType = function (this: Klass<LexicalNode>): string {
+      const synthesizedGetType = function (this: Klass<LexicalNode>): string {
         if (this !== synthesizedForKlass) {
           return LexicalNode.getType.call(this);
         }
         return ownNodeType;
       };
+      // Brand the closure so getStaticNodeConfig can recognize it and avoid
+      // calling it to derive the node type (which would recurse). See the note
+      // at the `ownGetType` computation above.
+      (synthesizedGetType as {[SYNTHESIZED_GET_TYPE]?: true})[
+        SYNTHESIZED_GET_TYPE
+      ] = true;
+      klass.getType = synthesizedGetType;
     }
     if (!hasOwnStaticMethod(klass, 'clone')) {
       // TextNode.length > 0 will only be true if the compiler output

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -2296,6 +2296,52 @@ describe('LexicalNode.$config() without registration', () => {
     expect(InnerConfigNode.getType()).toBe('inner-config-node');
   });
 
+  test('synthesized getType() inherited as an own static on a subclass does not recurse (#8867 follow-up)', () => {
+    // Regression for a stack-overflow that only reproduces under *compiled*
+    // class output (e.g. Meta's www bundle), where a superclass's synthesized
+    // getType() closure can end up as an *own* static on a subclass whose
+    // identity differs from the closure's captured `synthesizedForKlass`.
+    //
+    // Pre-fix cycle:
+    //   getStaticNodeConfig(Sub)  -> calls Sub.getType() (own, synthesized)
+    //     -> closure sees `this !== synthesizedForKlass` -> LexicalNode.getType.call(Sub)
+    //       -> getStaticNodeConfig(Sub) -> ... RangeError: Maximum call stack size exceeded
+    //
+    // Native ES classes don't inherit statics as own properties, so this must
+    // be constructed explicitly to mirror the compiled shape.
+    class ParentSynthNode extends TextNode {
+      $config() {
+        return this.config('parent-synth-node', {extends: TextNode});
+      }
+    }
+    class ChildSynthNode extends ParentSynthNode {
+      $config() {
+        return this.config('child-synth-node', {extends: ParentSynthNode});
+      }
+    }
+
+    // Force the parent's getType() to be synthesized as an own static.
+    expect(ParentSynthNode.getType()).toBe('parent-synth-node');
+    const parentSynthesizedGetType = Object.getOwnPropertyDescriptor(
+      ParentSynthNode,
+      'getType',
+    );
+    expect(parentSynthesizedGetType).toBeDefined();
+
+    // Simulate the compiled bundle copying that synthesized closure down onto
+    // the subclass as an OWN static (its captured `synthesizedForKlass` is
+    // still ParentSynthNode, not ChildSynthNode).
+    Object.defineProperty(ChildSynthNode, 'getType', {
+      configurable: true,
+      value: (parentSynthesizedGetType as PropertyDescriptor).value,
+      writable: true,
+    });
+
+    // Must not recurse; must resolve the child's own $config-derived type.
+    expect(() => ChildSynthNode.getType()).not.toThrow();
+    expect(ChildSynthNode.getType()).toBe('child-synth-node');
+  });
+
   test('abstract base class declares shared $config under a Symbol key', () => {
     // An abstract base class has no concrete node `type`, so it publishes the
     // configuration it shares with its subclasses (here a $transform) under a


### PR DESCRIPTION
## The problem this solves

After #8867, **registering or resolving the type of a `$config({extends})` node subclass can infinite-loop and crash with `RangeError: Maximum call stack size exceeded`** — but only under *compiled* class output (Babel/transpiled bundles, e.g. Meta's `www`). Any editor that registers such a node (a hashtag node, a code-highlight node, a custom `TextNode`/`ElementNode` subclass configured via `$config({extends})`) fails to initialize.

### Concrete breakage (real consumers)

In Meta's `www`, nodes like `HashtagNode` and `CodeHighlightNode` are defined as `$config({extends: TextNode})` subclasses. When the Lexical bundle containing #8867 was synced in, **7 previously-green test suites started failing** — 118 tests — every one blowing the stack in `getType()`:

```
RangeError: Maximum call stack size exceeded
  at getStaticNodeConfig            (Lexical.dev.js)
  at Function.getType               (LexicalNode static getType)
  at Function.klass.getType         (#8867 synthesized closure)
  at getStaticNodeConfig            (…loops forever)
```

## Root cause

#8867 fixed a real bug — a subclass inheriting a superclass's synthesized `getType()` and registering under the *wrong* type (collision). Its guard defers to the base for a foreign `this`:

```ts
klass.getType = function () {
  if (this !== synthesizedForKlass) {
    return LexicalNode.getType.call(this);   // -> getStaticNodeConfig(this)
  }
  return ownNodeType;
};
```

But `getStaticNodeConfig` derives a node's type by *calling* `klass.getType()`:

```ts
const nodeType =
  !isAbstract && hasOwnStaticMethod(klass, 'getType') ? klass.getType() : undefined;
```

Native ES classes don't inherit statics as own properties — but **compiled class output copies the superclass's synthesized closure down onto the subclass as an *own* static** (its captured `synthesizedForKlass` still points at the superclass). That closes the loop:

```
getStaticNodeConfig(Sub)
  -> Sub.getType()                    // own, synthesized, synthesizedForKlass = Super
    -> this (Sub) !== synthesizedForKlass (Super)
      -> LexicalNode.getType.call(Sub)
        -> getStaticNodeConfig(Sub)   // back to the top -> stack overflow
```

Because it only manifests under transpilation, Lexical's own (untranspiled) unit tests — including #8867's collision tests — never caught it.

## The fix

Brand the synthesized closure with an internal symbol, and never call a *synthesized* `getType()` to derive the type in `getStaticNodeConfig` — derive it from the `$config` record instead. A genuine user-defined `static getType()` is still called exactly as before.

```ts
const ownGetType =
  !isAbstract && hasOwnStaticMethod(klass, 'getType') ? klass.getType : undefined;
const nodeType =
  ownGetType && !(SYNTHESIZED_GET_TYPE in ownGetType) ? ownGetType.call(klass) : undefined;
```

This breaks the cycle while fully preserving #8867's collision fix.

## Test plan

- Added a regression test in `LexicalNode.test.ts` that reconstructs the compiled shape (a synthesized closure installed as an *own* static on a subclass whose identity differs from the closure's `synthesizedForKlass`). It throws `RangeError: Maximum call stack size exceeded` on `main` and passes with this fix.
- `tsc -p ./tsconfig.json --noEmit` — clean.
- `vitest --project unit` `LexicalNode.test` — 100/100 pass (including #8867's existing collision tests).
- **Validated against the actual compiled bundle:** patching the generated `Lexical.dev.js` with this change in Meta's `www` and re-running the 7 previously-failing suites takes them from **118 failed / 30 passed** to **148 passed / 148 total**.

## References

- #8640 — `$config()` port
- #8867 — `getType()` collision fix (this recursion is a follow-up to it)

## Scope

`getType()` recursion only. Touches the `$config()` synthesis runtime (`LexicalUtils.ts`) — disjoint from the separate `importJSON` nullable BC regression, which is fixed in #8868.