### PR TITLE
[lexical-rich-text] Bug Fix: Keep block cursor in editor when ArrowUp at start of root (#8886)

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextBlockCursorRootBoundary.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextBlockCursorRootBoundary.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createNodeSelection,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $setSelection,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  type LexicalEditor,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
+
+function makeArrowEvent(key: string): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+}
+
+// Structure used across tests:
+//   root
+//     decorator (block)   — index 0
+//     paragraph > text    — index 1
+//     decorator (block)   — index 2
+function createBoundaryEditor() {
+  return buildEditorFromExtensions({
+    $initialEditorState: () => {
+      const decorator1 = $createTestDecoratorNode().setIsInline(false);
+      const paragraph = $createParagraphNode().append($createTextNode('text'));
+      const decorator2 = $createTestDecoratorNode().setIsInline(false);
+      $getRoot().clear().append(decorator1, paragraph, decorator2);
+    },
+    dependencies: [RichTextExtension],
+    name: 'test',
+    nodes: [TestDecoratorNode],
+  });
+}
+
+function expectBlockCursorAt(editor: LexicalEditor, offset: number) {
+  editor.read(() => {
+    const s = $getSelection();
+    assert($isRangeSelection(s));
+    expect(s.isCollapsed()).toBe(true);
+    expect(s.anchor.type).toBe('element');
+    expect(s.anchor.key).toBe($getRoot().getKey());
+    expect(s.anchor.offset).toBe(offset);
+  });
+}
+
+describe('block cursor root boundary navigation (#8886)', () => {
+  test('ArrowUp at block cursor before the top decorator does not leave the editor', () => {
+    using editor = createBoundaryEditor();
+
+    // Select the leading decorator (NodeSelection)
+    editor.update(
+      () => {
+        const decorator = $getRoot().getChildAtIndex(0)!;
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+      {discrete: true},
+    );
+
+    // First ArrowUp collapses the NodeSelection to a block cursor at root:0
+    editor.dispatchCommand(KEY_ARROW_UP_COMMAND, makeArrowEvent('ArrowUp'));
+    expectBlockCursorAt(editor, 0);
+
+    // Second ArrowUp must be handled (preventDefault) so the native selection
+    // cannot escape above the editor, and the lexical selection stays put.
+    const event = makeArrowEvent('ArrowUp');
+    const handled = editor.dispatchCommand(KEY_ARROW_UP_COMMAND, event);
+    expect(handled).toBe(true);
+    expect(event.defaultPrevented).toBe(true);
+    expectBlockCursorAt(editor, 0);
+  });
+
+  test('ArrowDown at block cursor after the bottom decorator does not leave the editor', () => {
+    using editor = createBoundaryEditor();
+
+    // Select the trailing decorator (NodeSelection)
+    editor.update(
+      () => {
+        const decorator = $getRoot().getChildAtIndex(2)!;
+        const ns = $createNodeSelection();
+        ns.add(decorator.getKey());
+        $setSelection(ns);
+      },
+      {discrete: true},
+    );
+
+    // First ArrowDown collapses the NodeSelection to a block cursor at root:3
+    editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND, makeArrowEvent('ArrowDown'));
+    expectBlockCursorAt(editor, 3);
+
+    // Second ArrowDown must be handled (preventDefault) so the native
+    // selection cannot escape below the editor.
+    const event = makeArrowEvent('ArrowDown');
+    const handled = editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND, event);
+    expect(handled).toBe(true);
+    expect(event.defaultPrevented).toBe(true);
+    expectBlockCursorAt(editor, 3);
+  });
+});

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -575,6 +575,11 @@ function $isSelectionAtEndOfRoot(selection: RangeSelection) {
   return focus.key === 'root' && focus.offset === $getRoot().getChildrenSize();
 }
 
+function $isSelectionAtStartOfRoot(selection: RangeSelection) {
+  const focus = selection.focus;
+  return focus.key === 'root' && focus.offset === 0;
+}
+
 function $isSelectionCollapsedAtFrontOfIndentedBlock(
   selection: RangeSelection,
 ): boolean {
@@ -1347,6 +1352,10 @@ export function registerRichText(
             return true;
           }
         } else if ($isRangeSelection(selection)) {
+          if ($isSelectionAtStartOfRoot(selection)) {
+            event.preventDefault();
+            return true;
+          }
           if (
             !event.shiftKey &&
             $tryBlockCursorShadowRootNavigation(selection, 'previous')


### PR DESCRIPTION
## Description

Current behavior: when a non-inline decorator node is the first child of the document and the block cursor sits before it (a collapsed RangeSelection at root offset 0), pressing ArrowUp again fell through to the browser default. The native selection moved outside the editor, with browser-specific breakage — text entry and paste failing in Chrome, Firefox, and Safari.

The ArrowDown handler already guards the bottom boundary with $isSelectionAtEndOfRoot, but the ArrowUp handler had no symmetric top-boundary guard.

New behavior: this adds $isSelectionAtStartOfRoot (a mirror of $isSelectionAtEndOfRoot) and a guard at the top of the ArrowUp range-selection branch that calls preventDefault and returns true. At the top of root neither the native selection nor the lexical selection changes, keeping arrow navigation within the editor.

Closes #8886

## Test plan

### Before

Added a regression test that dispatches KEY_ARROW_UP_COMMAND from a block cursor before a leading decorator. Before the fix the event was not handled (event.defaultPrevented === false), so the browser default moved the native selection out of the editor.

### After

New unit test RichTextBlockCursorRootBoundary.test.ts covers both root boundaries (ArrowUp at start, ArrowDown at end): the command is handled, event.defaultPrevented is true, and the block cursor stays in place. Full rich-text unit suite passes (114/114); prettier, eslint, and tsc are clean.
