### PR TITLE
[lexical-table] Bug Fix: Import the dir attribute in table importDOM

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -13,6 +13,7 @@ import {
   $isInlineElementOrDecoratorNode,
   $isLineBreakNode,
   $isTextNode,
+  $setDirectionFromDOM,
   addClassNamesToElement,
   type DOMConversionOutput,
   type DOMExportOutput,
@@ -370,6 +371,7 @@ export function $convertTableCellNodeElement(
   if (isValidVerticalAlign(verticalAlign)) {
     tableCellNode.__verticalAlign = verticalAlign;
   }
+  $setDirectionFromDOM(tableCellNode, domNode_);
 
   const style = domNode_.style;
   const textDecoration = ((style && style.textDecoration) || '').split(' ');

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -17,6 +17,7 @@ import {
   $getDocument,
   $getEditor,
   $getNearestNodeFromDOMNode,
+  $setDirectionFromDOM,
   addClassNamesToElement,
   type BaseSelection,
   type DOMConversionOutput,
@@ -861,6 +862,7 @@ export function $convertTableElement(
       tableNode.setColWidths(columns);
     }
   }
+  $setDirectionFromDOM(tableNode, domNode);
   return {
     after: children => $descendantsMatching(children, $isTableRowNode),
     node: tableNode,

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -10,6 +10,7 @@ import {$descendantsMatching} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $getDocument,
+  $setDirectionFromDOM,
   addClassNamesToElement,
   type BaseSelection,
   type DOMConversionOutput,
@@ -134,7 +135,7 @@ export function $convertTableRowElement(domNode: Node): DOMConversionOutput {
 
   return {
     after: children => $descendantsMatching(children, $isTableCellNode),
-    node: $createTableRowNode(height),
+    node: $setDirectionFromDOM($createTableRowNode(height), domNode_),
   };
 }
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -9,7 +9,7 @@
 import type {TableNode} from '@lexical/table';
 
 import {$insertDataTransferForRichText} from '@lexical/clipboard';
-import {$generateHtmlFromNodes} from '@lexical/html';
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
 import {
   $createTableCellNode,
@@ -22,6 +22,7 @@ import {
   $isScrollableTablesActive,
   $isTableCellNode,
   $isTableNode,
+  $isTableRowNode,
 } from '@lexical/table';
 import {$dfs} from '@lexical/utils';
 import {
@@ -65,7 +66,7 @@ const editorConfig = Object.freeze({
 function wrapTableHtml(expected: string): string {
   return expected
     .replace(
-      /<table( dir="auto")?/g,
+      /<table( dir="(?:auto|ltr|rtl)")?/g,
       `<div$1 class="table-scrollable-wrapper"><table`,
     )
     .replace(/<\/table>/g, `</table></div>`);
@@ -134,10 +135,11 @@ describe('LexicalTableNode tests', () => {
       function expectReconciledTableHtmlToBeEqual(
         actual: string,
         expected: string,
+        dir: 'auto' | 'ltr' | 'rtl' = 'auto',
       ): void {
         return expectTableHtmlToBeEqual(
           actual,
-          expected.replace(/<table/g, '<table dir="auto"'),
+          expected.replace(/<table/g, `<table dir="${dir}"`),
         );
       }
 
@@ -799,6 +801,9 @@ describe('LexicalTableNode tests', () => {
               },
               {discrete: true},
             );
+            // The pasted table carries dir="ltr", which importDOM now
+            // preserves, so the table is explicitly ltr rather than auto and
+            // its rows no longer bidi-auto-detect.
             expectReconciledTableHtmlToBeEqual(
               testEnv.innerHTML,
               html`
@@ -808,7 +813,7 @@ describe('LexicalTableNode tests', () => {
                     <col style="width: 189px" />
                     <col style="width: 171px" />
                   </colgroup>
-                  <tr dir="auto" style="height: 21px;">
+                  <tr style="height: 21px;">
                     <td dir="auto" style="vertical-align: bottom">
                       <p dir="auto">
                         <strong data-lexical-text="true">Surface</strong>
@@ -825,7 +830,7 @@ describe('LexicalTableNode tests', () => {
                       </p>
                     </td>
                   </tr>
-                  <tr dir="auto" style="height: 21px;">
+                  <tr style="height: 21px;">
                     <td dir="auto" style="vertical-align: bottom">
                       <p dir="auto">
                         <span data-lexical-text="true">Lexical</span>
@@ -845,6 +850,7 @@ describe('LexicalTableNode tests', () => {
                   </tr>
                 </table>
               `,
+              'ltr',
             );
           }, 15000);
 
@@ -1899,5 +1905,73 @@ describe('LexicalTableNode tests', () => {
       {theme: editorConfig.theme},
       <TablePluginWrapper />,
     );
+  });
+
+  describe('importDOM preserves the dir attribute', () => {
+    initializeUnitTest(testEnv => {
+      test.for(['rtl', 'ltr', null] as const)('dir=%s', expected => {
+        const attr = expected === null ? '' : ` dir="${expected}"`;
+        const inputHtml = `<table${attr}><tr${attr}><td${attr}>a</td></tr></table>`;
+        const {editor} = testEnv;
+        editor.update(
+          () => {
+            const dom = new DOMParser().parseFromString(inputHtml, 'text/html');
+            $getRoot()
+              .clear()
+              .append(...$generateNodesFromDOM(editor, dom));
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const table = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isTableNode,
+          );
+          const row = $assertNodeType(table.getFirstChild(), $isTableRowNode);
+          const cell = $assertNodeType(row.getFirstChild(), $isTableCellNode);
+          expect(table.getDirection()).toBe(expected);
+          expect(row.getDirection()).toBe(expected);
+          expect(cell.getDirection()).toBe(expected);
+        });
+      });
+
+      test('round trips the dir attribute through exportDOM', () => {
+        const {editor} = testEnv;
+        let exported = '';
+        editor.update(
+          () => {
+            const table = $createTableNodeWithDimensions(1, 1, false);
+            table.setDirection('rtl');
+            $assertNodeType(
+              table.getFirstChild(),
+              $isTableRowNode,
+            ).setDirection('rtl');
+            $getRoot().clear().append(table);
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          exported = $generateHtmlFromNodes(editor);
+        });
+        editor.update(
+          () => {
+            const dom = new DOMParser().parseFromString(exported, 'text/html');
+            $getRoot()
+              .clear()
+              .append(...$generateNodesFromDOM(editor, dom));
+          },
+          {discrete: true},
+        );
+        editor.read(() => {
+          const table = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isTableNode,
+          );
+          const row = $assertNodeType(table.getFirstChild(), $isTableRowNode);
+          expect(table.getDirection()).toBe('rtl');
+          expect(row.getDirection()).toBe('rtl');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

`ElementNode.exportDOM` writes the explicit `dir` attribute for every element node, but the `@lexical/table` DOM converters never read it back. An explicit direction on a `TableNode`, `TableRowNode`, or `TableCellNode` therefore survives `exportJSON`/`importJSON` but is silently dropped through `$generateHtmlFromNodes` → `$generateNodesFromDOM`, and a pasted `<table dir="rtl">` is ignored.

#8412 fixed this for `ParagraphNode`, `HeadingNode`, `QuoteNode`, `ListNode` and `ListItemNode`, and added the shared `$setDirectionFromDOM` helper. Tables were missed. This applies the same helper in `$convertTableElement`, `$convertTableRowElement` and `$convertTableCellNodeElement`.

**One intentional consequence a reviewer should look at**, matching the snapshot updates #8412 made across its e2e specs: the existing `Copy table from an external source like gdoc with formatting` fixture carries `dir="ltr"` on its `<table>`, so that table is now explicitly `ltr` rather than bidi-`auto`, and its rows no longer auto-detect (a parent with an explicit `__dir` suppresses `dir="auto"` on descendants). The test expectation is updated accordingly, with an inline comment. If you'd rather tables keep auto-detecting for external pastes, that's the point to push back on.

I deliberately left table **indent** alone even though `data-lexical-indent` has the same asymmetry: all three table node types declare `canIndent(): false`, so indent isn't user-reachable there, and wiring it up would newly interpret `padding-inline-start` on arbitrary pasted `<table>`/`<td>` as indent on nodes that explicitly opt out.

## Test plan

### Before

New `importDOM preserves the dir attribute` block in `LexicalTableNode.test.tsx`, on `main`:

```
× dir=rtl
× dir=ltr
× round trips the dir attribute through exportDOM
× Copy table from an external source like gdoc with formatting (x2)

AssertionError: expected null to be 'rtl'
AssertionError: expected null to be 'ltr'

- <table class="test-table-class" dir="ltr">
+ <table class="test-table-class" dir="auto">
-   <tr style="height: 21px">
+   <tr dir="auto" style="height: 21px">

Tests  5 failed | 37 passed (42)
```

### After

```
Test Files  10 passed (10)
     Tests  152 passed (152)
```

Full `pnpm run test-unit`: 4940 passed. The only failures are the two pre-existing 5000ms `testTimeout` flakes in `MdastTextRuns.test.ts` and `FastPathCrossParent.test.ts` — timeouts, not assertion failures, in files this PR doesn't touch. `tsc --noEmit`, `eslint` and `prettier` all clean.