### PR TITLE
[lexical-html] Bug Fix: Dispatch unrestricted CSS selector groups

### DIFF
--- a/packages/lexical-html/src/__tests__/unit/DOMImportExtension.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/DOMImportExtension.test.ts
@@ -410,6 +410,29 @@ describe('DOMImportExtension', () => {
     });
   });
 
+  test('CSS selector lists dispatch tag-restricted and unrestricted groups', () => {
+    const importedTags = (selector: string): string[] => {
+      const rule = defineImportRule({
+        $import: (_ctx, el) => {
+          const p = $createParagraphNode();
+          p.append($createTextNode(el.nodeName.toLowerCase()));
+          return [p];
+        },
+        match: sel.css(selector),
+        name: 'test/css-selector-list',
+      });
+      using editor = buildTestEditor([rule]);
+      importInto(editor, '<p></p><div class="foo"></div><article></article>');
+      return editor.read(() =>
+        $rootParagraphs().map(node => node.getTextContent()),
+      );
+    };
+
+    expect(importedTags('p, .foo')).toEqual(['p', 'div']);
+    expect(importedTags('.foo, p')).toEqual(['p', 'div']);
+    expect(importedTags('p, .foo, article')).toEqual(['p', 'div', 'article']);
+  });
+
   test('isElementOfTag narrows correctly without instanceof', () => {
     const dom = new JSDOM(
       '<!doctype html><html><body><a href="x"></a><p></p></body></html>',

--- a/packages/lexical-html/src/import/parseCss.ts
+++ b/packages/lexical-html/src/import/parseCss.ts
@@ -191,13 +191,16 @@ export function parseSelector(
     return buildSelector(groups[0].tags, groups[0].predicates);
   }
 
-  // Comma-separated list. Merge tag sets and OR-combine the per-group
-  // refinement predicates so that each candidate node satisfies *some*
+  // Comma-separated list. Merge tag sets only when every group is tag-
+  // restricted; an unrestricted group requires wildcard dispatch. OR-combine
+  // the per-group refinement predicates so each candidate satisfies some
   // group entirely.
   const tags = new Set<string>();
-  for (const g of groups) {
-    for (const t of g.tags) {
-      tags.add(t);
+  if (groups.every(g => g.tags.size > 0)) {
+    for (const g of groups) {
+      for (const t of g.tags) {
+        tags.add(t);
+      }
     }
   }
   const orPredicate: Predicate = (node, captures) => {


### PR DESCRIPTION
## Description

Mixed tag-restricted and unrestricted selector lists passed to `sel.css(...)` were indexed only under their explicit tags. This meant an unrestricted group such as `.foo` was never evaluated for elements whose tag was not also listed.

This change uses wildcard dispatch whenever any selector group is unrestricted. The existing selector predicate still filters candidates, so each element must satisfy one of the original groups.

## Test plan

### Before

The focused regression assertion failed:

```text
expected [ 'p' ] to deeply equal [ 'p', 'div' ]
```

### After

- Focused `DOMImportExtension` tests: 23/23 passed.
- `lexical-html` unit tests: 89/89 passed.
- `pnpm run ci-check` passed.
