### PR TITLE
[lexical-rich-text] Bug Fix: Forward editorConfig to QuoteNode.updateDOM

### DIFF
--- a/packages/lexical-rich-text/flow/LexicalRichText.js.flow
+++ b/packages/lexical-rich-text/flow/LexicalRichText.js.flow
@@ -27,6 +27,7 @@ declare export var DRAG_DROP_PASTE: LexicalCommand<File[]>;
 declare export class QuoteNode extends ElementNode {
   constructor(key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
+  updateDOM(prevNode: QuoteNode, dom: HTMLElement, config: EditorConfig): boolean;
   insertNewAfter(
     selection: RangeSelection,
     restoreSelection?: boolean,

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
@@ -55,7 +55,11 @@ describe('LexicalQuoteNode tests', () => {
           '<blockquote class="my-quote-class"></blockquote>',
         );
         const newQuoteNode = $createQuoteNode();
-        const result = newQuoteNode.updateDOM(quoteNode, domElement);
+        const result = newQuoteNode.updateDOM(
+          quoteNode,
+          domElement,
+          editorConfig,
+        );
         expect(result).toBe(false);
         expect(domElement.outerHTML).toBe(
           '<blockquote class="my-quote-class"></blockquote>',

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -216,7 +216,7 @@ export class QuoteNode extends ElementNode {
     addClassNamesToElement(element, config.theme.quote);
     return element;
   }
-  updateDOM(prevNode: this, dom: HTMLElement): boolean {
+  updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
     return false;
   }
 


### PR DESCRIPTION
## Description

LexicalEditor already forwards `editor._config` to `updateDOM` for all nodes (see `LexicalEditor.ts:916`), but `QuoteNode` was not accepting the `config` parameter. This change aligns `QuoteNode.updateDOM` with every other node in the codebase (e.g. `HeadingNode`, `ParagraphNode`, `TextNode`) by adding the missing `config: EditorConfig` parameter.

Also updates the unit test and the Flow type declaration to match.

There is no runtime behavior change — this only makes the contract consistent so that future logic inside `QuoteNode.updateDOM` can safely reference the editor config (theme, namespace, etc.) just like sibling nodes already do.

## Test plan

### Before

- `QuoteNode.updateDOM(prevNode, dom)` accepted only two arguments.
- The reconciler passed `editor._config` anyway, but it was ignored by the type signature.

### After

- `QuoteNode.updateDOM(prevNode, dom, config)` matches the contract expected by the reconciler.
- Unit test `LexicalQuoteNode.test.ts` updated to pass `editorConfig` as the third argument.
- Flow type declaration updated accordingly.
- All existing tests in `packages/lexical-rich-text` pass.
