### PR TITLE
[lexical] Bug Fix: keep the text mode on every part of a split TextNode

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1052,6 +1052,9 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
     // Then handle all other parts
     const splitNodes: TextNode[] = [writableNode];
     let textSize = firstPart.length;
+    // Segmented nodes are downgraded to normal above, every other mode is
+    // kept so all of the parts match the node that was split.
+    const mode = writableNode.__mode;
 
     for (let i = 1; i < partsLength; i++) {
       const part = parts[i];
@@ -1060,6 +1063,7 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
       sibling.__format = format;
       sibling.__style = style;
       sibling.__detail = detail;
+      sibling.__mode = mode;
       sibling.__state = $cloneNodeState(self, sibling);
       const siblingKey = sibling.__key;
       const nextTextSize = textSize + partSize;

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -519,6 +519,21 @@ describe('LexicalTextNode tests', () => {
       },
     );
 
+    test('splitText keeps the token mode on every part', async () => {
+      await update(() => {
+        const paragraphNode = $createParagraphNode();
+        const textNode = $createTextNode('Hello World').setMode('token');
+        paragraphNode.append(textNode);
+
+        const splitNodes = textNode.splitText(5);
+
+        expect(splitNodes.map(node => node.getMode())).toEqual([
+          'token',
+          'token',
+        ]);
+      });
+    });
+
     test('splitText moves composition key to last node', async () => {
       await update(() => {
         const paragraphNode = $createParagraphNode();


### PR DESCRIPTION
## Description

`splitText()` copies format, style, detail and NodeState onto the parts it creates, but not `__mode`. The first part reuses the node being split so it keeps its mode; every later part is created as a normal-mode `TextNode`. Splitting a token node therefore yields a token head followed by editable tails, which are `isSimpleText()` and can be merged into adjacent text by normalization.

The siblings now inherit the mode of the first part. Segmented nodes are still downgraded to normal, because the first part is already replaced with a plain `TextNode` in that branch.

Related but distinct: #4167 asks that `RangeSelection.formatText` not call `splitText` on token nodes. That's a guard at one caller; this is `splitText`'s own contract losing the mode, which affects every caller (`$splitTextPointCaret`, drop handling, `$insertNodeToNearestRootAtCaret`, markdown and autolink transformers). You may want to consider them together.

## Test plan

### Before

New unit test `splitText keeps the token mode on every part` fails on main:

```
[ "token", -   "token" +   "normal" ]
```

### After

Passes; `Tests 102 passed (102)` in that file. The existing `convert segmented node into plain text` test is unaffected — the fix reads the mode off the already-created first part, so the segmented branch is unchanged. `pnpm run test-unit` green (227 files, 4939 passed).
