### PR TITLE
[lexical-table] Bug Fix: step by the visited cell's colSpan when walking left to insert a column

### DIFF
--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -560,7 +560,10 @@ export function $insertTableColumnAtNode(
       let insertAfterCellRowStart = currentStartRow;
       let prevCellIndex = insertAfterColumn;
       while (insertAfterCellRowStart !== i && insertAfterCell.__rowSpan > 1) {
-        prevCellIndex -= currentCell.__colSpan;
+        // prevCellIndex always sits on the last grid column of insertAfterCell,
+        // so stepping to the column before it means subtracting *that* cell's
+        // colSpan, not the colSpan of the cell we started from.
+        prevCellIndex -= insertAfterCell.__colSpan;
         if (prevCellIndex >= 0) {
           const {cell: cell_, startRow: startRow_} = rowMap[prevCellIndex];
           insertAfterCell = cell_;

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -8,9 +8,11 @@
 
 import {buildEditorFromExtensions} from '@lexical/extension';
 import {
+  $computeTableMapSkipCellCheck,
   $createTableCellNode,
   $createTableNode,
   $createTableRowNode,
+  $insertTableColumnAtNode,
   $isTableCellNode,
   $isTableNode,
   $isTableRowNode,
@@ -1260,6 +1262,62 @@ describe('$setTableColumnIsHeader', () => {
       ]);
       expect($getHeaderStates(table, TableCellHeaderStates.ROW)).toEqual([
         [true],
+      ]);
+    });
+  });
+});
+
+describe('$insertTableColumnAtNode', () => {
+  // Renders the resolved grid (accounting for row/col spans) as a matrix of the
+  // text at each grid coordinate, so column alignment across rows is asserted
+  // directly rather than via raw DOM child order.
+  function $getGridTexts(table: TableNode): string[][] {
+    const [tableMap] = $computeTableMapSkipCellCheck(table, null, null);
+    return tableMap.map(row => row.map(({cell}) => cell.getTextContent()));
+  }
+
+  test('walks left by each visited cell colSpan when a row is spanned', () => {
+    // Grid:
+    //   row0: [A0][X(rowSpan=2)][C(colSpan=2,rowSpan=2)][D0]
+    //   row1: [A1]                                      [D1]
+    editor.update(
+      () => {
+        const $mkCell = (text: string) =>
+          $createTableCellNode().append(
+            $createParagraphNode().append($createTextNode(text)),
+          );
+        const x = $mkCell('X');
+        x.setRowSpan(2);
+        const c = $mkCell('C');
+        c.setColSpan(2);
+        c.setRowSpan(2);
+        const row0 = $createTableRowNode().append(
+          $mkCell('A0'),
+          x,
+          c,
+          $mkCell('D0'),
+        );
+        const row1 = $createTableRowNode().append($mkCell('A1'), $mkCell('D1'));
+        $getRoot().append($createTableNode().append(row0, row1));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
+        const [tableMap] = $computeTableMapSkipCellCheck(table, null, null);
+        // C occupies grid columns 2-3 of row 0; insert a column after it.
+        $insertTableColumnAtNode(tableMap[0][2].cell, true, false);
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
+      expect($getGridTexts(table)).toEqual([
+        ['A0', 'X', 'C', 'C', '', 'D0'],
+        ['A1', 'X', 'C', 'C', '', 'D1'],
       ]);
     });
   });


### PR DESCRIPTION
## Description

When `$insertTableColumnAtNode` walks leftward to find the cell that physically lives in the current row, it always steps by `currentCell.__colSpan` — the colSpan of the cell at the insertion column, which is fixed for the whole walk:

```js
prevCellIndex -= currentCell.__colSpan;
```

`prevCellIndex` sits on the last grid column of `insertAfterCell`, so stepping to the column before it means subtracting **that** cell's colSpan. Using the starting cell's colSpan skips cells whenever the two differ, and the new column is inserted at the wrong grid position — misaligning columns in tables that contain merged cells.

This subtracts `insertAfterCell.__colSpan` instead.

Introduced in #5546; the line has not been revisited since.

## Test plan

### Before

New test `walks left by each visited cell colSpan when a row is spanned` fails on `main`, with the inserted cell landing in the wrong row:

```
- Expected
+ Received
     ["A1", "X", "C", "C",
-     "",
      "D1",
+     "",
     ],
```

### After

Passes. Full `packages/lexical-table` suite: 10 files, 149 tests passed. `eslint`, `prettier` and `tsc --noEmit` clean.