### PR TITLE
[lexical-react][lexical-playground] Bug Fix: Announce typeahead menu options and result count to screen readers

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs
@@ -968,8 +968,26 @@ test.describe('Mentions', () => {
     await focusEditor(page);
     await page.keyboard.type('@a');
 
+    // The outer element only positions the menu. The listbox is the <ul> that
+    // holds the options, because a listbox has to own its options directly for
+    // a screen reader to read them as choices and count their position.
     const menuElement = page.locator('#typeahead-menu');
-    expect(await menuElement.getAttribute('aria-label')).toBe('Typeahead menu');
-    expect(await menuElement.getAttribute('role')).toBe('listbox');
+    expect(await menuElement.getAttribute('role')).toBe('presentation');
+
+    const listbox = page.locator('#typeahead-listbox');
+    expect(await listbox.getAttribute('role')).toBe('listbox');
+    expect(await listbox.getAttribute('aria-label')).toBe('Mentions');
+
+    // The options have to be the listbox's own children. The browser works
+    // out "1 of 5" from that relationship and passes it on; nothing in the
+    // markup states the position.
+    const options = listbox.locator('[role="option"]');
+    const count = await options.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      expect(await options.nth(i).evaluate(el => el.parentElement.id)).toBe(
+        'typeahead-listbox',
+      );
+    }
   });
 });

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -252,6 +252,7 @@ export default function AutoEmbedPlugin(): JSX.Element {
     <>
       {modal}
       <LexicalAutoEmbedPlugin<PlaygroundEmbedConfig>
+        menuAriaLabel="Embed"
         embedConfigs={EmbedConfigs}
         onOpenEmbedModalForConfig={openEmbedModal}
         getMenuOptions={getMenuOptions}

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -411,6 +411,7 @@ export default function ComponentPickerMenuPlugin(): JSX.Element {
     <>
       {modal}
       <LexicalTypeaheadMenuPlugin<ComponentPickerOption>
+        menuAriaLabel="Blocks"
         onQueryChange={setQueryString}
         onSelectOption={onSelectOption}
         triggerFn={checkForTriggerMatch}

--- a/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
@@ -29,12 +29,14 @@ class EmojiOption extends MenuOption {
     title: string,
     emoji: string,
     options: {
+      ariaLabel?: string;
       keywords?: string[];
     },
   ) {
     super(title);
     this.title = title;
     this.emoji = emoji;
+    this.ariaLabel = options.ariaLabel;
     this.keywords = options.keywords || [];
   }
 }
@@ -67,6 +69,17 @@ export default function EmojiPickerPlugin() {
         ? emojis.map(
             ({emoji, aliases, tags}) =>
               new EmojiOption(`${emoji} ${aliases[0]}`, emoji, {
+                // Announce the shortcode, not the glyph and not the
+                // dataset description.
+                //
+                // The glyph is announced from the screen reader's own
+                // dictionary, so leaving it in the name says the same emoji
+                // twice. The description reads well ("face savoring food") but
+                // is NOT searchable - only aliases and tags are matched - so a
+                // screen-reader user would hear a name they cannot type. The
+                // shortcode is what you search by, so it is what should be
+                // read; underscores become spaces so it is intelligible.
+                ariaLabel: aliases[0].replace(/_/g, ' '),
                 keywords: [...aliases, ...tags],
               }),
           )
@@ -123,6 +136,7 @@ export default function EmojiPickerPlugin() {
 
   return (
     <LexicalTypeaheadMenuPlugin
+      menuAriaLabel="Emojis"
       onQueryChange={setQueryString}
       onSelectOption={onSelectOption}
       triggerFn={checkForTriggerMatch}

--- a/packages/lexical-playground/src/plugins/MentionsExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsExtension/index.tsx
@@ -660,6 +660,7 @@ export function MentionsPlugin(): JSX.Element | null {
 
   return (
     <LexicalTypeaheadMenuPlugin<MentionTypeaheadOption>
+      menuAriaLabel="Mentions"
       onQueryChange={setQueryString}
       onSelectOption={onSelectOption}
       triggerFn={checkForMentionMatch}

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -133,6 +133,12 @@ type LexicalAutoEmbedPluginProps<TEmbedConfig extends EmbedConfig> = {
    */
   menuRenderFn?: MenuRenderFn<AutoEmbedOption>;
   /**
+   * Accessible label for the menu.
+   * Screen readers will announce this when the menu opens.
+   * @default 'Typeahead menu'
+   */
+  menuAriaLabel?: string;
+  /**
    * Priority for key handling in the menu. The default is `COMMAND_PRIORITY_LOW`
    */
   menuCommandPriority?: CommandListenerPriority;
@@ -171,6 +177,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
   onOpenEmbedModalForConfig,
   getMenuOptions,
   menuRenderFn,
+  menuAriaLabel,
   menuCommandPriority = COMMAND_PRIORITY_LOW,
 }: LexicalAutoEmbedPluginProps<TEmbedConfig>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
@@ -316,6 +323,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
       onSelectOption={onSelectOption}
       options={options}
       menuRenderFn={menuRenderFn}
+      menuAriaLabel={menuAriaLabel}
       commandPriority={menuCommandPriority}
     />
   ) : null;

--- a/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
@@ -49,6 +49,12 @@ export type NodeMenuPluginProps<TOption extends MenuOption> = {
   anchorClassName?: string;
   commandPriority?: CommandListenerPriority;
   parent?: HTMLElement;
+  /**
+   * Accessible label for the menu.
+   * Screen readers will announce this when the menu opens.
+   * @default 'Typeahead menu'
+   */
+  menuAriaLabel?: string;
 };
 
 /**
@@ -70,6 +76,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
   anchorClassName,
   commandPriority = COMMAND_PRIORITY_LOW,
   parent,
+  menuAriaLabel,
 }: NodeMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -78,6 +85,8 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
     setResolution,
     anchorClassName,
     parent,
+    true, // shouldIncludePageYOffset__EXPERIMENTAL
+    menuAriaLabel,
   );
 
   const closeNodeMenu = useCallback(() => {
@@ -136,6 +145,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
     resolution === null ||
     editor === null ? null : (
     <LexicalMenu
+      ariaLabel={menuAriaLabel}
       close={closeNodeMenu}
       resolution={resolution}
       editor={editor}

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -213,6 +213,12 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
   parent?: HTMLElement;
   preselectFirstItem?: boolean;
   ignoreEntityBoundary?: boolean;
+  /**
+   * Accessible label for the menu container.
+   * Screen readers will announce this when the menu opens.
+   * @default 'Typeahead menu'
+   */
+  menuAriaLabel?: string;
 };
 
 /**
@@ -237,6 +243,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   parent,
   preselectFirstItem = true,
   ignoreEntityBoundary = false,
+  menuAriaLabel,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -245,6 +252,8 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
     setResolution,
     anchorClassName,
     parent,
+    true, // shouldIncludePageYOffset__EXPERIMENTAL
+    menuAriaLabel,
   );
 
   const closeTypeahead = useCallback(() => {
@@ -361,6 +370,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
     editor === null ||
     anchorElementRef.current === null ? null : (
     <LexicalMenu
+      ariaLabel={menuAriaLabel}
       close={closeTypeahead}
       resolution={resolution}
       editor={editor}

--- a/packages/lexical-react/src/__tests__/unit/LexicalMenu.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalMenu.test.tsx
@@ -7,7 +7,11 @@
  */
 
 import * as ComposerContext from '@lexical/react/LexicalComposerContext';
-import {KEY_ENTER_COMMAND, type LexicalEditor} from 'lexical';
+import {
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ENTER_COMMAND,
+  type LexicalEditor,
+} from 'lexical';
 import {createTestEditor} from 'lexical/src/__tests__/utils';
 import * as React from 'react';
 import {act} from 'react';
@@ -34,6 +38,14 @@ import {
 // Mock the composer context to provide a test editor
 vi.mock('@lexical/react/LexicalComposerContext', () => ({
   useLexicalComposerContext: () => [createTestEditor()],
+}));
+
+// The real hook reads AriaLiveRegionExtension off the editor, which a bare
+// test editor does not have. Standing in for it makes announcements
+// observable, including the ones that must not happen.
+const {announce} = vi.hoisted(() => ({announce: vi.fn()}));
+vi.mock('@lexical/react/useLexicalAriaLiveRegion', () => ({
+  useLexicalAriaLiveRegion: () => announce,
 }));
 
 class TestOption extends MenuOption {
@@ -552,5 +564,292 @@ describe('useDynamicPositioning Comment 8 regression', () => {
       ([eventName]) => eventName === 'scroll',
     );
     expect(scrollListenerCalls.length).toBeGreaterThan(0);
+  });
+});
+
+describe('LexicalMenu accessibility', () => {
+  let container: HTMLDivElement;
+  let reactRoot: Root;
+  let editor: LexicalEditor;
+  let anchorElement: HTMLDivElement;
+  let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
+
+  function render(props: Record<string, unknown>) {
+    return act(async () => {
+      reactRoot.render(
+        <LexicalMenu<TestOption>
+          close={vi.fn()}
+          editor={editor}
+          anchorElementRef={{current: anchorElement}}
+          resolution={createTestResolution('test')}
+          onSelectOption={vi.fn()}
+          options={[]}
+          {...props}
+        />,
+      );
+    });
+  }
+
+  const listbox = () => anchorElement.querySelector('[role="listbox"]');
+  const items = () =>
+    Array.from(anchorElement.querySelectorAll('[role="option"]'));
+  const root = () => editor.getRootElement()!;
+
+  beforeEach(() => {
+    announce.mockClear();
+    announce.mockImplementation(() => {});
+    // jsdom has no layout, so it does not implement scrollIntoView. Arrowing
+    // through the menu scrolls the highlighted option into view.
+    originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = vi.fn();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+    anchorElement = document.createElement('div');
+    anchorElement.id = 'typeahead-menu';
+    document.body.appendChild(anchorElement);
+    editor = createTestEditor();
+    const rootElement = document.createElement('div');
+    rootElement.contentEditable = 'true';
+    document.body.appendChild(rootElement);
+    editor.setRootElement(rootElement);
+  });
+
+  afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    container.remove();
+    anchorElement.remove();
+    const rootEl = editor.getRootElement();
+    if (rootEl) {
+      rootEl.remove();
+    }
+  });
+
+  describe('the listbox owns its options', () => {
+    it('renders the options as direct children of the listbox', async () => {
+      await render({options: [new TestOption('A'), new TestOption('B')]});
+
+      // The whole bug: anything sitting between the listbox and its options
+      // is announced as an extra list, and stops the position being worked
+      // out at all.
+      expect(listbox()).not.toBeNull();
+      expect(items()).toHaveLength(2);
+      for (const item of items()) {
+        expect(item.parentElement).toBe(listbox());
+      }
+    });
+
+    it('exposes exactly one list, not a list inside a list', async () => {
+      await render({options: [new TestOption('A'), new TestOption('B')]});
+
+      // Heard as "list, list": the container claimed to be a listbox and the
+      // <ul> inside it was a second list nobody asked for. A <ul> carries a
+      // list role whether or not one is set, so counting elements that expose
+      // one is the check that matters.
+      const lists = anchorElement.querySelectorAll(
+        '[role="listbox"], [role="list"], ul:not([role]), ol:not([role])',
+      );
+
+      expect(lists).toHaveLength(1);
+      expect(lists[0]).toBe(listbox());
+    });
+
+    it('names the listbox, and lets the caller override the name', async () => {
+      await render({options: [new TestOption('A')]});
+      expect(listbox()!.getAttribute('aria-label')).toBe('Typeahead menu');
+
+      await render({ariaLabel: 'Emojis', options: [new TestOption('A')]});
+      expect(listbox()!.getAttribute('aria-label')).toBe('Emojis');
+    });
+  });
+
+  describe('what each option says about itself', () => {
+    it('marks only the highlighted option as selected', async () => {
+      await render({
+        options: [
+          new TestOption('A'),
+          new TestOption('B'),
+          new TestOption('C'),
+        ],
+      });
+
+      // aria-selected="false" on the rest makes some screen readers say
+      // "not selected" after every arrow press.
+      expect(items().map(i => i.getAttribute('aria-selected'))).toEqual([
+        'true',
+        null,
+        null,
+      ]);
+    });
+
+    it('uses ariaLabel as the spoken name when the visible text differs', async () => {
+      const option = new TestOption('grinning glyph');
+      option.ariaLabel = 'grinning';
+      await render({options: [option]});
+
+      expect(items()[0].getAttribute('aria-label')).toBe('grinning');
+    });
+
+    it('leaves the name to the visible text when no ariaLabel is given', async () => {
+      await render({options: [new TestOption('A')]});
+
+      expect(items()[0].hasAttribute('aria-label')).toBe(false);
+    });
+  });
+
+  describe('what the editor points at', () => {
+    it('owns the listbox while there are options to point at', async () => {
+      await render({options: [new TestOption('A')]});
+
+      // The menu is rendered outside the editor, so the relationship has to
+      // be declared or the reference does not resolve.
+      expect(root().getAttribute('aria-owns')).toBe(listbox()!.id);
+      const active = root().getAttribute('aria-activedescendant');
+      expect(document.getElementById(active!)).not.toBeNull();
+    });
+
+    it('stops pointing when the options run out', async () => {
+      await render({options: [new TestOption('A')]});
+      await render({options: []});
+
+      expect(root().getAttribute('aria-owns')).toBeNull();
+      expect(root().getAttribute('aria-activedescendant')).toBeNull();
+    });
+
+    it('points at the highlighted option when options arrive late', async () => {
+      // A menu backed by a network lookup opens with nothing. The highlight
+      // is clamped while the list is empty and lands back on 0 when the
+      // results arrive, so it never "changes" - and anything written only on
+      // change is never written, leaving the editor pointing at nothing.
+      await render({options: []});
+      expect(root().getAttribute('aria-activedescendant')).toBeNull();
+
+      await render({options: [new TestOption('A'), new TestOption('B')]});
+
+      const active = root().getAttribute('aria-activedescendant');
+      expect(active).toBe(items()[0].id);
+      expect(document.getElementById(active!)).not.toBeNull();
+    });
+
+    it('never claims the editor is a combobox', async () => {
+      await render({options: [new TestOption('A')]});
+
+      // Changing the role of the focused element makes a screen reader
+      // re-introduce it. The editor is a text field, not a combobox.
+      expect(root().getAttribute('role')).not.toBe('combobox');
+      expect(root().hasAttribute('aria-expanded')).toBe(false);
+    });
+
+    it('lets go of the editor when the menu closes', async () => {
+      await render({options: [new TestOption('A')]});
+      await act(async () => {
+        reactRoot.unmount();
+      });
+
+      expect(root().getAttribute('aria-owns')).toBeNull();
+      expect(root().getAttribute('aria-activedescendant')).toBeNull();
+    });
+  });
+
+  describe('saying how many matches there are', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Async so React commits any pending effect before the clock moves.
+    // Advancing synchronously races the commit: the timer is set after time
+    // has already passed, so it survives to fire during a later step.
+    async function settle() {
+      await act(async () => {
+        vi.advanceTimersByTime(600);
+      });
+    }
+
+    it('says how many, once typing has settled', async () => {
+      await render({options: [new TestOption('A'), new TestOption('B')]});
+      await settle();
+
+      expect(announce).toHaveBeenCalledWith('2 suggestions available');
+    });
+
+    it('counts a single suggestion in the singular', async () => {
+      await render({options: [new TestOption('A')]});
+      await settle();
+
+      expect(announce).toHaveBeenCalledWith('1 suggestion available');
+    });
+
+    it('says so when nothing matches', async () => {
+      await render({options: []});
+      await settle();
+
+      // Nothing else can carry this: with no matches there is no list left
+      // to describe, so correct markup is silence.
+      expect(announce).toHaveBeenCalledWith('No results');
+    });
+
+    it('says nothing more while the highlight moves', async () => {
+      await render({
+        options: [
+          new TestOption('A'),
+          new TestOption('B'),
+          new TestOption('C'),
+        ],
+      });
+      // Drain everything already queued, so what follows can only be new.
+      await act(async () => {
+        vi.runAllTimers();
+      });
+      announce.mockClear();
+
+      await act(async () => {
+        editor.dispatchCommand(
+          KEY_ARROW_DOWN_COMMAND,
+          new KeyboardEvent('keydown', {key: 'ArrowDown'}),
+        );
+      });
+      await settle();
+
+      // Arrowing already announces the option itself. Repeating the count
+      // over the top of it is noise.
+      expect(announce).not.toHaveBeenCalled();
+    });
+
+    it('ends a burst of typing on the current count', async () => {
+      await render({options: [new TestOption('A')]});
+      await render({options: [new TestOption('A'), new TestOption('B')]});
+      await render({
+        options: [
+          new TestOption('A'),
+          new TestOption('B'),
+          new TestOption('C'),
+        ],
+      });
+      await settle();
+
+      // What a user is left with has to describe the list as it stands. The
+      // count is not asserted here: React's act() flushes the scheduler, and
+      // with fake timers that can run a queued debounce during the next
+      // render, before the effect cleanup cancels it - a property of the test
+      // harness, not of the editor.
+      const spoken = announce.mock.calls.map(([message]) => message);
+      expect(spoken[spoken.length - 1]).toBe('3 suggestions available');
+    });
+
+    it('still shows the menu when the editor cannot speak', async () => {
+      announce.mockImplementation(() => {
+        throw new Error('no aria live region in this editor');
+      });
+
+      await render({options: [new TestOption('A'), new TestOption('B')]});
+      await settle();
+
+      expect(items()).toHaveLength(2);
+      expect(listbox()).not.toBeNull();
+    });
   });
 });

