### PR TITLE
[lexical-playground] Bug Fix: Deterministic history coalescing for flaky webkit undo tests

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -33,6 +33,13 @@ test.describe('History', () => {
   }) => {
     test.skip(isCollab);
     await page.focus('div[contenteditable="true"]');
+    // Freeze the history merge clock before the first burst so "hello" coalesces
+    // into a single undo entry deterministically. Each advanceHistoryClock call
+    // only makes the bursts *after* it deterministic; without this leading call
+    // the initial "hello" is typed against the real 300ms merge window, and
+    // under WebKit/CI load a slow inter-keystroke gap can split it across undo
+    // entries and desync every undo/redo assertion below (flaky on webkit).
+    await advanceHistoryClock(page);
     await page.keyboard.type('hello');
     await advanceHistoryClock(page);
     await page.keyboard.type(' world');

--- a/packages/lexical-playground/__tests__/regression/1055-fast-typing-undo.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/1055-fast-typing-undo.spec.mjs
@@ -8,6 +8,7 @@
 
 import {undo} from '../keyboardShortcuts/index.mjs';
 import {
+  advanceHistoryClock,
   assertHTML,
   focusEditor,
   html,
@@ -23,12 +24,20 @@ test.describe('Regression test #1055', () => {
   }) => {
     test.skip(isCollab);
     await focusEditor(page);
+    // Freeze the history merge clock before typing so the whole burst coalesces
+    // into a single undo entry deterministically. History merges consecutive
+    // same-type keystrokes only while each lands within the 300ms merge window
+    // (@lexical/history's default `delay`) of the previous one, measured against
+    // the wall clock. With slowMo + WebKit under CI load an inter-keystroke gap
+    // can exceed that window, splitting "hello" across multiple undo-stack
+    // entries so the single undo() below reverts only the last fragment and the
+    // editor is not empty when we assert (flaky on the mac-plain/webkit suite).
+    // Freezing the clock removes the timing dimension: every keystroke observes
+    // the same instant, so the burst always coalesces regardless of scheduling.
+    await advanceHistoryClock(page);
     await page.keyboard.type('hello');
-    // Wait for the typed text to settle before undoing. On WebKit the input
-    // events dispatched by keyboard.type() can be applied after the call
-    // resolves; without this barrier the undo below races ahead of the typing
-    // and the still-queued input then re-applies the text, so the editor is
-    // not empty when we assert (flaky on the mac-plain/webkit suite).
+    // Barrier: ensure every keystroke has been applied before undoing so the
+    // undo can't race ahead of input that WebKit is still settling.
     await assertHTML(
       page,
       html`


### PR DESCRIPTION
## Description

The `@lexical/history` plugin merges consecutive same-type keystrokes into a single undo entry only while each one lands within the 300ms merge window (`HistoryConfig.delay`) of the previous keystroke, measured against the wall clock (`changeTime < prevChangeTime + delay`).

The first typed burst in each affected test runs before any clock freeze, so under `slowMo: 50` + WebKit on a loaded CI runner a slow inter-keystroke gap can exceed the merge window and split `hello` across multiple undo-stack entries. A single `undo()` then reverts only the last fragment (1055-fast-typing-undo hard-fails: editor not empty) or the counted undo/redo sequence desyncs (History.spec goes flaky). The previous `assertHTML` barrier could not help because the split happens during typing, before the barrier runs.

This change freezes the history merge clock with `advanceHistoryClock` before the first burst in both tests, so every keystroke observes the same instant and the burst always coalesces regardless of scheduling. In History.spec the existing post-`hello` freeze still creates the intended `hello` / ` world` undo boundary; the 1055 barrier assertion is kept (it guards typing completion) with its comment corrected to reflect the real cause.

## Test plan

### Before

[webkit] 1055-fast-typing-undo.spec.mjs › Adds new editor state into undo stack right after undo was done — fails (editor still contains "hello" after undo).

[webkit] History.spec.mjs › Can type two paragraphs of text and correctly undo and redo — flaky (intermittent undo/redo desync).

### After

Both tests type their first burst against a frozen history clock, so the burst coalesces into a single undo entry deterministically and the undo/redo assertions are stable across scheduling jitter on the webkit/mac-plain suite. Verified the merge-boundary reasoning against packages/lexical-history/src/index.ts; both spec files pass `node --check`. (A live WebKit run was not possible in this environment — Chromium only — and a ~1% timing race would not reproduce reliably in a single run.)
