### PR TITLE
[lexical] Bug Fix: keep parent __size correct when replace() is passed a sibling

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1681,7 +1681,13 @@ export class LexicalNode {
     }
     writableReplaceWith.__next = nextKey;
     writableReplaceWith.__parent = parentKey;
-    writableParent.__size = size;
+    // `size` was read before replaceWith was detached. When replaceWith was
+    // already a child of this same parent, two children collapse into one, so
+    // the restored size must account for the node that is not coming back.
+    writableParent.__size =
+      replaceWithOldParent !== null && replaceWithOldParent.is(writableParent)
+        ? size - 1
+        : size;
     // Snapshot replaceWith's children count before children transfer so
     // element-anchored selections on `this` can map to the equivalent offset
     // in writableReplaceWith.

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -1128,6 +1128,28 @@ describe('LexicalNode tests', () => {
         );
       });
 
+      test('LexicalNode.replace(): with a sibling in the same parent', async () => {
+        const {editor} = testEnv;
+
+        await editor.update(() => {
+          const paragraph = textNode.getParentOrThrow();
+          const barTextNode = new TextNode('bar');
+          paragraph.append(barTextNode);
+
+          // Replacing a node with one of its own siblings must not leave the
+          // parent's __size counting the sibling twice.
+          textNode.replace(barTextNode);
+
+          expect(paragraph.getChildrenSize()).toBe(1);
+          expect(paragraph.getChildren()).toHaveLength(1);
+          expect(paragraph.getFirstChild()!.getTextContent()).toBe('bar');
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="auto"><span data-lexical-text="true">bar</span></p></div>',
+        );
+      });
+
       test('LexicalNode.replace(): text', async () => {
         const {editor} = testEnv;
 


### PR DESCRIPTION
## Description

`LexicalNode.replace()` reads the parent's `__size` before detaching `replaceWith`, then restores that value at the end. When `replaceWith` is already a child of the same parent, the parent loses two children (`replaceWith` via `$removeFromParent`, `this` via `$removeNode`) but only gains one back, so the restored size is one too large:

```js
paragraph.append(a, b);
a.replace(b);
paragraph.getChildrenSize(); // 2
paragraph.getChildren();     // [b]  -> one actual child
```

The sibling links are correct — only the counter is wrong — but the desync trips the `$reconcileChildren: nextChildren.length !== nextChildrenSize` invariant on the next commit, which crashes the editor. `getChildrenSize()`, `ElementNode.select()`'s default offsets, and `splice`'s bounds check all read the inflated value first.

`NodeCaret.splice` already works around this by detaching same-parent nodes with `node.remove()` before calling `target.replace(node)` (`LexicalCaret.ts`). No other caller does. This fixes it at the source so they don't have to.

## Test plan

### Before

New test `LexicalNode.replace(): with a sibling in the same parent` fails:

```
AssertionError: expected 2 to be 1 // Object.is equality
- 1
+ 2

Tests  1 failed | 100 skipped (101)
```

Worth noting the existing `Element-anchored selection on old parent (#6031)` suite does cover within-parent moves, but only for `insertBefore`/`insertAfter` — `replace` is filtered out of that table via `actNoRestore: null`, so this path was uncovered.

### After

```
Test Files  1 passed (1)     Tests  101 passed (101)
```

Size, children and rendered HTML all agree. Full unit suite green (227 files, 4940 passed).