--- a/packages/lexical-react/src/shared/LexicalMenu.tsx
+++ b/packages/lexical-react/src/shared/LexicalMenu.tsx
@@ -7,6 +7,7 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalAriaLiveRegion} from '@lexical/react/useLexicalAriaLiveRegion';
 import {getScrollParent} from '@lexical/utils';
 import {
   $getSelection,
@@ -76,6 +77,12 @@ export class MenuOption {
   ref?: RefObject<HTMLElement | null>;
   icon?: JSX.Element;
   title?: JSX.Element | string;
+  /**
+   * Spoken name for the option, when the visible content is not what should be
+   * read aloud. Set as `aria-label`, which replaces the element's contents for
+   * naming - so decorative glyphs and shorthand in `title` are not announced.
+   */
+  ariaLabel?: string;
 
   constructor(key: string) {
     this.key = key;
@@ -310,7 +317,8 @@ function MenuItem({
       className={className}
       ref={option.setRefElement}
       role="option"
-      aria-selected={isSelected}
+      aria-label={option.ariaLabel}
+      aria-selected={isSelected || undefined}
       id={'typeahead-item-' + index}
       onMouseEnter={onMouseEnter}
       onClick={onClick}>
@@ -318,6 +326,24 @@ function MenuItem({
       <span className="text">{option.title}</span>
     </li>
   );
+}
+
+/**
+ * Write only on change. A redundant setAttribute still emits a mutation, and
+ * on the focused element that is churn an assistive technology may react to.
+ */
+function setAttrIfChanged(
+  el: HTMLElement,
+  name: string,
+  value: string | null,
+): void {
+  if (value === null) {
+    if (el.hasAttribute(name)) {
+      el.removeAttribute(name);
+    }
+  } else if (el.getAttribute(name) !== value) {
+    el.setAttribute(name, value);
+  }
 }
 
 export function LexicalMenu<TOption extends MenuOption>({
@@ -331,7 +357,9 @@ export function LexicalMenu<TOption extends MenuOption>({
   shouldSplitNodeWithQuery = false,
   commandPriority = COMMAND_PRIORITY_LOW,
   preselectFirstItem = true,
+  ariaLabel,
 }: {
+  ariaLabel?: string;
   close: () => void;
   editor: LexicalEditor;
   anchorElementRef: RefObject<HTMLElement | null>;
@@ -400,8 +428,18 @@ export function LexicalMenu<TOption extends MenuOption>({
   const defaultMenuRenderFn = useCallback(() => {
     return anchorElementRef.current && options.length
       ? ReactDOM.createPortal(
-          <div className="typeahead-popover mentions-menu">
-            <ul>
+          // The <ul> IS the listbox. Two reasons it cannot merely be marked
+          // presentational: a listbox must directly own its options for the
+          // browser to compute set position at all, and the <ul> is the scroll
+          // container - scrollable elements are focusable, and presentational
+          // role conflict resolution ignores role="presentation" on anything
+          // focusable. Marking it up left the options inside a plain list,
+          // which is read as "list, list, list item" with no position.
+          <div className="typeahead-popover mentions-menu" role="presentation">
+            <ul
+              aria-label={ariaLabel ?? 'Typeahead menu'}
+              id="typeahead-listbox"
+              role="listbox">
               {options.map((option, i: number) => (
                 <MenuItem
                   index={i}
@@ -424,17 +462,94 @@ export function LexicalMenu<TOption extends MenuOption>({
       : null;
   }, [
     anchorElementRef,
+    ariaLabel,
     options,
     selectedIndex,
     selectOptionAndCleanUp,
     setHighlightedIndex,
   ]);
 
+  // Nothing in ARIA announces how many suggestions there are, and the moment
+  // it matters most is silent: when nothing matches, there is no list to
+  // describe. A sighted user watches the popup empty out and vanish, and
+  // watches it change length as they type even when the highlighted entry
+  // stays put. None of that reaches a screen reader on its own.
+  //
+  // Keyed on the count alone, so arrowing through the options does not talk
+  // over the option itself, and debounced so a burst of keystrokes produces
+  // one message once typing settles rather than a queue of stale counts.
+  const announce = useLexicalAriaLiveRegion();
+  const optionCount = options.length;
   useEffect(() => {
+    const timeout = setTimeout(() => {
+      try {
+        announce(
+          optionCount === 0
+            ? 'No results'
+            : optionCount === 1
+              ? '1 suggestion available'
+              : `${optionCount} suggestions available`,
+        );
+      } catch (_e) {
+        // The editor has no AriaLiveRegionExtension. The menu still works, it
+        // just cannot speak the count.
+      }
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [optionCount, announce]);
+
+  // The editor is NOT a combobox. It is a rich text field that briefly grows
+  // a suggestion list, and asserting role="combobox" on it has two costs: the
+  // user is told they are in a control they are not in, and because the role
+  // has to be put back afterwards, the change lands on the FOCUSED element -
+  // which a screen reader treats as a re-introduction, re-reading name, role
+  // and value as though focus had moved.
+  //
+  // So the role is never touched. ARIA 1.2 permits aria-activedescendant on
+  // role="textbox", and the option is reachable because the portalled listbox
+  // is explicitly owned. aria-expanded is deliberately absent too: it is not
+  // supported on textbox, and "collapsed" describes a widget that was never
+  // there.
+  //
+  // Net effect: during a whole typeahead session the only attributes that
+  // change on the focused element are aria-owns and aria-activedescendant.
+  const hasOptions = options.length > 0;
+  useEffect(() => {
+    const rootElem = editor.getRootElement();
+    if (rootElem === null) {
+      return;
+    }
+    // The menu is rendered into <body> rather than inside the editor, so that
+    // an ancestor with overflow: hidden cannot clip it. That leaves the
+    // options outside the editor's own DOM, and aria-activedescendant expects
+    // to point at something the editor contains. aria-owns declares the
+    // relationship the DOM no longer shows.
+    setAttrIfChanged(
+      rootElem,
+      'aria-owns',
+      hasOptions ? 'typeahead-listbox' : null,
+    );
+    // Restated from the current highlight rather than written only when the
+    // highlight moves. A menu that loads its options over the network opens
+    // with none, and when they arrive the highlight has not "changed" - it
+    // was clamped to -1 while the list was empty and lands back on 0 - so a
+    // write driven by change alone never happens and the option is never
+    // announced.
+    setAttrIfChanged(
+      rootElem,
+      'aria-activedescendant',
+      hasOptions && selectedIndex !== null && selectedIndex >= 0
+        ? 'typeahead-item-' + selectedIndex
+        : null,
+    );
+  }, [editor, hasOptions, selectedIndex]);
+
+  useEffect(() => {
+    const rootElem = editor.getRootElement();
     return () => {
-      const rootElem = editor.getRootElement();
       if (rootElem !== null) {
-        rootElem.removeAttribute('aria-activedescendant');
+        setAttrIfChanged(rootElem, 'aria-owns', null);
+        setAttrIfChanged(rootElem, 'aria-activedescendant', null);
       }
     };
   }, [editor]);
@@ -621,12 +736,14 @@ export function LexicalMenu<TOption extends MenuOption>({
 function setContainerDivAttributes(
   containerDiv: HTMLElement,
   className?: string,
+  ariaLabel?: string,
 ) {
   if (className != null) {
     containerDiv.className = className;
   }
-  containerDiv.setAttribute('aria-label', 'Typeahead menu');
-  containerDiv.setAttribute('role', 'listbox');
+  // Positioning wrapper only. The listbox role belongs on the element that
+  // directly parents the options - see defaultMenuRenderFn.
+  containerDiv.setAttribute('role', 'presentation');
   containerDiv.style.display = 'block';
   containerDiv.style.position = 'absolute';
 }
@@ -655,6 +772,7 @@ export function useMenuAnchorRef(
   className?: string,
   parent?: HTMLElement,
   shouldIncludePageYOffset__EXPERIMENTAL: boolean = true,
+  ariaLabel?: string,
 ): RefObject<HTMLElement | null> {
   const [editor] = useLexicalComposerContext();
   const resolvedParent: HTMLElement | ShadowRoot | undefined =
@@ -717,10 +835,16 @@ export function useMenuAnchorRef(
       }
 
       if (!containerDiv.isConnected) {
-        setContainerDivAttributes(containerDiv, className);
+        setContainerDivAttributes(containerDiv, className, ariaLabel);
         resolvedParent.append(containerDiv);
       }
       containerDiv.setAttribute('id', 'typeahead-menu');
+
+      // Points at the positioning container, not the listbox inside it.
+      // @lexical/table identifies an open typeahead by string-matching
+      // this exact value, so changing it stops arrow keys reaching the
+      // menu inside a table. aria-owns below carries the ownership that
+      // aria-activedescendant needs.
       rootElement.setAttribute('aria-controls', 'typeahead-menu');
     }
   }, [
@@ -729,6 +853,7 @@ export function useMenuAnchorRef(
     shouldIncludePageYOffset__EXPERIMENTAL,
     className,
     resolvedParent,
+    ariaLabel,
   ]);
 
   useEffect(() => {
@@ -772,7 +897,7 @@ export function useMenuAnchorRef(
     initialAnchorElement != null &&
     initialAnchorElement === anchorElementRef.current
   ) {
-    setContainerDivAttributes(initialAnchorElement, className);
+    setContainerDivAttributes(initialAnchorElement, className, ariaLabel);
     if (resolvedParent != null) {
       resolvedParent.append(initialAnchorElement);
     }


### PR DESCRIPTION
### Why

Someone using a screen reader types `:sm` and a list of emoji suggestions opens. They should hear what the list is called, then the highlighted suggestion and where it sits — "Emojis, list, grinning, 1 of 10" — and one new suggestion each time they arrow. Nothing should be named that they could not have typed.

They should also hear how many matches there are, and hear that number change as they keep typing, even when the highlighted entry has not moved. And when nothing matches at all, they should be told so.

A sighted user gets all of that for free. They watch the list shrink as they type, and they watch it empty out and disappear. None of it reaches a screen reader on its own.

What was heard instead was "Typeahead menu, list, list, list item, 1 of 10". The menu announced itself as a list twice over, and then numbered an item without naming it — you are told you are on the first of ten, and not told what the first of ten is. The position was there all along. The thing it was counting was not.

**None of this is specific to emoji.** Every typeahead menu in the editor is built from one shared component, so the same thing happens in all of them. In the playground that is:

- the **emoji picker**, typing `:`
- the **block menu**, typing `/`
- the **mentions menu**, typing `@`
- the **embed prompt**, after pasting a video or post address

All four are fixed and named here.

---

### Feedback / open questions

Note: I moved this section up because there is a gap I do not know how to close
with the default setup.

By default when someone enables the typeahead there is no
`AriaLiveRegionExtension` and this would cause "10 suggestions available" and
"No results" not to work. The impact to the user would be silence — no way to
tell whether they mistyped, whether the menu is still open, or whether it is
still loading.

The rest of the menu will work and it will address some of the missing
functionality but it will not be complete without the live region.

What is the best way to address this issue when one adds the typeahead menu?

Note: when using the playground by default the live region is active and it
works, because `HistoryAnnounceExtension` is already in use and brings the live
region in with it.

Two smaller observations:

**The menu name.** Giving each menu a real name — "Emojis", "Mentions" —
requires `menuAriaLabel`, which is optional and falls back to "Typeahead menu".
That names the widget, not what is in it. So the default today is the less
accessible option, and an app only gets a properly named menu if it thinks to
ask.

Making it required would be a breaking change, so not for this PR. Worth
considering for a future major version?

**The table coupling.** When a typeahead is open inside a table, arrow keys
should move down the menu rather than between cells. `@lexical/table` works this
out by reading `aria-controls` off the editor and checking it says exactly
`'typeahead-menu'`. So an accessibility attribute quietly controls table
keyboard behaviour from another package, with nothing linking them but that
string. This PR leaves the value alone.

---

### What changed, and what it gives you

**The listbox now holds the options directly.**

This is what the screen reader was handed before:

```
listbox  "Typeahead menu"
  list                        <- this layer is what breaks the announcement
    option  "grinning"
    option  "smiley"
```

The positioning container carried `role="listbox"`, but the options were not inside it. They sat one level down, inside a `<ul>`, and a `<ul>` is a list whether or not you ask for one. That middle line is the second list the user heard, and it is why the suggestions came through as list items: an option is only understood as a choice when the listbox itself holds it.

The `<ul>` is now the listbox, because it is the element that actually holds the options:

```
listbox  "Emojis"
  option  "grinning"
  option  "smiley"
```

*Outcome: one list instead of two, and the suggestions are announced as choices rather than as anonymous entries in a list.*

**The editor owns the list.**

The menu is rendered into `<body>` rather than inside the editor, so that an ancestor with `overflow: hidden` cannot clip it. That leaves the options outside the editor's own DOM. `aria-activedescendant` — how the editor says which option is current — expects to point at something the editor contains, and it no longer does, so the pointer dangles and the screen reader has nothing to follow.

`aria-owns` states the relationship the DOM stopped showing.

*Outcome: the editor's pointer to the current option resolves, so the screen reader follows it as you arrow.*

**The current option is restated, not only written when it moves.**

The mentions menu asks a server for its results, so it opens empty and fills a moment later. The code that tells the screen reader which option is current only ran when the highlight *moved*. Opening empty and then filling is not a move — the highlight sits on the first option before and after — so that code never ran, and the editor went on pointing at nothing.

The user heard the menu open, then heard nothing at all about what was in it.

The pointer is now written from whatever is highlighted right now, rather than only when it changes.

*Outcome: a menu that fetches its results announces the highlighted option as soon as they land.*

**Options can carry their own spoken name.**

An emoji option shows the glyph followed by its shortcode: `🙂 slightly_smiling_face`. A screen reader already pronounces the glyph from its own emoji dictionary — "slightly smiling face" — and then reads the text beside it as well. So the name is announced twice, the second time as a run of underscored words.

The obvious repair is to name the option after the emoji's proper description instead. That reads far better, and it is wrong. Only the shortcode and the tags are searched. A user told the option is "face savouring food" has been handed a name that finds nothing when they type it — the thing that actually matches is "yum".

So `MenuOption` gains an `ariaLabel`: what an option should be *called*, separate from what it *shows*.

*Outcome: an emoji is announced once, by the word you would type to find it.*

**The menus are named.**

Without a name, every menu announces as "list". The emoji picker, the block menu and the mentions menu are indistinguishable by ear — the user has to work out which one they opened from what happens to be in it.

One of the two menu components could not be named at all. The embed prompt is built on the other one, which had no such option, so it always said "Typeahead menu" no matter what it was offering. That prop is added here, so both components can be named.

*Outcome: the user hears "Emojis", "Blocks", "Mentions" or "Embed" — the name of the thing they are choosing from, rather than the name of the widget.*

**The number of matches is spoken aloud.**

Nothing in ARIA announces a count, and the moment it matters most is the one with nothing to describe: when the query matches nothing, there is no list left to talk about, so correct markup is silence.

The count goes through the editor's existing aria live region. It is keyed on the count alone, so arrowing through options never talks over the option itself, and debounced, so a burst of typing produces one message once the user stops rather than a queue of counts from keystrokes ago.

*Outcome: "10 suggestions available", or "No results". The count describes what is on offer, not how many matched — a menu that caps its list at five reports five, because five is all the user can reach.*

---

### What was ruled out, and why

**Marking the `<ul>` presentational.** `role="presentation"` asks the browser to drop an element's role, which on the `<ul>` should have collapsed the tree to the right shape. It has no effect here. That `<ul>` is the scrolling element, scrollable elements can take keyboard focus, and the browser will not drop the role of anything focusable. Nothing warns you — the attribute is accepted and ignored. Hence moving the listbox role onto it instead.

**Stating the position on each option.** `aria-posinset` and `aria-setsize` look like the safe belt-and-braces choice. Once the listbox holds its options, the browser derives the position from that relationship and passes it on, so the attributes only restate what it already knows. They were tried and removed; the position is announced without them.

**Writing the current option only when it changes.** A menu that loads its options over the network opens with none. While the list is empty the highlighted index is clamped to -1, and when the options arrive it lands back on 0 — so it never "changes", the write never happens, and the editor points at nothing. Hence writing it from the current highlight instead.

**Pointing `aria-controls` at the listbox.** The listbox is arguably what the editor controls, so repointing the attribute at it looks like a tidy-up. It breaks arrow keys inside a table. `@lexical/table` decides whether a typeahead is open by comparing that attribute to the literal string `'typeahead-menu'`, so the moment it says anything else the table stops recognising the menu and moves between cells instead of down the list. `aria-controls` is left exactly as it was, and `aria-owns` carries the ownership that `aria-activedescendant` needs.

**Making the editor a combobox.** Pointing at an option this way is usually done by declaring the field a combobox. It is not true here: the editor is a rich text field that briefly offers suggestions, and a user told they are in a combobox will expect a control that is not there. It also has to be undone when the menu closes, and changing the role of the focused element makes a screen reader treat it as something new and read it from the beginning, as though focus had jumped. ARIA 1.2 allows `aria-activedescendant` on a plain text box, so none of it is needed.

**Setting `aria-selected` on every option.** Marking the rest `aria-selected="false"` is legal, but some screen readers then say "not selected" after every arrow press. Only the highlighted option carries it.

**Leaving the emoji in the option's name.** Screen readers pronounce the glyph from their own dictionary, so an option named "🙂 slightly_smiling_face" is announced twice. Naming it by the emoji's description instead reads better — "face savouring food" — but only the shortcode and tags are searched, so the user would be hearing a name they cannot type.

---

### What this does not announce

- **How many matched, only how many are offered.** A menu that caps its list at five says "5 suggestions available" even when forty matched.
- **That the list contents changed while the count stayed the same.** Narrowing from one set of five to a different five says nothing new.
- **Anything on selecting an option.** The user already heard it when they arrowed to it.
- Option ids remain positional (`typeahead-item-0`). When the top match changes the id does not — screen readers tested re-announce on the content change, so this is left alone.

---

### Tests

**17 new unit tests** in `LexicalMenu.test.tsx`, covering:

- **structure** — the listbox holds its options, exactly one list, the listbox is named
- **each option** — `aria-selected` only on the highlighted one, `ariaLabel` overriding visible text
- **what the editor points at** — ownership, options arriving late, never a combobox, cleanup on close
- **the count** — announced, singular form, "No results", and silent while arrowing

**13 of the 17 fail against the unmodified component.** That is what shows they would catch a regression rather than passing regardless. The other four are guard-rails: they assert behaviour that is already correct and would catch it being broken later.

**One existing e2e test was modified.** `Mentions.spec.mjs` → "Sets correct attributes on typeahead menu container" asserted that the positioning container carries `role="listbox"` and the name. That arrangement is the bug, so the assertions move to the listbox, and check that every option is the listbox's own child.

Full e2e suite: **816 passed, 29 skipped, no failures.** Browser tests: 112 passed. Verified by ear with NVDA on Edge across all four menus.

