### PR TITLE
[lexical] Performance: Skip redundant selection restoration in $removeTextFromCaretRange

### DIFF
--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -22,6 +22,7 @@ import {
   $getNodeByKeyOrThrow,
   $isRootOrShadowRoot,
   $isShadowRootNode,
+  $removeFromParent,
   $setSelection,
   INTERNAL_$isBlock,
 } from '../LexicalUtils';
@@ -254,8 +255,7 @@ export function $removeTextFromCaretRange<D extends CaretDirection>(
 
   // Mark the start of each ElementNode
   const seenStart = new Set<NodeKey>();
-  // Queue removals since removing the only child can cascade to having
-  // a parent remove itself which will affect iteration
+  // Queue removals to avoid mutating the tree during iteration
   const removedNodes: LexicalNode[] = [];
   for (const caret of range.iterNodeCarets(rootMode)) {
     if ($isChildCaret(caret)) {
@@ -267,8 +267,29 @@ export function $removeTextFromCaretRange<D extends CaretDirection>(
       }
     }
   }
+  // Use $removeFromParent instead of node.remove() to skip redundant
+  // per-node selection restoration — selection is rebuilt from
+  // anchor/focus candidates below.
+  const removedParents = new Set<ElementNode>();
   for (const node of removedNodes) {
-    node.remove();
+    const parent = node.getParent();
+    // Track parents not in seenStart — those in seenStart are traversal
+    // boundaries handled by block-merge logic below.
+    if (parent !== null && !seenStart.has(parent.getKey())) {
+      removedParents.add(parent);
+    }
+    $removeFromParent(node);
+  }
+  // Remove inline wrappers (canBeEmpty=false) that became empty
+  for (const parent of removedParents) {
+    if (
+      !parent.canBeEmpty() &&
+      !$isRootOrShadowRoot(parent) &&
+      parent.isEmpty() &&
+      parent.isAttached()
+    ) {
+      parent.remove();
+    }
   }
 
   // Splice text at the anchor and/or origin.

--- a/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
+++ b/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
@@ -13,6 +13,7 @@ import {
   type ListItemNode,
   type ListNode,
 } from '@lexical/list';
+import {$createMarkNode} from '@lexical/mark';
 import {$createHeadingNode, $isHeadingNode} from '@lexical/rich-text';
 import {
   $createTableCellNode,
@@ -27,6 +28,7 @@ import {
   $createTextNode,
   $getCaretRange,
   $getChildCaret,
+  $getChildCaretAtIndex,
   $getCommonAncestor,
   $getRoot,
   $getSelection,
@@ -1986,6 +1988,121 @@ describe('LexicalSelectionHelpers', () => {
 
         expect(testEnv.innerHTML).toBe(
           '<p dir="auto"><a href="https://"><span data-lexical-text="true">link</span></a><span data-lexical-text="true">foo</span></p>',
+        );
+      });
+    });
+
+    describe('canBeEmpty()=false parent cleanup', () => {
+      test('MarkNode is removed when all children are deleted via element-type range', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const p = $createParagraphNode();
+            const before = $createTextNode('before ');
+            const mark = $createMarkNode(['test-id']);
+            const markText1 = $createTextNode('aaa');
+            const markText2 = $createTextNode('bbb');
+            const after = $createTextNode(' after');
+            mark.append(markText1, markText2);
+            p.append(before, mark, after);
+            root.append(p);
+
+            const range = $getCaretRange(
+              $getChildCaretAtIndex(mark, 0, 'next'),
+              $getChildCaretAtIndex(mark, 2, 'next'),
+            );
+            $removeTextFromCaretRange(range);
+
+            expect(mark.isAttached()).toBe(false);
+            expect(before.isAttached()).toBe(true);
+            expect(after.isAttached()).toBe(true);
+          },
+          {discrete: true},
+        );
+      });
+
+      test('LinkNode is removed when all children are deleted via element-type range', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const p = $createParagraphNode();
+            const before = $createTextNode('before ');
+            const link = $createLinkNode('https://lexical.dev');
+            const linkText = $createTextNode('click');
+            const after = $createTextNode(' after');
+            link.append(linkText);
+            p.append(before, link, after);
+            root.append(p);
+
+            const range = $getCaretRange(
+              $getChildCaretAtIndex(link, 0, 'next'),
+              $getChildCaretAtIndex(link, 1, 'next'),
+            );
+            $removeTextFromCaretRange(range);
+
+            expect(link.isAttached()).toBe(false);
+            expect(before.isAttached()).toBe(true);
+            expect(after.isAttached()).toBe(true);
+          },
+          {discrete: true},
+        );
+      });
+
+      test('canBeEmpty()=false parent survives when only some children are removed', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const p = $createParagraphNode();
+            const mark = $createMarkNode(['test-id']);
+            const t1 = $createTextNode('aaa');
+            const t2 = $createTextNode('bbb');
+            const t3 = $createTextNode('ccc');
+            mark.append(t1, t2, t3);
+            p.append(mark);
+            root.append(p);
+
+            const range = $getCaretRange(
+              $getChildCaretAtIndex(mark, 0, 'next'),
+              $getSiblingCaret(t2, 'next'),
+            );
+            $removeTextFromCaretRange(range);
+
+            expect(mark.isAttached()).toBe(true);
+            expect(mark.getChildrenSize()).toBeGreaterThan(0);
+          },
+          {discrete: true},
+        );
+      });
+
+      test('multiple canBeEmpty()=false parents in same range are cleaned up', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const p = $createParagraphNode();
+            const mark1 = $createMarkNode(['id1']);
+            const mark2 = $createMarkNode(['id2']);
+            const t1 = $createTextNode('aaa');
+            const t2 = $createTextNode('bbb');
+            const spacer = $createTextNode(' ');
+            mark1.append(t1);
+            mark2.append(t2);
+            p.append(mark1, spacer, mark2);
+            root.append(p);
+
+            const range = $getCaretRange(
+              $getChildCaretAtIndex(p, 0, 'next'),
+              $getChildCaretAtIndex(p, 3, 'next'),
+            );
+            $removeTextFromCaretRange(range);
+
+            expect(mark1.isAttached()).toBe(false);
+            expect(mark2.isAttached()).toBe(false);
+          },
+          {discrete: true},
         );
       });
     });


