### PR TITLE
[lexical-table] Bug Fix: Table alignment fails when selecting in non-TL->BR direction

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -5576,11 +5576,6 @@ test.describe('Tables', () => {
     await focusEditor(page);
     await insertTable(page, 3, 3);
 
-    // Select every cell, but starting the drag at the bottom-right cell and
-    // ending at the top-left one — the opposite of the only direction that
-    // correctly aligned the table before the #8880 fix. The default
-    // insertTable marks row 0 and column 0 as headers, so {x:2,y:2} is a
-    // plain td and {x:0,y:0} is a th.
     await selectCellsFromTableCords(
       page,
       {x: 2, y: 2},
@@ -5591,7 +5586,6 @@ test.describe('Tables', () => {
 
     await selectFromAlignDropdown(page, '.center-align');
 
-    // The table itself should carry the alignment class...
     const tableIsCenterAligned = await evaluate(page, () => {
       const table = document.querySelector('div[contenteditable="true"] table');
       return table.classList.contains(
@@ -5600,8 +5594,6 @@ test.describe('Tables', () => {
     });
     expect(tableIsCenterAligned).toBe(true);
 
-    // ...and none of the individual cells' paragraphs should have been
-    // aligned instead (the bug's symptom: text centers, table doesn't).
     const cellParagraphsWithTextAlign = await evaluate(page, () => {
       const paragraphs = document.querySelectorAll(
         'div[contenteditable="true"] table th p, div[contenteditable="true"] table td p',

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -5565,6 +5565,52 @@ test.describe('Tables', () => {
     );
   });
 
+  test('Aligns the table itself (not cell text) when the whole table is selected in reverse, e.g. bottom-right to top-left (#8880)', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
+
+    await focusEditor(page);
+    await insertTable(page, 3, 3);
+
+    // Select every cell, but starting the drag at the bottom-right cell and
+    // ending at the top-left one — the opposite of the only direction that
+    // correctly aligned the table before the #8880 fix. The default
+    // insertTable marks row 0 and column 0 as headers, so {x:2,y:2} is a
+    // plain td and {x:0,y:0} is a th.
+    await selectCellsFromTableCords(
+      page,
+      {x: 2, y: 2},
+      {x: 0, y: 0},
+      false,
+      true,
+    );
+
+    await selectFromAlignDropdown(page, '.center-align');
+
+    // The table itself should carry the alignment class...
+    const tableIsCenterAligned = await evaluate(page, () => {
+      const table = document.querySelector('div[contenteditable="true"] table');
+      return table.classList.contains(
+        'PlaygroundEditorTheme__tableAlignmentCenter',
+      );
+    });
+    expect(tableIsCenterAligned).toBe(true);
+
+    // ...and none of the individual cells' paragraphs should have been
+    // aligned instead (the bug's symptom: text centers, table doesn't).
+    const cellParagraphsWithTextAlign = await evaluate(page, () => {
+      const paragraphs = document.querySelectorAll(
+        'div[contenteditable="true"] table th p, div[contenteditable="true"] table td p',
+      );
+      return Array.from(paragraphs).filter(p => p.hasAttribute('style')).length;
+    });
+    expect(cellParagraphsWithTextAlign).toBe(0);
+  });
+
   test('Paste and insert new lines after unmerging cells', async ({
     page,
     isPlainText,

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -901,8 +901,6 @@ export function applyTableHandlers(
           focusCell.startColumn,
         );
 
-        // Align the table itself if the selection covers every cell,
-        // regardless of which corner the drag started/ended on.
         if (
           minRow === 0 &&
           minColumn === 0 &&

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -882,12 +882,6 @@ export function applyTableHandlers(
           return false;
         }
 
-        // Align the table if the entire table is selected
-        if ($isFullTableSelection(selection, tableNode)) {
-          tableNode.setFormat(formatType);
-          return true;
-        }
-
         const [tableMap, anchorCell, focusCell] = $computeTableMap(
           tableNode,
           anchorNode,
@@ -906,6 +900,19 @@ export function applyTableHandlers(
           anchorCell.startColumn,
           focusCell.startColumn,
         );
+
+        // Align the table itself if the selection covers every cell,
+        // regardless of which corner the drag started/ended on.
+        if (
+          minRow === 0 &&
+          minColumn === 0 &&
+          maxRow === tableMap.length - 1 &&
+          maxColumn === tableMap[0].length - 1
+        ) {
+          tableNode.setFormat(formatType);
+          return true;
+        }
+
         const visited = new Set<TableCellNode>();
         for (let i = minRow; i <= maxRow; i++) {
           for (let j = minColumn; j <= maxColumn; j++) {
@@ -1919,24 +1926,6 @@ function $isSelectionInTable(
     return isAnchorInside && isFocusInside;
   }
 
-  return false;
-}
-
-function $isFullTableSelection(
-  selection: null | BaseSelection,
-  tableNode: TableNode,
-): boolean {
-  if ($isTableSelection(selection)) {
-    const anchorNode = selection.anchor.getNode() as TableCellNode;
-    const focusNode = selection.focus.getNode() as TableCellNode;
-    if (tableNode && anchorNode && focusNode) {
-      const [map] = $computeTableMap(tableNode, anchorNode, focusNode);
-      return (
-        anchorNode.getKey() === map[0][0].cell.getKey() &&
-        focusNode.getKey() === map[map.length - 1].at(-1)!.cell.getKey()
-      );
-    }
-  }
   return false;
 }
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -23,7 +23,9 @@ import {
   $isTableSelection,
   $mergeCells,
   INSERT_TABLE_COMMAND,
+  type TableCellNode,
   TableExtension,
+  type TableNode,
 } from '@lexical/table';
 import {
   $createParagraphNode,
@@ -35,6 +37,7 @@ import {
   $isRangeSelection,
   $setSelection,
   defineExtension,
+  FORMAT_ELEMENT_COMMAND,
   type LexicalEditorWithDispose,
   type NodeKey,
   SELECT_ALL_COMMAND,
@@ -947,6 +950,160 @@ describe('TableExtension', () => {
         editor.setRootElement(null);
         document.body.removeChild(container);
       }
+    });
+  });
+
+  describe('FORMAT_ELEMENT_COMMAND on a full table selection (#8880)', () => {
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      editor.setRootElement(container);
+    });
+
+    afterEach(() => {
+      editor.setRootElement(null);
+    });
+
+    function $getCell(
+      table: TableNode,
+      row: number,
+      column: number,
+    ): TableCellNode {
+      const rowNode = $assertNodeType(
+        table.getChildAtIndex(row),
+        $isTableRowNode,
+      );
+      return $assertNodeType(rowNode.getChildAtIndex(column), $isTableCellNode);
+    }
+
+    function createTable(): TableNode {
+      editor.update(
+        () => {
+          const root = $getRoot().clear();
+          const table = $createTableNodeWithDimensions(3, 3, false);
+          root.append(table);
+        },
+        {discrete: true},
+      );
+      // Commit in its own update so the TableNode mutation listener runs
+      // and registers the table's FORMAT_ELEMENT_COMMAND handler before the
+      // selection/dispatch happens in a later update.
+      return editor.read(() =>
+        $assertNodeType($getRoot().getFirstChild(), $isTableNode),
+      );
+    }
+
+    // A selection that covers every cell should align the table itself no
+    // matter which corner the drag started/ended on.
+    const directions: {
+      name: string;
+      anchor: [number, number];
+      focus: [number, number];
+    }[] = [
+      {anchor: [0, 0], focus: [2, 2], name: 'top-left -> bottom-right'},
+      {anchor: [2, 2], focus: [0, 0], name: 'bottom-right -> top-left'},
+      {anchor: [0, 2], focus: [2, 0], name: 'top-right -> bottom-left'},
+      {anchor: [2, 0], focus: [0, 2], name: 'bottom-left -> top-right'},
+    ];
+
+    for (const {name, anchor, focus} of directions) {
+      it(`aligns the table when selected ${name}`, () => {
+        const table = createTable();
+        editor.update(
+          () => {
+            const anchorCell = $getCell(table, anchor[0], anchor[1]);
+            const focusCell = $getCell(table, focus[0], focus[1]);
+            $setSelection(
+              $createTableSelectionFrom(table, anchorCell, focusCell),
+            );
+            editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
+          },
+          {discrete: true},
+        );
+
+        editor.read(() => {
+          expect(table.getFormatType()).toBe('center');
+
+          // The table was aligned as a whole, so individual cell contents
+          // must be untouched.
+          for (let row = 0; row < 3; row++) {
+            for (let column = 0; column < 3; column++) {
+              const cell = $getCell(table, row, column);
+              const paragraph = $assertNodeType(
+                cell.getFirstChild(),
+                $isParagraphNode,
+              );
+              expect(paragraph.getFormatType()).toBe('');
+            }
+          }
+        });
+      });
+    }
+
+    it('aligns the table when the full selection includes a merged cell, selected in reverse', () => {
+      const table = createTable();
+      editor.update(
+        () => {
+          const cell0_2 = $getCell(table, 0, 2);
+          const cell1_2 = $getCell(table, 1, 2);
+          $mergeCells([cell0_2, cell1_2]);
+        },
+        {discrete: true},
+      );
+
+      editor.update(
+        () => {
+          const anchorCell = $getCell(table, 2, 2);
+          const focusCell = $getCell(table, 0, 0);
+          $setSelection(
+            $createTableSelectionFrom(table, anchorCell, focusCell),
+          );
+          editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'justify');
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        expect(table.getFormatType()).toBe('justify');
+      });
+    });
+
+    it('applies per-cell alignment (not table alignment) when only part of the table is selected, even in reverse direction', () => {
+      const table = createTable();
+      editor.update(
+        () => {
+          // Select the top-left 2x2 subset, dragged from its bottom-right
+          // corner back to its top-left corner. This selection does not
+          // cover the whole table (row/column 2 are excluded), so it must
+          // fall back to per-cell alignment regardless of direction.
+          const anchorCell = $getCell(table, 1, 1);
+          const focusCell = $getCell(table, 0, 0);
+          $setSelection(
+            $createTableSelectionFrom(table, anchorCell, focusCell),
+          );
+          editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'right');
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        expect(table.getFormatType()).toBe('');
+
+        for (let row = 0; row < 3; row++) {
+          for (let column = 0; column < 3; column++) {
+            const cell = $getCell(table, row, column);
+            const paragraph = $assertNodeType(
+              cell.getFirstChild(),
+              $isParagraphNode,
+            );
+            const inSelectedSubset = row <= 1 && column <= 1;
+            expect(paragraph.getFormatType()).toBe(
+              inSelectedSubset ? 'right' : '',
+            );
+          }
+        }
+      });
     });
   });
 });

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -986,16 +986,11 @@ describe('TableExtension', () => {
         },
         {discrete: true},
       );
-      // Commit in its own update so the TableNode mutation listener runs
-      // and registers the table's FORMAT_ELEMENT_COMMAND handler before the
-      // selection/dispatch happens in a later update.
       return editor.read(() =>
         $assertNodeType($getRoot().getFirstChild(), $isTableNode),
       );
     }
 
-    // A selection that covers every cell should align the table itself no
-    // matter which corner the drag started/ended on.
     const directions: {
       name: string;
       anchor: [number, number];
@@ -1025,8 +1020,6 @@ describe('TableExtension', () => {
         editor.read(() => {
           expect(table.getFormatType()).toBe('center');
 
-          // The table was aligned as a whole, so individual cell contents
-          // must be untouched.
           for (let row = 0; row < 3; row++) {
             for (let column = 0; column < 3; column++) {
               const cell = $getCell(table, row, column);
@@ -1073,10 +1066,6 @@ describe('TableExtension', () => {
       const table = createTable();
       editor.update(
         () => {
-          // Select the top-left 2x2 subset, dragged from its bottom-right
-          // corner back to its top-left corner. This selection does not
-          // cover the whole table (row/column 2 are excluded), so it must
-          // fall back to per-cell alignment regardless of direction.
           const anchorCell = $getCell(table, 1, 1);
           const focusCell = $getCell(table, 0, 0);
           $setSelection(


### PR DESCRIPTION
# Description

### Current behavior

When a `TableSelection` covers every cell in a table, `FORMAT_ELEMENT_COMMAND` is expected to align the table itself instead of aligning the text inside each cell.

However, this only worked when the selection started at the **top-left** cell and ended at the **bottom-right** cell. The `$isFullTableSelection` helper compared the `anchor` and `focus` node keys directly against `map[0][0]` and `map[last][last]`, so it only recognised selections made in that specific direction.

Since `$computeTableMap` always builds the table grid in document order, regardless of where the drag starts, full-table selections made in the other three directions (bottom-right → top-left, top-right → bottom-left, and bottom-left → top-right) failed this check.

As a result, those selections incorrectly fell back to per-cell alignment. The text inside each cell was aligned, but the table itself never moved.

## Changes in this PR

This PR replaces the corner-based key comparison with a direction-independent bounding rectangle check. It reuses the existing min/max row and column span calculation that the per-cell fallback path already performs.

A selection is now treated as a full-table selection whenever its bounding rectangle spans from `[0,0]` to `[lastRow,lastCol]`, regardless of which corner the user starts or ends the drag from.

Since this logic makes `$isFullTableSelection` unnecessary, the helper has been removed along with its extra `$computeTableMap` call.

Closes #8880

# Test plan

## Before

1. Open the playground and insert a table (**Insert → Table**).
2. Drag-select the entire table starting from the **bottom-right** cell and ending at the **top-left** cell. The same issue also occurs for top-right → bottom-left and bottom-left → top-right.
3. Click an alignment button such as **Center**.

**Result:** The text inside each cell is centred, but the table itself is not centred on the page.



https://github.com/user-attachments/assets/ff2cb454-c2d2-48c2-a5a5-7ce76a67d24b



## After

Repeat the same steps.

**Result:** The table itself is centred on the page, while the text inside the cells remains unchanged. Alignment now behaves the same regardless of which corner the selection starts from.


https://github.com/user-attachments/assets/1b697e5b-a0de-469b-a882-716449b0939e



Regression coverage has been added at both levels:

- **Unit** (`packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts`)
  - Verifies all four drag directions (TL→BR, BR→TL, TR→BL, BL→TR) correctly align the table while leaving cell paragraphs unchanged.
  - Verifies a full-table selection containing a merged cell, selected in reverse, still aligns the table.
  - Verifies a partial selection made in reverse still falls back to per-cell alignment.

- **E2E** (`packages/lexical-playground/__tests__/e2e/Tables.spec.mjs`)
  - Selects a full table from bottom-right to top-left using real pointer and DOM interactions.
  - Verifies that the `<table>` receives the alignment class and that no cell paragraph receives an inline `text-align` style.

The full unit test suite (226 files, 4,923 tests) and the complete `Tables.spec.mjs` E2E suite (88 tests) pass without any regressions.