### PR TITLE
[Breaking Change][lexical] Chore: Remove redundant registerCommand/registerNodeTransform generics

### DIFF
--- a/dev-examples/dom-import/src/ToolbarExtension.tsx
+++ b/dev-examples/dom-import/src/ToolbarExtension.tsx
@@ -121,7 +121,7 @@ export function Toolbar({children}: ToolbarProps) {
       <button
         type="button"
         disabled={!canUndo}
-        onClick={() => editor.dispatchCommand(UNDO_COMMAND, undefined)}
+        onClick={() => editor.dispatchCommand(UNDO_COMMAND)}
         className="toolbar-item spaced"
         aria-label="Undo">
         ↶
@@ -129,7 +129,7 @@ export function Toolbar({children}: ToolbarProps) {
       <button
         type="button"
         disabled={!canRedo}
-        onClick={() => editor.dispatchCommand(REDO_COMMAND, undefined)}
+        onClick={() => editor.dispatchCommand(REDO_COMMAND)}
         className="toolbar-item spaced"
         aria-label="Redo">
         ↷
@@ -168,27 +168,21 @@ export function Toolbar({children}: ToolbarProps) {
       <Divider />
       <button
         type="button"
-        onClick={() =>
-          editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined)
-        }
+        onClick={() => editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND)}
         className="toolbar-item spaced"
         aria-label="Bullet list">
         •
       </button>
       <button
         type="button"
-        onClick={() =>
-          editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined)
-        }
+        onClick={() => editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND)}
         className="toolbar-item spaced"
         aria-label="Numbered list">
         1.
       </button>
       <button
         type="button"
-        onClick={() =>
-          editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND, undefined)
-        }
+        onClick={() => editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND)}
         className="toolbar-item spaced"
         aria-label="Check list">
         ☑

--- a/dev-examples/mdast-editor/src/Editor.tsx
+++ b/dev-examples/mdast-editor/src/Editor.tsx
@@ -172,7 +172,7 @@ function ResetButton({disabled}: {disabled: boolean}) {
       type="button"
       // Reset replaces the document, so it follows the pane's lock.
       disabled={disabled}
-      onClick={() => editor.dispatchCommand(RESET_MARKDOWN_COMMAND, undefined)}
+      onClick={() => editor.dispatchCommand(RESET_MARKDOWN_COMMAND)}
       className={paneButtonClass}>
       Reset
     </button>

--- a/dev-examples/mdast-editor/src/__tests__/browser/MdastEditorChrome.test.ts
+++ b/dev-examples/mdast-editor/src/__tests__/browser/MdastEditorChrome.test.ts
@@ -456,10 +456,10 @@ describe('read-only', () => {
     );
     const before = markdownOf(editor);
     editor.setEditable(false);
-    editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND, undefined);
-    editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined);
+    editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND);
+    editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND);
     editor.dispatchCommand(INSERT_ALERT_COMMAND, 'note');
-    editor.dispatchCommand(FORMAT_KBD_COMMAND, undefined);
+    editor.dispatchCommand(FORMAT_KBD_COMMAND);
     expect(markdownOf(editor)).toBe(before);
     // The one thing read-only still allows: moving the selection.
     root.querySelector<HTMLElement>('.footnote-ref a')!.click();

--- a/dev-examples/mdast-editor/src/__tests__/unit/MdastCustomConstructs.test.ts
+++ b/dev-examples/mdast-editor/src/__tests__/unit/MdastCustomConstructs.test.ts
@@ -223,7 +223,7 @@ describe('CollapsibleNode', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined);
+    editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND);
     editor.read(() => {
       const collapsible = $getRoot()
         .getChildren()
@@ -299,7 +299,7 @@ describe('KbdNode', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(FORMAT_KBD_COMMAND, undefined);
+    editor.dispatchCommand(FORMAT_KBD_COMMAND);
     expect(editor.read(() => $convertToMarkdownString())).toBe(
       'select <kbd>me</kbd> please',
     );
@@ -315,7 +315,7 @@ describe('KbdNode', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(FORMAT_KBD_COMMAND, undefined);
+    editor.dispatchCommand(FORMAT_KBD_COMMAND);
     expect(editor.read(() => $convertToMarkdownString())).toBe(
       'select me please',
     );
@@ -554,7 +554,7 @@ describe('footnotes', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND, undefined);
+    editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND);
     // `1` is taken, so the new footnote is `2` — and the caret moved into
     // its definition body.
     editor.read(() => {
@@ -757,10 +757,10 @@ describe('read-only', () => {
     );
     editor.setEditable(false);
     const before = editor.read(() => $convertToMarkdownString());
-    editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND, undefined);
-    editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined);
+    editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND);
+    editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND);
     editor.dispatchCommand(INSERT_ALERT_COMMAND, 'note');
-    editor.dispatchCommand(FORMAT_KBD_COMMAND, undefined);
+    editor.dispatchCommand(FORMAT_KBD_COMMAND);
     expect(editor.read(() => $convertToMarkdownString())).toBe(before);
     // Selection changes stay allowed.
     editor.update(

--- a/dev-examples/mdast-editor/src/extensions/MarkdownPersistenceExtension.ts
+++ b/dev-examples/mdast-editor/src/extensions/MarkdownPersistenceExtension.ts
@@ -159,10 +159,10 @@ export const MarkdownPersistenceExtension = defineExtension({
       suspendPersistence = false;
       const stored = readStoredMarkdown(storageKey);
       editor.update(() => {
-        editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+        editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
         $convertFromMarkdownString(stored ?? defaultMarkdown);
       });
-      editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+      editor.dispatchCommand(CLEAR_HISTORY_COMMAND);
     };
 
     const applyHashDocument = (doc: HashDocument): void => {
@@ -176,10 +176,10 @@ export const MarkdownPersistenceExtension = defineExtension({
           // the import land as one atomic change. (The `#doc=` path
           // below replaces the whole editor state, slots included, so
           // it needs no equivalent.)
-          editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+          editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
           $convertFromMarkdownString(doc.markdown);
         });
-        editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+        editor.dispatchCommand(CLEAR_HISTORY_COMMAND);
         return;
       }
       docFromHash(doc.hash)
@@ -194,7 +194,7 @@ export const MarkdownPersistenceExtension = defineExtension({
           editor.setEditorState(
             editorStateFromSerializedDocument(editor, parsed),
           );
-          editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+          editor.dispatchCommand(CLEAR_HISTORY_COMMAND);
         })
         // A malformed `#doc=` payload can reject anywhere in the chain
         // (base64 decode, gzip stream, JSON.parse, or an editor state
@@ -260,7 +260,7 @@ export const MarkdownPersistenceExtension = defineExtension({
           }
           editor.update(() => {
             // Document replacement, like the repro-link path above.
-            editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+            editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
             $convertFromMarkdownString(defaultMarkdown);
           });
           return true;

--- a/dev-examples/mdast-editor/src/extensions/MdastFootnoteExtension.ts
+++ b/dev-examples/mdast-editor/src/extensions/MdastFootnoteExtension.ts
@@ -1166,7 +1166,7 @@ export const MdastFootnoteExtension = defineExtension({
           ) {
             event.preventDefault();
             event.stopPropagation();
-            editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND, undefined);
+            editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND);
             return true;
           }
           return false;

--- a/dev-examples/mdast-editor/src/plugins/ToolbarPlugin.tsx
+++ b/dev-examples/mdast-editor/src/plugins/ToolbarPlugin.tsx
@@ -57,16 +57,16 @@ type InsertType = (typeof INSERT_TYPES)[number]['value'];
 function applyInsert(editor: LexicalEditor, type: InsertType): void {
   switch (type) {
     case 'kbd':
-      editor.dispatchCommand(FORMAT_KBD_COMMAND, undefined);
+      editor.dispatchCommand(FORMAT_KBD_COMMAND);
       return;
     case 'details':
-      editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined);
+      editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND);
       return;
     case 'alert':
       editor.dispatchCommand(INSERT_ALERT_COMMAND, 'note');
       return;
     case 'footnote':
-      editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND, undefined);
+      editor.dispatchCommand(INSERT_FOOTNOTE_COMMAND);
       return;
   }
 }
@@ -74,8 +74,8 @@ function applyInsert(editor: LexicalEditor, type: InsertType): void {
 function applyBlockType(editor: LexicalEditor, type: BlockType): void {
   switch (type) {
     case 'paragraph':
-      editor.dispatchCommand(REMOVE_LIST_COMMAND, undefined);
-      editor.dispatchCommand(FORMAT_PARAGRAPH_COMMAND, undefined);
+      editor.dispatchCommand(REMOVE_LIST_COMMAND);
+      editor.dispatchCommand(FORMAT_PARAGRAPH_COMMAND);
       return;
     case 'h1':
     case 'h2':
@@ -83,13 +83,13 @@ function applyBlockType(editor: LexicalEditor, type: BlockType): void {
       editor.dispatchCommand(FORMAT_HEADING_COMMAND, type);
       return;
     case 'bullet':
-      editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+      editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND);
       return;
     case 'number':
-      editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
+      editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND);
       return;
     case 'check':
-      editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND, undefined);
+      editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND);
       return;
   }
 }
@@ -144,7 +144,7 @@ export function ToolbarPlugin() {
       <button
         type="button"
         disabled={!isEditable || !canUndo}
-        onClick={() => editor.dispatchCommand(UNDO_COMMAND, undefined)}
+        onClick={() => editor.dispatchCommand(UNDO_COMMAND)}
         className={`${buttonBase} ${buttonInactive} text-xs`}
         aria-label="Undo">
         Undo
@@ -152,7 +152,7 @@ export function ToolbarPlugin() {
       <button
         type="button"
         disabled={!isEditable || !canRedo}
-        onClick={() => editor.dispatchCommand(REDO_COMMAND, undefined)}
+        onClick={() => editor.dispatchCommand(REDO_COMMAND)}
         className={`${buttonBase} ${buttonInactive} text-xs`}
         aria-label="Redo">
         Redo

--- a/dev-examples/shadow-dom-web-component/src/LexicalEditorElement.ts
+++ b/dev-examples/shadow-dom-web-component/src/LexicalEditorElement.ts
@@ -631,8 +631,8 @@ export class LexicalEditorElement extends HTMLElement {
         ),
       );
     }
-    addButton('↺', () => editor.dispatchCommand(UNDO_COMMAND, undefined));
-    addButton('↻', () => editor.dispatchCommand(REDO_COMMAND, undefined));
+    addButton('↺', () => editor.dispatchCommand(UNDO_COMMAND));
+    addButton('↻', () => editor.dispatchCommand(REDO_COMMAND));
     toolbar.appendChild(toolbarSpacer);
     toolbar.appendChild(toolbarSlot);
 

