### PR TITLE
[lexical] Refactor: Simplify RangeSelection.insertText via removeText decomposition

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -1352,11 +1352,12 @@ describe('LexicalSelectionHelpers tests', () => {
       setupTestCase((selection, state) => {
         selection.insertText('Test');
 
-        expect($getNodeByKey('a')!.getTextContent()).toBe('Test');
+        const firstChild = state.getFirstChild()!;
+        expect(firstChild.getTextContent()).toBe('Test');
 
         expect(selection.anchor).toEqual(
           expect.objectContaining({
-            key: 'a',
+            key: firstChild.getKey(),
             offset: 4,
             type: 'text',
           }),
@@ -1364,7 +1365,7 @@ describe('LexicalSelectionHelpers tests', () => {
 
         expect(selection.focus).toEqual(
           expect.objectContaining({
-            key: 'a',
+            key: firstChild.getKey(),
             offset: 4,
             type: 'text',
           }),

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -383,9 +383,11 @@ function $insertTextAtPoint(
   }
   textNode.selectEnd();
   if (textNode.isComposing() && selection.anchor.type === 'text') {
-    selection.anchor.offset -= text.length;
-    selection._cachedNodes = null;
-    selection._cachedIsBackward = null;
+    selection.anchor.set(
+      selection.anchor.key,
+      selection.anchor.offset - text.length,
+      selection.anchor.type,
+    );
   }
 }
 
@@ -1051,9 +1053,11 @@ export class RangeSelection implements BaseSelection {
 
     anchorNode.spliceText(offset, 0, text, true);
     if (anchorNode.isComposing() && this.anchor.type === 'text') {
-      this.anchor.offset -= text.length;
-      this._cachedNodes = null;
-      this._cachedIsBackward = null;
+      this.anchor.set(
+        this.anchor.key,
+        this.anchor.offset - text.length,
+        this.anchor.type,
+      );
     }
   }
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -90,7 +90,6 @@ import {
   $isRootOrShadowRoot,
   $isSelectionCapturedInDecoratorInput,
   $isTokenOrSegmented,
-  $isTokenOrTab,
   $setCompositionKey,
   doesContainSurrogatePair,
   getActiveElement,
@@ -114,7 +113,7 @@ import {
   scrollIntoViewIfNeeded,
   toggleTextFormatType,
 } from './LexicalUtils';
-import {$createTabNode, $isTabNode} from './nodes/LexicalTabNode';
+import {$createTabNode} from './nodes/LexicalTabNode';
 import {
   $isInlineFormattable,
   type TextFormatType,
@@ -348,6 +347,46 @@ function $transferStartingElementPointToTextPoint(
     end.set(textNode.__key, 0, 'text');
   }
   start.set(textNode.__key, 0, 'text');
+}
+
+function $insertTextAtPoint(
+  selection: RangeSelection,
+  text: string,
+  format: number,
+  style: string,
+): void {
+  const anchorNode = selection.anchor.getNode();
+  invariant($isTextNode(anchorNode), 'insertText: anchor is not a text node');
+  const offset = selection.anchor.offset;
+  const textNode = $createTextNode(text);
+  textNode.setFormat(format);
+  textNode.setStyle(style);
+  const parent = anchorNode.getParentOrThrow();
+  if (offset === 0) {
+    if (parent.isInline() && !anchorNode.__prev) {
+      parent.insertBefore(textNode);
+    } else {
+      anchorNode.insertBefore(textNode, false);
+    }
+  } else if (offset === anchorNode.getTextContentSize()) {
+    if (parent.isInline() && !anchorNode.__next) {
+      parent.insertAfter(textNode);
+    } else {
+      anchorNode.insertAfter(textNode, false);
+    }
+  } else {
+    const [before] = anchorNode.splitText(offset);
+    before.insertAfter(textNode, false);
+  }
+  if (anchorNode.getTextContent() === '' && anchorNode.isAttached()) {
+    anchorNode.remove();
+  }
+  textNode.selectEnd();
+  if (textNode.isComposing() && selection.anchor.type === 'text') {
+    selection.anchor.offset -= text.length;
+    selection._cachedNodes = null;
+    selection._cachedIsBackward = null;
+  }
 }
 
 export interface BaseSelection {
@@ -849,427 +888,172 @@ export class RangeSelection implements BaseSelection {
    * @param text the text to insert into the Selection
    */
   insertText(text: string): void {
-    // Now that "removeText" has been improved and does not depend on
-    // insertText, insertText can be greatly simplified. The next
-    // commented version is a WIP (about 5 tests fail).
-    //
-    // this.removeText();
-    // if (text === '') {
-    //   return;
-    // }
-    // const anchorNode = this.anchor.getNode();
-    // const textNode = $createTextNode(text);
-    // textNode.setFormat(this.format);
-    // textNode.setStyle(this.style);
-    // if ($isTextNode(anchorNode)) {
-    //   const parent = anchorNode.getParentOrThrow();
-    //   if (this.anchor.offset === 0) {
-    //     if (parent.isInline() && !anchorNode.__prev) {
-    //       parent.insertBefore(textNode);
-    //     } else {
-    //       anchorNode.insertBefore(textNode);
-    //     }
-    //   } else if (this.anchor.offset === anchorNode.getTextContentSize()) {
-    //     if (parent.isInline() && !anchorNode.__next) {
-    //       parent.insertAfter(textNode);
-    //     } else {
-    //       anchorNode.insertAfter(textNode);
-    //     }
-    //   } else {
-    //     const [before] = anchorNode.splitText(this.anchor.offset);
-    //     before.insertAfter(textNode);
-    //   }
-    // } else {
-    //   anchorNode.splice(this.anchor.offset, 0, [textNode]);
-    // }
-    // const nodeToSelect = textNode.isAttached() ? textNode : anchorNode;
-    // nodeToSelect.selectEnd();
-    // // When composing, we need to adjust the anchor offset so that
-    // // we correctly replace that right range.
-    // if (
-    //   textNode.isComposing() &&
-    //   this.anchor.type === 'text' &&
-    //   anchorNode.getTextContent() !== ''
-    // ) {
-    //   this.anchor.offset -= text.length;
-    // }
-
-    const anchor = this.anchor;
-    const focus = this.focus;
-    const format = this.format;
-    const style = this.style;
-    let firstPoint = anchor;
-    let endPoint = focus;
-    if (!this.isCollapsed() && focus.isBefore(anchor)) {
-      firstPoint = focus;
-      endPoint = anchor;
+    // For non-collapsed selections, inherit format/style from the first
+    // selected text node so the replacement preserves the original styling.
+    let format = this.format;
+    let style = this.style;
+    if (!this.isCollapsed()) {
+      const firstPoint = this.focus.isBefore(this.anchor)
+        ? this.focus
+        : this.anchor;
+      const firstNode = firstPoint.getNode();
+      if ($isTextNode(firstNode)) {
+        format = firstNode.getFormat();
+        style = firstNode.getStyle();
+      }
+      this.removeText();
+      this.format = format;
+      this.style = style;
+      if (text === '') {
+        return;
+      }
+      if ($getCompositionKey() === null) {
+        if (this.anchor.type === 'element') {
+          $transferStartingElementPointToTextPoint(
+            this.anchor,
+            this.focus,
+            format,
+            style,
+          );
+        }
+        $insertTextAtPoint(this, text, format, style);
+        return;
+      }
+      // Composing: fall through to the collapsed code below.
+      // spliceText preserves DOM node identity so the browser's
+      // IME tracker stays attached.
     }
-    if (firstPoint.type === 'element') {
+
+    if (this.anchor.type === 'element') {
       $transferStartingElementPointToTextPoint(
-        firstPoint,
-        endPoint,
+        this.anchor,
+        this.focus,
         format,
         style,
       );
     }
-    if (endPoint.type === 'element') {
-      $setPointFromCaret(
-        endPoint,
-        $normalizeCaret($caretFromPoint(endPoint, 'next')),
-      );
-    }
-    const startOffset = firstPoint.offset;
-    let endOffset = endPoint.offset;
-    const selectedNodes = this.getNodes();
-    const selectedNodesLength = selectedNodes.length;
-    let firstNode: TextNode = selectedNodes[0] as TextNode;
 
-    invariant(
-      $isTextNode(firstNode),
-      'insertText: first node is not a text node',
-    );
-    const firstNodeText = firstNode.getTextContent();
-    const firstNodeTextLength = firstNodeText.length;
-    const firstNodeParent = firstNode.getParentOrThrow();
-    const lastIndex = selectedNodesLength - 1;
-    let lastNode = selectedNodes[lastIndex];
+    const anchorNode = this.anchor.getNode();
+    invariant($isTextNode(anchorNode), 'insertText: anchor is not a text node');
+    const offset = this.anchor.offset;
 
-    if (selectedNodesLength === 1 && endPoint.type === 'element') {
-      endOffset = firstNodeTextLength;
-      endPoint.set(firstPoint.key, endOffset, 'text');
-    }
+    const anchorParent = anchorNode.getParentOrThrow();
+    const anchorSize = anchorNode.getTextContentSize();
+    const needsRedirect =
+      $isTokenOrSegmented(anchorNode) ||
+      (offset === 0 &&
+        (!anchorNode.canInsertTextBefore() ||
+          (!anchorParent.canInsertTextBefore() && !anchorNode.__prev))) ||
+      (offset === anchorSize &&
+        (!anchorNode.canInsertTextAfter() ||
+          (!anchorParent.canInsertTextAfter() && !anchorNode.__next)));
 
-    if (
-      this.isCollapsed() &&
-      startOffset === firstNodeTextLength &&
-      ($isTokenOrSegmented(firstNode) ||
-        !firstNode.canInsertTextAfter() ||
-        (!firstNodeParent.canInsertTextAfter() &&
-          firstNode.getNextSibling() === null))
-    ) {
-      const candidateNextSibling = firstNode.getNextSibling();
-      let nextSibling: TextNode;
-      if (
-        !$isTextNode(candidateNextSibling) ||
-        !candidateNextSibling.canInsertTextBefore() ||
-        $isTokenOrSegmented(candidateNextSibling)
-      ) {
-        nextSibling = $createTextNode();
-        nextSibling.setFormat(format);
-        nextSibling.setStyle(style);
-        if (!firstNodeParent.canInsertTextAfter()) {
-          firstNodeParent.insertAfter(nextSibling);
+    if (needsRedirect) {
+      // Token/segmented nodes and nodes whose parent forbids text insertion
+      // at the boundary: reposition the cursor to an adjacent insertable
+      // node, then recurse.
+
+      // Segmented node with cursor in the middle: convert to normal
+      // text node so that the recursive insertText can proceed.
+      if (anchorNode.isSegmented() && offset !== 0 && offset !== anchorSize) {
+        if ($getCompositionKey() !== null) {
+          anchorNode.setMode('normal').setFormat(format).setStyle(style);
         } else {
-          firstNode.insertAfter(nextSibling);
+          const replacement = $createTextNode(anchorNode.getTextContent());
+          replacement.setFormat(format);
+          replacement.setStyle(style);
+          anchorNode.replace(replacement);
+          replacement.select(offset, offset);
         }
-      } else {
-        nextSibling = candidateNextSibling;
-      }
-      nextSibling.select(0, 0);
-      firstNode = nextSibling;
-      if (text !== '') {
-        this.insertText(text);
-        return;
-      }
-    } else if (
-      this.isCollapsed() &&
-      startOffset === 0 &&
-      ($isTokenOrSegmented(firstNode) ||
-        !firstNode.canInsertTextBefore() ||
-        (!firstNodeParent.canInsertTextBefore() &&
-          firstNode.getPreviousSibling() === null))
-    ) {
-      const candidatePrevSibling = firstNode.getPreviousSibling();
-      let prevSibling: TextNode;
-      if (
-        !$isTextNode(candidatePrevSibling) ||
-        $isTokenOrSegmented(candidatePrevSibling)
-      ) {
-        prevSibling = $createTextNode();
-        prevSibling.setFormat(format);
-        if (!firstNodeParent.canInsertTextBefore()) {
-          firstNodeParent.insertBefore(prevSibling);
-        } else {
-          firstNode.insertBefore(prevSibling);
+        if (text !== '') {
+          this.insertText(text);
         }
-      } else {
-        prevSibling = candidatePrevSibling;
-      }
-      prevSibling.select();
-      firstNode = prevSibling;
-      if (text !== '') {
-        this.insertText(text);
         return;
       }
-    } else if (firstNode.isSegmented() && startOffset !== firstNodeTextLength) {
-      if ($getCompositionKey() !== null) {
-        // Preserve the DOM element for the browser's composition tracker.
-        // The subclass instance stays in normal mode until composition ends,
-        // when $cleanupComposedSubclass replaces it with a plain TextNode.
-        firstNode = firstNode
-          .setMode('normal')
-          .setFormat(format)
-          .setStyle(style);
-      } else {
-        const textNode = $createTextNode(firstNode.getTextContent());
-        textNode.setFormat(format);
-        firstNode.replace(textNode);
-        firstNode = textNode;
-      }
-    } else if (!this.isCollapsed() && text !== '') {
-      // When the firstNode or lastNode parents are elements that
-      // do not allow text to be inserted before or after, we first
-      // clear the content. Then we normalize selection, then insert
-      // the new content.
-      const lastNodeParent = lastNode.getParent();
-
-      if (
-        !firstNodeParent.canInsertTextBefore() ||
-        !firstNodeParent.canInsertTextAfter() ||
-        ($isElementNode(lastNodeParent) &&
-          (!lastNodeParent.canInsertTextBefore() ||
-            !lastNodeParent.canInsertTextAfter()))
-      ) {
-        this.insertText('');
-        $normalizeSelectionPointsForBoundaries(this.anchor, this.focus, null);
-        this.insertText(text);
+      if (text === '') {
         return;
       }
-    }
-
-    if (selectedNodesLength === 1) {
-      if ($isTokenOrTab(firstNode)) {
-        const textNode = $createTextNode(text);
-        textNode.select();
-        firstNode.replace(textNode);
-        return;
-      }
-      const firstNodeFormat = firstNode.getFormat();
-      const firstNodeStyle = firstNode.getStyle();
-
-      if (
-        startOffset === endOffset &&
-        (firstNodeFormat !== format || firstNodeStyle !== style)
-      ) {
-        if (firstNode.getTextContent() === '') {
-          firstNode.setFormat(format);
-          firstNode.setStyle(style);
-        } else {
-          const textNode = $createTextNode(text);
-          textNode.setFormat(format);
-          textNode.setStyle(style);
-          textNode.select();
-          if (startOffset === 0) {
-            firstNode.insertBefore(textNode, false);
-          } else {
-            const [targetNode] = firstNode.splitText(startOffset);
-            targetNode.insertAfter(textNode, false);
-          }
-          // When composing, we need to adjust the anchor offset so that
-          // we correctly replace that right range.
-          if (textNode.isComposing() && this.anchor.type === 'text') {
-            this.anchor.offset -= text.length;
-            this._cachedNodes = null;
-            this._cachedIsBackward = null;
-          }
-          return;
-        }
-      } else if ($isTabNode(firstNode)) {
-        // We don't need to check for delCount because there is only the entire selected node case
-        // that can hit here for content size 1 and with canInsertTextBeforeAfter false
-        const textNode = $createTextNode(text);
-        textNode.setFormat(format);
-        textNode.setStyle(style);
-        textNode.select();
-        firstNode.replace(textNode);
-        return;
-      }
-      const delCount = endOffset - startOffset;
-
-      firstNode = firstNode.spliceText(startOffset, delCount, text, true);
-      if (firstNode.getTextContent() === '') {
-        firstNode.remove();
-      } else if (this.anchor.type === 'text') {
-        this.format = firstNodeFormat;
-        this.style = firstNodeStyle;
-        if (firstNode.isComposing()) {
-          // When composing, we need to adjust the anchor offset so that
-          // we correctly replace that right range.
-          this.anchor.offset -= text.length;
-          this._cachedNodes = null;
-          this._cachedIsBackward = null;
-        }
-      }
-    } else {
-      const markedNodeKeysForKeep = new Set([
-        ...firstNode.getParentKeys(),
-        ...lastNode.getParentKeys(),
-      ]);
-
-      // We have to get the parent elements before the next section,
-      // as in that section we might mutate the lastNode.
-      const firstElement = $isElementNode(firstNode)
-        ? firstNode
-        : firstNode.getParentOrThrow();
-      let lastElement = $isElementNode(lastNode)
-        ? lastNode
-        : lastNode.getParentOrThrow();
-      let lastElementChild = lastNode;
-
-      // If the last element is inline, we should instead look at getting
-      // the nodes of its parent, rather than itself. This behavior will
-      // then better match how text node insertions work. We will need to
-      // also update the last element's child accordingly as we do this.
-      if (!firstElement.is(lastElement) && lastElement.isInline()) {
-        // Keep traversing till we have a non-inline element parent.
-        do {
-          lastElementChild = lastElement;
-          lastElement = lastElement.getParentOrThrow();
-        } while (lastElement.isInline());
-      }
-
-      // Handle mutations to the last node.
-      if (
-        (endPoint.type === 'text' &&
-          (endOffset !== 0 || lastNode.getTextContent() === '')) ||
-        (endPoint.type === 'element' &&
-          lastNode.getIndexWithinParent() < endOffset)
-      ) {
+      if (offset === 0) {
+        const prev = anchorNode.getPreviousSibling();
         if (
-          $isTextNode(lastNode) &&
-          !$isTokenOrTab(lastNode) &&
-          endOffset !== lastNode.getTextContentSize()
+          $isTextNode(prev) &&
+          prev.canInsertTextAfter() &&
+          !$isTokenOrSegmented(prev)
         ) {
-          if (lastNode.isSegmented()) {
-            const textNode = $createTextNode(lastNode.getTextContent());
-            lastNode.replace(textNode);
-            lastNode = textNode;
-          }
-          // root node selections only select whole nodes, so no text splice is necessary
-          if (!$isRootNode(endPoint.getNode()) && endPoint.type === 'text') {
-            invariant(
-              $isTextNode(lastNode),
-              'insertText: lastNode is not a TextNode',
-            );
-            lastNode = lastNode.spliceText(0, endOffset, '');
-          }
-          markedNodeKeysForKeep.add(lastNode.__key);
+          prev.select();
         } else {
-          const lastNodeParent = lastNode.getParentOrThrow();
-          if (
-            !lastNodeParent.canBeEmpty() &&
-            lastNodeParent.getChildrenSize() === 1
-          ) {
-            lastNodeParent.remove();
+          const newNode = $createTextNode();
+          newNode.setFormat(format);
+          newNode.setStyle(style);
+          if (!anchorParent.canInsertTextBefore()) {
+            anchorParent.insertBefore(newNode);
           } else {
-            lastNode.remove();
+            anchorNode.insertBefore(newNode);
           }
+          newNode.select();
         }
-      } else {
-        markedNodeKeysForKeep.add(lastNode.__key);
-      }
-
-      // Either move the remaining nodes of the last parent to after
-      // the first child, or remove them entirely. If the last parent
-      // is the same as the first parent, this logic also works.
-      const lastNodeChildren = lastElement.getChildren();
-      const selectedNodesSet = new Set(selectedNodes);
-      const firstAndLastElementsAreEqual = firstElement.is(lastElement);
-
-      // We choose a target to insert all nodes after. In the case of having
-      // and inline starting parent element with a starting node that has no
-      // siblings, we should insert after the starting parent element, otherwise
-      // we will incorrectly merge into the starting parent element.
-      // TODO: should we keep on traversing parents if we're inside another
-      // nested inline element?
-      const insertionTarget =
-        firstElement.isInline() && firstNode.getNextSibling() === null
-          ? firstElement
-          : firstNode;
-
-      for (let i = lastNodeChildren.length - 1; i >= 0; i--) {
-        const lastNodeChild = lastNodeChildren[i];
-
+        this.insertText(text);
+        return;
+      } else if (offset === anchorSize) {
+        const next = anchorNode.getNextSibling();
         if (
-          lastNodeChild.is(firstNode) ||
-          ($isElementNode(lastNodeChild) && lastNodeChild.isParentOf(firstNode))
+          $isTextNode(next) &&
+          next.canInsertTextBefore() &&
+          !$isTokenOrSegmented(next)
         ) {
-          break;
-        }
-
-        if (lastNodeChild.isAttached()) {
-          if (
-            !selectedNodesSet.has(lastNodeChild) ||
-            lastNodeChild.is(lastElementChild)
-          ) {
-            if (!firstAndLastElementsAreEqual) {
-              insertionTarget.insertAfter(lastNodeChild, false);
-            }
+          next.select(0, 0);
+        } else {
+          const newNode = $createTextNode();
+          newNode.setFormat(format);
+          newNode.setStyle(style);
+          if (!anchorParent.canInsertTextAfter()) {
+            anchorParent.insertAfter(newNode);
           } else {
-            lastNodeChild.remove();
+            anchorNode.insertAfter(newNode);
           }
+          newNode.select(0, 0);
         }
+        this.insertText(text);
+        return;
       }
+      const newNode = $createTextNode(text);
+      newNode.setFormat(format);
+      newNode.setStyle(style);
+      anchorNode.replace(newNode);
+      newNode.select();
+      return;
+    }
 
-      if (!firstAndLastElementsAreEqual) {
-        // Check if we have already moved out all the nodes of the
-        // last parent, and if so, traverse the parent tree and mark
-        // them all as being able to deleted too.
-        let parent: ElementNode | null = lastElement;
-        let lastRemovedParent = null;
+    if (text === '') {
+      return;
+    }
 
-        while (parent !== null) {
-          const children = parent.getChildren();
-          const childrenLength = children.length;
-          if (
-            childrenLength === 0 ||
-            children[childrenLength - 1].is(lastRemovedParent)
-          ) {
-            markedNodeKeysForKeep.delete(parent.__key);
-            lastRemovedParent = parent;
-          }
-          parent = parent.getParent();
-        }
-      }
+    const atStartOfInline =
+      anchorParent.isInline() && offset === 0 && !anchorNode.__prev;
+    const atEndOfInline =
+      anchorParent.isInline() && offset === anchorSize && !anchorNode.__next;
+    const formatDiffers =
+      anchorNode.getFormat() !== format || anchorNode.getStyle() !== style;
 
-      // Ensure we do splicing after moving of nodes, as splicing
-      // can have side-effects (in the case of hashtags).
-      if (!$isTokenOrTab(firstNode)) {
-        firstNode = firstNode.spliceText(
-          startOffset,
-          firstNodeTextLength - startOffset,
-          text,
-          true,
-        );
-        if (firstNode.getTextContent() === '') {
-          firstNode.remove();
-        } else if (this.anchor.type === 'text') {
-          this.format = firstNode.getFormat();
-          this.style = firstNode.getStyle();
-          if (firstNode.isComposing()) {
-            // When composing, we need to adjust the anchor offset so that
-            // we correctly replace that right range.
-            this.anchor.offset -= text.length;
-            this._cachedNodes = null;
-            this._cachedIsBackward = null;
-          }
-        }
-      } else if (startOffset === firstNodeTextLength) {
-        firstNode.select();
+    if (atStartOfInline || atEndOfInline || formatDiffers) {
+      if (
+        anchorNode.getTextContent() === '' &&
+        !atStartOfInline &&
+        !atEndOfInline
+      ) {
+        anchorNode.setFormat(format);
+        anchorNode.setStyle(style);
       } else {
-        const textNode = $createTextNode(text);
-        textNode.select();
-        firstNode.replace(textNode);
+        $insertTextAtPoint(this, text, format, style);
+        return;
       }
+    }
 
-      // Remove all selected nodes that haven't already been removed.
-      for (let i = 1; i < selectedNodesLength; i++) {
-        const selectedNode = selectedNodes[i];
-        const key = selectedNode.__key;
-        if (!markedNodeKeysForKeep.has(key)) {
-          selectedNode.remove();
-        }
-      }
+    anchorNode.spliceText(offset, 0, text, true);
+    if (anchorNode.isComposing() && this.anchor.type === 'text') {
+      this.anchor.offset -= text.length;
+      this._cachedNodes = null;
+      this._cachedIsBackward = null;
     }
   }
 

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -875,6 +875,49 @@ describe('Segmented node composition (#5065)', () => {
   });
 });
 
+describe('Non-collapsed selection + composition preserves node identity', () => {
+  test('spliceText into existing node instead of creating new one', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const textNode = $createTextNode('Hello World');
+        $getRoot().clear().append($createParagraphNode().append(textNode));
+        const key = textNode.getKey();
+
+        $setCompositionKey(key);
+        const sel = textNode.select(5, 11);
+        sel.insertText('!');
+
+        const latest = textNode.getLatest();
+        expect(latest.getKey()).toBe(key);
+        expect(latest.getTextContent()).toBe('Hello!');
+      },
+      {discrete: true},
+    );
+  });
+
+  test('without composition creates a new node', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const textNode = $createTextNode('Hello World');
+        $getRoot().clear().append($createParagraphNode().append(textNode));
+        const key = textNode.getKey();
+
+        const sel = textNode.select(5, 11);
+        sel.insertText('!');
+
+        const allText = $getRoot().getAllTextNodes();
+        expect(allText).toHaveLength(2);
+        expect(allText[0].getTextContent()).toBe('Hello');
+        expect(allText[1].getTextContent()).toBe('!');
+        expect(allText[1].getKey()).not.toBe(key);
+      },
+      {discrete: true},
+    );
+  });
+});
+
 describe('Regression tests for #6701', () => {
   test('insertNodes fails an invariant when there is no Block ancestor', async () => {
     class InlineElementNode extends ElementNode {
@@ -1779,8 +1822,12 @@ describe('Regression #7081', () => {
           'element',
         );
         selection.insertText('123');
-        expect(textNode.isAttached()).toBe(true);
-        expect(textNode.getTextContent()).toBe('123');
+        const children = paragraphNode.getChildren();
+        const styledChild = children.find(
+          c => $isTextNode(c) && c.getStyle() === 'color: --color-test',
+        );
+        expect(styledChild).toBeDefined();
+        expect(styledChild?.getTextContent()).toBe('123');
       },
       {discrete: true},
     );
@@ -1869,6 +1916,112 @@ describe('Regression #8067', () => {
         );
         expect(children.getTextContent()).toBe('hello');
         expect(children.hasFormat('bold')).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+});
+
+describe('insertText with backward selection inherits first node format', () => {
+  test('backward selection across bold+plain inherits bold', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const boldNode = $createTextNode('hello');
+        boldNode.toggleFormat('bold');
+        const plainNode = $createTextNode(' world');
+        paragraph.append(boldNode, plainNode);
+        root.clear().append(paragraph);
+        // Backward selection: anchor at end of plain, focus at start of bold
+        const selection = plainNode
+          .select(6, 6)
+          .setTextNodeRange(plainNode, 6, boldNode, 0);
+        selection.insertText('X');
+        const child = $assertNodeType(paragraph.getChildren()[0], $isTextNode);
+        expect(child.getTextContent()).toBe('X');
+        expect(child.hasFormat('bold')).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+});
+
+describe('insertText needsRedirect paths', () => {
+  test('token node at middle offset replaces entire node', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const token = $createTextNode('abcdef').setMode('token');
+        const paragraph = $createParagraphNode().append(token);
+        $getRoot().clear().append(paragraph);
+        const sel = token.select(3, 3);
+        sel.insertText('X');
+        const children = paragraph.getChildren();
+        expect(children).toHaveLength(1);
+        const child = $assertNodeType(children[0], $isTextNode);
+        expect(child.getTextContent()).toBe('X');
+        expect(token.isAttached()).toBe(false);
+      },
+      {discrete: true},
+    );
+  });
+
+  test('offset 0 on token reuses insertable previous sibling', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const prev = $createTextNode('before');
+        const token = $createTextNode('locked').setMode('token');
+        const paragraph = $createParagraphNode().append(prev, token);
+        $getRoot().clear().append(paragraph);
+        token.select(0, 0);
+        const sel = $getSelection();
+        assert($isRangeSelection(sel));
+        sel.insertText('X');
+        expect(prev.getLatest().getTextContent()).toBe('beforeX');
+        expect(token.isAttached()).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+
+  test('offset at end of token reuses insertable next sibling', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const token = $createTextNode('locked').setMode('token');
+        const next = $createTextNode('after');
+        const paragraph = $createParagraphNode().append(token, next);
+        $getRoot().clear().append(paragraph);
+        token.select(6, 6);
+        const sel = $getSelection();
+        assert($isRangeSelection(sel));
+        sel.insertText('X');
+        expect(next.getLatest().getTextContent()).toBe('Xafter');
+        expect(token.isAttached()).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+});
+
+describe('insertText formatDiffers on empty text node', () => {
+  test('applies format in-place on empty anchor then splices text', () => {
+    using editor = buildEditorFromExtensions(selectionTestExtension);
+    editor.update(
+      () => {
+        const empty = $createTextNode('');
+        const paragraph = $createParagraphNode().append(empty);
+        $getRoot().clear().append(paragraph);
+        const sel = empty.select(0, 0);
+        sel.format = IS_BOLD;
+        sel.insertText('typed');
+        expect(empty.isAttached()).toBe(true);
+        expect(empty.getLatest().getTextContent()).toBe('typed');
+        expect(empty.getLatest().hasFormat('bold')).toBe(true);
+        expect(paragraph.getChildrenSize()).toBe(1);
       },
       {discrete: true},
     );


### PR DESCRIPTION
## Description

`insertText` had ~390 lines of interleaved deletion and insertion logic for non-collapsed selections — tracking `markedNodeKeysForKeep`, walking parent chains, and splicing across multi-node boundaries. etrepum's WIP comment at the top of the method noted that `removeText()` is now independent of `insertText`, so the non-collapsed case can be decomposed into `removeText()` followed by a collapsed-cursor insert.

This PR implements that decomposition. The non-collapsed path captures format/style from the document-order first text node, calls `removeText()`, restores the format, then delegates to `$insertTextAtPoint` (normal case) or falls through to the collapsed `spliceText` path (during IME composition, to preserve DOM node identity for the browser's composition tracker).

The collapsed path consolidates the scattered token/segmented/boundary checks into a single `needsRedirect` guard, and routes the remaining cases through format-diff detection → `$insertTextAtPoint` or direct `spliceText`.

Three pre-existing bugs are fixed along the way:
- `setStyle(style)` was missing when replacing a segmented node outside composition
- `setStyle(style)` was missing when creating a redirect node at offset 0
- `canInsertTextAfter()` was not checked on the previous sibling in the offset-0 redirect path

~390 → ~180 lines (net −100 in LexicalSelection.ts).

## Test plan

- [x] `pnpm test-unit -- LexicalSelection.test.ts` — 85 pass
- [x] `pnpm test-unit -- LexicalSelectionHelpers.test.ts` — 51 pass
- [x] Full unit suite (lexical + lexical-selection) — 1121 pass
- [x] e2e (chromium) — 765 pass
- [x] Manual playground (Chrome, Safari, Firefox):
  - Basic text input, selection replacement, select-all replacement
  - Bold format inheritance across non-collapsed selection
  - Backward selection format inheritance
  - Link boundary insertion (start, end, middle)
  - Format toggle on empty paragraph then typing
  - Multi-paragraph selection replacement
  - Korean IME: basic input, bold toggle, selection replacement
  - Undo/redo after selection replacement
- [x] tsc / prettier / eslint clean