### PR TITLE
[lexical] Documentation Update: Add JSDoc comments to core package exports

### DIFF
--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -28,20 +28,27 @@ export function createCommand<T>(type?: string): LexicalCommand<T> {
   return {type};
 }
 
+/** Dispatched whenever the editor selection changes. */
 export const SELECTION_CHANGE_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('SELECTION_CHANGE_COMMAND');
+/** Dispatched to insert clipboard nodes at the current selection. */
 export const SELECTION_INSERT_CLIPBOARD_NODES_COMMAND: LexicalCommand<{
   nodes: LexicalNode[];
   selection: BaseSelection;
 }> = /* @__PURE__ */ createCommand('SELECTION_INSERT_CLIPBOARD_NODES_COMMAND');
+/** Dispatched on a mouse click event in the editor. */
 export const CLICK_COMMAND: LexicalCommand<MouseEvent> =
   /* @__PURE__ */ createCommand('CLICK_COMMAND');
+/** Dispatched on a beforeinput event. */
 export const BEFORE_INPUT_COMMAND: LexicalCommand<InputEvent> =
   /* @__PURE__ */ createCommand('BEFORE_INPUT_COMMAND');
+/** Dispatched on an input event. */
 export const INPUT_COMMAND: LexicalCommand<InputEvent> =
   /* @__PURE__ */ createCommand('INPUT_COMMAND');
+/** Dispatched when an IME composition session starts. */
 export const COMPOSITION_START_COMMAND: LexicalCommand<CompositionEvent> =
   /* @__PURE__ */ createCommand('COMPOSITION_START_COMMAND');
+/** Dispatched when an IME composition session ends. */
 export const COMPOSITION_END_COMMAND: LexicalCommand<CompositionEvent> =
   /* @__PURE__ */ createCommand('COMPOSITION_END_COMMAND');
 /**
@@ -58,13 +65,17 @@ export const DELETE_CHARACTER_COMMAND: LexicalCommand<boolean> =
  */
 export const INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean> =
   /* @__PURE__ */ createCommand('INSERT_LINE_BREAK_COMMAND');
+/** Dispatched to insert a new paragraph (Enter key). */
 export const INSERT_PARAGRAPH_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('INSERT_PARAGRAPH_COMMAND');
+/** Dispatched to insert text from an InputEvent or a string. */
 export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<
   InputEvent | string
 > = /* @__PURE__ */ createCommand('CONTROLLED_TEXT_INSERTION_COMMAND');
+/** Dispatched on a paste event. */
 export const PASTE_COMMAND: LexicalCommand<PasteCommandType> =
   /* @__PURE__ */ createCommand('PASTE_COMMAND');
+/** Dispatched to remove the currently selected text. */
 export const REMOVE_TEXT_COMMAND: LexicalCommand<InputEvent | null> =
   /* @__PURE__ */ createCommand('REMOVE_TEXT_COMMAND');
 /**
@@ -181,20 +192,28 @@ export const KEY_DELETE_COMMAND: LexicalCommand<KeyboardEvent> =
  */
 export const KEY_TAB_COMMAND: LexicalCommand<KeyboardEvent> =
   /* @__PURE__ */ createCommand('KEY_TAB_COMMAND');
+/** Dispatched to insert a tab character. */
 export const INSERT_TAB_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('INSERT_TAB_COMMAND');
+/** Dispatched to indent the selected content. */
 export const INDENT_CONTENT_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('INDENT_CONTENT_COMMAND');
+/** Dispatched to outdent the selected content. */
 export const OUTDENT_CONTENT_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('OUTDENT_CONTENT_COMMAND');
+/** Dispatched on a drop event. */
 export const DROP_COMMAND: LexicalCommand<DragEvent> =
   /* @__PURE__ */ createCommand('DROP_COMMAND');
+/** Dispatched to set the element format (alignment) of the selected block. */
 export const FORMAT_ELEMENT_COMMAND: LexicalCommand<ElementFormatType> =
   /* @__PURE__ */ createCommand('FORMAT_ELEMENT_COMMAND');