--- a/packages/lexical-a11y/src/__tests__/unit/HistoryAnnounceExtension.test.ts
+++ b/packages/lexical-a11y/src/__tests__/unit/HistoryAnnounceExtension.test.ts
@@ -44,9 +44,9 @@ describe('HistoryAnnounceExtension', () => {
       }),
     );
     mountRoot(editor);
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(readLiveRegion()).toBe('Undone');
-    editor.dispatchCommand(REDO_COMMAND, undefined);
+    editor.dispatchCommand(REDO_COMMAND);
     expect(readLiveRegion()).toBe('Redone');
   });
 
@@ -64,9 +64,9 @@ describe('HistoryAnnounceExtension', () => {
       }),
     );
     mountRoot(editor);
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(readLiveRegion()).toBe('Custom undo');
-    editor.dispatchCommand(REDO_COMMAND, undefined);
+    editor.dispatchCommand(REDO_COMMAND);
     expect(readLiveRegion()).toBe('Custom redo');
   });
 
@@ -84,9 +84,9 @@ describe('HistoryAnnounceExtension', () => {
     ).output;
     undone.value = 'Reverted';
     redone.value = 'Restored';
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(readLiveRegion()).toBe('Reverted');
-    editor.dispatchCommand(REDO_COMMAND, undefined);
+    editor.dispatchCommand(REDO_COMMAND);
     expect(readLiveRegion()).toBe('Restored');
   });
 
@@ -104,11 +104,11 @@ describe('HistoryAnnounceExtension', () => {
     ).output;
 
     disabled.value = true;
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(readLiveRegion()).toBe('');
 
     disabled.value = false;
-    editor.dispatchCommand(REDO_COMMAND, undefined);
+    editor.dispatchCommand(REDO_COMMAND);
     expect(readLiveRegion()).toBe('Redone');
   });
 
@@ -131,7 +131,7 @@ describe('HistoryAnnounceExtension', () => {
       },
       1,
     );
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(reached).toBe(true);
   });
 });

