### PR TITLE
[lexical] Bug Fix: Line breaks in a slot can't be inserted or deleted correctly

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1108,45 +1108,32 @@ export class RangeSelection implements BaseSelection {
     // slot-scoped Cmd+A leaves the selection on the slot's element point)
     // has __parent === null, so the block-finding walk below would throw.
     // Redirect into the slot subtree by collapsing the selection at the
-    // slot's first child and re-running insertNodes.
+    // slot's first child and re-running insertNodes. Only a container
+    // (shadow-root) value needs this: a block-shaped value IS the block, so
+    // the block-finding walk below (which stops at a slot host, see
+    // $removeTextAndSplitBlock) already lands on it directly at the right
+    // offset.
     const anchorNode = this.anchor.getNode();
     if (
       this.anchor.type === 'element' &&
       $isElementNode(anchorNode) &&
+      anchorNode.isShadowRoot() &&
       $getSlotHostKey(anchorNode) !== null
     ) {
-      // A container (shadow-root) value redirects into its first child; an
-      // empty one has no child to redirect into (its caret target is the
-      // reconciler's terminating <br>), so seed a paragraph first —
-      // insertNodes removes the seed again when block content replaces it. A
-      // block-shaped value (virtual shadow root around a single block) needs
-      // no seeding: it IS the block, so the block-finding walk below lands
-      // on it directly.
-      let firstChild = anchorNode.isShadowRoot()
-        ? (anchorNode.getFirstChild() ??
-          anchorNode.append($createParagraphNode()).getFirstChild())
-        : anchorNode.getFirstChild();
-      // A shadow-root slot whose first child is a non-element (typically a
-      // decorator like HorizontalRuleNode) would re-enter this same branch
-      // forever: `firstChild.selectStart()` resolves back to the slot value's
-      // own element-mode caret (no sibling, parent = the slot value root),
-      // which matches the entry condition above. Seed a paragraph before the
+      // An empty container has no child to redirect into (its caret target
+      // is the reconciler's terminating <br>), so seed a paragraph first —
+      // insertNodes removes the seed again when block content replaces it.
+      let firstChild =
+        anchorNode.getFirstChild() ??
+        anchorNode.append($createParagraphNode()).getFirstChild();
+      // A first child that is a non-element (typically a decorator like
+      // HorizontalRuleNode) would re-enter this same branch forever:
+      // `firstChild.selectStart()` resolves back to the slot value's own
+      // element-mode caret (no sibling, parent = the slot value root), which
+      // matches the entry condition above. Seed a paragraph before the
       // non-element first child so the redirected selection lands in a block
       // and the recursion terminates.
-      //
-      // The seed paragraph is the redirect target only — if `nodes` carries
-      // inline content the recursion fills the paragraph in place, and if it
-      // carries block content the recursion's root/shadow-root branch
-      // (`splice` after `$wrapInlineNodes`) inserts the new blocks before the
-      // existing non-element first child while the seed sits at offset 0 as
-      // the new shadow-root first child. In either case the seed ends up
-      // hosting either the inserted content or an empty leading line, never
-      // a stranded paragraph next to the original non-element child.
-      if (
-        anchorNode.isShadowRoot() &&
-        firstChild !== null &&
-        !$isElementNode(firstChild)
-      ) {
+      if (firstChild !== null && !$isElementNode(firstChild)) {
         const seed = $createParagraphNode();
         firstChild.insertBefore(seed);
         firstChild = seed;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1783,6 +1783,12 @@ export class RangeSelection implements BaseSelection {
               }
               // always stop when a decorator is encountered
               return;
+            } else if ($isLineBreakNode(caret.origin)) {
+              // A LineBreakNode is a single deletable unit, same as a
+              // decorator: remove it directly instead of falling through to
+              // the slot-edge boundary check below with nothing deleted.
+              caret.origin.remove();
+              return;
             }
             break;
           }

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -3291,6 +3291,64 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
     });
   });
 