+/** Dispatched when a drag operation starts. */
 export const DRAGSTART_COMMAND: LexicalCommand<DragEvent> =
   /* @__PURE__ */ createCommand('DRAGSTART_COMMAND');
+/** Dispatched when a dragged element is over the editor. */
 export const DRAGOVER_COMMAND: LexicalCommand<DragEvent> =
   /* @__PURE__ */ createCommand('DRAGOVER_COMMAND');
+/** Dispatched when a drag operation ends. */
 export const DRAGEND_COMMAND: LexicalCommand<DragEvent> =
   /* @__PURE__ */ createCommand('DRAGEND_COMMAND');
 /**
@@ -217,16 +236,22 @@ export const CUT_COMMAND: LexicalCommand<
  */
 export const SELECT_ALL_COMMAND: LexicalCommand<KeyboardEvent> =
   /* @__PURE__ */ createCommand('SELECT_ALL_COMMAND');
+/** Dispatched to clear all editor content. */
 export const CLEAR_EDITOR_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('CLEAR_EDITOR_COMMAND');
+/** Dispatched to clear the undo/redo history stack. */
 export const CLEAR_HISTORY_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('CLEAR_HISTORY_COMMAND');
+/** Dispatched when the redo availability changes. Payload is true if redo is available. */
 export const CAN_REDO_COMMAND: LexicalCommand<boolean> =
   /* @__PURE__ */ createCommand('CAN_REDO_COMMAND');
+/** Dispatched when the undo availability changes. Payload is true if undo is available. */
 export const CAN_UNDO_COMMAND: LexicalCommand<boolean> =
   /* @__PURE__ */ createCommand('CAN_UNDO_COMMAND');
+/** Dispatched when the editor receives focus. */
 export const FOCUS_COMMAND: LexicalCommand<FocusEvent> =
   /* @__PURE__ */ createCommand('FOCUS_COMMAND');
+/** Dispatched when the editor loses focus. */
 export const BLUR_COMMAND: LexicalCommand<FocusEvent> =
   /* @__PURE__ */ createCommand('BLUR_COMMAND');
 /**

--- a/packages/lexical/src/LexicalConstants.ts
+++ b/packages/lexical/src/LexicalConstants.ts
@@ -32,19 +32,27 @@ export const IS_TOKEN = 1;
 export const IS_SEGMENTED = 2;
 // IS_INERT = 3
 
-// Text node formatting
+/** Bitmask for bold text formatting. */
 export const IS_BOLD = 1;
+/** Bitmask for italic text formatting. */
 export const IS_ITALIC = 1 << 1;
+/** Bitmask for strikethrough text formatting. */
 export const IS_STRIKETHROUGH = 1 << 2;
+/** Bitmask for underline text formatting. */
 export const IS_UNDERLINE = 1 << 3;
+/** Bitmask for code (monospace) text formatting. */
 export const IS_CODE = 1 << 4;
+/** Bitmask for subscript text formatting. */
 export const IS_SUBSCRIPT = 1 << 5;
+/** Bitmask for superscript text formatting. */
 export const IS_SUPERSCRIPT = 1 << 6;
+/** Bitmask for highlighted text formatting. */
 export const IS_HIGHLIGHT = 1 << 7;
 export const IS_LOWERCASE = 1 << 8;
 export const IS_UPPERCASE = 1 << 9;
 export const IS_CAPITALIZE = 1 << 10;
 
+/** Bitmask combining all text format flags. */
 export const IS_ALL_FORMATTING =
   IS_BOLD |
   IS_ITALIC |
@@ -98,6 +106,7 @@ export const RTL_REGEX = new RegExp('^[^' + LTR + ']*[' + RTL + ']');
 // eslint-disable-next-line no-misleading-character-class
 export const LTR_REGEX = new RegExp('^[^' + RTL + ']*[' + LTR + ']');
 
