### PR TITLE
[lexical-selection] Bug Fix: apply a function-valued style patch only once to an empty element

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -3278,4 +3278,40 @@ describe('$patchStyleText', () => {
       expect(newFocus.offset).toBe(0);
     });
   });
+
+  test('applies a function-valued patch exactly once to an empty element', async () => {
+    const editor = createTestEditor();
+
+    const element = document.createElement('div');
+
+    editor.setRootElement(element);
+
+    let paragraphStyle = '';
+    let selectionStyle = '';
+
+    await editor.update(() => {
+      const root = $getRoot();
+
+      const paragraph = $createParagraphNode();
+      root.append(paragraph);
+      paragraph.selectStart();
+
+      const selection = $getSelection()!;
+
+      // Mirrors the playground font-size +/- buttons, which patch with a
+      // function of the previous value rather than a constant.
+      $patchStyleText(selection, {
+        'font-size': currentValue => {
+          const size = parseInt(currentValue || '', 10);
+          return `${(Number.isNaN(size) ? 16 : size) + 2}px`;
+        },
+      });
+
+      selectionStyle = ($getSelection() as RangeSelection).style;
+      paragraphStyle = paragraph.getTextStyle();
+    });
+
+    expect(selectionStyle).toBe('font-size: 18px;');
+    expect(paragraphStyle).toBe('font-size: 18px;');
+  });
 });

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -320,10 +320,15 @@ export function $patchStyleText(
       ) => string)
   >,
 ): void {
+  // Shared with the empty-element loop below so that a node patched here is
+  // not patched a second time. A function-valued patch is not idempotent —
+  // it is evaluated against the value the previous application wrote.
+  const patchedElementKeys = new Set<NodeKey>();
   if ($isRangeSelection(selection) && selection.isCollapsed()) {
     $patchStyle(selection, patch);
     const emptyNode = selection.anchor.getNode();
     if ($isElementNode(emptyNode) && emptyNode.isEmpty()) {
+      patchedElementKeys.add(emptyNode.getKey());
       $patchStyle(emptyNode, patch);
     }
   }
@@ -333,7 +338,6 @@ export function $patchStyleText(
 
   const nodes = selection.getNodes();
   if (nodes.length > 0) {
-    const patchedElementKeys = new Set<NodeKey>();
     for (const node of nodes) {
       if (
         !$isElementNode(node) ||


### PR DESCRIPTION
## Description

For a collapsed selection in an **empty block**, `$patchStyleText` patches the same node twice. The collapsed branch patches the anchor element, and the trailing `selection.getNodes()` loop then patches it again. `patchedElementKeys` was declared inside that loop, so it never saw the first application.

That is harmless for a plain string patch, but `$patchStyle` re-reads the target's current style on every call, so a **function-valued** patch is evaluated against the value its own previous application just wrote.

This is user-visible in the playground. The font-size `+` button patches with a function of the previous size, so a single click with the caret on an empty line writes `18px` to `selection.style` but `20px` to the block's `textStyle` — the toolbar reads 18px while the line renders at 20px.

Hoisting the `Set` above the collapsed branch and recording the empty element's key there makes the later loop skip it.

The second loop was added in #8003 without accounting for the pre-existing collapsed branch from #7024; function patches arrived in #6472.

## Test plan

### Before

New test in `LexicalSelectionHelpers.test.ts` fails on `main`:

```
AssertionError: expected 'font-size: 20px;' to be 'font-size: 18px;'
Expected: "font-size: 18px;"
Received: "font-size: 20px;"
```

### After

Passes. Full `packages/lexical-selection` suite: 4 files, 311 tests passed. `eslint`, `prettier` and `tsc --noEmit` clean.