+  test('backspace deletes trailing linebreaks in a bare block value one at a time (#8898)', () => {
+    using editor = createSlotEditor();
+    let lineKey = '';
+    editor.update(
+      () => {
+        const {line} = $createLineSlotHost();
+        lineKey = line.getKey();
+        const text = line.getFirstChild();
+        assert(text !== null && $isTextNode(text));
+        text.select(5, 5).insertLineBreak();
+        line.getLastChild()!.selectEnd().insertLineBreak();
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const line = $getNodeByKey(lineKey);
+      assert(line !== null && $isParagraphNode(line));
+      expect(line.getChildren().filter(c => $isLineBreakNode(c)).length).toBe(
+        2,
+      );
+    });
+    // Same element-mode anchor shape as the insertLineBreak tests above:
+    // deleteCharacter's sibling-caret exploration must delete the
+    // LineBreakNode it finds instead of falling through to the slot-edge
+    // boundary check with nothing deleted.
+    editor.update(
+      () => {
+        const line = $getNodeByKey(lineKey);
+        assert(line !== null && $isParagraphNode(line));
+        line.getLastChild()!.selectEnd().deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const line = $getNodeByKey(lineKey);
+      assert(line !== null && $isParagraphNode(line));
+      expect(line.getChildren().filter(c => $isLineBreakNode(c)).length).toBe(
+        1,
+      );
+    });
+    editor.update(
+      () => {
+        const line = $getNodeByKey(lineKey);
+        assert(line !== null && $isParagraphNode(line));
+        line.getLastChild()!.selectEnd().deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const line = $getNodeByKey(lineKey);
+      assert(line !== null && $isParagraphNode(line));
+      expect(line.getTextContent()).toBe('Title');
+      expect(line.getChildren().filter(c => $isLineBreakNode(c)).length).toBe(
+        0,
+      );
+    });
+  });
+
   test('the boundary still scopes selection and select-all', () => {
     using editor = createSlotEditor();
     let lineKey = '';

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -31,6 +31,7 @@ import {
   $getSlotNames,
   $getSlotNameWithinHost,
   $isElementNode,
+  $isLineBreakNode,
   $isParagraphNode,
   $isRangeSelection,
   $isSlotHost,
@@ -3222,6 +3223,71 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
       const first = line.getFirstChild();
       assert(first !== null);
       expect($isTextNode(first)).toBe(true);
+    });
+  });
+
+  test('repeated linebreaks into a bare block value stay in insertion order (#8897)', () => {
+    using editor = createSlotEditor();
+    let lineKey = '';
+    editor.update(
+      () => {
+        const {line} = $createLineSlotHost();
+        lineKey = line.getKey();
+        const text = line.getFirstChild();
+        assert(text !== null && $isTextNode(text));
+        text.select(5, 5).insertLineBreak();
+      },
+      {discrete: true},
+    );
+    // A LineBreakNode with no next sibling resolves selectEnd() to an
+    // element-mode anchor directly on the slot value, the same shape
+    // insertNodes' slot-value redirect branch handles for Cmd+A.
+    editor.update(
+      () => {
+        for (let i = 0; i < 3; i++) {
+          const line = $getNodeByKey(lineKey);
+          assert(line !== null && $isParagraphNode(line));
+          const last = line.getLastChild();
+          assert(last !== null);
+          last.selectEnd().insertLineBreak();
+        }
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const line = $getNodeByKey(lineKey);
+      assert(line !== null && $isParagraphNode(line));
+      const children = line.getChildren();
+      expect(children[0]!.getTextContent()).toBe('Title');
+      expect(children.filter(c => $isLineBreakNode(c)).length).toBe(4);
+    });
+  });
+
+  test('insertNodes at the end of a bare block value inserts at the end, not the start', () => {
+    using editor = createSlotEditor();
+    let lineKey = '';
+    editor.update(
+      () => {
+        const {line} = $createLineSlotHost();
+        lineKey = line.getKey();
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const line = $getNodeByKey(lineKey);
+        assert(line !== null && $isParagraphNode(line));
+        // Element-mode anchor on the slot value itself, offset at the end.
+        line
+          .select(line.getChildrenSize(), line.getChildrenSize())
+          .insertNodes([$createTextNode('!')]);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const line = $getNodeByKey(lineKey);
+      assert(line !== null && $isParagraphNode(line));
+      expect(line.getTextContent()).toBe('Title!');
     });
   });
 


