### PR TITLE
[lexical-playground] Chore: Use ownerDocument and $getDocument() for shadow DOM safety

### DIFF
--- a/packages/lexical-playground/src/PlaygroundDOMRenderExtension.ts
+++ b/packages/lexical-playground/src/PlaygroundDOMRenderExtension.ts
@@ -8,6 +8,7 @@
 
 import {domOverride, DOMRenderExtension} from '@lexical/html';
 import {
+  $getDocument,
   configExtension,
   defineExtension,
   isBlockDomNode,
@@ -49,7 +50,7 @@ export const PlaygroundDOMRenderExtension = /* @__PURE__ */ defineExtension({
                 }
                 for (const childNode of generatedElement.childNodes) {
                   if (isBlockDomNode(childNode)) {
-                    const div = document.createElement('div');
+                    const div = $getDocument().createElement('div');
                     div.setAttribute('role', 'paragraph');
                     for (const attr of generatedElement.attributes) {
                       div.setAttribute(attr.name, attr.value);

--- a/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeNode.tsx
+++ b/packages/lexical-playground/src/nodes/DateTimeNode/DateTimeNode.tsx
@@ -14,6 +14,7 @@ import {
   type SerializedDecoratorTextNode,
 } from '@lexical/extension';
 import {
+  $getDocument,
   $getState,
   $setState,
   createState,
@@ -85,8 +86,8 @@ export class DateTimeNode extends DecoratorTextNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('span');
-    const textDom: HTMLElement | Text = document.createTextNode(
+    const element = $getDocument().createElement('span');
+    const textDom: HTMLElement | Text = $getDocument().createTextNode(
       getDateTimeText(this.getDateTime()),
     );
     element.setAttribute(
@@ -99,7 +100,7 @@ export class DateTimeNode extends DecoratorTextNode {
   }
 
   createDOM(): HTMLElement {
-    const element = document.createElement('span');
+    const element = $getDocument().createElement('span');
     element.setAttribute(
       'data-lexical-datetime',
       this.getDateTime()?.toString() || '',

--- a/packages/lexical-playground/src/nodes/EmojiNode.tsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.tsx
@@ -8,6 +8,7 @@
 
 import {
   $applyNodeReplacement,
+  $getDocument,
   type EditorConfig,
   type LexicalNode,
   type NodeKey,
@@ -40,7 +41,7 @@ export class EmojiNode extends TextNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const dom = document.createElement('span');
+    const dom = $getDocument().createElement('span');
     const inner = super.createDOM(config);
     dom.className = this.__className;
     inner.className = 'emoji-inner';

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -11,6 +11,7 @@ import type {JSX} from 'react';
 import katex from 'katex';
 import {
   $applyNodeReplacement,
+  $getDocument,
   DecoratorNode,
   type DOMExportOutput,
   type EditorConfig,
@@ -67,7 +68,9 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(_config: EditorConfig): HTMLElement {
-    const element = document.createElement(this.__inline ? 'span' : 'div');
+    const element = $getDocument().createElement(
+      this.__inline ? 'span' : 'div',
+    );
     // EquationNodes should implement `user-action:none` in their CSS to avoid issues with deletion on Android.
     element.className = 'editor-equation';
     element.setAttribute('role', 'math');
@@ -76,7 +79,9 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement(this.__inline ? 'span' : 'div');
+    const element = $getDocument().createElement(
+      this.__inline ? 'span' : 'div',
+    );
     // Encode the equation as base64 to avoid issues with special characters
     const equation = btoa(this.__equation);
     element.setAttribute('data-lexical-equation', equation);

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -9,6 +9,7 @@
 import type {JSX} from 'react';
 
 import {
+  $getDocument,
   DecoratorNode,
   type DOMExportOutput,
   type EditorConfig,
@@ -73,7 +74,7 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
 
   // View
   createDOM(config: EditorConfig): HTMLElement {
-    const span = document.createElement('span');
+    const span = $getDocument().createElement('span');
     const theme = config.theme;
     const className = theme.image;
     if (className !== undefined) {
@@ -87,7 +88,7 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = document.createElement('span');
+    const element = $getDocument().createElement('span');
 
     element.style.display = 'inline-block';
 

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -24,6 +24,7 @@ import {
   $createRangeSelection,
   $extendCaretToRange,
   $getChildCaret,
+  $getDocument,
   $getRoot,
   $isElementNode,
   $isParagraphNode,
@@ -178,7 +179,7 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
   }
 
   exportDOM(): DOMExportOutput {
-    const imgElement = document.createElement('img');
+    const imgElement = $getDocument().createElement('img');
     imgElement.setAttribute('src', this.__src);
     imgElement.setAttribute('alt', this.__altText);
     imgElement.setAttribute('width', this.__width.toString());
@@ -208,8 +209,8 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
         return $generateHtmlFromNodes(captionEditor, selection);
       });
       if (captionHtml) {
-        const figureElement = document.createElement('figure');
-        const figcaptionElement = document.createElement('figcaption');
+        const figureElement = $getDocument().createElement('figure');
+        const figcaptionElement = $getDocument().createElement('figcaption');
         figcaptionElement.innerHTML = captionHtml;
 
         figureElement.appendChild(imgElement);
@@ -277,7 +278,7 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
   // View
 
   createDOM(config: EditorConfig): HTMLElement {
-    const span = document.createElement('span');
+    const span = $getDocument().createElement('span');
     const theme = config.theme;
     const className = theme.image;
     if (className !== undefined) {

--- a/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  $getDocument,
   addClassNamesToElement,
   type DOMExportOutput,
   type EditorConfig,
@@ -42,7 +43,7 @@ export class LayoutContainerNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const dom = document.createElement('div');
+    const dom = $getDocument().createElement('div');
     dom.style.gridTemplateColumns = this.__templateColumns;
     if (typeof config.theme.layoutContainer === 'string') {
       addClassNamesToElement(dom, config.theme.layoutContainer);
@@ -51,7 +52,7 @@ export class LayoutContainerNode extends ElementNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('div');
+    const element = $getDocument().createElement('div');
     element.style.gridTemplateColumns = this.__templateColumns;
     element.setAttribute('data-lexical-layout-container', 'true');
     return {element};

--- a/packages/lexical-playground/src/nodes/LayoutItemNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutItemNode.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  $getDocument,
   $isParagraphNode,
   addClassNamesToElement,
   type EditorConfig,
@@ -31,7 +32,7 @@ export class LayoutItemNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const dom = document.createElement('div');
+    const dom = $getDocument().createElement('div');
     dom.setAttribute('data-lexical-layout-item', 'true');
     if (typeof config.theme.layoutItem === 'string') {
       addClassNamesToElement(dom, config.theme.layoutItem);

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -8,6 +8,7 @@
 
 import {
   $applyNodeReplacement,
+  $getDocument,
   type DOMExportOutput,
   type EditorConfig,
   type LexicalNode,
@@ -63,7 +64,7 @@ export class MentionNode extends TextNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('span');
+    const element = $getDocument().createElement('span');
     element.setAttribute('data-lexical-mention', 'true');
     if (this.__text !== this.__mention) {
       element.setAttribute('data-lexical-mention-name', this.__mention);

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -11,6 +11,7 @@ import './index.css';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {
+  $getDocument,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   DecoratorNode,
@@ -67,7 +68,7 @@ export class PageBreakNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(): HTMLElement {
-    const el = document.createElement('hr');
+    const el = $getDocument().createElement('hr');
     el.style.pageBreakAfter = 'always';
     el.setAttribute('data-lexical-page-break', 'true');
     return el;

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -9,6 +9,7 @@
 import type {JSX} from 'react';
 
 import {
+  $getDocument,
   $getState,
   $setState,
   createState,
@@ -162,7 +163,7 @@ export class PollNode extends DecoratorNode<JSX.Element> {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('span');
+    const element = $getDocument().createElement('span');
     element.setAttribute('data-lexical-poll-question', this.getQuestion());
     element.setAttribute(
       'data-lexical-poll-options',
@@ -172,7 +173,7 @@ export class PollNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(): HTMLElement {
-    const elem = document.createElement('span');
+    const elem = $getDocument().createElement('span');
     elem.style.display = 'inline-block';
     return elem;
   }

--- a/packages/lexical-playground/src/nodes/SlotContainerNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/SlotContainerNode/index.tsx
@@ -8,6 +8,7 @@
 
 import {
   $create,
+  $getDocument,
   type DOMExportOutput,
   ElementNode,
   type LexicalEditor,
@@ -23,14 +24,14 @@ export class SlotContainerNode extends ElementNode {
   }
 
   createDOM(): HTMLElement {
-    const div = document.createElement('div');
+    const div = $getDocument().createElement('div');
     div.className = 'lexical-slot-container';
     return div;
   }
 
   // Export as a fragment since it "is" the slot wrapper created by the host
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    return {element: document.createDocumentFragment()};
+    return {element: $getDocument().createDocumentFragment()};
   }
 
   updateDOM(): false {

--- a/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
+++ b/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
@@ -8,6 +8,7 @@
 
 import {
   $applyNodeReplacement,
+  $getDocument,
   addClassNamesToElement,
   type EditorConfig,
   type LexicalNode,
@@ -21,7 +22,7 @@ export class SpecialTextNode extends TextNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const dom = document.createElement('span');
+    const dom = $getDocument().createElement('span');
     addClassNamesToElement(dom, config.theme.specialText);
     dom.textContent = this.getTextContent();
     return dom;

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -62,6 +62,8 @@ export default function StickyComponent({
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const stickyContainerRef = useRef<null | HTMLDivElement>(null);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => dragCleanupRef.current?.(), []);
   const positioningRef = useRef<Positioning>({
     isDragging: false,
     offsetX: 0,
@@ -162,8 +164,8 @@ export default function StickyComponent({
         }
       });
     }
-    document.removeEventListener('pointermove', handlePointerMove);
-    document.removeEventListener('pointerup', handlePointerUp);
+    dragCleanupRef.current?.();
+    dragCleanupRef.current = null;
   };
 
   const handleDelete = () => {
@@ -207,8 +209,12 @@ export default function StickyComponent({
             positioning.offsetY = event.clientY / zoom - top;
             positioning.isDragging = true;
             stickContainer.classList.add('dragging');
-            document.addEventListener('pointermove', handlePointerMove);
-            document.addEventListener('pointerup', handlePointerUp);
+            const doc = stickContainer.ownerDocument;
+            dragCleanupRef.current?.();
+            dragCleanupRef.current = mergeRegister(
+              registerEventListener(doc, 'pointermove', handlePointerMove),
+              registerEventListener(doc, 'pointerup', handlePointerUp),
+            );
             event.preventDefault();
           }
         }}>

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -19,6 +19,7 @@ import {
   mergeRegister,
   type NodeKey,
   registerEventListener,
+  registerEventListeners,
 } from 'lexical';
 import * as React from 'react';
 import {type JSX, useEffect, useLayoutEffect, useRef} from 'react';
@@ -211,10 +212,10 @@ export default function StickyComponent({
             stickContainer.classList.add('dragging');
             const doc = stickContainer.ownerDocument;
             dragCleanupRef.current?.();
-            dragCleanupRef.current = mergeRegister(
-              registerEventListener(doc, 'pointermove', handlePointerMove),
-              registerEventListener(doc, 'pointerup', handlePointerUp),
-            );
+            dragCleanupRef.current = registerEventListeners(doc, {
+              pointermove: handlePointerMove,
+              pointerup: handlePointerUp,
+            });
             event.preventDefault();
           }
         }}>

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -17,6 +17,7 @@ import {PlainTextExtension} from '@lexical/plain-text';
 import {ReactExtension} from '@lexical/react/ReactExtension';
 import {ReactProviderExtension} from '@lexical/react/ReactProviderExtension';
 import {
+  $getDocument,
   $setSelection,
   configExtension,
   DecoratorNode,
@@ -138,7 +139,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const div = document.createElement('div');
+    const div = $getDocument().createElement('div');
     div.style.display = 'contents';
     return div;
   }
@@ -170,7 +171,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
         nodeKey={this.getKey()}
         caption={this.__caption}
       />,
-      document.body,
+      editor.getRootElement()?.ownerDocument?.body ?? document.body,
     );
   }
 

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -6,21 +6,21 @@
  *
  */
 
-import type {
-  DOMExportOutput,
-  EditorConfig,
-  ElementFormatType,
-  LexicalEditor,
-  LexicalNode,
-  NodeKey,
-  Spread,
-} from 'lexical';
-
 import {BlockWithAlignableContents} from '@lexical/react/LexicalBlockWithAlignableContents';
 import {
   DecoratorBlockNode,
   type SerializedDecoratorBlockNode,
 } from '@lexical/react/LexicalDecoratorBlockNode';
+import {
+  $getDocument,
+  type DOMExportOutput,
+  type EditorConfig,
+  type ElementFormatType,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+  type Spread,
+} from 'lexical';
 import * as React from 'react';
 import {type JSX, useCallback, useEffect, useRef, useState} from 'react';
 
@@ -78,10 +78,11 @@ function TweetComponent({
       setIsTweetLoading(true);
 
       if (isTwitterScriptLoading) {
-        const script = document.createElement('script');
+        const doc = containerRef.current?.ownerDocument ?? document;
+        const script = doc.createElement('script');
         script.src = WIDGET_SCRIPT_URL;
         script.async = true;
-        document.body?.appendChild(script);
+        doc.body?.appendChild(script);
         script.onload = createTweet;
         if (onError) {
           script.onerror = onError as OnErrorEventHandler;
@@ -141,9 +142,9 @@ export class TweetNode extends DecoratorBlockNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('div');
+    const element = $getDocument().createElement('div');
     element.setAttribute('data-lexical-tweet-id', this.__id);
-    const text = document.createTextNode(this.getTextContent());
+    const text = $getDocument().createTextNode(this.getTextContent());
     element.append(text);
     return {element};
   }

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -6,15 +6,6 @@
  *
  */
 
-import type {
-  DOMExportOutput,
-  EditorConfig,
-  ElementFormatType,
-  LexicalEditor,
-  LexicalNode,
-  NodeKey,
-  Spread,
-} from 'lexical';
 import type {JSX} from 'react';
 
 import {BlockWithAlignableContents} from '@lexical/react/LexicalBlockWithAlignableContents';
@@ -22,6 +13,16 @@ import {
   DecoratorBlockNode,
   type SerializedDecoratorBlockNode,
 } from '@lexical/react/LexicalDecoratorBlockNode';
+import {
+  $getDocument,
+  type DOMExportOutput,
+  type EditorConfig,
+  type ElementFormatType,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+  type Spread,
+} from 'lexical';
 import * as React from 'react';
 
 type YouTubeComponentProps = Readonly<{
@@ -95,7 +96,7 @@ export class YouTubeNode extends DecoratorBlockNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('iframe');
+    const element = $getDocument().createElement('iframe');
     element.setAttribute('data-lexical-youtube', this.__id);
     element.setAttribute('width', '560');
     element.setAttribute('height', '315');

--- a/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompleteExtension/index.tsx
@@ -279,7 +279,7 @@ function syncGhost(
   if (!dom) {
     return;
   }
-  const ghost = document.createElement('span');
+  const ghost = dom.ownerDocument.createElement('span');
   ghost.setAttribute(AUTOCOMPLETE_GHOST_ATTR, 'true');
   ghost.setAttribute('contenteditable', 'false');
   ghost.className = 'PlaygroundEditorTheme__autocomplete';

--- a/packages/lexical-playground/src/plugins/CardExtension/CardNode.tsx
+++ b/packages/lexical-playground/src/plugins/CardExtension/CardNode.tsx
@@ -10,6 +10,7 @@ import {$appendNodeToHTML} from '@lexical/html';
 import {
   $create,
   $createParagraphNode,
+  $getDocument,
   $getSlot,
   $getSlotNames,
   $setSlot,
@@ -33,7 +34,7 @@ export class CardNode extends ElementNode {
   }
 
   createDOM(): HTMLElement {
-    const div = document.createElement('div');
+    const div = $getDocument().createElement('div');
     div.className = 'lexical-card-node';
     return div;
   }
@@ -61,12 +62,12 @@ export class CardNode extends ElementNode {
   // (the outer $appendNodesToHTML loop recurses into `target.getChildren()`
   // when no `$getChildNodes` override is supplied).
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = document.createElement('div');
+    const element = $getDocument().createElement('div');
     element.className = 'lexical-card-node';
     for (const name of $getSlotNames(this)) {
       const slot = $getSlot(this, name);
       if (slot) {
-        const wrapper = document.createElement('div');
+        const wrapper = $getDocument().createElement('div');
         wrapper.setAttribute('data-lexical-slot', name);
         $appendNodeToHTML(editor, slot, wrapper);
         element.append(wrapper);

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  $getDocument,
   $getSiblingCaret,
   $isElementNode,
   $rewindSiblingCaret,
@@ -77,10 +78,10 @@ export class CollapsibleContainerNode extends ElementNode {
     // details is not well supported in Chrome #5582 and Firefox #8348
     let dom: HTMLElement;
     if (IS_CHROME || IS_FIREFOX) {
-      dom = document.createElement('div');
+      dom = $getDocument().createElement('div');
       dom.setAttribute('open', '');
     } else {
-      const detailsDom = document.createElement('details');
+      const detailsDom = $getDocument().createElement('details');
       detailsDom.open = this.__open;
       detailsDom.addEventListener('toggle', () => {
         const open = editor.read('latest', () => this.getOpen());
@@ -134,7 +135,7 @@ export class CollapsibleContainerNode extends ElementNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('details');
+    const element = $getDocument().createElement('details');
     element.classList.add('Collapsible__container');
     element.setAttribute('open', this.__open.toString());
     return {element};

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContentNode.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  $getDocument,
   type DOMExportOutput,
   type EditorConfig,
   ElementNode,
@@ -25,7 +26,7 @@ export class CollapsibleContentNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const dom = document.createElement('div');
+    const dom = $getDocument().createElement('div');
     dom.classList.add('Collapsible__content');
     if (IS_CHROME || IS_FIREFOX) {
       editor.read('latest', () => {
@@ -61,7 +62,7 @@ export class CollapsibleContentNode extends ElementNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('div');
+    const element = $getDocument().createElement('div');
     element.classList.add('Collapsible__content');
     element.setAttribute('data-lexical-collapsible-content', 'true');
     return {element};

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleTitleNode.ts
@@ -8,6 +8,7 @@
 
 import {
   $createParagraphNode,
+  $getDocument,
   $isElementNode,
   type EditorConfig,
   ElementNode,
@@ -36,7 +37,7 @@ export class CollapsibleTitleNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const dom = document.createElement('summary');
+    const dom = $getDocument().createElement('summary');
     dom.classList.add('Collapsible__title');
     if (IS_CHROME || IS_FIREFOX) {
       dom.addEventListener('click', () => {

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -224,11 +224,11 @@ function CommentInputBox({
   const boxRef = useRef<HTMLDivElement>(null);
   const selectionState = useMemo(
     () => ({
-      container: document.createElement('div'),
-      elements: [],
+      elements: [] as HTMLSpanElement[],
     }),
     [],
   );
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const selectionRef = useRef<RangeSelection | null>(null);
   const author = useCollabAuthorName();
 
@@ -257,13 +257,18 @@ function CommentInputBox({
             correctedLeft = 10;
           }
           boxElem.style.left = `${correctedLeft}px`;
+          const doc = boxElem.ownerDocument;
           boxElem.style.top = `${
             bottom +
             20 +
-            (window.pageYOffset || document.documentElement.scrollTop)
+            ((doc.defaultView?.pageYOffset ?? 0) ||
+              doc.documentElement.scrollTop)
           }px`;
           const selectionRectsLength = selectionRects.length;
-          const {container} = selectionState;
+          const container = containerRef.current;
+          if (container === null) {
+            return;
+          }
           const elements: HTMLSpanElement[] = selectionState.elements;
           const elementsLength = elements.length;
 
@@ -271,7 +276,7 @@ function CommentInputBox({
             const selectionRect = selectionRects[i];
             let elem: HTMLSpanElement = elements[i];
             if (elem === undefined) {
-              elem = document.createElement('span');
+              elem = container.ownerDocument.createElement('span');
               elements[i] = elem;
               container.appendChild(elem);
             }
@@ -279,7 +284,8 @@ function CommentInputBox({
             elem.style.position = 'absolute';
             elem.style.top = `${
               selectionRect.top +
-              (window.pageYOffset || document.documentElement.scrollTop)
+              ((doc.defaultView?.pageYOffset ?? 0) ||
+                doc.documentElement.scrollTop)
             }px`;
             elem.style.left = `${selectionRect.left}px`;
             elem.style.height = `${selectionRect.height}px`;
@@ -299,20 +305,22 @@ function CommentInputBox({
   }, [editor, selectionState]);
 
   useLayoutEffect(() => {
-    updateLocation();
-    const container = selectionState.container;
-    const body = document.body;
-    if (body !== null) {
-      body.appendChild(container);
-      return () => {
-        body.removeChild(container);
-      };
+    const body = editor.getRootElement()?.ownerDocument?.body ?? document.body;
+    if (containerRef.current === null) {
+      containerRef.current = body.ownerDocument.createElement('div');
     }
-  }, [selectionState.container, updateLocation]);
+    const container = containerRef.current;
+    updateLocation();
+    body.appendChild(container);
+    return () => {
+      body.removeChild(container);
+    };
+  }, [editor, updateLocation]);
 
   useEffect(() => {
-    return registerEventListener(window, 'resize', updateLocation);
-  }, [updateLocation]);
+    const win = editor.getRootElement()?.ownerDocument?.defaultView ?? window;
+    return registerEventListener(win, 'resize', updateLocation);
+  }, [editor, updateLocation]);
 
   const onEscape = (event: KeyboardEvent): boolean => {
     event.preventDefault();
@@ -951,6 +959,9 @@ export default function CommentPlugin({
     editor.dispatchCommand(INSERT_INLINE_COMMAND);
   };
 
+  const portalTarget =
+    editor.getRootElement()?.ownerDocument?.body ?? document.body;
+
   return (
     <>
       {showCommentInput &&
@@ -960,7 +971,7 @@ export default function CommentPlugin({
             cancelAddComment={cancelAddComment}
             submitAddComment={submitAddComment}
           />,
-          document.body,
+          portalTarget,
         )}
       {activeAnchorKey !== null &&
         activeAnchorKey !== undefined &&
@@ -971,7 +982,7 @@ export default function CommentPlugin({
             editor={editor}
             onAddComment={onAddComment}
           />,
-          document.body,
+          portalTarget,
         )}
       {createPortal(
         <Button
@@ -982,7 +993,7 @@ export default function CommentPlugin({
           title={showComments ? 'Hide Comments' : 'Show Comments'}>
           <i className="comments" />
         </Button>,
-        document.body,
+        portalTarget,
       )}
       {showComments &&
         createPortal(
@@ -993,7 +1004,7 @@ export default function CommentPlugin({
             activeIDs={activeIDs}
             markNodeMap={markNodeMap}
           />,
-          document.body,
+          portalTarget,
         )}
     </>
   );

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -122,8 +122,12 @@ export default function DraggableBlockPlugin({
       setIsPickerOpen(false);
       setPickerState(null);
     };
-    return registerEventListener(document, 'mousedown', handleClickOutside);
-  }, [isPickerOpen]);
+    return registerEventListener(
+      anchorElem.ownerDocument,
+      'mousedown',
+      handleClickOutside,
+    );
+  }, [isPickerOpen, anchorElem]);
 
   const selectOption = useCallback(
     (option: ComponentPickerOption) => {
@@ -266,7 +270,7 @@ export default function DraggableBlockPlugin({
                 ))}
               </ul>
             </div>,
-            document.body,
+            anchorElem.ownerDocument.body,
           )
         : null}
       <DraggableBlockPlugin_EXPERIMENTAL

--- a/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesExtension/index.tsx
@@ -336,6 +336,8 @@ export const ImagesExtension = /* @__PURE__ */ defineExtension({
 
 const TRANSPARENT_IMAGE =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+// Detached element for setDragImage() visual feedback — not inserted into
+// any DOM tree, so it does not need shadow-root-aware $getDocument().
 const img = document.createElement('img');
 img.src = TRANSPARENT_IMAGE;
 

--- a/packages/lexical-playground/src/plugins/PagesExtension/PageContentNode.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PageContentNode.ts
@@ -9,6 +9,7 @@
 import {getExtensionDependencyFromEditor} from '@lexical/extension';
 import {
   $create,
+  $getDocument,
   $getEditor,
   addClassNamesToElement,
   ElementNode,
@@ -26,7 +27,7 @@ export class PageContentNode extends ElementNode {
   }
 
   createDOM(): HTMLElement {
-    const dom = document.createElement('div');
+    const dom = $getDocument().createElement('div');
     addClassNamesToElement(
       dom,
       getExtensionDependencyFromEditor($getEditor(), PagesExtension).config

--- a/packages/lexical-playground/src/plugins/PagesExtension/PageNode.ts
+++ b/packages/lexical-playground/src/plugins/PagesExtension/PageNode.ts
@@ -9,6 +9,7 @@
 import {getExtensionDependencyFromEditor} from '@lexical/extension';
 import {
   $create,
+  $getDocument,
   $getEditor,
   addClassNamesToElement,
   ElementNode,
@@ -36,7 +37,7 @@ export class PageNode extends ElementNode {
   }
 
   createDOM(): HTMLElement {
-    const dom = document.createElement('div');
+    const dom = $getDocument().createElement('div');
     addClassNamesToElement(
       dom,
       getExtensionDependencyFromEditor($getEditor(), PagesExtension).config

--- a/packages/lexical-playground/src/plugins/PullQuoteExtension/PullQuoteNode.tsx
+++ b/packages/lexical-playground/src/plugins/PullQuoteExtension/PullQuoteNode.tsx
@@ -15,6 +15,7 @@ import {
   $create,
   $createParagraphNode,
   $createTextNode,
+  $getDocument,
   $getSlot,
   $getSlotNames,
   $setSlot,
@@ -64,7 +65,7 @@ export class PullQuoteNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(): HTMLElement {
-    const div = document.createElement('div');
+    const div = $getDocument().createElement('div');
     div.className = 'lexical-pullquote-node';
     return div;
   }
@@ -87,12 +88,12 @@ export class PullQuoteNode extends DecoratorNode<JSX.Element> {
   // `<blockquote>` importer (QuoteNode's importDOM also matches
   // `blockquote`).
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const host = document.createElement('div');
+    const host = $getDocument().createElement('div');
     host.className = 'lexical-pullquote-node';
     for (const name of $getSlotNames(this)) {
       const slot = $getSlot(this, name);
       if (slot) {
-        const wrapper = document.createElement('div');
+        const wrapper = $getDocument().createElement('div');
         wrapper.setAttribute('data-lexical-slot', name);
         $appendNodeToHTML(editor, slot, wrapper);
         host.append(wrapper);

--- a/packages/lexical-playground/src/plugins/ReviewExtension/ReviewNode.tsx
+++ b/packages/lexical-playground/src/plugins/ReviewExtension/ReviewNode.tsx
@@ -10,6 +10,7 @@ import {$appendNodeToHTML} from '@lexical/html';
 import {
   $create,
   $createParagraphNode,
+  $getDocument,
   $getEditor,
   $getSlot,
   $getState,
@@ -68,7 +69,7 @@ export class ReviewNode extends ElementNode {
   }
 
   createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const dom = document.createElement('div');
+    const dom = $getDocument().createElement('div');
     dom.className = 'lexical-review-node';
     // The shell is chrome: only the slot containers and the children element
     // flip back to contentEditable=true (the reconciler opts slot containers
@@ -85,7 +86,7 @@ export class ReviewNode extends ElementNode {
     // containers, applied to the getDOMSlot channel. The reconciler renders the
     // linked-list children into it synchronously wherever it sits; the React
     // chrome attaches and reveals it.
-    const children = document.createElement('div');
+    const children = $getDocument().createElement('div');
     children.className = 'lexical-review-children';
     children.style.display = 'none';
     // The body is a getDOMSlot editable island inside the contentEditable=false
@@ -134,12 +135,12 @@ export class ReviewNode extends ElementNode {
   // implicitly either; round-trip it as a data attribute the import reads back
   // through setRating().
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = document.createElement('div');
+    const element = $getDocument().createElement('div');
     element.className = 'lexical-review-node';
     element.setAttribute('data-rating', String(this.getRating()));
     const author = $getSlot(this, 'author');
     if ($isElementNode(author)) {
-      const wrapper = document.createElement('div');
+      const wrapper = $getDocument().createElement('div');
       wrapper.setAttribute('data-lexical-slot', 'author');
       $appendNodeToHTML(editor, author, wrapper);
       element.append(wrapper);

--- a/packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts
+++ b/packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts
@@ -10,6 +10,7 @@ import {addClassNamesToElement} from '@lexical/utils';
 import {
   $create,
   $createTextNode,
+  $getDocument,
   $getSelection,
   $getState,
   $getStateChange,
@@ -47,7 +48,7 @@ export class RubyNode extends TextNode {
       inner,
       config.theme.ruby || 'PlaygroundEditorTheme__ruby',
     );
-    const wrapper = document.createElement('span');
+    const wrapper = $getDocument().createElement('span');
     wrapper.setAttribute('role', 'group');
     wrapper.setAttribute(
       'aria-label',
@@ -82,15 +83,15 @@ export class RubyNode extends TextNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const ruby = document.createElement('ruby');
+    const ruby = $getDocument().createElement('ruby');
     ruby.textContent = this.getTextContent();
-    const rpOpen = document.createElement('rp');
+    const rpOpen = $getDocument().createElement('rp');
     rpOpen.textContent = '(';
     ruby.appendChild(rpOpen);
-    const rt = document.createElement('rt');
+    const rt = $getDocument().createElement('rt');
     rt.textContent = this.getAnnotation();
     ruby.appendChild(rt);
-    const rpClose = document.createElement('rp');
+    const rpClose = $getDocument().createElement('rp');
     rpClose.textContent = ')';
     ruby.appendChild(rpClose);
     return {element: ruby};

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -668,7 +668,7 @@ function TableActionMenu({
         </span>
       </button>
     </div>,
-    document.body,
+    editor.getRootElement()?.ownerDocument?.body ?? document.body,
   );
 }
 

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -66,6 +66,8 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
   const [hasTable, setHasTable] = useState(false);
 
   const pointerStartPosRef = useRef<PointerPosition | null>(null);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => resizeCleanupRef.current?.(), []);
   const [pointerCurrentPos, updatePointerCurrentPos] =
     useState<PointerPosition | null>(null);
 
@@ -351,7 +353,8 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           }
 
           resetState();
-          document.removeEventListener('pointerup', handler);
+          resizeCleanupRef.current?.();
+          resizeCleanupRef.current = null;
         }
       };
       return handler;
@@ -378,7 +381,12 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
         updatePointerCurrentPos(pointerStartPosRef.current);
         updateDraggingDirection(direction);
 
-        document.addEventListener('pointerup', pointerUpHandler(direction));
+        resizeCleanupRef.current?.();
+        resizeCleanupRef.current = registerEventListener(
+          activeCell.elem.ownerDocument,
+          'pointerup',
+          pointerUpHandler(direction),
+        );
       },
     [activeCell, pointerUpHandler],
   );
@@ -502,11 +510,14 @@ export default function TableCellResizerPlugin(): null | ReactPortal {
   const [editor] = useLexicalComposerContext();
   const isEditable = useLexicalEditable();
 
+  const portalTarget =
+    editor.getRootElement()?.ownerDocument?.body ?? document.body;
+
   return useMemo(
     () =>
       isEditable
-        ? createPortal(<TableCellResizer editor={editor} />, document.body)
+        ? createPortal(<TableCellResizer editor={editor} />, portalTarget)
         : null,
-    [editor, isEditable],
+    [editor, isEditable, portalTarget],
   );
 }

--- a/packages/lexical-playground/src/plugins/VisibleNonPrintingExtension.ts
+++ b/packages/lexical-playground/src/plugins/VisibleNonPrintingExtension.ts
@@ -20,6 +20,7 @@ import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {$canShowPlaceholder} from '@lexical/text';
 import {
   $findMatchingParent,
+  $getDocument,
   $isTabNode,
   configExtension,
   defineExtension,
@@ -132,7 +133,7 @@ export const VisibleNonPrintingExtension = /* @__PURE__ */ defineExtension({
               if ($skipForCodeChild(node)) {
                 return inner;
               }
-              const wrapper = document.createElement('span');
+              const wrapper = $getDocument().createElement('span');
               wrapper.setAttribute(VISIBLE_NON_PRINTING_LINEBREAK_ATTR, 'true');
               wrapper.appendChild(inner);
               return wrapper;

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -9,8 +9,9 @@
 import './ColorPicker.css';
 
 import {calculateZoomLevel} from '@lexical/utils';
+import {mergeRegister, registerEventListener} from 'lexical';
 import * as React from 'react';
-import {type JSX, useMemo, useRef, useState} from 'react';
+import {type JSX, useEffect, useMemo, useRef, useState} from 'react';
 
 import {isKeyboardInput} from '../utils/focusUtils';
 import TextInput from './TextInput';
@@ -182,6 +183,8 @@ interface MoveWrapperProps {
 function MoveWrapper({className, style, onChange, children}: MoveWrapperProps) {
   const divRef = useRef<HTMLDivElement>(null);
   const draggedRef = useRef(false);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => dragCleanupRef.current?.(), []);
 
   const move = (e: React.MouseEvent | MouseEvent): void => {
     if (divRef.current) {
@@ -202,26 +205,36 @@ function MoveWrapper({className, style, onChange, children}: MoveWrapperProps) {
 
     move(e);
 
+    const div = divRef.current;
+    if (div === null) {
+      return;
+    }
+
     const onMouseMove = (_e: MouseEvent): void => {
       draggedRef.current = true;
       skipAddingToHistoryStack = true;
       move(_e);
     };
 
+    const doc = div.ownerDocument;
+
     const onMouseUp = (_e: MouseEvent): void => {
       if (draggedRef.current) {
         skipAddingToHistoryStack = false;
       }
 
-      document.removeEventListener('mousemove', onMouseMove, false);
-      document.removeEventListener('mouseup', onMouseUp, false);
+      dragCleanupRef.current?.();
+      dragCleanupRef.current = null;
 
       move(_e);
       draggedRef.current = false;
     };
 
-    document.addEventListener('mousemove', onMouseMove, false);
-    document.addEventListener('mouseup', onMouseUp, false);
+    dragCleanupRef.current?.();
+    dragCleanupRef.current = mergeRegister(
+      registerEventListener(doc, 'mousemove', onMouseMove, false),
+      registerEventListener(doc, 'mouseup', onMouseUp, false),
+    );
   };
 
   return (

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -9,7 +9,7 @@
 import './ColorPicker.css';
 
 import {calculateZoomLevel} from '@lexical/utils';
-import {mergeRegister, registerEventListener} from 'lexical';
+import {registerEventListeners} from 'lexical';
 import * as React from 'react';
 import {type JSX, useEffect, useMemo, useRef, useState} from 'react';
 
@@ -231,9 +231,10 @@ function MoveWrapper({className, style, onChange, children}: MoveWrapperProps) {
     };
 
     dragCleanupRef.current?.();
-    dragCleanupRef.current = mergeRegister(
-      registerEventListener(doc, 'mousemove', onMouseMove, false),
-      registerEventListener(doc, 'mouseup', onMouseUp, false),
+    dragCleanupRef.current = registerEventListeners(
+      doc,
+      {mousemove: onMouseMove, mouseup: onMouseUp},
+      false,
     );
   };
 

--- a/packages/lexical-playground/src/ui/DropDown.tsx
+++ b/packages/lexical-playground/src/ui/DropDown.tsx
@@ -233,16 +233,21 @@ export default function DropDown({
           }
         }
       };
-      return registerEventListener(document, 'click', handle);
+      const doc = button.ownerDocument;
+      return registerEventListener(doc, 'click', handle);
     }
   }, [dropDownRef, buttonRef, showDropDown, stopCloseOnClickSelf]);
 
   useEffect(() => {
+    const button = buttonRef.current;
+    if (button === null) {
+      return;
+    }
+
     const handleButtonPositionUpdate = () => {
       if (showDropDown) {
-        const button = buttonRef.current;
         const dropDown = dropDownRef.current;
-        if (button !== null && dropDown !== null) {
+        if (dropDown !== null) {
           const {top} = button.getBoundingClientRect();
           const newPosition = top + button.offsetHeight + dropDownPadding;
           if (newPosition !== dropDown.getBoundingClientRect().top) {
@@ -253,7 +258,7 @@ export default function DropDown({
     };
 
     return registerEventListener(
-      document,
+      button.ownerDocument,
       'scroll',
       handleButtonPositionUpdate,
     );
@@ -288,7 +293,7 @@ export default function DropDown({
             autofocus={shouldAutofocus}>
             {children}
           </DropDownItems>,
-          document.body,
+          buttonRef.current?.ownerDocument?.body ?? document.body,
         )}
     </>
   );

--- a/packages/lexical-playground/src/ui/ImageResizer.tsx
+++ b/packages/lexical-playground/src/ui/ImageResizer.tsx
@@ -6,11 +6,14 @@
  *
  */
 
-import type {LexicalEditor} from 'lexical';
-
 import {calculateZoomLevel} from '@lexical/utils';
+import {
+  type LexicalEditor,
+  mergeRegister,
+  registerEventListener,
+} from 'lexical';
 import * as React from 'react';
-import {type JSX, useRef} from 'react';
+import {type JSX, useEffect, useRef} from 'react';
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
@@ -45,6 +48,8 @@ export default function ImageResizer({
   captionsEnabled: boolean;
 }): JSX.Element {
   const controlWrapperRef = useRef<HTMLDivElement>(null);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => resizeCleanupRef.current?.(), []);
   const userSelect = useRef({
     priority: '',
     value: 'default',
@@ -101,23 +106,16 @@ export default function ImageResizer({
         'important',
       );
     }
-    if (document.body !== null) {
-      document.body.style.setProperty(
-        'cursor',
-        `${cursorDir}-resize`,
-        'important',
-      );
-      userSelect.current.value = document.body.style.getPropertyValue(
+    const body = imageRef.current?.ownerDocument?.body;
+    if (body != null) {
+      body.style.setProperty('cursor', `${cursorDir}-resize`, 'important');
+      userSelect.current.value = body.style.getPropertyValue(
         '-webkit-user-select',
       );
-      userSelect.current.priority = document.body.style.getPropertyPriority(
+      userSelect.current.priority = body.style.getPropertyPriority(
         '-webkit-user-select',
       );
-      document.body.style.setProperty(
-        '-webkit-user-select',
-        `none`,
-        'important',
-      );
+      body.style.setProperty('-webkit-user-select', `none`, 'important');
     }
   };
 
@@ -125,9 +123,10 @@ export default function ImageResizer({
     if (editorRootElement !== null) {
       editorRootElement.style.setProperty('cursor', 'text');
     }
-    if (document.body !== null) {
-      document.body.style.setProperty('cursor', 'default');
-      document.body.style.setProperty(
+    const body = imageRef.current?.ownerDocument?.body;
+    if (body != null) {
+      body.style.setProperty('cursor', 'default');
+      body.style.setProperty(
         '-webkit-user-select',
         userSelect.current.value,
         userSelect.current.priority,
@@ -168,8 +167,12 @@ export default function ImageResizer({
       image.style.height = `${height}px`;
       image.style.width = `${width}px`;
 
-      document.addEventListener('pointermove', handlePointerMove);
-      document.addEventListener('pointerup', handlePointerUp);
+      const doc = image.ownerDocument;
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = mergeRegister(
+        registerEventListener(doc, 'pointermove', handlePointerMove),
+        registerEventListener(doc, 'pointerup', handlePointerUp),
+      );
     }
   };
   const handlePointerMove = (event: PointerEvent) => {
@@ -247,8 +250,8 @@ export default function ImageResizer({
       setEndCursor();
       onResizeEnd(width, height);
 
-      document.removeEventListener('pointermove', handlePointerMove);
-      document.removeEventListener('pointerup', handlePointerUp);
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = null;
     }
   };
   return (

--- a/packages/lexical-playground/src/ui/ImageResizer.tsx
+++ b/packages/lexical-playground/src/ui/ImageResizer.tsx
@@ -7,11 +7,7 @@
  */
 
 import {calculateZoomLevel} from '@lexical/utils';
-import {
-  type LexicalEditor,
-  mergeRegister,
-  registerEventListener,
-} from 'lexical';
+import {type LexicalEditor, registerEventListeners} from 'lexical';
 import * as React from 'react';
 import {type JSX, useEffect, useRef} from 'react';
 
@@ -169,10 +165,10 @@ export default function ImageResizer({
 
       const doc = image.ownerDocument;
       resizeCleanupRef.current?.();
-      resizeCleanupRef.current = mergeRegister(
-        registerEventListener(doc, 'pointermove', handlePointerMove),
-        registerEventListener(doc, 'pointerup', handlePointerUp),
-      );
+      resizeCleanupRef.current = registerEventListeners(doc, {
+        pointermove: handlePointerMove,
+        pointerup: handlePointerUp,
+      });
     }
   };
   const handlePointerMove = (event: PointerEvent) => {


### PR DESCRIPTION
## Description

The playground serves as reference code for developers embedding Lexical in shadow DOM or iframes, but many files used raw `document` references that silently break in those contexts.

This PR converts all playground `document.createElement`/`createTextNode`/`createDocumentFragment` calls to `$getDocument()` (35 node and plugin files), scopes event listeners to `ownerDocument` instead of the global `document`, and points `createPortal` targets at `editor.getRootElement()?.ownerDocument?.body`. Event listener cleanup uses `registerEventListener` with cleanup refs and double-down guards to prevent leaks during drag/resize interactions.

Files intentionally left unchanged: `Modal.tsx`, `ExcalidrawModal.tsx`, `FlashMessage.tsx` (app-level overlays without editor context), `ImagesExtension` module-level constant, `TestRecorderPlugin` (standalone utility), `ColorPicker.toHex()` (canvas color utility), `TweetNode` Twitter widget script injection (scripts don't execute inside shadow roots), and `PagesExtension` `:root` CSS custom properties.

## Test plan

- [x] `pnpm test-unit` — 3996 pass
- [x] `pnpm test-e2e-chromium` — 771 pass
- [x] tsc clean
- [x] Manual playground testing:
  - S1: Image resize — drag handles, cursor changes during drag, cursor restore on release
  - S2: Color picker — saturation area drag, hue bar drag, real-time color update
  - S3: Sticky note — header drag to move, position fixed on release
  - S4: Table cell resize — column border hover, drag to resize width
  - S5: Table action menu — cell selection menu button, menu items, outside click dismiss
  - S6: Comments — text select, inline comment UI, comment marker + sidebar
  - S7: Draggable block menu — hover + button, component picker popup, item insertion
  - S8: Dropdown menus — toolbar dropdowns open/position, item selection, outside click dismiss, scroll tracking
  - S9: Image node — insert, display, copy-paste round-trip
  - S10: Equation node — insert, render math expression
  - S11: Sticky note rendering — display check (via S3)
  - S12: Columns layout — 2/3/4 column insert, text input per column
  - S13: Poll node — insert, question + options render
  - S14: Page break — insert, `<hr>` display
  - S15: Emoji node — shortcut trigger (`:)`), conversion display
  - S16: Excalidraw node — insert, draw, save, render
  - S17: YouTube node — insert URL, iframe display
  - S18: Tweet node — insert ID, tweet render
  - S19: Mention node — `@` trigger, autocomplete select, badge display
  - S20: DateTime node — insert, date display
  - S21: SlotContainer — collapsible insert, toggle expand/collapse