+/** Maps {@link TextFormatType} string names to their bitmask values. */
 export const TEXT_TYPE_TO_FORMAT: Record<TextFormatType | string, number> = {
   bold: IS_BOLD,
   capitalize: IS_CAPITALIZE,
@@ -150,5 +159,6 @@ export const TEXT_TYPE_TO_MODE: Record<number, TextModeType> = {
   [IS_TOKEN]: 'token',
 };
 
+/** The property key used to store node state on serialized node JSON. */
 export const NODE_STATE_KEY = '$';
 export const PROTOTYPE_CONFIG_METHOD = '$config';

--- a/packages/lexical/src/LexicalNormalization.ts
+++ b/packages/lexical/src/LexicalNormalization.ts
@@ -96,6 +96,7 @@ export function $normalizeTextNode(textNode: TextNode): void {
   }
 }
 
+/** Descends element-type anchor and focus points of a RangeSelection toward the deepest text-type points, stopping at non-element leaf nodes. */
 export function $normalizeSelection(selection: RangeSelection): RangeSelection {
   $normalizePoint(selection.anchor);
   $normalizePoint(selection.focus);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -246,6 +246,7 @@ export class Point {
   }
 }
 
+/** Creates a selection endpoint (Point) targeting the given node key at the specified offset. */
 export function $createPoint(
   key: NodeKey,
   offset: number,
@@ -575,6 +576,7 @@ function $ensureRootHasParagraph(): void {
   }
 }
 
+/** Returns true if the given value is a RangeSelection. */
 export function $isRangeSelection(x: unknown): x is RangeSelection {
   return x instanceof RangeSelection;
 }
@@ -2018,6 +2020,7 @@ export class RangeSelection implements BaseSelection {
   }
 }
 
+/** Returns true if the given value is a NodeSelection. */
 export function $isNodeSelection(x: unknown): x is NodeSelection {
   return x instanceof NodeSelection;
 }
@@ -2251,6 +2254,7 @@ function getCharacterOffset(point: PointType): number {
     : 0;
 }
 
+/** Returns the character offsets of the selection's anchor and focus points as an [anchor, focus] tuple. */
 export function $getCharacterOffsets(
   selection: BaseSelection,
 ): [number, number] {
@@ -3283,6 +3287,7 @@ function $internalResolveSelectionPoints(
   ];
 }
 
