### PR TITLE
[lexical-rich-text] Bug Fix: preserve heading format and style when splitting a heading

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
@@ -161,6 +161,27 @@ describe('LexicalHeadingNode tests', () => {
       );
     });
 
+    test('HeadingNode.insertNewAfter() middle keeps format and style', async () => {
+      const {editor} = testEnv;
+      let headingNode: HeadingNode;
+      await editor.update(() => {
+        const root = $getRoot();
+        headingNode = new HeadingNode('h1');
+        headingNode.setFormat('center');
+        headingNode.setStyle('color: red;');
+        const headingTextNode = $createTextNode('hello world');
+        root.append(headingNode.append(headingTextNode));
+        headingTextNode.select(5, 5);
+      });
+      await editor.update(() => {
+        const selection = $getSelection() as RangeSelection;
+        const result = headingNode.insertNewAfter(selection);
+        expect(result).toBeInstanceOf(HeadingNode);
+        expect(result.getFormatType()).toBe('center');
+        expect(result.getStyle()).toBe('color: red;');
+      });
+    });
+
     test('HeadingNode.insertNewAfter() end', async () => {
       const {editor} = testEnv;
       let headingNode: HeadingNode;

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -438,7 +438,11 @@ export class HeadingNode extends ElementNode {
     const newElement =
       isAtEnd || !selection
         ? $createParagraphNode()
-        : $createHeadingNode(this.getTag());
+        : // The heading is split in two, so the second half keeps the
+          // block format and style of the first, like ParagraphNode does.
+          $createHeadingNode(this.getTag())
+            .setFormat(this.getFormatType())
+            .setStyle(this.getStyle());
     const direction = this.getDirection();
     newElement.setDirection(direction);
     this.insertAfter(newElement, restoreSelection);


### PR DESCRIPTION
## Description

`HeadingNode.insertNewAfter()` copies the tag and direction onto the second half of a split heading but not the block format or style. Pressing Enter in the middle of a centered heading produces a left-aligned one. `ParagraphNode.insertNewAfter()` and `ListItemNode.insertNewAfter()` (via `$copyNode`) already carry both over.

This copies `getFormatType()` and `getStyle()` onto the new heading. Only the heading-to-heading split path is affected; the end-of-heading path still creates a plain paragraph.

## Test plan

### Before

New unit test `HeadingNode.insertNewAfter() middle keeps format and style` fails on main:

```
AssertionError: expected '' to be 'center'
```

### After

Passes; `Tests 20 passed (20)` in that file. `pnpm run test-unit` green (227 files, 4939 passed).