### PR DESCRIPTION
# Description

Two related bugs in how a bare block slot value (for example the attribution line on a Pull Quote) handles `LineBreakNode`s, both stemming from the same underlying shape: once a line break ends up with no sibling in a given direction, `LineBreakNode.selectStart()`/`selectEnd()` fall back to an element-mode point directly on the slot value's root, and two different pieces of code mishandle that shape.

## Insertion (#8897)

`RangeSelection.insertNodes` has a redirect branch for when the selection anchor is an element-mode point sitting directly on a slot value's root (for example after a slot-scoped `Cmd+A`). That branch was scoped to any slot value, not just container (shadow-root) values, so a bare block slot value went through it too.

The redirect always jumps to `anchorNode.getFirstChild()` and ignores the anchor's actual offset. For a bare block value this meant every insert collapsed to the start of the block instead of landing at the caret. Once a `LineBreakNode` ended up as the first child, `LineBreakNode.selectStart()` resolved back to the exact same element-mode anchor the branch had just entered on, so the recursive call re-entered itself with unchanged input and the stack overflowed.

**Repro:** type text in a bare block slot value, place the caret at the end, press `Shift+Enter` twice. The text shifts after the second line break, and a third line break (or arrow-key navigation through the block) throws `RangeError: Maximum call stack size exceeded`.

**Fix:** scope the redirect to `anchorNode.isShadowRoot()` containers only. A bare block value doesn't need it: `$removeTextAndSplitBlock` already stops the block-finding walk at a slot host, so the existing fallthrough logic lands on the block directly, at the correct offset, without recursing through a child at all.

## Deletion (#8898)

`RangeSelection.deleteCharacter` has a loop that explores what sits next to the caret when there is no text left in the deletion direction. That loop only has cases for `ElementNode` and `DecoratorNode` origins, so a `LineBreakNode` falls through unhandled.

Past that loop sits a boundary guard: if the caret's node is a slot value, it stops immediately, since slot content behaves like a virtual shadow root and deletion shouldn't cross into the host's real DOM. That guard only checks whether the caret is on a slot value, not whether there was still something left to delete. So when a bare block slot value ends in a line break, the caret lands as an element-mode point directly on the slot value, the sibling-caret loop passes over the line break, and the boundary guard bails out with nothing deleted.

**Repro:** with the caret at the end of a bare block slot value that ends in one or more line breaks, press Backspace. Nothing happens, repeatably.

**Fix:** add the missing `LineBreakNode` case to the sibling-caret loop, mirroring the existing decorator handling, removing the node directly instead of letting it fall through to the boundary guard.

These were originally two separate PRs (this one for insertion, #8900 for deletion) since they were found at different points during testing, but they touch the same function family and the same underlying selection shape, so combining them here per review feedback. #8900 is closed in favor of this one.

Closes #8897
Closes #8898

# Test plan

Added three unit tests to `packages/lexical/src/__tests__/unit/LexicalSlot.test.ts`:

- `repeated linebreaks into a bare block value stay in insertion order (#8897)`: drives the exact recursive stack-overflow path with repeated `Shift+Enter` equivalents and asserts the text stays first.
- `insertNodes at the end of a bare block value inserts at the end, not the start`: pins the offset-respecting behavior directly.
- `backspace deletes trailing linebreaks in a bare block value one at a time (#8898)`: builds a bare block slot value ending in two line breaks, backspaces twice, and asserts the count drops 2 → 1 → 0 with the text left intact.

All three fail against the pre-fix code with the symptoms described above, and pass with the fixes. Full lexical core unit suite passes with no regressions.

# Before

Line break insertion:

https://github.com/user-attachments/assets/cbbf5972-b4f0-42cb-8758-16bd0f167ae9




Backspace:

https://github.com/user-attachments/assets/91d541f4-bc4f-4222-96d8-e53bd9c9bac3



# After

Line break insertion:


https://github.com/user-attachments/assets/28558e78-1897-4080-921c-ae9b04673616



Backspace:

https://github.com/user-attachments/assets/09e88abc-1144-4efe-8e26-f7ad1e4cb496