+/** Returns true if the given node is a non-inline ElementNode. */
 export function $isBlockElementNode(
   node: LexicalNode | null | undefined,
 ): node is ElementNode {
@@ -3313,12 +3318,14 @@ export function $internalMakeRangeSelection(
   return selection;
 }
 
+/** Creates a detached RangeSelection anchored at the root element origin (offset 0). */
 export function $createRangeSelection(): RangeSelection {
   const anchor = $createPoint('root', 0, 'element');
   const focus = $createPoint('root', 0, 'element');
   return new RangeSelection(anchor, focus, 0, '');
 }
 
+/** Creates an empty NodeSelection with no selected node keys. */
 export function $createNodeSelection(): NodeSelection {
   return new NodeSelection(new Set());
 }
@@ -3342,6 +3349,7 @@ export function $internalCreateSelection(
   return lastSelection.clone();
 }
 
+/** Creates a RangeSelection from the given DOM selection, or returns null if one cannot be resolved. */
 export function $createRangeSelectionFromDom(
   domSelection: Selection | null,
   editor: LexicalEditor,
@@ -3494,11 +3502,13 @@ function $validatePoint(name: 'anchor' | 'focus', point: PointType): void {
   }
 }
 
+/** Returns the current selection of the active editor state, or null if none exists. */
 export function $getSelection(): null | BaseSelection {
   const editorState = getActiveEditorState();
   return editorState._selection;
 }
 
+/** Returns the selection from the previous editor state, or null if none existed. */
 export function $getPreviousSelection(): null | BaseSelection {
   const editor = getActiveEditor();
   return editor._editorState._selection;
@@ -4001,6 +4011,7 @@ export function $updateDOMSelection(
   markSelectionChangeFromDOMUpdate(editor);
 }
 
+/** Inserts nodes into the current selection, falling back to the previous selection or the end of the root. */
 export function $insertNodes(nodes: LexicalNode[]) {
   let selection = $getSelection() || $getPreviousSelection();
 
@@ -4066,6 +4077,7 @@ export function $generateNodesFromRawText(
   return nodes;
 }
 
+/** Returns the text content of the current selection, or an empty string if no selection exists. */
 export function $getTextContent(): string {
   const selection = $getSelection();
   if (selection === null) {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -93,6 +93,7 @@ const observerOptions = {
   subtree: true,
 };
 
+/** Returns true if the current editor update context is read-only. */
 export function isCurrentlyReadOnlyMode(): boolean {
   return (
     isReadOnlyMode ||
@@ -397,6 +398,7 @@ type InternalSerializedNode = {
   version: number;
 };
 
+/** Deserializes a SerializedLexicalNode JSON object into its corresponding LexicalNode instance. */
 export function $parseSerializedNode(
   serializedNode: SerializedLexicalNode,
 ): LexicalNode {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -149,6 +149,7 @@ const INTERNAL_SKIP_AFTER_CLONE_FROM: unique symbol = Symbol(
 
 let keyCounter = 1;
 
+/** Resets the internal key counter, primarily for deterministic test output. */
 export function resetRandomKey(): void {
   keyCounter = 1;
 }
@@ -192,6 +193,7 @@ export const scheduleMicroTask: (fn: () => void) => void =
         Promise.resolve().then(fn);
       };
 
+/** Returns true if the active element (resolved from the anchor's root) is a decorator's own input (e.g. an input, textarea, or foreign contentEditable) rather than Lexical-managed content. */
 export function $isSelectionCapturedInDecoratorInput(
   anchorDOM: Node,
   preResolvedActiveElement?: Element | null,
@@ -230,6 +232,7 @@ export function $isSelectionCapturedInDecoratorInput(
 export const isSelectionCapturedInDecoratorInput =
   $isSelectionCapturedInDecoratorInput;
 
+/** Returns true if the given DOM anchor and focus nodes are inside the editor's root element and not captured by a decorator input. */
 export function isSelectionWithinEditor(
   editor: LexicalEditor,
   anchorDOM: null | Node,
@@ -267,6 +270,7 @@ export function isLexicalEditor(editor: unknown): editor is LexicalEditor {
   return editor instanceof LexicalEditor;
 }
 
+/** Returns the nearest LexicalEditor instance by walking up the DOM tree from the given node, or null if none is found. */
 export function getNearestEditorFromDOMNode(
   node: Node | null,
 ): LexicalEditor | null {
@@ -287,6 +291,7 @@ export function getEditorPropertyFromDOMNode(node: Node | null): unknown {
   return node ? node.__lexicalEditor : null;
 }
 
+/** Returns the text direction ('ltr' or 'rtl') of the given string, or null if it contains no strong directional characters. */
 export function getTextDirection(text: string): 'ltr' | 'rtl' | null {
   if (RTL_REGEX.test(text)) {
     return 'rtl';
@@ -327,6 +332,7 @@ export function isDOMDocumentNode(node: unknown): node is Document {
   return isDOMNode(node) && node.nodeType === DOM_DOCUMENT_TYPE;
 }
 
+/** Returns the first DOM Text node found by descending the firstChild chain from the given node, or null. */
 export function getDOMTextNode(element: Node | null): Text | null {
   let node = element;
   while (node != null) {
@@ -338,6 +344,7 @@ export function getDOMTextNode(element: Node | null): Text | null {
   return null;
 }
 
+/** Toggles the given text format type on a format bitmask, clearing mutually exclusive formats (subscript/superscript, lowercase/uppercase/capitalize). */
 export function toggleTextFormatType(
   format: number,
   type: TextFormatType,
@@ -368,6 +375,7 @@ export function toggleTextFormatType(
   return newFormat;
 }
 
+/** Returns true if the given node is a leaf (TextNode, LineBreakNode, or DecoratorNode). */
 export function $isLeafNode(
   node: LexicalNode | null | undefined,
 ): node is TextNode | LineBreakNode | DecoratorNode<unknown> {
@@ -593,6 +601,7 @@ export function internalMarkSiblingsAsDirty(node: LexicalNode) {
   }
 }
 
+/** Sets the active composition key, marking the previous and new composition nodes as dirty for re-rendering. */
 export function $setCompositionKey(compositionKey: null | NodeKey): void {
   errorOnReadOnly();
   const editor = getActiveEditor();
@@ -652,6 +661,7 @@ export function $getNodeByKey(
   return node;
 }
 
+/** Returns the LexicalNode directly associated with the given DOM node, or null if the DOM node has no Lexical key. */
 export function $getNodeFromDOMNode(
   dom: Node,
   editorState?: EditorState,
@@ -686,6 +696,7 @@ export function getNodeKeyFromDOMNode(
   return (dom as Node & Record<typeof prop, NodeKey | undefined>)[prop];
 }
 
+/** Returns the nearest LexicalNode by walking up the DOM tree from the given node, or null if no Lexical node is found. */
 export function $getNearestNodeFromDOMNode(
   startingDOM: Node,
   editorState?: EditorState,
@@ -754,6 +765,7 @@ export function markNodesWithTypesAsDirty(
   );
 }
 
+/** Returns the RootNode of the active EditorState. */
 export function $getRoot(): RootNode {
   return internalGetRoot(getActiveEditorState());
 }
@@ -762,6 +774,7 @@ export function internalGetRoot(editorState: EditorState): RootNode {
   return editorState._nodeMap.get('root') as RootNode;
 }
 
+/** Sets the current selection in the active EditorState, marking it dirty and clamping to slot boundaries when applicable. */
 export function $setSelection(selection: null | BaseSelection): void {
   errorOnReadOnly();
   const editorState = getActiveEditorState();
@@ -1345,6 +1358,7 @@ export function isSelectAll(event: KeyboardEventModifiers): boolean {
   return isExactShortcutMatch(event, 'a', CONTROL_OR_META);
 }
 
+/** Selects all content within the root. If a selection is provided, scopes to the nearest root or shadow root; otherwise creates a new RangeSelection spanning the entire root. */
 export function $selectAll(selection?: RangeSelection | null): RangeSelection {
   const root = $getRoot();
 
@@ -1507,6 +1521,7 @@ function resolveElement(
   return block.getChildAtIndex(isBackward ? offset - 1 : offset);
 }
 
+/** Returns the node adjacent to the given selection point in the specified direction, or null if at a boundary. */
 export function $getAdjacentNode(
   focus: PointType,
   isBackward: boolean,
@@ -1576,6 +1591,7 @@ export function getElementByKeyOrThrow(
   return element;
 }
 
+/** Returns the parent element of a DOM node, crossing shadow root boundaries and following slot assignments. */
 export function getParentElement(node: Node): HTMLElement | null {
   const parentElement =
     (node as HTMLSlotElement).assignedSlot || node.parentElement;
@@ -1590,6 +1606,7 @@ export function getParentElement(node: Node): HTMLElement | null {
   return isDOMShadowRoot(parentNode) ? (parentNode.host as HTMLElement) : null;
 }
 
+/** Returns the owner Document of the given EventTarget, or the target itself if it is a Document. */
 export function getDOMOwnerDocument(
   target: EventTarget | null,
 ): Document | null {
@@ -1690,11 +1707,13 @@ export function scrollIntoViewIfNeeded(
   }
 }
 
+/** Returns true if the given tag has been added to the current update via $addUpdateTag. */
 export function $hasUpdateTag(tag: UpdateTag): boolean {
   const editor = getActiveEditor();
   return editor._updateTags.has(tag);
 }
 
+/** Adds a tag to the current update, which can be read by update listeners and $hasUpdateTag. */
 export function $addUpdateTag(tag: UpdateTag): void {
   errorOnReadOnly();
   const editor = getActiveEditor();
@@ -1733,6 +1752,7 @@ export function $maybeMoveChildrenSelectionToParent(
   return selection;
 }
 
+/** Returns true if targetNode is an ancestor of child by walking up the parent chain. */
 export function $hasAncestor(
   child: LexicalNode,
   targetNode: LexicalNode,
@@ -1762,6 +1782,7 @@ export function getWindow(editor: LexicalEditor): Window {
 
 const InlineNodeBrand: unique symbol = Symbol.for('@lexical/InlineNodeBrand');
 
+/** Returns true if the given node is an inline ElementNode or an inline DecoratorNode. */
 export function $isInlineElementOrDecoratorNode<T>(node: LexicalNode): node is (
   | ElementNode
   | DecoratorNode<T>
@@ -1775,6 +1796,7 @@ export function $isInlineElementOrDecoratorNode<T>(node: LexicalNode): node is (
   );
 }
 
+/** Returns the given node itself (if it is a slot boundary) or its nearest ancestor that is a RootNode, ShadowRootNode, or slot boundary. */
 export function $getNearestRootOrShadowRoot(
   node: LexicalNode,
 ): RootNode | ElementNode {
@@ -1803,12 +1825,14 @@ export interface ShadowRootNode extends ElementNode {
   isShadowRoot(): true;
 }
 
+/** Returns true if the given node is an ElementNode whose isShadowRoot() returns true. */
 export function $isShadowRootNode(
   node: null | LexicalNode,
 ): node is ShadowRootNode {
   return $isElementNode(node) && node.isShadowRoot();
 }
 
+/** Returns true if the given node is a RootNode or a ShadowRootNode. */
 export function $isRootOrShadowRoot(
   node: null | LexicalNode,
 ): node is RootNode | ShadowRootNode {
@@ -1844,6 +1868,7 @@ export function $copyNode<T extends LexicalNode>(
   return copy;
 }
 
+/** Applies any registered node replacement for the given node's type, returning the replacement node or the original if none is registered. */
 export function $applyNodeReplacement<N extends LexicalNode>(node: N): N {
   const editor = getActiveEditor();
   const nodeType = node.getType();
@@ -2520,6 +2545,7 @@ export function getComposedEventTarget(event: Event): EventTarget | null {
   return target;
 }
 
+/** Splits an ElementNode at the given child offset, returning [original, newCopy]. The original is mutated (children after offset moved out); the first element may be null per the return type contract. Recursively splits ancestors up to the nearest root or shadow root. */
 export function $splitNode(
   node: ElementNode,
   offset: number,
@@ -2992,6 +3018,7 @@ export function $cloneWithPropertiesEphemeral<T extends LexicalNode>(
   return $markEphemeral($cloneWithProperties(latestNode));
 }
 
+/** Reads the indent level from a DOM element's `data-lexical-indent` attribute or `paddingInlineStart` style, and applies it to the given ElementNode. */
 export function setNodeIndentFromDOM(
   elementDom: HTMLElement,
   elementNode: ElementNode,
@@ -3515,6 +3542,7 @@ export const $findMatchingParent: {
   return null;
 };
 
+/** Builds an ordered array of child node keys for the given ElementNode by walking its linked-list pointers. */
 export function $createChildrenArray(
   element: ElementNode,
   nodeMap: null | NodeMap,

--- a/packages/lexical/src/environment.ts
+++ b/packages/lexical/src/environment.ts
@@ -6,6 +6,7 @@
  *
  */
 
+/** Whether a browser DOM environment is available. */
 export const CAN_USE_DOM: boolean =
   typeof window !== 'undefined' &&
   // eslint-disable-next-line no-restricted-syntax
@@ -27,29 +28,33 @@ const documentMode =
   // eslint-disable-next-line no-restricted-syntax
   CAN_USE_DOM && 'documentMode' in document ? document.documentMode : null;
 
+/** Whether the current platform is Apple (macOS, iOS, iPadOS, iPod). */
 export const IS_APPLE: boolean =
   CAN_USE_DOM && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
+/** Whether the current browser is Firefox (excludes SeaMonkey). */
 export const IS_FIREFOX: boolean =
   CAN_USE_DOM && /^(?!.*Seamonkey)(?=.*Firefox).*/i.test(navigator.userAgent);
 
+/** Whether the browser supports the `beforeinput` event via `InputEvent.getTargetRanges()`. */
 export const CAN_USE_BEFORE_INPUT: boolean =
   CAN_USE_DOM && 'InputEvent' in window && !documentMode
     ? // eslint-disable-next-line no-restricted-syntax
       'getTargetRanges' in new window.InputEvent('input')
     : false;
 
+/** Whether the current platform is iOS (iPhone, iPad, iPod). */
 export const IS_IOS: boolean =
   CAN_USE_DOM &&
   /iPad|iPhone|iPod/.test(navigator.userAgent) &&
   // eslint-disable-next-line no-restricted-syntax
   !window.MSStream;
 
+/** Whether the current platform is Android. */
 export const IS_ANDROID: boolean =
   CAN_USE_DOM && /Android/.test(navigator.userAgent);
 
-// Exclude Android — Android WebView's UA contains "Version/X.X ... Safari/537.36"
-// which falsely matches the Safari regex, activating wrong composition code paths.
+/** Whether the current browser is Safari (excludes Android WebView which has a similar UA string). */
 export const IS_SAFARI: boolean =
   CAN_USE_DOM &&
   /Version\/[\d.]+.*Safari/.test(navigator.userAgent) &&
@@ -57,13 +62,16 @@ export const IS_SAFARI: boolean =
 
 // Keep these in case we need to use them in the future.
 // export const IS_WINDOWS: boolean = CAN_USE_DOM && /Win/.test(navigator.platform);
+/** Whether the current browser is Chrome (or Chromium-based). */
 export const IS_CHROME: boolean =
   CAN_USE_DOM && /^(?=.*Chrome).*/i.test(navigator.userAgent);
 // export const canUseTextInputEvent: boolean = CAN_USE_DOM && 'TextEvent' in window && !documentMode;
 
+/** Whether the current browser is Chrome on Android. */
 export const IS_ANDROID_CHROME: boolean =
   CAN_USE_DOM && IS_ANDROID && IS_CHROME;
 
+/** Whether the current browser is Apple WebKit (Safari on macOS/iOS, excludes Chrome). */
 export const IS_APPLE_WEBKIT =
   CAN_USE_DOM &&
   /AppleWebKit\/[\d.]+/.test(navigator.userAgent) &&

--- a/packages/lexical/src/nodes/LexicalDecoratorNode.ts
+++ b/packages/lexical/src/nodes/LexicalDecoratorNode.ts
@@ -82,6 +82,7 @@ export class DecoratorNode<T>
   }
 }
 
+/** Returns true if the given node is a DecoratorNode. */
 export function $isDecoratorNode<T>(
   node: LexicalNode | null | undefined,
 ): node is DecoratorNode<T> {

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -999,6 +999,7 @@ export class ElementNode
   }
 }
 
+/** Returns true if the given node is an ElementNode. */
 export function $isElementNode(
   node: LexicalNode | null | undefined,
 ): node is ElementNode {

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -64,10 +64,12 @@ function $convertLineBreakElement(node: Node): DOMConversionOutput {
   return {node: $createLineBreakNode()};
 }
 
+/** Creates a LineBreakNode representing a soft line break (Shift+Enter). */
 export function $createLineBreakNode(): LineBreakNode {
   return $applyNodeReplacement(new LineBreakNode());
 }
 
+/** Returns true if the given node is a LineBreakNode. */
 export function $isLineBreakNode(
   node: LexicalNode | null | undefined,
 ): node is LineBreakNode {

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -177,10 +177,12 @@ function $convertParagraphElement(element: HTMLElement): DOMConversionOutput {
   return {node};
 }
 
+/** Creates a ParagraphNode, the default block-level container for text. */
 export function $createParagraphNode(): ParagraphNode {
   return $applyNodeReplacement(new ParagraphNode());
 }
 
+/** Returns true if the given node is a ParagraphNode. */
 export function $isParagraphNode(
   node: LexicalNode | null | undefined,
 ): node is ParagraphNode {

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -105,6 +105,7 @@ export function $createRootNode(): RootNode {
   return new RootNode();
 }
 
+/** Returns true if the given node is a RootNode. */
 export function $isRootNode(
   node: RootNode | LexicalNode | null | undefined,
 ): node is RootNode {

--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -95,10 +95,12 @@ export class TabNode extends TextNode {
   }
 }
 
+/** Creates a TabNode representing a horizontal tab character. */
 export function $createTabNode(): TabNode {
   return $applyNodeReplacement(new TabNode());
 }
 
+/** Returns true if the given node is a TabNode. */
 export function $isTabNode(
   node: LexicalNode | null | undefined,
 ): node is TabNode {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -314,6 +314,7 @@ export interface InlineFormattableNode {
   toggleFormat(type: TextFormatType): unknown;
 }
 
+/** Returns true if the given node supports inline text formatting. */
 export function $isInlineFormattable(
   node: (LexicalNode & {__isInlineFormattable?: unknown}) | null | undefined,
 ): node is LexicalNode & InlineFormattableNode {
@@ -1391,10 +1392,12 @@ function convertTextFormatElement(domNode: HTMLElement): DOMConversionOutput {
   };
 }
 
+/** Creates a TextNode initialized with the given text, defaulting to empty. */
 export function $createTextNode(text = ''): TextNode {
   return $applyNodeReplacement(new TextNode(text));
 }
 
+/** Returns true if the given node is a TextNode. */
 export function $isTextNode(
   node: LexicalNode | null | undefined,
 ): node is TextNode {


### PR DESCRIPTION
## Description

The `lexical` core package exports ~100 public functions and constants that had no JSDoc. IDE autocomplete showed bare signatures with no hint of what each function does. This PR adds single-line `/** ... */` JSDoc comments to the exported symbols that were missing them across 14 files.

Coverage by file group:

- **Commands** (`LexicalCommands.ts`) — 25 command constants (`SELECTION_CHANGE_COMMAND`, `CLICK_COMMAND`, `PASTE_COMMAND`, etc.). Pattern: "Dispatched when/on/to...".
- **Constants** (`LexicalConstants.ts`) — 11 formatting bitmasks and lookup tables. Pattern: "Bitmask for...".
- **Environment** (`environment.ts`) — 10 platform/browser detection flags (`IS_APPLE`, `IS_FIREFOX`, `CAN_USE_BEFORE_INPUT`, etc.).
- **Selection** (`LexicalSelection.ts`) — 12 selection utilities (`$getSelection`, `$createRangeSelection`, `$isBlockElementNode`, etc.).
- **Utils** (`LexicalUtils.ts`) — 28 utility functions (`$getRoot`, `$splitNode`, `$applyNodeReplacement`, `toggleTextFormatType`, etc.).
- **Normalization / Updates** — `$normalizeSelection`, `isCurrentlyReadOnlyMode`, `$parseSerializedNode`.
- **Node files** (7 files) — type guards (`$isTextNode`, `$isElementNode`, ...) and factory functions (`$createParagraphNode`, `$createLineBreakNode`, ...).

Existing JSDoc (e.g. on `DELETE_CHARACTER_COMMAND`, `INSERT_LINE_BREAK_COMMAND`, `CUT_COMMAND`, `SELECT_ALL_COMMAND`) was left untouched. The 3-line deletion is the `// Text node formatting` line comment in `LexicalConstants.ts` and the Android WebView UA comment in `environment.ts`, both replaced by their JSDoc equivalents.

## Test plan

- [x] `pnpm test-unit` — all pass. No code changes, only JSDoc additions.
- [x] tsc / flow / prettier / eslint clean.