### PR TITLE
[lexical-react] Bug Fix: Use the SSR-safe useLayoutEffect in Placeholder

### DIFF
--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -9,13 +9,14 @@
 import type {LexicalEditor} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {forwardRef, type JSX, type Ref, useLayoutEffect, useState} from 'react';
+import {forwardRef, type JSX, type Ref, useState} from 'react';
 
 import {
   ContentEditableElement,
   type ContentEditableElementProps,
 } from './shared/LexicalContentEditableElement';
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
+import useLayoutEffect from './shared/useLayoutEffect';
 
 export {ContentEditableElement, type ContentEditableElementProps};
 
@@ -76,7 +77,6 @@ function Placeholder({
 
   const [isEditable, setEditable] = useState(editor.isEditable());
   useLayoutEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setEditable(editor.isEditable());
     return editor.registerEditableListener(currentIsEditable => {
       setEditable(currentIsEditable);


### PR DESCRIPTION
## Description

- `Placeholder` imported `useLayoutEffect` straight from react
- every server render logs `useLayoutEffect does nothing on the server`

This PR uses the `shared/useLayoutEffect` instead, which removes the warning and seems to be the way this has been used in the past.

I also removed `react-hooks/set-state-in-effect` since it doesn't trigger anymore


## Test plan

`renderToString` of a `ContentEditable` with a `placeholder`, dev build:

### Before
1 warning

### After
0 warnings

`pnpm run lint`, `pnpm run test-unit` clean.