### PR TITLE
[lexical-list] Bug Fix: don't merge adjacent nested lists of a different listType

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -372,7 +372,11 @@ export class ListItemNode extends ElementNode {
       prevSibling &&
       nextSibling &&
       $isNestedListNode(prevSibling) &&
-      $isNestedListNode(nextSibling)
+      $isNestedListNode(nextSibling) &&
+      // Only join the surrounding sublists when they are the same kind of
+      // list, otherwise the second one loses its listType.
+      prevSibling.getFirstChild().getListType() ===
+        nextSibling.getFirstChild().getListType()
     ) {
       mergeLists(prevSibling.getFirstChild(), nextSibling.getFirstChild());
       nextSibling.remove();

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -723,6 +723,68 @@ describe('LexicalListItemNode tests', () => {
         );
       });
 
+      //   - A
+      // - x
+      //   1. B
+      test('both siblings are nested with a different listType', async () => {
+        const {editor} = testEnv;
+        let x: ListItemNode;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const parent = new ListNode('bullet', 1);
+
+          const A_listItem = new ListItemNode();
+          const A_nestedList = new ListNode('bullet', 1);
+          const A_nestedListItem = new ListItemNode();
+          A_listItem.append(A_nestedList);
+          A_nestedList.append(A_nestedListItem);
+          A_nestedListItem.append(new TextNode('A'));
+
+          x = new ListItemNode();
+          x.append(new TextNode('x'));
+
+          const B_listItem = new ListItemNode();
+          const B_nestedList = new ListNode('number', 1);
+          const B_nestedListItem = new ListItemNode();
+          B_listItem.append(B_nestedList);
+          B_nestedList.append(B_nestedListItem);
+          B_nestedListItem.append(new TextNode('B'));
+
+          parent.append(A_listItem, x, B_listItem);
+          root.append(parent);
+        });
+
+        await editor.update(() => x.remove());
+
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul dir="auto">
+                <li value="1">
+                  <ul>
+                    <li value="1">
+                      <span data-lexical-text="true">A</span>
+                    </li>
+                  </ul>
+                </li>
+                <li value="1">
+                  <ol>
+                    <li value="1">
+                      <span data-lexical-text="true">B</span>
+                    </li>
+                  </ol>
+                </li>
+              </ul>
+            </div>
+          `,
+        );
+      });
+
       //  - A1
       //     - A2
       // - x

--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -774,3 +774,44 @@ describe('ListItemNode.collapseAtStart', () => {
     });
   });
 });
+
+describe('mergeNextSiblingListIfSameType', () => {
+  initializeUnitTest(testEnv => {
+    test('does not merge nested sublists of a different listType', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(
+        () => {
+          const $nested = (listType: ListType, text: string) =>
+            $createListItemNode().append(
+              $createListNode(listType).append(
+                $createListItemNode().append($createTextNode(text)),
+              ),
+            );
+          const list1 = $createListNode('bullet').append(
+            $createListItemNode().append($createTextNode('a')),
+            $nested('number', 'one'),
+          );
+          const list2 = $createListNode('bullet').append(
+            $nested('bullet', 'two'),
+            $createListItemNode().append($createTextNode('b')),
+          );
+          $getRoot().clear().append(list1, list2);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const [list] = $getRoot().getChildren();
+        invariant($isListNode(list), 'Expected ListNode');
+        // The two bullet lists merge, but their sublists stay separate.
+        const sublistTypes = list
+          .getChildren()
+          .map(child => ($isListItemNode(child) ? child.getFirstChild() : null))
+          .filter($isListNode)
+          .map(sublist => sublist.getListType());
+        expect(sublistTypes).toEqual(['number', 'bullet']);
+      });
+    });
+  });
+});

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -230,7 +230,11 @@ export function mergeLists(list1: ListNode, list2: ListNode): void {
     listItem1 &&
     listItem2 &&
     $isNestedListNode(listItem1) &&
-    $isNestedListNode(listItem2)
+    $isNestedListNode(listItem2) &&
+    // A nested <ul> must not swallow a nested <ol>, same rule as
+    // mergeNextSiblingListIfSameType applies at the top level.
+    listItem1.getFirstChild().getListType() ===
+      listItem2.getFirstChild().getListType()
   ) {
     mergeLists(listItem1.getFirstChild(), listItem2.getFirstChild());
     listItem2.remove();


### PR DESCRIPTION
## Description

`mergeNextSiblingListIfSameType()` documents that a `<ul>` merges with a `<ul>` but not with an `<ol>`. That check is only applied to the two top-level lists. The recursive step inside `mergeLists()`, and the same merge in `ListItemNode.remove()`, join the sublists at the boundary without looking at `listType`, so the second sublist loses its type and its items are absorbed into the first.

Two reachable paths:

- Deleting a list item between a nested `<ul>` and a nested `<ol>` turns the `<ol>` into bullets.
- The `ListNode` `$transform` merges two adjacent `<ul>`s whose boundary sublists differ, with the same result.

Both sites now compare `listType` before merging. When they differ the sublists stay as separate list items; nothing is dropped.

## Test plan

### Before

Two new unit tests fail on main — the `<ol>` is replaced by a second `<li>` inside the `<ul>`:

```
-     </ul>
-   </li>
-   <li value="1">
-     <ol>
-       <li value="1"><span data-lexical-text="true">B</span></li>
+       <li value="2"><span data-lexical-text="true">B</span></li>
-     </ol>
+     </ul>
```

### After

Both pass. `pnpm run test-unit` green (227 files, 4940 passed).
