### PR TITLE
[lexical] Deprecate CAN_UNDO_COMMAND and CAN_REDO_COMMAND in favour of HistoryExtension's signals

### DIFF
--- a/packages/lexical-history/README.md
+++ b/packages/lexical-history/README.md
@@ -20,7 +20,7 @@ function registerHistory(
 
 ### Commands
 
-History package handles `UNDO_COMMAND`, `REDO_COMMAND` and `CLEAR_HISTORY_COMMAND` commands. It also triggers `CAN_UNDO_COMMAND` and `CAN_REDO_COMMAND` commands when history state is changed. These commands could be used to work with history state:
+History package handles `UNDO_COMMAND`, `REDO_COMMAND` and `CLEAR_HISTORY_COMMAND` commands. These commands could be used to work with history state:
 
 ```jsx
 import {UNDO_COMMAND, REDO_COMMAND} from 'lexical';
@@ -29,4 +29,32 @@ import {UNDO_COMMAND, REDO_COMMAND} from 'lexical';
   <Button onClick={() => editor.dispatchCommand(UNDO_COMMAND, undefined)}>Undo</Button>
   <Button onClick={() => editor.dispatchCommand(REDO_COMMAND, undefined)}>Redo</Button>
 </Toolbar>;
+```
+
+### Undo/redo availability
+
+`CAN_UNDO_COMMAND` and `CAN_REDO_COMMAND` are **deprecated**. A command only reports a change, so a listener registered after the editor is initialized never sees the current value, and there is no way to read it.
+
+Use the `canUndo` and `canRedo` signals from `HistoryExtension` instead. They are derived from the history stacks and always hold the current value:
+
+In React, use the `useExtensionSignalValue` hook:
+
+```jsx
+import {HistoryExtension} from '@lexical/history';
+import {useExtensionSignalValue} from '@lexical/react/useExtensionSignalValue';
+
+function UndoButton() {
+  const canUndo = useExtensionSignalValue(HistoryExtension, 'canUndo');
+  return <Button disabled={!canUndo}>Undo</Button>;
+}
+```
+
+Outside React, read the signal directly:
+
+```js
+import {getExtensionDependencyFromEditor} from '@lexical/extension';
+import {HistoryExtension} from '@lexical/history';
+
+const {output} = getExtensionDependencyFromEditor(editor, HistoryExtension);
+output.canUndo.peek();
 ```

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -242,10 +242,26 @@ export const CLEAR_EDITOR_COMMAND: LexicalCommand<void> =
 /** Dispatched to clear the undo/redo history stack. */
 export const CLEAR_HISTORY_COMMAND: LexicalCommand<void> =
   /* @__PURE__ */ createCommand('CLEAR_HISTORY_COMMAND');
-/** Dispatched when the redo availability changes. Payload is true if redo is available. */
+/**
+ * @deprecated in v0.49.0, use the `canRedo` signal from `HistoryExtension`.
+ *
+ * A command only reports a change, so a listener registered after the editor
+ * is initialized has no way to read the current value. The signal always
+ * holds it.
+ *
+ * Dispatched when the redo availability changes. Payload is true if redo is available.
+ */
 export const CAN_REDO_COMMAND: LexicalCommand<boolean> =
   /* @__PURE__ */ createCommand('CAN_REDO_COMMAND');
-/** Dispatched when the undo availability changes. Payload is true if undo is available. */
+/**
+ * @deprecated in v0.49.0, use the `canUndo` signal from `HistoryExtension`.
+ *
+ * A command only reports a change, so a listener registered after the editor
+ * is initialized has no way to read the current value. The signal always
+ * holds it.
+ *
+ * Dispatched when the undo availability changes. Payload is true if undo is available.
+ */
 export const CAN_UNDO_COMMAND: LexicalCommand<boolean> =
   /* @__PURE__ */ createCommand('CAN_UNDO_COMMAND');
 /** Dispatched when the editor receives focus. */


### PR DESCRIPTION
## Description

Per the review: `CAN_UNDO_COMMAND` and `CAN_REDO_COMMAND` are deprecated in favour of `HistoryExtension`'s `canUndo` / `canRedo` signals.

A command only reports a *change*. A listener registered after the editor is initialized never sees the current value and has no way to read it, so there is no correct way to bootstrap a toolbar button from these commands. The signals are derived from the history stacks by `syncFromHistoryState` and always hold the current value.

- `@deprecated` JSDoc on both commands, pointing at the signals.
- `@lexical/history` README: an "Undo/redo availability" section with a React example using `useExtensionSignalValue`, and a non-React one reading the signal via `getExtensionDependencyFromEditor`.

The commands are still dispatched, matching how `KEY_MODIFIER_COMMAND` was handled.

## Test plan

Docs and JSDoc only — nothing to test. `tsc --noEmit` clean, prettier and eslint clean. No deprecation lint rule in the repo, and `KEY_MODIFIER_COMMAND` is still dispatched internally while deprecated, so no call sites needed changing.