### PR DESCRIPTION
## Description

`$removeTextFromCaretRange` rebuilds selection from pre-computed anchor/focus candidates after removing nodes, so the per-node selection restoration inside `node.remove()` (`$removeNode` → `$setSelection`) is wasted work. This PR replaces `node.remove()` with `$removeFromParent(node)` in the removedNodes loop to skip it.

The swap also means `canBeEmpty()=false` inline parents (MarkNode, LinkNode) no longer auto-remove themselves during child removal — `$removeNode`'s selection-aware path handled that as a side effect. A cleanup pass after the loop handles this explicitly: any tracked parent that ended up empty, non-root, and still attached gets removed.

Benchmark (`removeText` on 500-node document, 500 iterations, Node v22, `performance.now()`):

| | Mean | P50 | P95 |
|---|---|---|---|
| Before | 1.841 ms | 1.379 ms | 4.182 ms |
| After | 1.197 ms | 0.809 ms | 2.708 ms |
| Speedup | 1.54× | 1.70× | 1.54× |

## Test plan

- [x] `pnpm test-unit -- packages/lexical/src/caret` — 4940 pass, 0 regressions
- [x] 4 new tests for `canBeEmpty()=false` parent cleanup:
  - MarkNode removed when all children deleted via element-type range
  - LinkNode removed when all children deleted
  - canBeEmpty()=false parent survives partial removal
  - Multiple canBeEmpty()=false parents cleaned up in same range
- [x] e2e (chromium) — pass
- [x] tsc clean