### PR TITLE
[lexical-text] Bug Fix: preserve style and detail when a text entity reverts to plain text

### DIFF
--- a/packages/lexical-text/src/__tests__/unit/registerLexicalTextEntity.test.ts
+++ b/packages/lexical-text/src/__tests__/unit/registerLexicalTextEntity.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $applyNodeReplacement,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type LexicalNode,
+  TextNode,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+import {type EntityMatch, registerLexicalTextEntity} from '../..';
+
+class TestEntityNode extends TextNode {
+  $config() {
+    return this.config('test-entity', {extends: TextNode});
+  }
+
+  isTextEntity(): true {
+    return true;
+  }
+}
+
+function $createTestEntityNode(text: string): TestEntityNode {
+  return $applyNodeReplacement(new TestEntityNode(text));
+}
+
+function $isTestEntityNode(node: LexicalNode | null): node is TestEntityNode {
+  return node instanceof TestEntityNode;
+}
+
+function getMatch(text: string): null | EntityMatch {
+  const match = /#\w+/.exec(text);
+  return match === null
+    ? null
+    : {end: match.index + match[0].length, start: match.index};
+}
+
+describe('registerLexicalTextEntity', () => {
+  initializeUnitTest(
+    testEnv => {
+      test('preserves style and detail when reverting an entity to simple text', async () => {
+        const {editor} = testEnv;
+        registerLexicalTextEntity(editor, getMatch, TestEntityNode, textNode =>
+          $createTestEntityNode(textNode.getTextContent()),
+        );
+
+        await editor.update(() => {
+          const paragraph = $createParagraphNode();
+          paragraph.append($createTextNode('#lexical'));
+          $getRoot().clear().append(paragraph);
+        });
+
+        await editor.update(() => {
+          const node = $getRoot().getFirstDescendant();
+          expect($isTestEntityNode(node)).toBe(true);
+          (node as TestEntityNode)
+            .setFormat('bold')
+            .setStyle('color: red')
+            .setDetail('directionless');
+        });
+
+        // Break the match so the entity reverts to a plain TextNode.
+        await editor.update(() => {
+          const node = $getRoot().getFirstDescendant() as TextNode;
+          node.setTextContent('lexical');
+        });
+
+        editor.getEditorState().read(() => {
+          const node = $getRoot().getFirstDescendant() as TextNode;
+          expect($isTestEntityNode(node)).toBe(false);
+          expect(node.getTextContent()).toBe('lexical');
+          expect(node.hasFormat('bold')).toBe(true);
+          expect(node.getStyle()).toBe('color: red');
+          expect(node.isDirectionless()).toBe(true);
+        });
+      });
+    },
+    {namespace: 'test', nodes: [TestEntityNode], theme: {}},
+  );
+});

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -48,8 +48,10 @@ export function registerLexicalTextEntity<T extends TextNode>(
   };
 
   const $replaceWithSimpleText = (node: TextNode): void => {
-    const textNode = $createTextNode(node.getTextContent());
-    textNode.setFormat(node.getFormat());
+    const textNode = $createTextNode(node.getTextContent())
+      .setFormat(node.getFormat())
+      .setStyle(node.getStyle())
+      .setDetail(node.getDetail());
     node.replace(textNode);
   };
 


### PR DESCRIPTION
## Description

`registerLexicalTextEntity` replaces an entity node with a plain `TextNode` (`$replaceWithSimpleText`) whenever the text stops matching. It copies `format` but not `style` or `detail`, so inline styling applied to an entity node is silently dropped the moment the entity breaks — a coloured hashtag loses its colour when you delete the `#`, keeping bold but turning black.

`@lexical/link` already does this correctly when it builds the text node for an auto-link:

```js
textNode.setFormat(linkTextNode.getFormat());
textNode.setDetail(linkTextNode.getDetail());
textNode.setStyle(linkTextNode.getStyle());
```

This copies `style` and `detail` as well, so the two paths agree.

## Test plan

### Before

New unit test at `packages/lexical-text/src/__tests__/unit/registerLexicalTextEntity.test.ts` fails:

```
AssertionError: expected '' to be 'color: red' // Object.is equality
- color: red

Tests  1 failed (1)
```

### After

```
Test Files  2 passed (2)     Tests  2 passed (2)
```

`format`, `style` and `detail` all survive the revert, verified alongside `packages/lexical-hashtag`. Full unit suite green (228 files, 4939 passed).
