### PR TITLE
[lexical-rich-text] Bug Fix: Don't deselect a selected node when clicking inside it

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionClick.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/RichTextNodeSelectionClick.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createNodeSelection,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isNodeSelection,
+  $setSelection,
+  CLICK_COMMAND,
+  type LexicalEditor,
+} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  TestDecoratorNode,
+} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+function makeClick(target: EventTarget | null): MouseEvent {
+  const event = new MouseEvent('click', {bubbles: true, cancelable: true});
+  Object.defineProperty(event, 'target', {value: target});
+  return event;
+}
+
+function createEditor(inline: boolean) {
+  return buildEditorFromExtensions({
+    $initialEditorState: () => {
+      const decorator = $createTestDecoratorNode().setIsInline(inline);
+      if (inline) {
+        // Inline decorator flows inside the paragraph, as in #8907.
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('before'), decorator),
+        );
+      } else {
+        // Block decorator sits at root level, next to the paragraph.
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('before')),
+          decorator,
+        );
+      }
+    },
+    dependencies: [RichTextExtension],
+    name: 'test',
+    nodes: [TestDecoratorNode],
+    register: editor => {
+      const rootElement = document.createElement('div');
+      document.body.appendChild(rootElement);
+      editor.setRootElement(rootElement);
+      return () => rootElement.remove();
+    },
+  });
+}
+
+/** The decorator is the last root child (block) or its last child (inline). */
+function $decorator(): TestDecoratorNode {
+  const last = $getRoot().getLastChild()!;
+  if ($isElementNode(last)) {
+    return last.getLastChild() as TestDecoratorNode;
+  }
+  return last as TestDecoratorNode;
+}
+
+function selectDecorator(editor: LexicalEditor): void {
+  editor.update(
+    () => {
+      const selection = $createNodeSelection();
+      selection.add($decorator().getKey());
+      $setSelection(selection);
+    },
+    {discrete: true},
+  );
+}
+
+function decoratorKey(editor: LexicalEditor): string {
+  return editor.getEditorState().read(() => $decorator().getKey());
+}
+
+describe('CLICK_COMMAND on a NodeSelection', () => {
+  // Regression for facebook/lexical#8907: a click on an already-selected
+  // decorator used to clear the NodeSelection, so click-to-select inline
+  // decorators (whose click handler sets the NodeSelection) lost their
+  // selection immediately. A click inside the selected node's DOM is an
+  // interaction with that node, not a deselect gesture.
+  test('inline decorator: click inside the node keeps the selection', () => {
+    using editor = createEditor(true);
+    selectDecorator(editor);
+
+    const key = decoratorKey(editor);
+    const decoratorDOM = editor.getElementByKey(key)!;
+    const target = document.createElement('span');
+    decoratorDOM.appendChild(target);
+
+    const handled = editor.dispatchCommand(CLICK_COMMAND, makeClick(target));
+    expect(handled).toBe(false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      if ($isNodeSelection(selection)) {
+        expect(selection.has(key)).toBe(true);
+      } else {
+        expect.fail('expected a NodeSelection');
+      }
+    });
+  });
+
+  test('block decorator: click inside the node keeps the selection', () => {
+    using editor = createEditor(false);
+    selectDecorator(editor);
+
+    const key = decoratorKey(editor);
+    const decoratorDOM = editor.getElementByKey(key)!;
+    const target = document.createElement('span');
+    decoratorDOM.appendChild(target);
+
+    const handled = editor.dispatchCommand(CLICK_COMMAND, makeClick(target));
+    expect(handled).toBe(false);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      if ($isNodeSelection(selection)) {
+        expect(selection.has(key)).toBe(true);
+      } else {
+        expect.fail('expected a NodeSelection');
+      }
+    });
+  });
+
+  test('click outside the selected node still deselects', () => {
+    using editor = createEditor(true);
+    selectDecorator(editor);
+
+    const outside = document.createElement('div');
+
+    const handled = editor.dispatchCommand(CLICK_COMMAND, makeClick(outside));
+    expect(handled).toBe(true);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      expect(selection).toBeNull();
+    });
+  });
+
+  test('click with a non-element target still deselects', () => {
+    using editor = createEditor(true);
+    selectDecorator(editor);
+
+    const handled = editor.dispatchCommand(CLICK_COMMAND, makeClick(null));
+    expect(handled).toBe(true);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      expect(selection).toBeNull();
+    });
+  });
+});

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1134,9 +1134,23 @@ export function registerRichText(
   const removeListener = mergeRegister(
     editor.registerCommand(
       CLICK_COMMAND,
-      () => {
+      event => {
         const selection = $getSelection();
         if ($isNodeSelection(selection)) {
+          // A click on an already-selected node is an interaction with that
+          // node (its own click handler may select it, open an editor, …),
+          // not a deselect gesture. Keep the selection when the click target
+          // is inside the selected node's DOM; clicking anywhere else still
+          // deselects (facebook/lexical#8907).
+          const eventTarget = event.target;
+          if (isHTMLElement(eventTarget)) {
+            for (const node of selection.getNodes()) {
+              const dom = editor.getElementByKey(node.getKey());
+              if (dom !== null && dom.contains(eventTarget)) {
+                return false;
+              }
+            }
+          }
           selection.clear();
           return true;
         }


### PR DESCRIPTION
## Context

Fixes facebook/lexical#8907. A `NodeSelection` set by an inline `DecoratorNode`'s own click handler (`useLexicalNodeSelection` + `onClick`, or any programmatic `$setSelection` in the click event) is immediately cleared by `@lexical/rich-text`'s `CLICK_COMMAND` handler, which deselects on any click. The mechanism is verified in the issue thread, starting from [the request to submit a PR](https://github.com/facebook/lexical/issues/8907#issuecomment-5167437817): React renders decorator content in a root inside the editor root, so the decorator's `onClick` runs before Lexical's click handler; the click then reaches `registerRichText`'s deselect handler, which clears whatever NodeSelection was just committed. The deselect contract only makes sense for clicks *away* from the selected node; a click *on* a selected decorator is an interaction with that node (its own click handler may select it, open an editor, ...), not a deselect gesture.

Base: `origin/main` (`a933222c4`). Standalone repro used for the analysis: https://gist.github.com/alvorithm/73199ba7f08c65b9cf1586593a72345c

One finding from investigating e2e coverage (see Verification): the playground never hits this bug because every playground decorator consumes `CLICK_COMMAND` at a priority above rich-text's deselect. Command listeners run in descending priority order (`COMMAND_PRIORITY_CRITICAL` = 4 first, `COMMAND_PRIORITY_EDITOR` = 0 last; `LexicalUpdates.ts` dispatches `for (let i = 4; i >= 0; i--)`), and a listener that returns `true` stops propagation. `ImageComponent`, `EquationComponent`, `PollComponent`, `ExcalidrawComponent` and `PageBreakNode` all register `CLICK_COMMAND` at `COMMAND_PRIORITY_LOW` or higher and return `true` for clicks on their own node, so rich-text's deselect handler never runs for those clicks. The deselect only fires when no higher-priority consumer handled the click, which is exactly the #8907 pattern: selection set from a React `onClick` inside decorator content, with no `CLICK_COMMAND` consumer registered.

## Changes

- `6b7a8bebe` `[lexical-rich-text] Bug Fix: Don't deselect a selected node when clicking inside it (#8907)`
  - In `registerRichText`'s `CLICK_COMMAND` handler, when the selection is a `NodeSelection`, skip the deselect if the click target is an `HTMLElement` contained in any selected node's DOM (`editor.getElementByKey(...).contains(target)`), and return `false` so lower-priority handlers (e.g. the playground's decorator click handlers at `COMMAND_PRIORITY_LOW`) still run. Clicks anywhere else keep the existing deselect behavior.
  - Adds `RichTextNodeSelectionClick.test.ts` (4 unit tests): click inside a selected inline decorator keeps the selection; same for a block decorator; click outside still deselects; a non-element target still deselects.

## Verification

- `npx vitest --project unit --run packages/lexical-rich-text`; 13 files, 121 tests passed.
- Regression test proven: with the source change reverted, `RichTextNodeSelectionClick.test.ts` fails exactly the two "click inside keeps the selection" cases; with the fix, 4/4 pass.
- `npx tsc --noEmit -p tsconfig.json` clean for both changed files.
- `npx eslint` clean on both changed files.
- Not verified: browser e2e suites (playwright) and the standalone vite repro against this branch. The fix logic is identical to the patch validated against the repro on 0.47.0 (patched/pristine dists in the repro), and main's handler had the same shape; unit tests exercise the same code path with a real DOM root element.
- Playground e2e coverage was investigated and deliberately not added. A spec was prototyped (two images, shift-click multi-select, then shift-click the already-selected image again) and ran green both with and without the fix: the image's own `CLICK_COMMAND` handler at `COMMAND_PRIORITY_LOW` consumes the click before rich-text's deselect runs (see Context). Any e2e for this fix would need a new playground decorator component that selects from a React `onClick` and does not consume `CLICK_COMMAND`; that component does not exist today. The unit tests cover the same handler contract deterministically.
