### PR TITLE
[lexical] Bug Fix: don't create a sibling cycle when splice re-inserts the node after the range

### DIFF
--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -687,7 +687,7 @@ export class ElementNode
     const writableSelfKey = writableSelf.__key;
     const nodesToInsertKeys = [];
     const nodesToRemoveKeys = [];
-    const nodeAfterRange = this.getChildAtIndex(start + deleteCount);
+    let nodeAfterRange = this.getChildAtIndex(start + deleteCount);
     let nodeBeforeRange = null;
     let newSize = oldSize - deleteCount + nodesToInsert.length;
 
@@ -725,6 +725,9 @@ export class ElementNode
       if (prevNode !== null && nodeToInsert.is(prevNode)) {
         nodeBeforeRange = prevNode = prevNode.getPreviousSibling();
       }
+      if (nodeAfterRange !== null && nodeToInsert.is(nodeAfterRange)) {
+        nodeAfterRange = nodeAfterRange.getNextSibling();
+      }
       const writableNodeToInsert = nodeToInsert.getWritable();
       if (writableNodeToInsert.__parent === writableSelfKey) {
         newSize--;
@@ -748,13 +751,13 @@ export class ElementNode
       prevNode = nodeToInsert;
     }
 
-    if (start + deleteCount === oldSize) {
+    if (nodeAfterRange === null) {
       if (prevNode !== null) {
         const writablePrevNode = prevNode.getWritable();
         writablePrevNode.__next = null;
         writableSelf.__last = prevNode.__key;
       }
-    } else if (nodeAfterRange !== null) {
+    } else {
       const writableNodeAfterRange = nodeAfterRange.getWritable();
       if (prevNode !== null) {
         const writablePrevNode = prevNode.getWritable();

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -714,6 +714,47 @@ describe('LexicalElementNode tests', () => {
         });
       });
     });
+
+    // The assertions run inside the same update as the splice so that a
+    // failure aborts before a corrupt sibling list can reach the reconciler.
+    it('Re-inserting the node after the range does not create a cycle', async () => {
+      await update(() => {
+        const [first, second, third] = block.getChildren();
+
+        // A no-op splice: the node already sits at this position.
+        block.splice(1, 0, [second]);
+
+        // Checked before any sibling walk so a cycle fails fast.
+        expect(second.getNextSibling()!.getKey()).toEqual(third.getKey());
+        expect(block.getChildrenSize()).toEqual(3);
+        expect(block.getChildrenKeys()).toEqual([
+          first.getKey(),
+          second.getKey(),
+          third.getKey(),
+        ]);
+        expect(block.getLastChild()!.getKey()).toEqual(third.getKey());
+        expect(block.getTextContent()).toEqual('FooBarBaz');
+      });
+    });
+
+    it('Replacing a node with a later sibling does not create a cycle', async () => {
+      await update(() => {
+        const [first, , third] = block.getChildren();
+
+        // Delete "Bar" and move "Baz" into its place.
+        block.splice(1, 1, [third]);
+
+        // Checked before any sibling walk so a cycle fails fast.
+        expect(third.getNextSibling()).toBe(null);
+        expect(block.getChildrenSize()).toEqual(2);
+        expect(block.getChildrenKeys()).toEqual([
+          first.getKey(),
+          third.getKey(),
+        ]);
+        expect(block.getLastChild()!.getKey()).toEqual(third.getKey());
+        expect(block.getTextContent()).toEqual('FooBaz');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Description

`ElementNode.splice()` captures `nodeAfterRange` before mutating and uses it at the end to re-link the tail of the range. The insert loop already handles the case where a node being inserted is `prevNode`, but not the case where it is `nodeAfterRange`. When that happens the node ends up as `prevNode` too, and the tail fix-up sets `node.__prev = node.__key` and `node.__next = node.__key` — a self-referencing sibling link.

Any children walk then never terminates: `getChildren()`, `getChildrenKeys()`, `getNextSibling()` loops, and the reconciler all spin until the process dies with `RangeError: Invalid array length`.

Two ordinary calls reproduce it:

- `parent.splice(1, 0, [parent.getChildAtIndex(1)])` — a no-op re-insert
- `parent.splice(1, 1, [laterSibling])` — delete one child and move a later sibling into its place

`splice` is public API and is also reached via the caret API — `ChildCaretFirst.insert()` calls `origin.splice(0, 0, [node])`.

The fix mirrors the existing `prevNode` guard: advance `nodeAfterRange` past a node that is being re-inserted. The tail branch is keyed off `nodeAfterRange === null` instead of `start + deleteCount === oldSize` — equivalent when no re-insert happens, and correct when the advance runs off the end so `__last` is still fixed up.

## Test plan

### Before

Two new tests in the existing `splice` describe fail, showing a node whose `__next` and `__prev` both equal its own `__key`:

```
+ Received:
TextNode { "__key": "8", "__next": "8", "__prev": "8", "__parent": "5", "__text": "Baz", ... }

Tests  2 failed | 40 skipped (42)
```

Both assertions live inside the same `editor.update()` as the `splice`, with the sibling-pointer check first — so on `main` the test fails fast with a readable message instead of hanging, and the aborted update discards the corrupt pending state rather than handing it to the reconciler. With that fast assertion removed, the same tests instead spin for ~21s and die with `RangeError: Invalid array length` inside `getChildrenKeys`, which is the real-world symptom.

### After

```
Test Files  1 passed (1)     Tests  42 passed (42)
```

Sibling links, `getChildrenKeys()`, `getChildrenSize()`, `getLastChild()` and `getTextContent()` all correct. Full unit suite green (227 files, 4940 passed).