--- a/packages/lexical-code-core/src/CodeExtension.ts
+++ b/packages/lexical-code-core/src/CodeExtension.ts
@@ -43,12 +43,14 @@ export const CodeExtension = /* @__PURE__ */ defineExtension({
   nodes: () => [CodeNode, CodeHighlightNode],
   register(editor) {
     return mergeRegister(
-      editor.registerCommand<KeyboardEvent>(
+      editor.registerCommand(
         KEY_ENTER_COMMAND,
         event => {
           const selection = $getSelection();
           if ($isRangeSelection(selection) && $exitCodeNodeOnEnter(selection)) {
-            event.preventDefault();
+            if (event !== null) {
+              event.preventDefault();
+            }
             return true;
           }
           return false;

--- a/packages/lexical-code-core/src/CodeIndentation.ts
+++ b/packages/lexical-code-core/src/CodeIndentation.ts
@@ -542,7 +542,7 @@ export function registerCodeIndentation(
           return false;
         }
         event.preventDefault();
-        editor.dispatchCommand(command, undefined);
+        editor.dispatchCommand(command);
         return true;
       },
       COMMAND_PRIORITY_LOW,

--- a/packages/lexical-code-core/src/__tests__/outdentTestUtils.ts
+++ b/packages/lexical-code-core/src/__tests__/outdentTestUtils.ts
@@ -70,7 +70,7 @@ export function $runOutdentScenario(
       point = $getSiblingCaret(matching, 'next');
     }
     $setSelectionFromCaretRange($getCollapsedCaretRange(point));
-    editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+    editor.dispatchCommand(OUTDENT_CONTENT_COMMAND);
   });
 
   return editor.read(() => {

--- a/packages/lexical-code-prism/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-prism/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -26,10 +26,10 @@ import {
   $getSelection,
   $isLineBreakNode,
   $setSelectionFromCaretRange,
+  type AnyLexicalCommand,
   configExtension,
   INDENT_CONTENT_COMMAND,
   KEY_TAB_COMMAND,
-  type LexicalCommand,
   OUTDENT_CONTENT_COMMAND,
 } from 'lexical';
 import {
@@ -210,7 +210,7 @@ describe('LexicalCodeNode tests', () => {
               // selectionTarget.getBoundingClientRect is not a function Error
               editor.dispatchCommand(
                 ...(getDispatchArgs(scenario[2]) as [
-                  LexicalCommand<unknown>,
+                  AnyLexicalCommand,
                   unknown,
                 ]),
               );

--- a/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -36,10 +36,10 @@ import {
   $isLineBreakNode,
   $isTabNode,
   $setSelectionFromCaretRange,
+  type AnyLexicalCommand,
   configExtension,
   INDENT_CONTENT_COMMAND,
   KEY_TAB_COMMAND,
-  type LexicalCommand,
   OUTDENT_CONTENT_COMMAND,
 } from 'lexical';
 import {
@@ -247,7 +247,7 @@ describe('LexicalCodeNode tests', () => {
               // selectionTarget.getBoundingClientRect is not a function Error
               editor.dispatchCommand(
                 ...(getDispatchArgs(scenario[2]) as [
-                  LexicalCommand<unknown>,
+                  AnyLexicalCommand,
                   unknown,
                 ]),
               );

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
@@ -424,7 +424,7 @@ describe('LexicalCodeNode tests', () => {
         selection.focus.set(lastCodeText.getKey(), 3, 'text');
         $setSelection(selection);
       });
-      await editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+      await editor.dispatchCommand(INDENT_CONTENT_COMMAND);
       expect(testEnv.innerHTML)
         .toBe(`<code spellcheck="false" data-language="javascript" data-highlight-language="javascript" dir="auto" data-gutter="1
 2"><br><span data-lexical-text="true">\t</span><span data-lexical-text="true">hello</span></code>`);

--- a/packages/lexical-extension/src/HorizontalRuleExtension.ts
+++ b/packages/lexical-extension/src/HorizontalRuleExtension.ts
@@ -55,7 +55,7 @@ export type SerializedHorizontalRuleNode = SerializedLexicalNode;
 /**
  * Command that inserts a {@link HorizontalRuleNode} at the current selection.
  * Dispatch it with
- * `editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined)`.
+ * `editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND)`.
  */
 export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('INSERT_HORIZONTAL_RULE_COMMAND');

--- a/packages/lexical-extension/src/TabIndentationExtension.ts
+++ b/packages/lexical-extension/src/TabIndentationExtension.ts
@@ -85,7 +85,7 @@ export function registerTabIndentation(
     | ReadonlySignal<CanIndentPredicate> = $defaultCanIndent,
 ) {
   return mergeRegister(
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_TAB_COMMAND,
       event => {
         const selection = $getSelection();

--- a/packages/lexical-extension/src/TabIndentationExtension.ts
+++ b/packages/lexical-extension/src/TabIndentationExtension.ts
@@ -98,7 +98,7 @@ export function registerTabIndentation(
             ? OUTDENT_CONTENT_COMMAND
             : INDENT_CONTENT_COMMAND
           : INSERT_TAB_COMMAND;
-        return editor.dispatchCommand(command, undefined);
+        return editor.dispatchCommand(command);
       },
       COMMAND_PRIORITY_EDITOR,
     ),

--- a/packages/lexical-extension/src/__tests__/unit/ClearEditorExtension.test.ts
+++ b/packages/lexical-extension/src/__tests__/unit/ClearEditorExtension.test.ts
@@ -40,7 +40,7 @@ function setUpEditor(
 describe('ClearEditorExtension', () => {
   test('CLEAR_EDITOR_COMMAND empties the document', () => {
     using editor = setUpEditor();
-    editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+    editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('');
     });
@@ -58,7 +58,7 @@ describe('ClearEditorExtension', () => {
         },
       }),
     );
-    editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+    editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('cleared');
     });
@@ -72,7 +72,7 @@ describe('ClearEditorExtension', () => {
     // wrapped it in editor.update(), the nested update would be QUEUED and
     // clear the editor after the content below was appended.
     editor.update(() => {
-      editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+      editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
       const root = $getRoot();
       root.clear();
       root.append(

--- a/packages/lexical-file/src/fileImportExport.ts
+++ b/packages/lexical-file/src/fileImportExport.ts
@@ -72,7 +72,7 @@ export function editorStateFromSerializedDocument(
 export function importFile(editor: LexicalEditor) {
   readTextFileFromSystem(text => {
     editor.setEditorState(editorStateFromSerializedDocument(editor, text));
-    editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+    editor.dispatchCommand(CLEAR_HISTORY_COMMAND);
   });
 }
 

--- a/packages/lexical-history/src/__tests__/unit/HistorySnapshotCutPaste.test.ts
+++ b/packages/lexical-history/src/__tests__/unit/HistorySnapshotCutPaste.test.ts
@@ -97,11 +97,11 @@ describe.each([
     editor.update(() => $type('d'), {discrete: true});
 
     // Undo removes only the trailing keystroke...
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(editor.read(() => $getRoot().getTextContent())).toBe('abcX');
 
     // ...then the tagged change, leaving the earlier typing intact.
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(editor.read(() => $getRoot().getTextContent())).toBe('abc');
   });
 });
@@ -172,7 +172,7 @@ describe('rich-text paste is isolated from the preceding typing (#8609)', () => 
     editor.dispatchCommand(PASTE_COMMAND, clipboardEvent('paste', 'X'));
     expect(editor.read(() => $getRoot().getTextContent())).toBe('abcX');
 
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(editor.read(() => $getRoot().getTextContent())).toBe('abc');
   });
 });

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -261,7 +261,7 @@ describe('LexicalHistory tests', () => {
       reactRoot.render(<Test key="smth" />);
     });
 
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       CAN_REDO_COMMAND,
       payload => {
         canRedo = payload;
@@ -270,7 +270,7 @@ describe('LexicalHistory tests', () => {
       COMMAND_PRIORITY_CRITICAL,
     );
 
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       CAN_UNDO_COMMAND,
       payload => {
         canUndo = payload;
@@ -360,7 +360,7 @@ describe('LexicalHistory tests', () => {
       reactRoot.render(<Test key="smth" />);
     });
 
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       CAN_REDO_COMMAND,
       payload => {
         canRedo = payload;
@@ -369,7 +369,7 @@ describe('LexicalHistory tests', () => {
       COMMAND_PRIORITY_CRITICAL,
     );
 
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       CAN_UNDO_COMMAND,
       payload => {
         canUndo = payload;

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -280,7 +280,7 @@ describe('LexicalHistory tests', () => {
     );
 
     await act(async () => {
-      editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+      editor.dispatchCommand(CLEAR_HISTORY_COMMAND);
     });
 
     expect(canRedo).toBe(false);
@@ -343,7 +343,7 @@ describe('LexicalHistory tests', () => {
 
     await act(async () => {
       await editor.update(() => {
-        editor.dispatchCommand(UNDO_COMMAND, undefined);
+        editor.dispatchCommand(UNDO_COMMAND);
       });
     });
 
@@ -400,7 +400,7 @@ describe('LexicalHistory tests', () => {
     // undo
     await act(async () => {
       await editor.update(() => {
-        editor.dispatchCommand(UNDO_COMMAND, undefined);
+        editor.dispatchCommand(UNDO_COMMAND);
       });
     });
     expect(canRedo).toBe(true);
@@ -409,7 +409,7 @@ describe('LexicalHistory tests', () => {
     // redo
     await act(async () => {
       await editor.update(() => {
-        editor.dispatchCommand(REDO_COMMAND, undefined);
+        editor.dispatchCommand(REDO_COMMAND);
       });
     });
     expect(canRedo).toBe(false);
@@ -418,7 +418,7 @@ describe('LexicalHistory tests', () => {
     // undo
     await act(async () => {
       await editor.update(() => {
-        editor.dispatchCommand(UNDO_COMMAND, undefined);
+        editor.dispatchCommand(UNDO_COMMAND);
       });
     });
     expect(canRedo).toBe(true);
@@ -477,7 +477,7 @@ describe('LexicalHistory tests', () => {
     });
 
     expect(sharedHistory.undoStack.length).toBe(2);
-    await editor_.dispatchCommand(UNDO_COMMAND, undefined);
+    await editor_.dispatchCommand(UNDO_COMMAND);
     expect($isNodeSelection(editor_.getEditorState()._selection)).toBe(true);
   });
 
@@ -592,7 +592,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   test('canRedo becomes true after undo, canUndo goes false', () => {
     using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     expect(output.canUndo.peek()).toBe(false);
     expect(output.canRedo.peek()).toBe(true);
   });
@@ -600,8 +600,8 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
   test('canRedo clears after redo, canUndo returns true', () => {
     using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
-    editor.dispatchCommand(REDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
+    editor.dispatchCommand(REDO_COMMAND);
     expect(output.canUndo.peek()).toBe(true);
     expect(output.canRedo.peek()).toBe(false);
   });
@@ -610,7 +610,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     using editor = makeEditorWithOneUndoEntry();
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     expect(output.canUndo.peek()).toBe(true);
-    editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+    editor.dispatchCommand(CLEAR_HISTORY_COMMAND);
     expect(output.canUndo.peek()).toBe(false);
     expect(output.canRedo.peek()).toBe(false);
   });
@@ -620,7 +620,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
     const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
     // Wrap UNDO dispatch in editor.update so that the HISTORIC_TAG from
     // undo's setEditorState does not leak into the subsequent edit.
-    editor.update(() => editor.dispatchCommand(UNDO_COMMAND, undefined), {
+    editor.update(() => editor.dispatchCommand(UNDO_COMMAND), {
       discrete: true,
     });
     expect(output.canRedo.peek()).toBe(true);
@@ -645,7 +645,7 @@ describe('HistoryExtension canUndo/canRedo signals', () => {
 
   test('canRedo is true immediately when initialized with a non-empty redoStack', () => {
     using donor = makeEditorWithOneUndoEntry();
-    donor.dispatchCommand(UNDO_COMMAND, undefined);
+    donor.dispatchCommand(UNDO_COMMAND);
     const donorHistory = getExtensionDependencyFromEditor(
       donor,
       HistoryExtension,
@@ -828,8 +828,8 @@ describe('SharedHistoryExtension', () => {
       ).output.historyState.peek(),
     );
 
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
+    editor.dispatchCommand(UNDO_COMMAND);
     editor.read(() => {
       expect($getChildEditor().read(() => $getRoot().getTextContent())).toEqual(
         'Child editor',
@@ -849,7 +849,7 @@ describe('SharedHistoryExtension', () => {
         <p dir="auto"><br data-lexical-managed-linebreak="true" /></p>
       `,
     );
-    editor.update(() => editor.dispatchCommand(UNDO_COMMAND, undefined), {
+    editor.update(() => editor.dispatchCommand(UNDO_COMMAND), {
       discrete: true,
     });
     expectHtmlToBeEqual(

--- a/packages/lexical-list/src/__tests__/unit/ListExtension.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListExtension.test.ts
@@ -97,7 +97,7 @@ describe('CheckListExtension', () => {
       }
     });
 
-    editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+    editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
 
     editor.update(() => {
       const root = $getRoot();

--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -249,7 +249,7 @@ describe('$handleListInsertParagraph', () => {
         listNode.append(listItemWithContent, listItemEmpty);
         $getRoot().append(listNode);
         listItemEmpty.select();
-        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
       });
 
       editor.read(() => {
@@ -278,7 +278,7 @@ describe('$handleListInsertParagraph', () => {
         listNode.append(listItemWithContent, listItemWhitespace);
         $getRoot().append(listNode);
         whitespaceTextNode.select();
-        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
       });
 
       editor.read(() => {
@@ -306,7 +306,7 @@ describe('$handleListInsertParagraph', () => {
         listNode.append(listItem1, listItem2);
         $getRoot().append(listNode);
         textNode.selectEnd();
-        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
       });
 
       editor.read(() => {
@@ -332,7 +332,7 @@ describe('$handleListInsertParagraph', () => {
         listNode.append(listItem1, listItem2);
         $getRoot().append(listNode);
         listItem2.select();
-        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
       });
 
       editor.read(() => {
@@ -363,7 +363,7 @@ describe('$handleListInsertParagraph', () => {
         );
         $getRoot().append(listNode);
         listItemEmpty.select();
-        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
       });
 
       editor.read(() => {

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -121,21 +121,21 @@ export function registerCheckList(
       },
       COMMAND_PRIORITY_LOW,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_DOWN_COMMAND,
       event => {
         return handleArrowUpOrDown(event, editor, false);
       },
       COMMAND_PRIORITY_LOW,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_UP_COMMAND,
       event => {
         return handleArrowUpOrDown(event, editor, true);
       },
       COMMAND_PRIORITY_LOW,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ESCAPE_COMMAND,
       () => {
         const activeItem = getActiveCheckListItem(editor);
@@ -154,7 +154,7 @@ export function registerCheckList(
       },
       COMMAND_PRIORITY_LOW,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_SPACE_COMMAND,
       event => {
         const activeItem = getActiveCheckListItem(editor);
@@ -175,7 +175,7 @@ export function registerCheckList(
       },
       COMMAND_PRIORITY_LOW,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_LEFT_COMMAND,
       event => {
         return editor.read('latest', () => {

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
@@ -308,7 +308,7 @@ describe('HISTORY', () => {
 
     editor.update(
       () => {
-        editor.dispatchCommand(UNDO_COMMAND, undefined);
+        editor.dispatchCommand(UNDO_COMMAND);
       },
       {discrete: true},
     );

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -135,7 +135,7 @@ function onCutForPlainText(
 
 export function registerPlainText(editor: LexicalEditor): () => void {
   const removeListener = mergeRegister(
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       DELETE_CHARACTER_COMMAND,
       isBackward => {
         const selection = $getSelection();
@@ -149,7 +149,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       DELETE_WORD_COMMAND,
       isBackward => {
         const selection = $getSelection();
@@ -163,7 +163,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       DELETE_LINE_COMMAND,
       isBackward => {
         const selection = $getSelection();
@@ -177,7 +177,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<InputEvent | string>(
+    editor.registerCommand(
       CONTROLLED_TEXT_INSERTION_COMMAND,
       eventOrText => {
         const selection = $getSelection();
@@ -220,7 +220,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       INSERT_LINE_BREAK_COMMAND,
       selectStart => {
         const selection = $getSelection();
@@ -248,7 +248,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_LEFT_COMMAND,
       payload => {
         const selection = $getSelection();
@@ -270,7 +270,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_RIGHT_COMMAND,
       payload => {
         const selection = $getSelection();
@@ -292,7 +292,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_BACKSPACE_COMMAND,
       event => {
         const selection = $getSelection();
@@ -316,7 +316,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_DELETE_COMMAND,
       event => {
         const selection = $getSelection();
@@ -330,7 +330,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent | null>(
+    editor.registerCommand(
       KEY_ENTER_COMMAND,
       event => {
         const selection = $getSelection();
@@ -423,12 +423,12 @@ export function registerPlainText(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<DragEvent>(
+    editor.registerCommand(
       DROP_COMMAND,
       event => $handlePlainTextDrop(event, editor),
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<DragEvent>(
+    editor.registerCommand(
       DRAGSTART_COMMAND,
       event => {
         const selection = $getSelection();

--- a/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
+++ b/packages/lexical-playground/__tests__/unit/FindReplace.test.ts
@@ -749,18 +749,18 @@ describe('FindReplaceExtension — command dispatch integration', () => {
     using editor = buildEditorFromExtensions(FindReplaceExtension);
     const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
     expect(dep.output.isOpen.peek()).toBe(false);
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     expect(dep.output.isOpen.peek()).toBe(true);
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     expect(dep.output.isOpen.peek()).toBe(false);
   });
 
   test('CLOSE_FIND_REPLACE_COMMAND sets isOpen to false', () => {
     using editor = buildEditorFromExtensions(FindReplaceExtension);
     const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     expect(dep.output.isOpen.peek()).toBe(true);
-    editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND);
     expect(dep.output.isOpen.peek()).toBe(false);
   });
 
@@ -777,7 +777,7 @@ describe('FindReplaceExtension — command dispatch integration', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.searchTerm.value = 'hello';
     expect(dep.output.matches.peek()).toHaveLength(2);
     expect(dep.output.matches.peek()[0]).toMatchObject({
@@ -797,35 +797,35 @@ describe('FindReplaceExtension — command dispatch integration', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.searchTerm.value = 'a';
     expect(dep.output.matches.peek()).toHaveLength(3);
     expect(dep.output.currentIndex.peek()).toBe(0);
 
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(1);
 
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(2);
 
     // wrap around
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(0);
 
     // backward wrap
-    editor.dispatchCommand(FIND_PREV_COMMAND, undefined);
+    editor.dispatchCommand(FIND_PREV_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(2);
   });
 
   test('FIND_NEXT_COMMAND with zero matches is a no-op', () => {
     using editor = buildEditorFromExtensions(FindReplaceExtension);
     const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.searchTerm.value = 'nonexistent';
     expect(dep.output.matches.peek()).toHaveLength(0);
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(0);
-    editor.dispatchCommand(FIND_PREV_COMMAND, undefined);
+    editor.dispatchCommand(FIND_PREV_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(0);
   });
 
@@ -843,7 +843,7 @@ describe('FindReplaceExtension — command dispatch integration', () => {
     dep.output.searchTerm.value = 'hello';
     expect(dep.output.isOpen.peek()).toBe(false);
     expect(dep.output.matches.peek()).toEqual([]);
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     expect(dep.output.matches.peek()).toHaveLength(1);
   });
 
@@ -858,11 +858,11 @@ describe('FindReplaceExtension — command dispatch integration', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.searchTerm.value = 'a';
     expect(dep.output.matches.peek()).toHaveLength(3);
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(2);
     dep.output.searchTerm.value = 'a b';
     expect(dep.output.matches.peek()).toHaveLength(2);
@@ -872,7 +872,7 @@ describe('FindReplaceExtension — command dispatch integration', () => {
   test('regexError computed returns true for invalid regex', () => {
     using editor = buildEditorFromExtensions(FindReplaceExtension);
     const dep = getExtensionDependencyFromEditor(editor, FindReplaceExtension);
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.isRegex.value = true;
     dep.output.searchTerm.value = '[invalid';
     expect(dep.output.regexError.peek()).toBe(true);
@@ -891,10 +891,10 @@ describe('FindReplaceExtension — command dispatch integration', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.searchTerm.value = 'a';
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(2);
     editor.dispatchCommand(SET_SEARCH_TERM_COMMAND, 'b');
     expect(dep.output.currentIndex.peek()).toBe(0);
@@ -912,17 +912,17 @@ describe('FindReplaceExtension — command dispatch integration', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.searchTerm.value = 'a';
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(1);
-    editor.dispatchCommand(TOGGLE_CASE_SENSITIVE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_CASE_SENSITIVE_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(0);
     expect(dep.output.caseSensitive.peek()).toBe(true);
 
-    editor.dispatchCommand(FIND_NEXT_COMMAND, undefined);
+    editor.dispatchCommand(FIND_NEXT_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(1);
-    editor.dispatchCommand(TOGGLE_REGEX_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_REGEX_COMMAND);
     expect(dep.output.currentIndex.peek()).toBe(0);
     expect(dep.output.isRegex.peek()).toBe(true);
   });
@@ -940,11 +940,11 @@ describe('FindReplaceExtension — command dispatch integration', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.searchTerm.value = 'foo';
     dep.output.replaceTerm.value = 'baz';
     expect(dep.output.matches.peek()).toHaveLength(2);
-    editor.dispatchCommand(REPLACE_CURRENT_COMMAND, undefined);
+    editor.dispatchCommand(REPLACE_CURRENT_COMMAND);
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('baz bar foo');
     });
@@ -963,11 +963,11 @@ describe('FindReplaceExtension — command dispatch integration', () => {
       },
       {discrete: true},
     );
-    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+    editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
     dep.output.searchTerm.value = 'foo';
     dep.output.replaceTerm.value = 'qux';
     expect(dep.output.matches.peek()).toHaveLength(2);
-    editor.dispatchCommand(REPLACE_ALL_COMMAND, undefined);
+    editor.dispatchCommand(REPLACE_ALL_COMMAND);
     editor.read(() => {
       expect($getRoot().getTextContent()).toBe('qux bar qux');
     });

--- a/packages/lexical-playground/src/__tests__/unit/RubyComposition.test.ts
+++ b/packages/lexical-playground/src/__tests__/unit/RubyComposition.test.ts
@@ -203,7 +203,7 @@ describe('RubyNode composition at boundary (Safari IME)', () => {
         ruby1.select(0, 0);
         $setCompositionKey(keys.ruby1Key);
 
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
 
         const after = $getSelection();
         anchorKey = $isRangeSelection(after) ? after.anchor.key : null;
@@ -224,7 +224,7 @@ describe('RubyNode composition at boundary (Safari IME)', () => {
         assert($isRubyNode(ruby1));
         ruby1.select(0, 0);
 
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
 
         const after = $getSelection();
         anchorKey = $isRangeSelection(after) ? after.anchor.key : null;
@@ -245,7 +245,7 @@ describe('RubyNode composition at boundary (Safari IME)', () => {
         assert($isRubyNode(ruby2));
         ruby2.select(1, 1);
 
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
 
         const after = $getSelection();
         result = $isRangeSelection(after)

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -95,7 +95,7 @@ export default function EquationComponent({
   // root-level element point that swallows further keystrokes — the
   // user sees an editor that won't accept text after a fresh equation.
   const $onEnter = useCallback(
-    (event: KeyboardEvent) => {
+    (event: null | KeyboardEvent) => {
       const latestSelection = $getSelection();
       if (
         !(
@@ -129,7 +129,7 @@ export default function EquationComponent({
         node.insertAfter(paragraph);
         paragraph.select();
       }
-      event.preventDefault();
+      event?.preventDefault();
       return true;
     },
     [nodeKey],

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -275,7 +275,7 @@ export default function ImageComponent({
   );
 
   const $onEnter = useCallback(
-    (event: KeyboardEvent) => {
+    (event: KeyboardEvent | null) => {
       const latestSelection = $getSelection();
       const buttonElem = buttonRef.current;
       if (
@@ -286,7 +286,7 @@ export default function ImageComponent({
         if (showCaption) {
           // Move focus into nested editor
           $setSelection(null);
-          event.preventDefault();
+          event?.preventDefault();
           caption.focus();
           return true;
         } else if (
@@ -295,7 +295,7 @@ export default function ImageComponent({
           // the shadow host when the editor is in a shadow root.
           buttonElem !== getActiveElement(buttonElem)
         ) {
-          event.preventDefault();
+          event?.preventDefault();
           buttonElem.focus();
           return true;
         }
@@ -392,12 +392,8 @@ export default function ImageComponent({
   }, [editor]);
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommand<MouseEvent>(
-        CLICK_COMMAND,
-        onClick,
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand<MouseEvent>(
+      editor.registerCommand(CLICK_COMMAND, onClick, COMMAND_PRIORITY_LOW),
+      editor.registerCommand(
         RIGHT_CLICK_IMAGE_COMMAND,
         onClick,
         COMMAND_PRIORITY_LOW,

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -286,7 +286,9 @@ export default function ImageComponent({
         if (showCaption) {
           // Move focus into nested editor
           $setSelection(null);
-          event?.preventDefault();
+          if (event !== null) {
+            event.preventDefault();
+          }
           caption.focus();
           return true;
         } else if (
@@ -295,7 +297,9 @@ export default function ImageComponent({
           // the shadow host when the editor is in a shadow root.
           buttonElem !== getActiveElement(buttonElem)
         ) {
-          event?.preventDefault();
+          if (event !== null) {
+            event.preventDefault();
+          }
           buttonElem.focus();
           return true;
         }

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -149,7 +149,7 @@ export default function PollComponent({
       editor.registerUpdateListener(({editorState}) => {
         setSelection(editorState.read(() => $getSelection()));
       }),
-      editor.registerCommand<MouseEvent>(
+      editor.registerCommand(
         CLICK_COMMAND,
         payload => {
           const event = payload;

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -235,7 +235,7 @@ export default function ActionsPlugin({
       editor.registerEditableListener(editable => {
         setIsEditable(editable);
       }),
-      editor.registerCommand<boolean>(
+      editor.registerCommand(
         CONNECTED_COMMAND,
         payload => {
           const isConnected = payload;

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -226,7 +226,7 @@ export default function ActionsPlugin({
     docFromHash(window.location.hash).then(doc => {
       if (doc && doc.source === 'Playground') {
         editor.setEditorState(editorStateFromSerializedDocument(editor, doc));
-        editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+        editor.dispatchCommand(CLEAR_HISTORY_COMMAND);
       }
     });
   }, [editor]);
@@ -399,7 +399,7 @@ export default function ActionsPlugin({
             <button
               className="action-button versions"
               onClick={() => {
-                editor.dispatchCommand(SHOW_VERSIONS_COMMAND, undefined);
+                editor.dispatchCommand(SHOW_VERSIONS_COMMAND);
               }}>
               <i className="versions" />
             </button>
@@ -424,7 +424,7 @@ function ShowClearDialog({
       <div className="Modal__content">
         <Button
           onClick={() => {
-            editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+            editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
             editor.focus();
             onClose();
           }}>

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -391,7 +391,7 @@ function CommentsComposer({
       submitAddComment(createComment(content, author), false, thread);
       const editor = editorRef.current;
       if (editor !== null) {
-        editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+        editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
       }
     }
   };
@@ -948,7 +948,7 @@ export default function CommentPlugin({
   }, [editor, markNodeMap]);
 
   const onAddComment = () => {
-    editor.dispatchCommand(INSERT_INLINE_COMMAND, undefined);
+    editor.dispatchCommand(INSERT_INLINE_COMMAND);
   };
 
   return (

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -184,20 +184,17 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
     new ComponentPickerOption('Numbered List', {
       icon: <i className="icon number" />,
       keywords: ['numbered list', 'ordered list', 'ol'],
-      onSelect: () =>
-        editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND),
     }),
     new ComponentPickerOption('Bulleted List', {
       icon: <i className="icon bullet" />,
       keywords: ['bulleted list', 'unordered list', 'ul'],
-      onSelect: () =>
-        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND),
     }),
     new ComponentPickerOption('Check List', {
       icon: <i className="icon check" />,
       keywords: ['check list', 'todo list'],
-      onSelect: () =>
-        editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND),
     }),
     new ComponentPickerOption('Quote', {
       icon: <i className="icon quote" />,
@@ -233,19 +230,17 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
     new ComponentPickerOption('Divider', {
       icon: <i className="icon horizontal-rule" />,
       keywords: ['horizontal rule', 'divider', 'hr'],
-      onSelect: () =>
-        editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND),
     }),
     new ComponentPickerOption('Page Break', {
       icon: <i className="icon page-break" />,
       keywords: ['page break', 'divider'],
-      onSelect: () => editor.dispatchCommand(INSERT_PAGE_BREAK, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_PAGE_BREAK),
     }),
     new ComponentPickerOption('Excalidraw', {
       icon: <i className="icon diagram-2" />,
       keywords: ['excalidraw', 'diagram', 'drawing'],
-      onSelect: () =>
-        editor.dispatchCommand(INSERT_EXCALIDRAW_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_EXCALIDRAW_COMMAND),
     }),
     new ComponentPickerOption('Poll', {
       icon: <i className="icon poll" />,
@@ -330,24 +325,22 @@ export function getBaseOptions(editor: LexicalEditor, showModal: ShowModal) {
     new ComponentPickerOption('Collapsible', {
       icon: <i className="icon caret-right" />,
       keywords: ['collapse', 'collapsible', 'toggle'],
-      onSelect: () =>
-        editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND),
     }),
     new ComponentPickerOption('Card', {
       icon: <i className="icon caret-right" />,
       keywords: ['card', 'slot', 'named slots'],
-      onSelect: () => editor.dispatchCommand(INSERT_CARD_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_CARD_COMMAND),
     }),
     new ComponentPickerOption('Pull Quote', {
       icon: <i className="icon quote" />,
       keywords: ['pull quote', 'quote', 'attribution', 'cite', 'slot'],
-      onSelect: () =>
-        editor.dispatchCommand(INSERT_PULLQUOTE_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_PULLQUOTE_COMMAND),
     }),
     new ComponentPickerOption('Review', {
       icon: <i className="icon star" />,
       keywords: ['review', 'testimonial', 'rating', 'stars', 'react', 'slot'],
-      onSelect: () => editor.dispatchCommand(INSERT_REVIEW_COMMAND, undefined),
+      onSelect: () => editor.dispatchCommand(INSERT_REVIEW_COMMAND),
     }),
     new ComponentPickerOption('Columns Layout', {
       icon: <i className="icon columns" />,

--- a/packages/lexical-playground/src/plugins/DateTimeExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/DateTimeExtension/index.tsx
@@ -93,7 +93,7 @@ export const DateTimeExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/DateTime',
   nodes: [DateTimeNode],
   register: editor =>
-    editor.registerCommand<CommandPayload>(
+    editor.registerCommand(
       INSERT_DATETIME_COMMAND,
       payload => {
         const {dateTime} = payload;

--- a/packages/lexical-playground/src/plugins/EquationsExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/EquationsExtension/index.tsx
@@ -68,7 +68,7 @@ export const EquationsExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/Equations',
   nodes: [EquationNode],
   register: editor =>
-    editor.registerCommand<CommandPayload>(
+    editor.registerCommand(
       INSERT_EQUATION_COMMAND,
       payload => {
         const {equation, inline} = payload;

--- a/packages/lexical-playground/src/plugins/FigmaExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/FigmaExtension/index.ts
@@ -23,7 +23,7 @@ export const FigmaExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/Figma',
   nodes: [FigmaNode],
   register: editor =>
-    editor.registerCommand<string>(
+    editor.registerCommand(
       INSERT_FIGMA_COMMAND,
       payload => {
         const figmaNode = $createFigmaNode(payload);

--- a/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/FindReplaceExtension/index.tsx
@@ -739,7 +739,7 @@ export const FindReplaceExtension = /* @__PURE__ */ defineExtension({
             isExactShortcutMatch(event, 'f', {altKey: true, metaKey: true})
           ) {
             event.preventDefault();
-            editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND, undefined);
+            editor.dispatchCommand(TOGGLE_FIND_REPLACE_COMMAND);
             return true;
           }
           if (output.isOpen.peek()) {
@@ -753,7 +753,6 @@ export const FindReplaceExtension = /* @__PURE__ */ defineExtension({
               event.preventDefault();
               editor.dispatchCommand(
                 event.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
-                undefined,
               );
               return true;
             }
@@ -820,7 +819,7 @@ function FindReplacePanel({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.preventDefault();
-      editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
+      editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND);
       editor.focus();
       return;
     }
@@ -850,7 +849,6 @@ function FindReplacePanel({
       e.preventDefault();
       editor.dispatchCommand(
         e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
-        undefined,
       );
       return;
     }
@@ -861,7 +859,6 @@ function FindReplacePanel({
       e.preventDefault();
       editor.dispatchCommand(
         e.shiftKey ? FIND_PREV_COMMAND : FIND_NEXT_COMMAND,
-        undefined,
       );
     } else if (
       isExactShortcutMatch(e, 'f', CONTROL_OR_META) ||
@@ -913,7 +910,7 @@ function FindReplacePanel({
         className="find-replace-toggle"
         style={{gridColumn: 3, gridRow: 1}}
         onClick={() => {
-          editor.dispatchCommand(TOGGLE_CASE_SENSITIVE_COMMAND, undefined);
+          editor.dispatchCommand(TOGGLE_CASE_SENSITIVE_COMMAND);
         }}
         title="Match case"
         aria-label="Match case"
@@ -924,7 +921,7 @@ function FindReplacePanel({
         className="find-replace-toggle"
         style={{gridColumn: 4, gridRow: 1}}
         onClick={() => {
-          editor.dispatchCommand(TOGGLE_REGEX_COMMAND, undefined);
+          editor.dispatchCommand(TOGGLE_REGEX_COMMAND);
         }}
         title="Use regular expression"
         aria-label="Use regular expression"
@@ -934,7 +931,7 @@ function FindReplacePanel({
       <button
         className="find-replace-btn"
         style={{gridColumn: 6, gridRow: 1}}
-        onClick={() => editor.dispatchCommand(FIND_PREV_COMMAND, undefined)}
+        onClick={() => editor.dispatchCommand(FIND_PREV_COMMAND)}
         disabled={matches.length === 0}
         title={
           IS_APPLE ? 'Previous match (⇧⌘G)' : 'Previous match (Ctrl+Shift+G)'
@@ -947,7 +944,7 @@ function FindReplacePanel({
       <button
         className="find-replace-btn"
         style={{gridColumn: 7, gridRow: 1}}
-        onClick={() => editor.dispatchCommand(FIND_NEXT_COMMAND, undefined)}
+        onClick={() => editor.dispatchCommand(FIND_NEXT_COMMAND)}
         disabled={matches.length === 0}
         title={IS_APPLE ? 'Next match (⌘G)' : 'Next match (Ctrl+G)'}
         aria-label="Next match">
@@ -958,16 +955,14 @@ function FindReplacePanel({
       <div className="find-replace-row2-actions">
         <button
           className="find-replace-action"
-          onClick={() =>
-            editor.dispatchCommand(REPLACE_CURRENT_COMMAND, undefined)
-          }
+          onClick={() => editor.dispatchCommand(REPLACE_CURRENT_COMMAND)}
           disabled={matches.length === 0}
           aria-label="Replace current match">
           Replace
         </button>
         <button
           className="find-replace-action"
-          onClick={() => editor.dispatchCommand(REPLACE_ALL_COMMAND, undefined)}
+          onClick={() => editor.dispatchCommand(REPLACE_ALL_COMMAND)}
           disabled={matches.length === 0}
           aria-label="Replace all matches">
           All
@@ -977,7 +972,7 @@ function FindReplacePanel({
         className="find-replace-btn"
         style={{gridColumn: 9, gridRow: 1}}
         onClick={() => {
-          editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND, undefined);
+          editor.dispatchCommand(CLOSE_FIND_REPLACE_COMMAND);
           editor.focus();
         }}
         title="Close (Escape)"

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -95,7 +95,7 @@ function TextFormatFloatingToolbar({
   }, [editor, isLink, setIsLinkEditMode]);
 
   const insertComment = () => {
-    editor.dispatchCommand(INSERT_INLINE_COMMAND, undefined);
+    editor.dispatchCommand(INSERT_INLINE_COMMAND);
   };
 
   function mouseMoveListener(e: MouseEvent) {

--- a/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
@@ -303,7 +303,7 @@ export const ImagesExtension = /* @__PURE__ */ defineExtension({
   nodes: [ImageNode],
   register: editor =>
     mergeRegister(
-      editor.registerCommand<InsertImagePayload>(
+      editor.registerCommand(
         INSERT_IMAGE_COMMAND,
         payload => {
           const imageNode = $createImageNode(payload);
@@ -316,17 +316,17 @@ export const ImagesExtension = /* @__PURE__ */ defineExtension({
         },
         COMMAND_PRIORITY_EDITOR,
       ),
-      editor.registerCommand<DragEvent>(
+      editor.registerCommand(
         DRAGSTART_COMMAND,
         event => $onDragStart(event),
         COMMAND_PRIORITY_HIGH,
       ),
-      editor.registerCommand<DragEvent>(
+      editor.registerCommand(
         DRAGOVER_COMMAND,
         event => $onDragover(event),
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand<DragEvent>(
+      editor.registerCommand(
         DROP_COMMAND,
         event => $onDrop(event, editor),
         COMMAND_PRIORITY_HIGH,

--- a/packages/lexical-playground/src/plugins/PasteLogPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/PasteLogPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {PasteCommandType} from 'lexical';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {COMMAND_PRIORITY_NORMAL, PASTE_COMMAND} from 'lexical';
 import * as React from 'react';
@@ -21,15 +23,17 @@ export default function PasteLogPlugin(): JSX.Element {
     if (isActive) {
       return editor.registerCommand(
         PASTE_COMMAND,
-        (e: ClipboardEvent) => {
-          const {clipboardData} = e;
-          const allData: string[] = [];
-          if (clipboardData && clipboardData.types) {
-            clipboardData.types.forEach(type => {
-              allData.push(type.toUpperCase(), clipboardData.getData(type));
-            });
+        (e: PasteCommandType) => {
+          if ('clipboardData' in e) {
+            const {clipboardData} = e;
+            const allData: string[] = [];
+            if (clipboardData && clipboardData.types) {
+              clipboardData.types.forEach(type => {
+                allData.push(type.toUpperCase(), clipboardData.getData(type));
+              });
+            }
+            setLastClipboardData(allData.join('\n\n'));
           }
-          setLastClipboardData(allData.join('\n\n'));
           return false;
         },
         COMMAND_PRIORITY_NORMAL,

--- a/packages/lexical-playground/src/plugins/PollExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/PollExtension/index.tsx
@@ -60,7 +60,7 @@ export const PollExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/Poll',
   nodes: [PollNode],
   register: editor =>
-    editor.registerCommand<string>(
+    editor.registerCommand(
       INSERT_POLL_COMMAND,
       payload => {
         const pollNode = $createPollNode(payload, [

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
@@ -101,9 +101,9 @@ export default function ShortcutsPlugin({
       } else if (isCapitalize(event)) {
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'capitalize');
       } else if (isIndent(event)) {
-        editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+        editor.dispatchCommand(INDENT_CONTENT_COMMAND);
       } else if (isOutdent(event)) {
-        editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+        editor.dispatchCommand(OUTDENT_CONTENT_COMMAND);
       } else if (isCenterAlign(event)) {
         editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
       } else if (isLeftAlign(event)) {
@@ -137,7 +137,7 @@ export default function ShortcutsPlugin({
         setIsLinkEditMode(!toolbarState.isLink);
         editor.dispatchCommand(TOGGLE_LINK_COMMAND, url);
       } else if (isAddComment(event)) {
-        editor.dispatchCommand(INSERT_INLINE_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_INLINE_COMMAND);
       } else {
         // No match for any of the event handlers
         return false;

--- a/packages/lexical-playground/src/plugins/SpeechToTextPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/SpeechToTextPlugin/index.ts
@@ -35,10 +35,10 @@ const VOICE_COMMANDS: Readonly<
     selection.insertParagraph();
   },
   redo: ({editor}) => {
-    editor.dispatchCommand(REDO_COMMAND, undefined);
+    editor.dispatchCommand(REDO_COMMAND);
   },
   undo: ({editor}) => {
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
   },
 };
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -824,7 +824,7 @@ export default function ToolbarPlugin({
           {editor: activeEditor},
         );
       }),
-      activeEditor.registerCommand<boolean>(
+      activeEditor.registerCommand(
         CAN_UNDO_COMMAND,
         payload => {
           updateToolbarState('canUndo', payload);
@@ -832,7 +832,7 @@ export default function ToolbarPlugin({
         },
         COMMAND_PRIORITY_CRITICAL,
       ),
-      activeEditor.registerCommand<boolean>(
+      activeEditor.registerCommand(
         CAN_REDO_COMMAND,
         payload => {
           updateToolbarState('canRedo', payload);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -42,6 +42,7 @@ import {
   $isNodeSelection,
   $isRangeSelection,
   $isRootOrShadowRoot,
+  type AnyLexicalCommand,
   CAN_REDO_COMMAND,
   CAN_UNDO_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
@@ -52,7 +53,6 @@ import {
   HISTORIC_TAG,
   INDENT_CONTENT_COMMAND,
   IS_APPLE,
-  type LexicalCommand,
   type LexicalEditor,
   type LexicalNode,
   mergeRegister,
@@ -585,7 +585,7 @@ export default function ToolbarPlugin({
   const focusManagerRef = useLexicalFocusManagerRef();
   const toolbarRef = useMergeRefs([rovingRef, focusManagerRef]);
 
-  const dispatchToolbarCommand = <T extends LexicalCommand<unknown>>(
+  const dispatchToolbarCommand = <T extends AnyLexicalCommand>(
     command: T,
     payload: CommandPayloadType<T> | undefined = undefined,
     skipRefocus: boolean = false,

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -523,7 +523,7 @@ function ElementFormatDropdown({
       <Divider />
       <DropDownItem
         onClick={() => {
-          editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+          editor.dispatchCommand(OUTDENT_CONTENT_COMMAND);
         }}
         className="item wide">
         <div className="icon-text-container">
@@ -534,7 +534,7 @@ function ElementFormatDropdown({
       </DropDownItem>
       <DropDownItem
         onClick={() => {
-          editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+          editor.dispatchCommand(INDENT_CONTENT_COMMAND);
         }}
         className="item wide">
         <div className="icon-text-container">

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -210,7 +210,7 @@ export const formatBulletList = (editor: LexicalEditor, blockType: string) => {
   if (blockType !== 'bullet') {
     editor.update(() => {
       $addUpdateTag(SKIP_SELECTION_FOCUS_TAG);
-      editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+      editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND);
     });
   } else {
     formatParagraph(editor);
@@ -221,7 +221,7 @@ export const formatCheckList = (editor: LexicalEditor, blockType: string) => {
   if (blockType !== 'check') {
     editor.update(() => {
       $addUpdateTag(SKIP_SELECTION_FOCUS_TAG);
-      editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND, undefined);
+      editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND);
     });
   } else {
     formatParagraph(editor);
@@ -235,7 +235,7 @@ export const formatNumberedList = (
   if (blockType !== 'number') {
     editor.update(() => {
       $addUpdateTag(SKIP_SELECTION_FOCUS_TAG);
-      editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
+      editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND);
     });
   } else {
     formatParagraph(editor);

--- a/packages/lexical-playground/src/plugins/TwitterExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/TwitterExtension/index.ts
@@ -36,7 +36,7 @@ export const TwitterExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/Twitter',
   nodes: [TweetNode],
   register: editor =>
-    editor.registerCommand<string>(
+    editor.registerCommand(
       INSERT_TWEET_COMMAND,
       payload => {
         const tweetNode = $createTweetNode(payload);

--- a/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/VersionsPlugin/index.tsx
@@ -97,10 +97,7 @@ export function VersionsPlugin({id}: {id: string}) {
         ),
         editor.registerEditableListener(isEditable => {
           if (isEditable && isDiffMode) {
-            editor.dispatchCommand(
-              CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL,
-              undefined,
-            );
+            editor.dispatchCommand(CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL);
           }
         }),
       ),
@@ -233,7 +230,6 @@ function VersionsModal({
               onClick={() => {
                 editor.dispatchCommand(
                   CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL,
-                  undefined,
                 );
                 onClose();
               }}>

--- a/packages/lexical-playground/src/plugins/YouTubeExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/YouTubeExtension/index.ts
@@ -38,7 +38,7 @@ export const YouTubeExtension = /* @__PURE__ */ defineExtension({
   name: '@lexical/playground/YouTube',
   nodes: [YouTubeNode],
   register: editor =>
-    editor.registerCommand<string>(
+    editor.registerCommand(
       INSERT_YOUTUBE_COMMAND,
       payload => {
         const youTubeNode = $createYouTubeNode(payload);

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -59,7 +59,7 @@ export function BlockWithAlignableContents({
 
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommand<ElementFormatType>(
+      editor.registerCommand(
         FORMAT_ELEMENT_COMMAND,
         formatType => {
           if (isSelected) {
@@ -91,7 +91,7 @@ export function BlockWithAlignableContents({
         },
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand<MouseEvent>(
+      editor.registerCommand(
         CLICK_COMMAND,
         event => {
           if (getComposedEventTarget(event) === ref.current) {

--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -476,7 +476,7 @@ describe('Collaboration', () => {
 
         await waitForReact(() => {
           // Undo the insertion of the initial paragraph and text node
-          client1.getEditor().dispatchCommand(UNDO_COMMAND, undefined);
+          client1.getEditor().dispatchCommand(UNDO_COMMAND);
         });
 
         // We expect the safety check in syncYjsChangesToLexical to

--- a/packages/lexical-react/src/__tests__/unit/CollaborationSnapshot.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationSnapshot.test.ts
@@ -488,10 +488,7 @@ describe('CollaborationSnapshot', () => {
       });
 
       await waitForReact(() =>
-        editor1.dispatchCommand(
-          CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL,
-          undefined,
-        ),
+        editor1.dispatchCommand(CLEAR_DIFF_VERSIONS_COMMAND__EXPERIMENTAL),
       );
 
       await new Promise(resolve => setTimeout(resolve, 100));

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -466,7 +466,7 @@ export function LexicalMenu<TOption extends MenuOption>({
 
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommand<KeyboardEvent>(
+      editor.registerCommand(
         KEY_ARROW_DOWN_COMMAND,
         payload => {
           const event = payload;
@@ -504,7 +504,7 @@ export function LexicalMenu<TOption extends MenuOption>({
         },
         commandPriority,
       ),
-      editor.registerCommand<KeyboardEvent>(
+      editor.registerCommand(
         KEY_ARROW_UP_COMMAND,
         payload => {
           const event = payload;
@@ -536,7 +536,7 @@ export function LexicalMenu<TOption extends MenuOption>({
         },
         commandPriority,
       ),
-      editor.registerCommand<KeyboardEvent>(
+      editor.registerCommand(
         KEY_ESCAPE_COMMAND,
         payload => {
           const event = payload;
@@ -547,7 +547,7 @@ export function LexicalMenu<TOption extends MenuOption>({
         },
         commandPriority,
       ),
-      editor.registerCommand<KeyboardEvent>(
+      editor.registerCommand(
         KEY_TAB_COMMAND,
         payload => {
           const event = payload;

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalTabNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalTabNode.test.ts
@@ -44,7 +44,7 @@ describe('LexicalTabNode tests', () => {
       });
 
       await editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
-      await editor.dispatchCommand(INSERT_TAB_COMMAND, undefined);
+      await editor.dispatchCommand(INSERT_TAB_COMMAND);
 
       await editor.read(() => {
         const root = $getRoot();
@@ -85,8 +85,8 @@ describe('LexicalTabNode tests', () => {
         textNode.select(1, 1);
       });
 
-      await editor.dispatchCommand(INSERT_TAB_COMMAND, undefined);
-      await editor.dispatchCommand(INSERT_TAB_COMMAND, undefined);
+      await editor.dispatchCommand(INSERT_TAB_COMMAND);
+      await editor.dispatchCommand(INSERT_TAB_COMMAND);
 
       await editor.update(() => {
         const root = $getRoot();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -92,7 +92,6 @@ import {
   DRAGSTART_COMMAND,
   DROP_COMMAND,
   type EditorConfig,
-  type ElementFormatType,
   ElementNode,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
@@ -833,7 +832,7 @@ function $tryDecoratorLineNavigation(
   if (
     focus.type === 'element' &&
     $isElementNode(focusNode) &&
-    ($isRootNode(focusNode) || $isShadowRootNode(focusNode))
+    $isRootOrShadowRoot(focusNode)
   ) {
     const adjacentChild = focusCaret.getNodeAtCaret();
     if (adjacentChild !== null && $isSelectableBlockDecorator(adjacentChild)) {
@@ -1148,7 +1147,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       DELETE_CHARACTER_COMMAND,
       isBackward => {
         const selection = $getSelection();
@@ -1163,7 +1162,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       DELETE_WORD_COMMAND,
       isBackward => {
         const selection = $getSelection();
@@ -1175,7 +1174,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       DELETE_LINE_COMMAND,
       isBackward => {
         const selection = $getSelection();
@@ -1228,7 +1227,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<TextFormatType>(
+    editor.registerCommand(
       FORMAT_TEXT_COMMAND,
       format => {
         const selection = $getSelection();
@@ -1252,7 +1251,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<ElementFormatType>(
+    editor.registerCommand(
       FORMAT_ELEMENT_COMMAND,
       format => {
         const selection = $getSelection();
@@ -1274,7 +1273,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<boolean>(
+    editor.registerCommand(
       INSERT_LINE_BREAK_COMMAND,
       selectStart => {
         const selection = $getSelection();
@@ -1334,7 +1333,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_UP_COMMAND,
       event => {
         const selection = $getSelection();
@@ -1371,7 +1370,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_DOWN_COMMAND,
       event => {
         const selection = $getSelection();
@@ -1415,7 +1414,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_LEFT_COMMAND,
       event => {
         const selection = $getSelection();
@@ -1463,7 +1462,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_ARROW_RIGHT_COMMAND,
       event => {
         const selection = $getSelection();
@@ -1511,7 +1510,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_BACKSPACE_COMMAND,
       event => {
         const selection = $getSelection();
@@ -1549,7 +1548,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       KEY_DELETE_COMMAND,
       event => {
         const selection = $getSelection();
@@ -1569,7 +1568,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent | null>(
+    editor.registerCommand(
       KEY_ENTER_COMMAND,
       event => {
         let selection = $getSelection();
@@ -1636,7 +1635,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<DragEvent>(
+    editor.registerCommand(
       DROP_COMMAND,
       event => {
         const [, files] = eventFiles(event);
@@ -1672,7 +1671,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<DragEvent>(
+    editor.registerCommand(
       DRAGSTART_COMMAND,
       event => {
         const [isFileTransfer] = eventFiles(event);
@@ -1700,7 +1699,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<DragEvent>(
+    editor.registerCommand(
       DRAGOVER_COMMAND,
       event => {
         const [isFileTransfer] = eventFiles(event);
@@ -1830,7 +1829,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       MOVE_TO_END,
       event => {
         const selection = $getSelection();
@@ -1871,7 +1870,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<KeyboardEvent>(
+    editor.registerCommand(
       MOVE_TO_START,
       event => {
         const selection = $getSelection();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1528,7 +1528,7 @@ export function registerRichText(
         if ($isRangeSelection(selection)) {
           if ($isSelectionCollapsedAtFrontOfIndentedBlock(selection)) {
             event.preventDefault();
-            return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+            return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND);
           }
           // On iOS, blocking the keydown event's default prevents the system
           // keyboard from updating its autocomplete/autocorrect suggestion bar
@@ -1619,7 +1619,7 @@ export function registerRichText(
             return editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
           }
         }
-        return editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+        return editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
       },
       COMMAND_PRIORITY_EDITOR,
     ),

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -340,7 +340,7 @@ export class TableObserver {
     $updateDOMForSelection(editor, grid, null);
     if (setEmptySelection && $getSelection() !== null) {
       $setSelection(null);
-      editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
     }
   }
 
@@ -463,7 +463,7 @@ export class TableObserver {
           );
 
           $setSelection(this.tableSelection);
-          editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+          editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
           $updateDOMForSelection(editor, this.table, this.tableSelection);
           return true;
         }
@@ -562,7 +562,7 @@ export class TableObserver {
 
     $setSelection(selection);
 
-    this.editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+    this.editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
   }
 
   $clearText() {
@@ -599,7 +599,7 @@ export class TableObserver {
       tableNode.remove();
       // Handle case when table was the only node
       if ($isRootNode(parent) && parent.isEmpty()) {
-        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
       }
       return;
     }
@@ -622,6 +622,6 @@ export class TableObserver {
 
     $setSelection(null);
 
-    editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+    editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
   }
 }

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -253,7 +253,7 @@ export function registerTableWindowHandlers(
             observer.$clearHighlight(false);
           }
           $setSelection(null);
-          editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+          editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
         }
         if (!selectionInfo) {
           return;
@@ -354,7 +354,7 @@ function $handleTableClick(
           override,
           tableKey: tableObserver.tableNodeKey,
         });
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
       }
     };
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
@@ -87,7 +87,7 @@ describe('LexicalTableSelectionHelpers', () => {
       );
 
       expect(() =>
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined),
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND),
       ).not.toThrow();
     });
 
@@ -108,8 +108,8 @@ describe('LexicalTableSelectionHelpers', () => {
 
       // Without self-healing every subsequent selection change throws
       expect(() => {
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
       }).not.toThrow();
 
       // New tables still work after the registry healed itself
@@ -120,7 +120,7 @@ describe('LexicalTableSelectionHelpers', () => {
         {discrete: true},
       );
       expect(() =>
-        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined),
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND),
       ).not.toThrow();
     });
   });

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -211,7 +211,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
     TextNode,
     $textNodeTransform,
   );
-  const removeReverseNodeTransform = editor.registerNodeTransform<T>(
+  const removeReverseNodeTransform = editor.registerNodeTransform(
     targetNode,
     $reverseNodeTransform,
   );

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -10,8 +10,13 @@
 /**
  * LexicalCommands
  */
+export opaque type LexicalCommand<P> = Readonly<{type?: string}>;
 
-export type LexicalCommand<P> = Readonly<{type?: string}>;
+export type CommandPayloadType<TCommand> =
+  TCommand extends LexicalCommand<infer P> ? P : empty;
+
+export type CommandPayloadArgs<P> =
+  [P extends void ? true : empty] extends [empty] ? [payload: P] : [payload?: P];
 
 declare export var SELECTION_CHANGE_COMMAND: LexicalCommand<void>;
 declare export var CLICK_COMMAND: LexicalCommand<MouseEvent>;
@@ -287,7 +292,7 @@ declare export class LexicalEditor {
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;
-  dispatchCommand<P>(command: LexicalCommand<P>, payload: P): boolean;
+  dispatchCommand<P>(command: LexicalCommand<P>, ...args: CommandPayloadArgs<P>): boolean;
   hasNode(node: Class<LexicalNode>): boolean;
   hasNodes(nodes: Class<LexicalNode>[]): boolean;
   getKey(): string;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -12,6 +12,9 @@
  */
 export opaque type LexicalCommand<P> = Readonly<{type?: string}>;
 
+// $FlowFixMe[unclear-type]
+export type AnyLexicalCommand = LexicalCommand<any>;
+
 export type CommandPayloadType<TCommand> =
   TCommand extends LexicalCommand<infer P> ? P : empty;
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -667,10 +667,12 @@ function normalizePriority(
   return (priority & 7) as CommandListenerPriority;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type LexicalCommand<TPayload> = {
+declare const LexicalCommandBrand: unique symbol;
+
+export interface LexicalCommand<TPayload> {
   type?: string;
-};
+  readonly [LexicalCommandBrand]?: TPayload;
+}
 
 /**
  * Type helper for extracting the payload type from a command.
@@ -694,6 +696,12 @@ export type LexicalCommand<TPayload> = {
  */
 export type CommandPayloadType<TCommand extends LexicalCommand<unknown>> =
   TCommand extends LexicalCommand<infer TPayload> ? TPayload : never;
+
+export type CommandPayloadArgs<TPayload> = [
+  TPayload extends undefined ? true : never,
+] extends [never]
+  ? [payload: TPayload]
+  : [payload?: TPayload];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyCommandListener = CommandListener<any>;
@@ -1574,9 +1582,9 @@ export class LexicalEditor {
    */
   dispatchCommand<TCommand extends LexicalCommand<unknown>>(
     type: TCommand,
-    payload: CommandPayloadType<TCommand>,
+    ...args: CommandPayloadArgs<CommandPayloadType<TCommand>>
   ): boolean {
-    return dispatchCommand(this, type, payload);
+    return dispatchCommand(this, type, ...args);
   }
 
   /**

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -671,8 +671,12 @@ declare const LexicalCommandBrand: unique symbol;
 
 export interface LexicalCommand<TPayload> {
   type?: string;
-  readonly [LexicalCommandBrand]?: TPayload;
+  // TPayload must be invariant
+  readonly [LexicalCommandBrand]?: (payload: TPayload) => TPayload;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyLexicalCommand = LexicalCommand<any>;
 
 /**
  * Type helper for extracting the payload type from a command.
@@ -694,7 +698,7 @@ export interface LexicalCommand<TPayload> {
  * }
  * ```
  */
-export type CommandPayloadType<TCommand extends LexicalCommand<unknown>> =
+export type CommandPayloadType<TCommand extends AnyLexicalCommand> =
   TCommand extends LexicalCommand<infer TPayload> ? TPayload : never;
 
 export type CommandPayloadArgs<TPayload> = [
@@ -706,10 +710,7 @@ export type CommandPayloadArgs<TPayload> = [
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyCommandListener = CommandListener<any>;
 
-type Commands = Map<
-  LexicalCommand<unknown>,
-  Tuple5<DequeSet<AnyCommandListener>>
->;
+type Commands = Map<AnyLexicalCommand, Tuple5<DequeSet<AnyCommandListener>>>;
 
 export type ListenerMap<T> = Map<T, undefined | (() => void)>;
 
@@ -1580,7 +1581,7 @@ export class LexicalEditor {
    * @param type - the type of command listeners to trigger.
    * @param payload - the data to pass as an argument to the command listeners.
    */
-  dispatchCommand<TCommand extends LexicalCommand<unknown>>(
+  dispatchCommand<TCommand extends AnyLexicalCommand>(
     type: TCommand,
     ...args: CommandPayloadArgs<CommandPayloadType<TCommand>>
   ): boolean {

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -486,7 +486,7 @@ function onSelectionChange(
       }
     }
 
-    dispatchCommand(editor, SELECTION_CHANGE_COMMAND, undefined);
+    dispatchCommand(editor, SELECTION_CHANGE_COMMAND);
   });
 }
 
@@ -1021,7 +1021,7 @@ function $handleBeforeInput(event: InputEvent): boolean {
       dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, false);
     } else if (data === DOUBLE_LINE_BREAK) {
       event.preventDefault();
-      dispatchCommand(editor, INSERT_PARAGRAPH_COMMAND, undefined);
+      dispatchCommand(editor, INSERT_PARAGRAPH_COMMAND);
     } else if (data == null && event.dataTransfer) {
       // Gets around a Safari text replacement bug.
       const text = event.dataTransfer.getData('text/plain');
@@ -1097,7 +1097,7 @@ function $handleBeforeInput(event: InputEvent): boolean {
         inputState.isInsertLineBreak = false;
         dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, false);
       } else {
-        dispatchCommand(editor, INSERT_PARAGRAPH_COMMAND, undefined);
+        dispatchCommand(editor, INSERT_PARAGRAPH_COMMAND);
       }
 
       break;
@@ -1180,12 +1180,12 @@ function $handleBeforeInput(event: InputEvent): boolean {
     }
 
     case 'historyUndo': {
-      dispatchCommand(editor, UNDO_COMMAND, undefined);
+      dispatchCommand(editor, UNDO_COMMAND);
       break;
     }
 
     case 'historyRedo': {
-      dispatchCommand(editor, REDO_COMMAND, undefined);
+      dispatchCommand(editor, REDO_COMMAND);
       break;
     }
 
@@ -1657,10 +1657,10 @@ function $handleKeyDown(event: KeyboardEvent): boolean {
     dispatchCommand(editor, KEY_TAB_COMMAND, event);
   } else if (isUndo(event)) {
     event.preventDefault();
-    dispatchCommand(editor, UNDO_COMMAND, undefined);
+    dispatchCommand(editor, UNDO_COMMAND);
   } else if (isRedo(event)) {
     event.preventDefault();
-    dispatchCommand(editor, REDO_COMMAND, undefined);
+    dispatchCommand(editor, REDO_COMMAND);
   } else {
     const prevSelection = editor._editorState._selection;
     if (isSelectAll(event)) {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -19,9 +19,9 @@ import {
 } from '.';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './LexicalConstants';
 import {
+  type AnyLexicalCommand,
   type CommandPayloadType,
   type EditorUpdateOptions,
-  type LexicalCommand,
   LexicalEditor,
   type MapListeners,
   type MutatedNodes,
@@ -875,9 +875,7 @@ export function triggerListeners<T extends keyof MapListeners>(
   }
 }
 
-export function triggerCommandListeners<
-  TCommand extends LexicalCommand<unknown>,
->(
+export function triggerCommandListeners<TCommand extends AnyLexicalCommand>(
   editor: LexicalEditor,
   type: TCommand,
   payload: CommandPayloadType<TCommand>,

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -765,7 +765,7 @@ function $commitPendingUpdatesImpl(
     pendingSelection !== null &&
     (currentSelection === null || !currentSelection.is(pendingSelection))
   ) {
-    editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+    editor.dispatchCommand(SELECTION_CHANGE_COMMAND);
   }
   /**
    * Capture pendingDecorators after garbage collecting detached decorators

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -56,6 +56,7 @@ import {
 } from './LexicalConstants';
 import {type DOMSlot, ElementDOMSlot} from './LexicalDOMSlot';
 import {
+  type AnyLexicalCommand,
   type CommandPayloadArgs,
   type CommandPayloadType,
   type DOMSlotForNode,
@@ -63,7 +64,6 @@ import {
   type EditorDOMRenderConfig,
   type EditorThemeClasses,
   type Klass,
-  type LexicalCommand,
   LexicalEditor,
   type MutatedNodes,
   type MutationListeners,
@@ -1546,7 +1546,7 @@ export function isFirefoxClipboardEvents(editor: LexicalEditor): boolean {
   );
 }
 
-export function dispatchCommand<TCommand extends LexicalCommand<unknown>>(
+export function dispatchCommand<TCommand extends AnyLexicalCommand>(
   editor: LexicalEditor,
   command: TCommand,
   ...args: CommandPayloadArgs<CommandPayloadType<TCommand>>

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -56,6 +56,7 @@ import {
 } from './LexicalConstants';
 import {type DOMSlot, ElementDOMSlot} from './LexicalDOMSlot';
 import {
+  type CommandPayloadArgs,
   type CommandPayloadType,
   type DOMSlotForNode,
   type EditorConfig,
@@ -1548,9 +1549,14 @@ export function isFirefoxClipboardEvents(editor: LexicalEditor): boolean {
 export function dispatchCommand<TCommand extends LexicalCommand<unknown>>(
   editor: LexicalEditor,
   command: TCommand,
-  payload: CommandPayloadType<TCommand>,
+  ...args: CommandPayloadArgs<CommandPayloadType<TCommand>>
 ): boolean {
-  return triggerCommandListeners(editor, command, payload, editor);
+  return triggerCommandListeners(
+    editor,
+    command,
+    args[0] as CommandPayloadType<TCommand>,
+    editor,
+  );
 }
 
 export function getElementByKeyOrThrow(

--- a/packages/lexical/src/__tests__/browser/LexicalComposition.test.ts
+++ b/packages/lexical/src/__tests__/browser/LexicalComposition.test.ts
@@ -255,7 +255,7 @@ describe('compose() helper — browser composition tests', () => {
     await compose({editor, rootElement}, korean(['ㅎ', '하', '한']));
     expect(editor.read(() => $getRoot().getTextContent())).toBe('abc한');
 
-    editor.dispatchCommand(UNDO_COMMAND, undefined);
+    editor.dispatchCommand(UNDO_COMMAND);
     await waitForRender();
 
     const text = editor.read(() => $getRoot().getTextContent());

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -58,12 +58,14 @@ import {
   getDOMSelection,
   HISTORY_MERGE_TAG,
   type Klass,
+  type LexicalCommand,
   type LexicalEditor,
   type LexicalNode,
   type LexicalNodeReplacement,
   mergeRegister,
   ParagraphNode,
   RootNode,
+  safeCast,
   SKIP_DOM_SELECTION_TAG,
   TextNode,
   type UpdateListenerPayload,
@@ -81,7 +83,16 @@ import {
 } from 'react';
 import {createPortal} from 'react-dom';
 import {createRoot, type Root} from 'react-dom/client';
-import {afterEach, assert, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  afterEach,
+  assert,
+  assertType,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
 import {emptyFunction} from '../../LexicalUtils';
 import {
@@ -3420,6 +3431,85 @@ describe('LexicalEditor tests', () => {
     calls.length = 0;
     editor.dispatchCommand(command, undefined);
     expect(calls).toHaveLength(0);
+  });
+
+  it('has an invariant payload type for commands', () => {
+    const EVENT_COMMAND = createCommand<Event>('EVENT_COMMAND');
+    const MOUSE_EVENT_COMMAND = createCommand<MouseEvent>(
+      'MOUSE_EVENT_COMMAND',
+    );
+    const MAYBE_MOUSE_EVENT_COMMAND = createCommand<undefined | MouseEvent>(
+      'MAYBE_MOUSE_EVENT_COMMAND',
+    );
+    const VOID_COMMAND = createCommand<void>('VOID_COMMAND');
+    // Test expected correct paths
+    editor.dispatchCommand(EVENT_COMMAND, new Event('test_event'));
+    editor.dispatchCommand(MOUSE_EVENT_COMMAND, new MouseEvent('mouse'));
+    editor.dispatchCommand(MAYBE_MOUSE_EVENT_COMMAND, new MouseEvent('mouse'));
+    editor.dispatchCommand(MAYBE_MOUSE_EVENT_COMMAND);
+    editor.dispatchCommand(VOID_COMMAND, undefined);
+    editor.dispatchCommand(VOID_COMMAND);
+    // Test expected inference
+    editor.registerCommand(
+      EVENT_COMMAND,
+      e => {
+        assertType<Event>(e);
+        return false;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    )();
+    editor.registerCommand(
+      MOUSE_EVENT_COMMAND,
+      e => {
+        assertType<MouseEvent>(e);
+        return false;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    )();
+    editor.registerCommand(
+      MAYBE_MOUSE_EVENT_COMMAND,
+      e => {
+        assertType<undefined | MouseEvent>(e);
+        return false;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    )();
+    editor.registerCommand(
+      VOID_COMMAND,
+      e => {
+        assertType<void>(e);
+        return false;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    )();
+    // Verify that types can't be narrowed with annotations
+    editor.registerCommand(
+      // @ts-expect-error
+      EVENT_COMMAND,
+      (e: MouseEvent) => false,
+      COMMAND_PRIORITY_EDITOR,
+    )();
+    editor.registerCommand<LexicalCommand<MouseEvent>>(
+      // @ts-expect-error
+      EVENT_COMMAND,
+      (e: MouseEvent) => false,
+      COMMAND_PRIORITY_EDITOR,
+    )();
+    // Verify that types can't be widened with annotations
+    // @ts-expect-error
+    safeCast<LexicalCommand<Event>>(MOUSE_EVENT_COMMAND);
+    // @ts-expect-error
+    safeCast<LexicalCommand<unknown>>(MOUSE_EVENT_COMMAND);
+    // @ts-expect-error
+    safeCast<LexicalCommand<undefined>>(MAYBE_MOUSE_EVENT_COMMAND);
+    // @ts-expect-error
+    safeCast<LexicalCommand<MouseEvent>>(MAYBE_MOUSE_EVENT_COMMAND);
+    editor.registerCommand(
+      // @ts-expect-error
+      EVENT_COMMAND,
+      (e: MouseEvent) => false,
+      COMMAND_PRIORITY_EDITOR,
+    )();
   });
 
   it('allows using the same listener for multiple node types', async () => {

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1395,7 +1395,7 @@ describe('LexicalEditor tests', () => {
     });
 
     for (let i = 0; i < 150; i++) {
-      editor.dispatchCommand(BURST_COMMAND, undefined);
+      editor.dispatchCommand(BURST_COMMAND);
       // Yield only microtasks: commits flush, but the macrotask budget reset
       // never gets a chance to run within the burst.
       for (let j = 0; j < 4; j++) {
@@ -1432,7 +1432,7 @@ describe('LexicalEditor tests', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     const unregisterMutation = editor.registerMutationListener(TextNode, () => {
-      editor.dispatchCommand(NOOP_COMMAND, undefined);
+      editor.dispatchCommand(NOOP_COMMAND);
     });
     // Unbounded: flips the text content again on every commit, forever.
     const unregisterUpdate = editor.registerUpdateListener(() => {
@@ -1505,7 +1505,7 @@ describe('LexicalEditor tests', () => {
       // dropping the mutation). It should now be deferred to a writable update
       // so the mutation actually applies, and warn in DEV.
       editor.read(() => {
-        editor.dispatchCommand(READONLY_MUTATE_COMMAND, undefined);
+        editor.dispatchCommand(READONLY_MUTATE_COMMAND);
       });
       // Deferred update flushes on the next tick.
       await Promise.resolve();
@@ -1518,7 +1518,7 @@ describe('LexicalEditor tests', () => {
 
       // A top-level (writable) dispatch must NOT warn and applies inline.
       warnSpy.mockClear();
-      editor.dispatchCommand(READONLY_MUTATE_COMMAND, undefined);
+      editor.dispatchCommand(READONLY_MUTATE_COMMAND);
       expect(warnSpy).toHaveBeenCalledTimes(0);
     } finally {
       warnSpy.mockRestore();

--- a/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
@@ -88,7 +88,7 @@ describe('@lexical/list tests', () => {
     await act(async () => {
       await editor.update(() => {
         editor.focus();
-        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND);
       });
     });
 
@@ -113,7 +113,7 @@ describe('@lexical/list tests', () => {
     await act(async () => {
       await editor.update(() => {
         editor.focus();
-        editor.dispatchCommand(REMOVE_LIST_COMMAND, undefined);
+        editor.dispatchCommand(REMOVE_LIST_COMMAND);
       });
     });
 
@@ -143,7 +143,7 @@ describe('@lexical/list tests', () => {
     await act(async () => {
       await editor.update(() => {
         editor.focus();
-        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND);
       });
     });
 
@@ -168,7 +168,7 @@ describe('@lexical/list tests', () => {
     await act(async () => {
       await editor.update(() => {
         editor.focus();
-        editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+        editor.dispatchCommand(INDENT_CONTENT_COMMAND);
       });
     });
 
@@ -195,7 +195,7 @@ describe('@lexical/list tests', () => {
     await act(async () => {
       await editor.update(() => {
         editor.focus();
-        editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+        editor.dispatchCommand(OUTDENT_CONTENT_COMMAND);
       });
     });
 
@@ -226,10 +226,10 @@ describe('@lexical/list tests', () => {
     await act(async () => {
       await editor.update(() => {
         editor.focus();
-        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND);
         $insertNodes([$createTextNode('First item')]);
         editor.dispatchCommand(KEY_ENTER_COMMAND, null);
-        editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+        editor.dispatchCommand(INDENT_CONTENT_COMMAND);
         $insertNodes([$createTextNode('Nested item')]);
         editor.dispatchCommand(KEY_ENTER_COMMAND, null);
         $setBlocksType($getSelection(), $createParagraphNode);

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -140,6 +140,7 @@ export type {
   CommandListener,
   CommandListenerPriority,
   CommandListenerPriorityBefore,
+  CommandPayloadArgs,
   CommandPayloadType,
   CreateEditorArgs,
   DOMSlotForNode,

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -137,6 +137,7 @@ export {
 export type {DOMSlot} from './LexicalDOMSlot';
 export type {ElementDOMSlot} from './LexicalDOMSlot';
 export type {
+  AnyLexicalCommand,
   CommandListener,
   CommandListenerPriority,
   CommandListenerPriorityBefore,


### PR DESCRIPTION
## Breaking Change

This PR makes the type for `LexicalCommand` stricter by carrying a brand to invariantly witness the phantom payload type. When not using inference (e.g. with an explicit generic or in some cases by annotating the handler function) it was previously possible to write unsafe code that still passed the type checker because all `LexicalCommand` were structurally compatible from TypeScript's perspective. Previously correct code requires no changes, even if it was using annotations or explicit generics.

To correct this code, you can either annotate the correct type, or remove the explicit annotation altogether and let TypeScript infer the correct type from the command argument.

If you were using the unsafe `LexicalCommand<unknown>` you should switch to the newly exported `AnyLexicalCommand` alias or write `LexicalCommand<any>` instead (backwards compatible).

## Description

Every `LexicalCommand<T>` constant already carries its payload type, so the explicit generic on `registerCommand<T>(...)` is always inferred. This removes the redundant generic from 61 call sites (57 `registerCommand` + 4 in tests) across 20 files.

Also includes two small opportunistic cleanups in the same files:
- Replaces one `$isRootNode(x) || $isShadowRootNode(x)` with `$isRootOrShadowRoot(x)` in `lexical-rich-text`
- `registerNodeTransform<T>` in `lexical-text` (same redundancy — `Klass<T>` argument already infers `T`)

Two `KEY_ENTER_COMMAND` listeners in `lexical-code-core` and `lexical-playground/ImageComponent` previously used `<KeyboardEvent>` to narrow away the command's `null` payload. Removing the generic surfaced this, so explicit null checks were added (matching the pattern already used in `lexical-rich-text` and `lexical-plain-text`).

The type for `dispatchCommand` was also modified to allow the `payload` argument to be optional when it can be `undefined` or void. The codebase was cleaned up to remove the redundant trailing `undefined` arguments accordingly.

## Test plan

- [x] `pnpm test-unit` — 3984 pass
- [x] `pnpm test-e2e-chromium` — 771 pass
- [x] tsc / flow / prettier / eslint clean