### PR TITLE
[lexical-extension] Bug Fix: Normalize multiple clicks

### DIFF
--- a/packages/lexical-extension/src/NormalizeTripleClickSelectionExtension.ts
+++ b/packages/lexical-extension/src/NormalizeTripleClickSelectionExtension.ts
@@ -174,7 +174,7 @@ export const NormalizeTripleClickSelectionExtension =
           }
           let lastTripleClick = 0;
           const refreshTripleClick = (event: null | MouseEvent) => {
-            if (event ? event.detail === 3 : lastTripleClick > 0) {
+            if (event ? event.detail > 2 : lastTripleClick > 0) {
               const now = stores.dateNow.peek()();
               lastTripleClick =
                 (event && event.type === 'mousedown') ||

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1029,6 +1029,59 @@ test.describe('Selection', () => {
     );
   });
 
+  test('Can adjust selection on 3+ clicks', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+
+    await page.keyboard.type('Paragraph 1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Paragraph 2');
+    await page
+      .locator('div[contenteditable="true"] > p')
+      .first()
+      .click({clickCount: 4});
+    const expectedSelection = createHumanReadableSelection(
+      'the whole first paragraph',
+      {
+        anchorOffset: {desc: 'start of Paragraph 1 text', value: 0},
+        anchorPath: [
+          {desc: 'first paragraph', value: 0},
+          {desc: 'first span', value: 0},
+          {desc: 'Text node', value: 0},
+        ],
+        focusOffset: {
+          desc: 'end of Paragraph 1 text',
+          value: 'Paragraph 1'.length,
+        },
+        focusPath: [
+          {desc: 'first paragraph', value: 0},
+          {desc: 'first span', value: 0},
+          {desc: 'Text node', value: 0},
+        ],
+      },
+    );
+
+    await assertSelection(page, expectedSelection);
+
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .item:has(.icon.h1)');
+
+    await assertHTML(
+      page,
+      html`
+        <h1 class="PlaygroundEditorTheme__h1" dir="auto">
+          <span data-lexical-text="true">Paragraph 1</span>
+        </h1>
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Paragraph 2</span>
+        </p>
+      `,
+    );
+  });
+
   test('Can adjust triple click selection linebreak', async ({
     page,
     isCollab,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

An extension was previously added to handle triple-clicks. In fact, the browser can also select a block if you click more than three times in a row, which leads to the original problem when selecting an entire block contains the boundaries of adjacent nodes

This PR normalizes multiple clicks of three or more

Follow-up https://github.com/facebook/lexical/pull/8520

## Test plan

New e2e test for quadruple click