### PR TITLE
[lexical][lexical-selection][lexical-list] Bug Fix: Skip named-slot values in block converters, diagnose replace() on a slot value, and delete slot-bearing decorator hosts at the selection boundary

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/LexicalFormatListSlots.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalFormatListSlots.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createListItemNode,
+  $createListNode,
+  $insertList,
+  $isListNode,
+  $removeList,
+  ListItemNode,
+  ListNode,
+} from '@lexical/list';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSlot,
+  $isParagraphNode,
+  $setSlot,
+  type ParagraphNode,
+  type TextNode,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+function runInEditor(fn: () => void): void {
+  using editor = buildEditorFromExtensions({
+    name: '@formatList-slots-test',
+    nodes: [ListNode, ListItemNode],
+  });
+  editor.update(fn, {discrete: true});
+}
+
+function $createHostWithSlottedList(): {
+  host: ParagraphNode;
+  list: ListNode;
+  text: TextNode;
+} {
+  const host = $createParagraphNode();
+  $getRoot().append(host);
+  const list = $createListNode('bullet');
+  const text = $createTextNode('item');
+  const item = $createListItemNode().append(text);
+  list.append(item);
+  $setSlot(host, 'items', list);
+  return {host, list, text};
+}
+
+// A named-slot value has no __parent (its up-link is __slotHost), so it is not
+// eligible for generic list conversion: the slot assignment is managed by the
+// node or extension that owns the slot. See the review discussion on
+// facebook/lexical#8901 ($setBlocksType has the same rule).
+describe('$insertList and named slots', () => {
+  test('no-ops on a non-empty bare-block slot value', () => {
+    runInEditor(() => {
+      const host = $createParagraphNode();
+      $getRoot().append(host);
+      const text = $createTextNode('title text');
+      const slotPara = $createParagraphNode().append(text);
+      $setSlot(host, 'title', slotPara);
+      text.select(0, 0);
+
+      $insertList('bullet');
+
+      const value = $getSlot(host, 'title');
+      expect(value).not.toBe(null);
+      expect(value!.is(slotPara)).toBe(true);
+      expect($isParagraphNode(value)).toBe(true);
+    });
+  });
+
+  test('no-ops on an empty bare-block slot value', () => {
+    runInEditor(() => {
+      const host = $createParagraphNode();
+      $getRoot().append(host);
+      const slotPara = $createParagraphNode();
+      $setSlot(host, 'title', slotPara);
+      slotPara.select();
+
+      $insertList('bullet');
+
+      const value = $getSlot(host, 'title');
+      expect(value).not.toBe(null);
+      expect(value!.is(slotPara)).toBe(true);
+      expect($isParagraphNode(value)).toBe(true);
+    });
+  });
+
+  test('does not change the type of a slotted list', () => {
+    runInEditor(() => {
+      const {host, list, text} = $createHostWithSlottedList();
+      text.select(0, 0);
+
+      $insertList('number');
+
+      const value = $getSlot(host, 'items');
+      expect(value).not.toBe(null);
+      expect(value!.is(list)).toBe(true);
+      expect($isListNode(value)).toBe(true);
+      expect(list.getListType()).toBe('bullet');
+    });
+  });
+
+  test('does not change the type of a slotted list from an empty item', () => {
+    runInEditor(() => {
+      const host = $createParagraphNode();
+      $getRoot().append(host);
+      const list = $createListNode('bullet');
+      const item = $createListItemNode();
+      list.append(item);
+      $setSlot(host, 'items', list);
+      item.select();
+
+      $insertList('number');
+
+      const value = $getSlot(host, 'items');
+      expect(value).not.toBe(null);
+      expect(value!.is(list)).toBe(true);
+      expect(list.getListType()).toBe('bullet');
+      expect(item.isAttached()).toBe(true);
+    });
+  });
+});
+
+describe('$removeList and named slots', () => {
+  test('no-ops on a slotted list', () => {
+    runInEditor(() => {
+      const {host, list, text} = $createHostWithSlottedList();
+      text.select(0, 0);
+
+      $removeList();
+
+      const value = $getSlot(host, 'items');
+      expect(value).not.toBe(null);
+      expect(value!.is(list)).toBe(true);
+      expect($isListNode(value)).toBe(true);
+      expect(list.getTextContent()).toBe('item');
+    });
+  });
+});

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -15,6 +15,7 @@ import {
   $createParagraphNode,
   $getChildCaret,
   $getSelection,
+  $getSlotHost,
   $isElementNode,
   $isLeafNode,
   $isRangeSelection,
@@ -98,8 +99,14 @@ export function $insertList(listType: ListType): void {
           list.append(listItem);
         } else if ($isListItemNode(anchorNode)) {
           const parent = anchorNode.getParentOrThrow();
-          append(list, parent.getChildren());
-          parent.replace(list);
+          // A named-slot value has no __parent (its up-link is __slotHost);
+          // its slot assignment is managed by the node or extension that
+          // owns the slot, so converting it is a no-op rather than a
+          // replace (which would throw).
+          if ($getSlotHost(parent) === null) {
+            append(list, parent.getChildren());
+            parent.replace(list);
+          }
         }
 
         return;
@@ -114,6 +121,10 @@ export function $insertList(listType: ListType): void {
         $isElementNode(node) &&
         node.isEmpty() &&
         !$isListItemNode(node) &&
+        // A named-slot value's slot assignment is managed by the node or
+        // extension that owns the slot, so it is not eligible for list
+        // conversion (see $setBlocksType).
+        $getSlotHost(node) === null &&
         !handled.has(node.getKey())
       ) {
         $createListOrMerge(node, listType);
@@ -130,7 +141,10 @@ export function $insertList(listType: ListType): void {
         const parentKey = parent.getKey();
 
         if ($isListNode(parent)) {
-          if (!handled.has(parentKey)) {
+          // A list occupying a named slot is left as-is — its slot
+          // assignment is managed by the node or extension that owns the
+          // slot.
+          if (!handled.has(parentKey) && $getSlotHost(parent) === null) {
             const newListNode = $createListNode(listType);
             append(newListNode, parent.getChildren());
             parent.replace(newListNode);
@@ -275,6 +289,13 @@ export function $removeList(): void {
     }
 
     for (const listNode of listNodes) {
+      // A list occupying a named slot is left as-is: unwinding it would
+      // insert siblings through the tree API (which would throw) and vacate
+      // a slot whose assignment is managed by the node or extension that
+      // owns it.
+      if ($getSlotHost(listNode) !== null) {
+        continue;
+      }
       let insertionPoint: ListNode | ParagraphNode = listNode;
 
       const listItems = $getAllListItems(listNode);

--- a/packages/lexical-selection/src/__tests__/unit/LexicalIsAtEdgeOfElement.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalIsAtEdgeOfElement.test.ts
@@ -34,7 +34,7 @@ function $pointAt(
   return selection.anchor;
 }
 
-function $runInEditor(
+function runInEditor(
   fn: () => void,
   spec: Parameters<typeof buildEditorFromExtensions>[0] = {
     name: '@isAtEdgeOfElement-test',
@@ -46,7 +46,7 @@ function $runInEditor(
 
 describe('$isAtEdgeOfElement', () => {
   test('text point at the start/end of a block', async () => {
-    $runInEditor(() => {
+    runInEditor(() => {
       const block = $createParagraphNode();
       const text = $createTextNode('hello');
       $getRoot().append(block.append(text));
@@ -76,7 +76,7 @@ describe('$isAtEdgeOfElement', () => {
   });
 
   test('a sibling between the point and the edge disqualifies it', async () => {
-    $runInEditor(() => {
+    runInEditor(() => {
       const block = $createParagraphNode();
       const a = $createTextNode('a');
       const b = $createTextNode('b');
@@ -102,7 +102,7 @@ describe('$isAtEdgeOfElement', () => {
   });
 
   test('descends through nested inline elements', async () => {
-    $runInEditor(
+    runInEditor(
       () => {
         const block = $createParagraphNode();
         const link = $createLinkNode('https://lexical.dev');
@@ -128,7 +128,7 @@ describe('$isAtEdgeOfElement', () => {
   });
 
   test('an empty element is at both of its edges', async () => {
-    $runInEditor(() => {
+    runInEditor(() => {
       const block = $createParagraphNode();
       $getRoot().append(block);
 
@@ -145,7 +145,7 @@ describe('$isAtEdgeOfElement', () => {
   });
 
   test('element points at the leading/trailing child edge', async () => {
-    $runInEditor(() => {
+    runInEditor(() => {
       const block = $createParagraphNode();
       const a = $createTextNode('a');
       const b = $createTextNode('b');
@@ -169,7 +169,7 @@ describe('$isAtEdgeOfElement', () => {
   });
 
   test('a point outside the element is never at its edge', async () => {
-    $runInEditor(() => {
+    runInEditor(() => {
       const block1 = $createParagraphNode();
       const block2 = $createParagraphNode();
       const text1 = $createTextNode('one');
@@ -191,7 +191,7 @@ describe('$isAtEdgeOfElement', () => {
   // a point inside the slot against the slot element — this backs the
   // slot-host backspace / arrow-escape behavior in @lexical/utils.
   test('resolves against a named slot value (slot boundary)', async () => {
-    $runInEditor(
+    runInEditor(
       () => {
         const host = $createParagraphNode();
         const slot = $createTestShadowRootNode();

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSetBlocksTypeSlots.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSetBlocksTypeSlots.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createHeadingNode,
+  $createQuoteNode,
+  $isHeadingNode,
+  HeadingNode,
+  QuoteNode,
+} from '@lexical/rich-text';
+import {$setBlocksType, $wrapNodes} from '@lexical/selection';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSlot,
+  $isParagraphNode,
+  $setSlot,
+} from 'lexical';
+import {
+  $createTestShadowRootNode,
+  TestShadowRootNode,
+} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+function runInEditor(fn: () => void): void {
+  using editor = buildEditorFromExtensions({
+    name: '@setBlocksType-slots-test',
+    nodes: [TestShadowRootNode, HeadingNode, QuoteNode],
+  });
+  editor.update(fn, {discrete: true});
+}
+
+// A bare (non-shadow-root) block used as a named-slot value has no __parent —
+// its up-link is __slotHost — so it is not eligible for generic block
+// conversion: the slot assignment is managed by the node or extension that
+// owns the slot. See the review discussion on facebook/lexical#8901.
+describe('$setBlocksType and named slots', () => {
+  test('no-ops on a bare-block slot value', () => {
+    runInEditor(() => {
+      const host = $createParagraphNode();
+      $getRoot().append(host);
+      const text = $createTextNode('title text');
+      const slotPara = $createParagraphNode().append(text);
+      $setSlot(host, 'title', slotPara);
+      const selection = text.select(0, 0);
+
+      $setBlocksType(selection, () => $createHeadingNode('h2'));
+
+      const value = $getSlot(host, 'title');
+      expect(value).not.toBe(null);
+      expect(value!.is(slotPara)).toBe(true);
+      expect($isParagraphNode(value)).toBe(true);
+      expect(value!.getTextContent()).toBe('title text');
+    });
+  });
+
+  test('no-ops on an empty bare-block slot value', () => {
+    runInEditor(() => {
+      const host = $createParagraphNode();
+      $getRoot().append(host);
+      const slotPara = $createParagraphNode();
+      $setSlot(host, 'title', slotPara);
+      const selection = slotPara.select();
+
+      $setBlocksType(selection, () => $createHeadingNode('h2'));
+
+      const value = $getSlot(host, 'title');
+      expect(value).not.toBe(null);
+      expect(value!.is(slotPara)).toBe(true);
+      expect($isParagraphNode(value)).toBe(true);
+    });
+  });
+
+  test('converts blocks inside a shadow-root slot value normally', () => {
+    runInEditor(() => {
+      const host = $createParagraphNode();
+      $getRoot().append(host);
+      const container = $createTestShadowRootNode();
+      const text = $createTextNode('quoted');
+      const innerPara = $createParagraphNode().append(text);
+      container.append(innerPara);
+      $setSlot(host, 'quote', container);
+      const selection = text.select(0, 0);
+
+      $setBlocksType(selection, () => $createHeadingNode('h2'));
+
+      // The container keeps its slot; the block inside it converted.
+      const value = $getSlot(host, 'quote');
+      expect(value).not.toBe(null);
+      expect(value!.is(container)).toBe(true);
+      const child = container.getFirstChild();
+      expect($isHeadingNode(child)).toBe(true);
+      expect(child!.getTextContent()).toBe('quoted');
+    });
+  });
+});
+
+describe('$wrapNodes and named slots', () => {
+  test('no-ops on a bare-block slot value', () => {
+    runInEditor(() => {
+      const host = $createParagraphNode();
+      $getRoot().append(host);
+      const text = $createTextNode('title text');
+      const slotPara = $createParagraphNode().append(text);
+      $setSlot(host, 'title', slotPara);
+      const selection = text.select(0, 0);
+
+      $wrapNodes(selection, () => $createQuoteNode());
+
+      const value = $getSlot(host, 'title');
+      expect(value).not.toBe(null);
+      expect(value!.is(slotPara)).toBe(true);
+      expect($isParagraphNode(value)).toBe(true);
+      expect(value!.getTextContent()).toBe('title text');
+    });
+  });
+});

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -12,6 +12,7 @@ import {
   $extendCaretToRange,
   $findMatchingParent,
   $getPreviousSelection,
+  $getSlotFrame,
   $getSlotHost,
   $hasAncestor,
   $isChildCaret,
@@ -234,6 +235,20 @@ export function $wrapNodes(
   const anchor = anchorAndFocus ? anchorAndFocus[0] : null;
   const nodes = selection.getNodes();
   const nodesLength = nodes.length;
+
+  // A selection inside a bare-block named-slot value has nothing eligible to
+  // wrap: the slot value is the only block in its virtual scope and its slot
+  // assignment is managed by the node or extension that owns the slot, so
+  // this is a no-op (same rule as $setBlocksType). A shadow-root slot value
+  // is root-like and wraps its own subtree below, as usual. (A selection
+  // never crosses a slot boundary, so checking the anchor covers the whole
+  // selection.)
+  if (anchor !== null) {
+    const slotFrame = $getSlotFrame(anchor.getNode());
+    if (slotFrame !== null && !$isRootOrShadowRoot(slotFrame)) {
+      return;
+    }
+  }
 
   if (
     anchor !== null &&

--- a/packages/lexical-website/docs/concepts/named-slots.md
+++ b/packages/lexical-website/docs/concepts/named-slots.md
@@ -338,6 +338,13 @@ re-applying it from `updateDOM` so an editable toggle reaches the island.
   presses) is provided by the opt-in
   [`SelectBlockExtension`](/docs/api/modules/lexical_extension#selectblockextension)
   from `@lexical/extension`.
+- **Generic block conversion skips slot values.** A slot value has no
+  parent — its up-link is `$getSlotHost` — so selection-driven block
+  converters (`$setBlocksType`, `$wrapNodes`, `$insertList` / `$removeList`,
+  the markdown block shortcuts) treat it as ineligible and do nothing rather
+  than replace it: the slot assignment is managed by the node or extension
+  that owns the slot. Calling `LexicalNode.replace` directly on a slot value
+  throws; reassign the slot with `$setSlot` on its host instead.
 - **A NodeSelection of an element carries its children.** Copy and export
   of a whole-host NodeSelection (e.g. a chrome click that selects "the whole
   Card") include the host's body children even though they aren't in the

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1635,6 +1635,22 @@ export class LexicalNode {
     errorOnInsertTextNodeOnRoot(this, replaceWith);
     const self = this.getLatest();
     const toReplaceKey = this.__key;
+    // A named-slot value has no parent (its up-link is __slotHost), so the
+    // getParentOrThrow below would throw an unhelpful generic error. Fail with
+    // an actionable one instead, mirroring the $removeFromParent guard for
+    // remove(): the slot assignment is managed by the node or extension that
+    // owns the slot, so generic tree surgery must go through $setSlot.
+    const slotHost = $getSlotHost(self);
+    if (slotHost !== null) {
+      invariant(
+        false,
+        'replace: node %s (type %s) is slotted into host %s (type %s); a slot value cannot be replaced through the tree API. Use $setSlot on its host to assign a replacement.',
+        toReplaceKey,
+        self.getType(),
+        slotHost.getKey(),
+        slotHost.getType(),
+      );
+    }
     const key = replaceWith.__key;
     const writableReplaceWith = replaceWith.getWritable();
     const writableParent = this.getParentOrThrow().getWritable();

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1744,24 +1744,6 @@ export class RangeSelection implements BaseSelection {
             } else if ($isDecoratorNode(caret.origin)) {
               if (caret.origin.isIsolated()) {
                 // do nothing, shouldn't delete an isolated decorator
-              } else if ($getSlotNames(caret.origin).length > 0) {
-                // A slot-bearing decorator is removed only as a unit by an
-                // explicit host deletion, never silently via backspace —
-                // same policy as the merge-block branch below for
-                // ElementNode-as-host. When the anchor is an empty
-                // paragraph next to the host, drop the paragraph and
-                // select the host (matches the shadow-root ElementNode
-                // path at line 1951–1962 above); otherwise leave both in
-                // place.
-                if (
-                  $isElementNode(initialRange.anchor.origin) &&
-                  initialRange.anchor.origin.isEmpty()
-                ) {
-                  initialRange.anchor.origin.remove();
-                  const nodeSelection = $createNodeSelection();
-                  nodeSelection.add(caret.origin.getKey());
-                  $setSelection(nodeSelection);
-                }
               } else if (
                 state.type === 'merge-next-block' &&
                 (caret.origin.isKeyboardSelectable() ||
@@ -1800,8 +1782,10 @@ export class RangeSelection implements BaseSelection {
           // The cross-block merge below removes `block` (it merges into the
           // adjacent block). If `block` owns slots, that removal would discard
           // them, since slots are not children and are not carried over. Leave
-          // the caret in place instead: a slot-bearing host is removed only as
-          // a unit by an explicit host deletion, never silently via backspace.
+          // the caret in place instead: unlike an adjacent decorator host,
+          // which backspace removes as a whole unit (slots included, #8904),
+          // merging would keep the host's children while silently dropping
+          // its slots.
           if ($getSlotNames(block).length > 0) {
             return;
           }

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -32,6 +32,7 @@ import {
   $getSlotNameWithinHost,
   $isElementNode,
   $isLineBreakNode,
+  $isNodeSelection,
   $isParagraphNode,
   $isRangeSelection,
   $isSlotHost,
@@ -2013,6 +2014,79 @@ describe('named-slots: core foundation', () => {
       remaining = $getSlot(host, 'title')!.getTextContent();
     });
     expect(remaining).toBe('TEXT');
+  });
+
+  // #8904: a slot-bearing decorator host at the selection boundary is
+  // deleted by backspace like any other block decorator — as a whole unit,
+  // slots included. (Merging an ElementNode host away is still refused, see
+  // the next test: a merge keeps children but silently drops slots.)
+  test('backspace after a slot-bearing decorator host removes it (#8904)', () => {
+    using editor = createSlotEditor();
+    let hostKey = '';
+    let textKey = '';
+    editor.update(
+      () => {
+        const host = $createTestDecoratorNode().setIsInline(false);
+        $setSlot(host, 'quote', $slotContainer('QUOTE'));
+        const text = $createTextNode('after');
+        $getRoot().append(host, $createParagraphNode().append(text));
+        hostKey = host.getKey();
+        textKey = text.getKey();
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const sel = $createRangeSelection();
+        sel.anchor.set(textKey, 0, 'text');
+        sel.focus.set(textKey, 0, 'text');
+        $setSelection(sel);
+        sel.deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect($getNodeByKey(hostKey)).toBe(null);
+      expect($getRoot().getChildrenSize()).toBe(1);
+      expect($getRoot().getTextContent()).toBe('after');
+    });
+  });
+
+  test('backspace in an empty paragraph after a slot-bearing decorator host selects it (#8904)', () => {
+    using editor = createSlotEditor();
+    let hostKey = '';
+    let paragraphKey = '';
+    editor.update(
+      () => {
+        const host = $createTestDecoratorNode().setIsInline(false);
+        $setSlot(host, 'quote', $slotContainer('QUOTE'));
+        const paragraph = $createParagraphNode();
+        $getRoot().append(host, paragraph);
+        hostKey = host.getKey();
+        paragraphKey = paragraph.getKey();
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const sel = $createRangeSelection();
+        sel.anchor.set(paragraphKey, 0, 'element');
+        sel.focus.set(paragraphKey, 0, 'element');
+        $setSelection(sel);
+        sel.deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      // The empty paragraph is dropped and the host is node-selected, same
+      // as any other block decorator; the next backspace deletes it.
+      expect($getNodeByKey(paragraphKey)).toBe(null);
+      const host = $getNodeByKey(hostKey);
+      expect(host).not.toBe(null);
+      const sel = $getSelection();
+      assert($isNodeSelection(sel));
+      expect(sel.getNodes().map(node => node.getKey())).toEqual([hostKey]);
+    });
   });
 
   test('backspace at the start of a host child does not merge the slot-bearing host away', () => {

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -415,6 +415,31 @@ describe('named-slots: core foundation', () => {
     );
   });
 
+  test('replace() on a slotted node throws (use $setSlot)', () => {
+    using editor = createSlotEditor();
+
+    editor.update(
+      () => {
+        const host = $createParagraphNode();
+        $getRoot().append(host);
+        const slot = $createTestShadowRootNode();
+        $setSlot(host, 'title', slot);
+
+        // Without the slot-aware guard this would throw the generic
+        // getParentOrThrow invariant; the guard names the actual mistake
+        // (including the node and host types) and the fix ($setSlot on
+        // the host).
+        expect(() => slot.replace($createParagraphNode())).toThrow(
+          /\(type paragraph\)[\s\S]*\$setSlot/,
+        );
+        // Nothing was mutated by the failed replace.
+        expect($getSlot(host, 'title')).not.toBe(null);
+        expect($getSlot(host, 'title')!.is(slot)).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+
   test('remove() on a slotted node throws (use $removeSlot)', () => {
     using editor = createSlotEditor();
 


### PR DESCRIPTION
## Description

Follow-up to #8901 (fix for #8894), which made `$setBlocksType` skip named slot values. The same crash class exists in every other selection-driven block converter that resolves the current block and replaces it through the tree API, and a direct `replace()` of a slot value still fails with the unhelpful generic `"Expected node %s to have a parent"` invariant. This audits and fixes the rest, applying the same rule: a slot value's assignment is managed by the node or extension that owns the slot, so generic converters leave it as-is. The eligibility checks test the slot up-link (`$getSlotHost`) rather than parentless-ness, so a detached node is never conflated with a slot value and keeps failing loudly.

- `lexical`: `LexicalNode.replace()` on a slot value now throws a slot-specific invariant before any mutation, including the keys and types of the value and its host for debugging (`replace: node %s (type %s) is slotted into host %s (type %s); … Use $setSlot on its host to assign a replacement.`), mirroring the existing `$removeFromParent` guard for `remove()` on a slotted node.
- `@lexical/selection`: the deprecated `$wrapNodes` no-ops when the selection lives in a bare-block slot frame (it previously threw in the sibling walk); a shadow-root slot value still wraps its own subtree normally.
- `@lexical/list`: `$insertList` skips slot values in its empty-block branch, its empty-list-item branch, and its walk-up list-type-change branch; `$removeList` skips a slotted top-level list (they previously threw or vacated the slot).
- `@lexical/markdown`: audited, already safe — the element/multiline shortcut runners bail unless the block's parent is a root or shadow root, which excludes slot values.

The rule is documented in the named-slots concepts page.

The audit also turned up the inverse problem: deleting a slot-bearing host from outside. Backspace with the caret at the boundary after a slot-bearing `DecoratorNode` host (e.g. the playground PullQuote) was a silent no-op — `deleteCharacter` special-cased slot-bearing decorators to never be removed via backspace, leaving them undeletable from the keyboard. That special case is removed, so a slot-bearing decorator behaves like any other block decorator at the boundary: backspace removes it as a whole unit (slots included), and from an adjacent empty paragraph it drops the paragraph and node-selects the host so the next backspace deletes it. The ElementNode-host merge guard is intentionally unchanged: a cross-block merge would keep the host's children while silently dropping its slots, so backspace at the start of a slot-bearing host's child still leaves the host in place.

Closes #8904

## Test plan

### Before

`$insertList`, `$removeList`, and `$wrapNodes` threw `"Expected node %s to have a parent"` (or silently vacated a slot) when the selection was inside a bare-block named-slot value or a slotted list; `replace()` on a slot value threw the same generic invariant. Backspace after a slot-bearing decorator host did nothing; the host could not be deleted from the keyboard.

### After

The converters leave slot values as-is and `replace()` on a slot value throws a diagnostic pointing at `$setSlot`. Backspace removes a slot-bearing decorator host at the boundary (or node-selects it from an adjacent empty paragraph, matching normal block decorator behavior). New unit tests in `LexicalSetBlocksTypeSlots.test.ts` and `LexicalFormatListSlots.test.ts`, plus `replace()` and boundary-deletion tests in `LexicalSlot.test.ts`; the existing test that a slot-bearing ElementNode host is not merged away still passes.