### PR TITLE
[lexical] Bug Fix: Detect iPadOS desktop-class user agents

### DIFF
--- a/packages/lexical/src/__tests__/unit/environment.test.ts
+++ b/packages/lexical/src/__tests__/unit/environment.test.ts
@@ -27,11 +27,7 @@ const IPAD_USER_AGENT =
   'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 ' +
   'Mobile/15E148 Safari/604.1';
 
-const IPAD_DESKTOP_USER_AGENT =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
-  'AppleWebKit/605.1.15 (KHTML, like Gecko)';
-
-const MAC_USER_AGENT =
+const MACINTOSH_USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
   'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 ' +
   'Safari/605.1.15';
@@ -40,9 +36,6 @@ const WINDOWS_TOUCH_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
   'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 ' +
   'Safari/537.36';
-
-const originalUserAgent = navigator.userAgent;
-const originalMaxTouchPoints = navigator.maxTouchPoints;
 
 function setNavigator(userAgent: string, maxTouchPoints: number): void {
   Object.defineProperty(navigator, 'userAgent', {
@@ -53,6 +46,13 @@ function setNavigator(userAgent: string, maxTouchPoints: number): void {
     configurable: true,
     get: () => maxTouchPoints,
   });
+}
+
+// Remove the own properties installed by setNavigator so lookups fall back
+// to the navigator prototype or other values provided by the test environment.
+function resetNavigator(): void {
+  Reflect.deleteProperty(navigator, 'userAgent');
+  Reflect.deleteProperty(navigator, 'maxTouchPoints');
 }
 
 async function getIsIOS(
@@ -68,7 +68,7 @@ async function getIsIOS(
 }
 
 afterEach(() => {
-  setNavigator(originalUserAgent, originalMaxTouchPoints);
+  resetNavigator();
   vi.resetModules();
 });
 
@@ -89,26 +89,26 @@ describe('IS_IOS', () => {
     {
       expected: true,
       maxTouchPoints: 5,
-      name: 'iPadOS desktop-class user agent with multi-touch',
-      userAgent: IPAD_DESKTOP_USER_AGENT,
+      name: 'iPadOS desktop-class Macintosh user agent with multi-touch',
+      userAgent: MACINTOSH_USER_AGENT,
     },
     {
       expected: true,
       maxTouchPoints: 2,
       name: 'Macintosh user agent at the multi-touch boundary',
-      userAgent: IPAD_DESKTOP_USER_AGENT,
+      userAgent: MACINTOSH_USER_AGENT,
     },
     {
       expected: false,
       maxTouchPoints: 1,
       name: 'Macintosh user agent without multi-touch',
-      userAgent: IPAD_DESKTOP_USER_AGENT,
+      userAgent: MACINTOSH_USER_AGENT,
     },
     {
       expected: false,
       maxTouchPoints: 0,
       name: 'macOS user agent without touch support',
-      userAgent: MAC_USER_AGENT,
+      userAgent: MACINTOSH_USER_AGENT,
     },
     {
       expected: false,

--- a/packages/lexical/src/__tests__/unit/environment.test.ts
+++ b/packages/lexical/src/__tests__/unit/environment.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Tests iOS and iPadOS detection, including iPadOS environments that expose
+ * a desktop-class Macintosh user agent.
+ *
+ * environment.ts computes its exports at module load time, so each test
+ * overrides navigator values, resets the module registry, and re-imports the
+ * module.
+ */
+
+import {afterEach, describe, expect, test, vi} from 'vitest';
+
+const IPHONE_USER_AGENT =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) ' +
+  'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 ' +
+  'Mobile/15E148 Safari/604.1';
+
+const IPAD_USER_AGENT =
+  'Mozilla/5.0 (iPad; CPU OS 18_0 like Mac OS X) ' +
+  'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 ' +
+  'Mobile/15E148 Safari/604.1';
+
+const IPAD_DESKTOP_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+  'AppleWebKit/605.1.15 (KHTML, like Gecko)';
+
+const MAC_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+  'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 ' +
+  'Safari/605.1.15';
+
+const WINDOWS_TOUCH_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+  'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 ' +
+  'Safari/537.36';
+
+const originalUserAgent = navigator.userAgent;
+const originalMaxTouchPoints = navigator.maxTouchPoints;
+
+function setNavigator(userAgent: string, maxTouchPoints: number): void {
+  Object.defineProperty(navigator, 'userAgent', {
+    configurable: true,
+    get: () => userAgent,
+  });
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    get: () => maxTouchPoints,
+  });
+}
+
+async function getIsIOS(
+  userAgent: string,
+  maxTouchPoints: number,
+): Promise<boolean> {
+  setNavigator(userAgent, maxTouchPoints);
+  vi.resetModules();
+
+  const {IS_IOS} = await import('../../environment');
+
+  return IS_IOS;
+}
+
+afterEach(() => {
+  setNavigator(originalUserAgent, originalMaxTouchPoints);
+  vi.resetModules();
+});
+
+describe('IS_IOS', () => {
+  test.each([
+    {
+      expected: true,
+      maxTouchPoints: 5,
+      name: 'iPhone user agent',
+      userAgent: IPHONE_USER_AGENT,
+    },
+    {
+      expected: true,
+      maxTouchPoints: 5,
+      name: 'iPad user agent',
+      userAgent: IPAD_USER_AGENT,
+    },
+    {
+      expected: true,
+      maxTouchPoints: 5,
+      name: 'iPadOS desktop-class user agent with multi-touch',
+      userAgent: IPAD_DESKTOP_USER_AGENT,
+    },
+    {
+      expected: true,
+      maxTouchPoints: 2,
+      name: 'Macintosh user agent at the multi-touch boundary',
+      userAgent: IPAD_DESKTOP_USER_AGENT,
+    },
+    {
+      expected: false,
+      maxTouchPoints: 1,
+      name: 'Macintosh user agent without multi-touch',
+      userAgent: IPAD_DESKTOP_USER_AGENT,
+    },
+    {
+      expected: false,
+      maxTouchPoints: 0,
+      name: 'macOS user agent without touch support',
+      userAgent: MAC_USER_AGENT,
+    },
+    {
+      expected: false,
+      maxTouchPoints: 10,
+      name: 'non-Apple touch device',
+      userAgent: WINDOWS_TOUCH_USER_AGENT,
+    },
+  ])(
+    'returns $expected for $name',
+    async ({expected, maxTouchPoints, userAgent}) => {
+      await expect(getIsIOS(userAgent, maxTouchPoints)).resolves.toBe(expected);
+    },
+  );
+});

--- a/packages/lexical/src/environment.ts
+++ b/packages/lexical/src/environment.ts
@@ -43,12 +43,15 @@ export const CAN_USE_BEFORE_INPUT: boolean =
       'getTargetRanges' in new window.InputEvent('input')
     : false;
 
-/** Whether the current platform is iOS (iPhone, iPad, iPod). */
+/** Whether the current platform is iOS or iPadOS (iPhone, iPad, iPod). */
 export const IS_IOS: boolean =
   CAN_USE_DOM &&
-  /iPad|iPhone|iPod/.test(navigator.userAgent) &&
   // eslint-disable-next-line no-restricted-syntax
-  !window.MSStream;
+  !window.MSStream &&
+  (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    // iPadOS may report a desktop-class Macintosh user agent.
+    // Real Macs don't support multi-touch, so maxTouchPoints distinguishes them.
+    (/Macintosh/.test(navigator.userAgent) && navigator.maxTouchPoints > 1));
 
 /** Whether the current platform is Android. */
 export const IS_ANDROID: boolean =


### PR DESCRIPTION
## Description

`IS_IOS` currently only matches when `navigator.userAgent` contains `iPad`, `iPhone`, or `iPod`.

On the physical iPad tested, both Safari and a React Native app using `react-native-webview` without a custom user agent reported a desktop-class `Macintosh` user agent with `navigator.maxTouchPoints` of `5`, while a real Mac reported `0`.

As a result, `IS_IOS` evaluates to `false` when iPadOS presents a desktop-class `Macintosh` user agent, preventing existing iOS-specific input handling from running.

This change identifies a `Macintosh` user agent with `navigator.maxTouchPoints > 1` as iPadOS.

### Side-effect review

Every current internal use of `IS_IOS` in this repository was reviewed.

The remaining internal uses continue to behave as before because they are already gated by `IS_SAFARI` or `IS_APPLE_WEBKIT`.

Behavior changes in the following areas:

- Backspace handling in `lexical-plain-text`
- Backspace handling in `lexical-rich-text`
- `LexicalEvents.ts` handling of non-collapsed `targetRange` values during `deleteContentBackward`
- `LexicalEvents.ts` handling of `insertParagraph` when `inputState.isInsertLineBreak` is set
- `LexicalEvents.ts` `compositionend` timing

The `compositionend` path was verified manually on a physical iPad using the Japanese Romaji IME, which emits composition events.

## Test plan

### Before

On a physical iPad:

- `navigator.userAgent` contained `Macintosh`
- `navigator.maxTouchPoints` was `5`
- `IS_IOS` evaluated to `false`
- During Korean IME input, the non-collapsed `targetRange` provided by `beforeinput` was ignored because `IS_IOS` evaluated to `false`, causing Lexical to fall through to `DELETE_CHARACTER_COMMAND`.
- As a result, Backspace deleted a whole Hangul syllable instead of the last jamo. Continuing to type could then reintroduce characters from the deleted syllable. For example, while composing `가나다`, pressing Backspace deleted the entire final syllable, typing `ㄹ` produced `가달`, and completing the syllable resulted in `가다라` instead of the expected `가나라`.

### After

Automated verification:

- Added `environment.test.ts` coverage for:
  - iPhone
  - iPad
  - Desktop-class `Macintosh` user agent with multi-touch
  - `maxTouchPoints` boundary (`1` vs `2`)
  - Real Mac (`0`)
  - Non-Apple touch device
- Environment tests: **7 passed**
- Full unit suite: **228 test files**, **4,945 passed**, **1 skipped**
- ESLint passed
- Prettier passed

Manual verification on a physical iPad using Safari on iPadOS 26.5.2:

- Rich Text with the on-screen Korean keyboard
  - During Korean IME composition:
    - `가나다` → Backspace → `가낟`
    - Continuing to type did not reintroduce deleted characters
- Plain Text with the on-screen Korean keyboard
  - During Korean IME composition:
    - `가나다` → Backspace → `가낟`
    - Continuing to type did not reintroduce deleted characters
- Bluetooth keyboard with Korean input
  - Verified Backspace, Space, Enter, arrow keys, and Korean/English switching
  - Only `beforeinput` events were observed; no composition events were emitted
- On-screen Japanese Romaji keyboard
  - Verified `compositionstart`, `compositionupdate`, and `compositionend`
  - `nihon` → `日本` → Backspace → re-enter `hon`
  - No duplicated, dropped, or replaced characters were observed
- iPhone
  - Regression-checked typing, Backspace, and Enter
  - No behavioral changes were observed