### PR TITLE
Fix/backspace linebreak slot boundary

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1796,6 +1796,12 @@ export class RangeSelection implements BaseSelection {
               }
               // always stop when a decorator is encountered
               return;
+            } else if ($isLineBreakNode(caret.origin)) {
+              // A LineBreakNode is a single deletable unit, same as a
+              // decorator: remove it directly instead of falling through to
+              // the slot-edge boundary check below with nothing deleted.
+              caret.origin.remove();
+              return;
             }
             break;
           }

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -3233,10 +3233,11 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
       () => {
         const {line} = $createLineSlotHost();
         lineKey = line.getKey();
-        const text = line.getFirstChild();
-        assert(text !== null && $isTextNode(text));
-        text.select(5, 5).insertLineBreak();
-        line.getLastChild()!.selectEnd().insertLineBreak();
+        // Built directly rather than via two insertLineBreak() calls: a
+        // LineBreakNode with no next sibling resolves selectEnd() to an
+        // element-mode anchor directly on the slot value, the same shape
+        // deleteCharacter must handle below.
+        line.append($createLineBreakNode(), $createLineBreakNode());
       },
       {discrete: true},
     );
@@ -3247,7 +3248,6 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
         2,
       );
     });
-    // Same element-mode anchor shape as the insertLineBreak tests above:
     // deleteCharacter's sibling-caret exploration must delete the
     // LineBreakNode it finds instead of falling through to the slot-edge
     // boundary check with nothing deleted.

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -31,6 +31,7 @@ import {
   $getSlotNames,
   $getSlotNameWithinHost,
   $isElementNode,
+  $isLineBreakNode,
   $isParagraphNode,
   $isRangeSelection,
   $isSlotHost,
@@ -3222,6 +3223,64 @@ describe('named-slots: block slot values (virtual shadow root)', () => {
       const first = line.getFirstChild();
       assert(first !== null);
       expect($isTextNode(first)).toBe(true);
+    });
+  });
+
+  test('backspace deletes trailing linebreaks in a bare block value one at a time (#8898)', () => {
+    using editor = createSlotEditor();
+    let lineKey = '';
+    editor.update(
+      () => {
+        const {line} = $createLineSlotHost();
+        lineKey = line.getKey();
+        const text = line.getFirstChild();
+        assert(text !== null && $isTextNode(text));
+        text.select(5, 5).insertLineBreak();
+        line.getLastChild()!.selectEnd().insertLineBreak();
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const line = $getNodeByKey(lineKey);
+      assert(line !== null && $isParagraphNode(line));
+      expect(line.getChildren().filter(c => $isLineBreakNode(c)).length).toBe(
+        2,
+      );
+    });
+    // Same element-mode anchor shape as the insertLineBreak tests above:
+    // deleteCharacter's sibling-caret exploration must delete the
+    // LineBreakNode it finds instead of falling through to the slot-edge
+    // boundary check with nothing deleted.
+    editor.update(
+      () => {
+        const line = $getNodeByKey(lineKey);
+        assert(line !== null && $isParagraphNode(line));
+        line.getLastChild()!.selectEnd().deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const line = $getNodeByKey(lineKey);
+      assert(line !== null && $isParagraphNode(line));
+      expect(line.getChildren().filter(c => $isLineBreakNode(c)).length).toBe(
+        1,
+      );
+    });
+    editor.update(
+      () => {
+        const line = $getNodeByKey(lineKey);
+        assert(line !== null && $isParagraphNode(line));
+        line.getLastChild()!.selectEnd().deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const line = $getNodeByKey(lineKey);
+      assert(line !== null && $isParagraphNode(line));
+      expect(line.getTextContent()).toBe('Title');
+      expect(line.getChildren().filter(c => $isLineBreakNode(c)).length).toBe(
+        0,
+      );
     });
   });
 


### PR DESCRIPTION
# Description

While looking into `RangeSelection.deleteCharacter`, I found an edge case in the logic that handles deletion when there is no text left in the current deletion direction.

The method first walks through the node next to the caret to see if there is anything special it should handle before falling back to the generic deletion behavior. That logic currently only accounts for `ElementNode` and `DecoratorNode`. Since `LineBreakNode` isn't handled, it simply falls through without any action.

After that comes the slot boundary guard. If the caret ends up on a slot value, the function exits immediately because slot content behaves like a virtual shadow root, and deletion shouldn't cross into the host's real DOM. The problem is that this guard only checks whether the caret is on a slot value, it doesn't verify whether there was still a node that could have been deleted first.

As a result, when a bare block slot value (such as the attribution line in a Pull Quote) ends with one or more line breaks, placing the caret at the end and pressing Backspace does nothing. The sibling-caret loop skips over the `LineBreakNode`, the boundary guard returns early, and nothing gets deleted. Repeated Backspace presses continue to be silent no-ops.

**Fix:** Add the missing `LineBreakNode` case to the sibling-caret loop, mirroring the existing `DecoratorNode` handling. This allows trailing line breaks to be removed before the slot boundary guard is reached, while keeping the existing slot-boundary protection intact.

Closes #8898

# Test plan

Added a unit test in `packages/lexical/src/__tests__/unit/LexicalSlot.test.ts`:

- **backspace deletes trailing linebreaks in a bare block value one at a time (#8898)**  
  Creates a bare block slot value ending with two trailing line breaks, performs Backspace twice, and verifies that the number of line breaks decreases from `2 → 1 → 0` while leaving the text content unchanged.

The new test reproduces the issue on the original code (the line break count remains at `2` after pressing Backspace) and passes with the fix applied.

I also ran the full Lexical core unit test suite (818 tests), and everything passed without regressions. Finally, I verified the behavior manually in the browser: repeated Backspace presses now remove one trailing line break at a time, normal character deletion behaves as expected, and the existing slot-boundary protection at the true start of the slot content still correctly prevents deletion across the boundary.

# Before


https://github.com/user-attachments/assets/a597c7f3-e0da-4696-86c1-b76d8f34bac2



# After


https://github.com/user-attachments/assets/59122411-59d4-4903-9ffc-7b9a406e9264

