### PR TITLE
[lexical-playground] Chore: Stabilize the collab dangling-text e2e tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,14 +286,27 @@ For full details on the browser platform APIs involved, see
 [Shadow DOM and iframes](packages/lexical-website/docs/concepts/shadow-dom.md).
 
 ### Commits and Pull Requests
-- Write every commit message to match `.github/pull_request_template.md` so it can seed a PR directly: a `[Affected Packages] PR Type: title` subject line, then the `## Description` and `## Test plan` (Before/After) sections.
+Every commit message — not just PR bodies — must be written to the shape of
+`.github/pull_request_template.md`, so any commit can seed a PR directly
+without being rewritten. This applies to every commit you author, including
+one-line fixes; do not wait to be asked. Read the template rather than working
+from memory, and fill in its sections:
 
-### Build System
-- Uses Rollup for bundling
-- Build script: `scripts/build.mjs`
-- Supports multiple build modes: development, production, www (Meta internal)
-- TypeScript source → compiled to CommonJS and ESM
-- Package manager logic in `scripts/shared/packagesManager.mjs`
+- **Subject line**: `[Affected Packages] PR Type: title`, where the packages are
+  the directory names under `packages/` that the diff touches and the type is
+  one of Breaking change / Refactor / Feature / Bug Fix / Documentation Update /
+  Chore. Test-only and tooling changes are `Chore`.
+- **`## Description`**: what the current behavior is and what this change makes
+  it do. Add `Closes #<issue>` only when there is a real issue number; drop the
+  line otherwise rather than leaving the template's placeholder behind.
+- **`## Test plan`** with `### Before` and `### After` subsections: the command
+  you ran, plus the actual failing output before and passing output after.
+  Paste real output — do not describe it. If a platform or browser in the
+  matrix could not be exercised, say so explicitly under `### After`.
+
+Drop any template section that does not apply to the diff instead of carrying
+an empty heading, and treat the template's HTML comments as instructions to
+follow, not text to copy into the message.
 
 ### Commit and PR Hygiene for Agents
 This is an open source project: never include agent-session URLs or other
@@ -304,3 +317,10 @@ everyone else. Co-authorship attribution (e.g. `Co-Authored-By:`) is fine.
 For Claude Code this is enforced mechanically via `attribution.sessionUrl:
 false` in the checked-in `.claude/settings.json`; agents from other vendors
 should follow this rule as written.
+
+### Build System
+- Uses Rollup for bundling
+- Build script: `scripts/build.mjs`
+- Supports multiple build modes: development, production, www (Meta internal)
+- TypeScript source → compiled to CommonJS and ESM
+- Package manager logic in `scripts/shared/packagesManager.mjs`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Agent Instructions
-
-For detailed architectural guidance, build commands, and development workflows, see **[AGENTS.md](./AGENTS.md)**.
+@AGENTS.md

--- a/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
@@ -25,6 +25,7 @@ import {
   freezeCollabUndoGrouping,
   html,
   initialize,
+  reloadCollabFrame,
   test,
 } from '../utils/index.mjs';
 
@@ -235,6 +236,11 @@ test.describe('Collaboration', () => {
 
     // Left collaborator types two paragraphs of text
     await focusEditor(page);
+    // The undo below expects to revert the whole "This is a test. " burst as a
+    // unit, so drop the Yjs UndoManager's wall-clock capture window — a CI
+    // stall between two keystrokes must not split the burst across stack items
+    // and leave a partial revert behind. See the helper's doc.
+    await freezeCollabUndoGrouping(page);
     await page.keyboard.type('Line 1');
     await page.keyboard.press('Enter');
     await advanceHistoryClock(page);
@@ -287,11 +293,7 @@ test.describe('Collaboration', () => {
     );
 
     // Left collaborator refreshes their page
-    await page.evaluate(() => {
-      document
-        .querySelector('iframe[name="left"]')
-        .contentDocument.location.reload();
-    });
+    await reloadCollabFrame(page, 'left');
 
     // Page content should be the same as before the refresh
     await assertHTML(
@@ -317,6 +319,10 @@ test.describe('Collaboration', () => {
 
     // Left collaborator types two pieces of text in the same paragraph, but with different styling.
     await focusEditor(page);
+    // The undo below expects to revert the bold format *and* the "bold" burst
+    // it applies to as a unit, so drop the Yjs UndoManager's wall-clock capture
+    // window — see the helper's doc.
+    await freezeCollabUndoGrouping(page);
     await page.keyboard.type('normal');
     await assertHTML(
       page,
@@ -386,11 +392,7 @@ test.describe('Collaboration', () => {
     );
 
     // Left collaborator refreshes their page
-    await page.evaluate(() => {
-      document
-        .querySelector('iframe[name="left"]')
-        .contentDocument.location.reload();
-    });
+    await reloadCollabFrame(page, 'left');
 
     // Page content should be the same as before the refresh
     await assertHTML(

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -220,6 +220,56 @@ function rejectOnPageError(page) {
 }
 
 /**
+ * Wait for one collab iframe to finish booting: its toolbar toggle reports a
+ * live provider ("Disconnect" is what it offers once connected) and the editor
+ * has rendered at least one paragraph.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {'left' | 'right'} name the iframe's name attribute
+ */
+export async function waitForCollabFrame(page, name) {
+  const frameLocator = page.frameLocator(`[name="${name}"]`);
+  await expect(frameLocator.locator('.action-button.connect')).toHaveAttribute(
+    'title',
+    /Disconnect/,
+    {timeout: 15000},
+  );
+  await expect(
+    frameLocator.locator('[data-lexical-editor="true"] p').first(),
+  ).toBeVisible({timeout: 15000});
+}
+
+/**
+ * Reload a single collab iframe and wait until it has booted and reconnected.
+ *
+ * A bare `contentDocument.location.reload()` returns as soon as the navigation
+ * is *scheduled*, so a following `assertHTML` has to absorb the whole reload —
+ * bundle fetch, editor mount, websocket connect and the initial Yjs sync —
+ * inside its own 5s polling budget. On a loaded CI runner that overruns, and
+ * the assertion fails while the frame is still booting (the contenteditable
+ * isn't in the DOM yet), which is an intermittent failure that has nothing to
+ * do with what the test is checking. Wait for the navigation to actually start
+ * and for the frame to come back up, so the assertion that follows measures the
+ * restored document rather than the page load.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {'left' | 'right'} name the iframe's name attribute
+ */
+export async function reloadCollabFrame(page, name) {
+  const navigated = page.waitForEvent(
+    'framenavigated',
+    frame => frame.name() === name,
+  );
+  await page.evaluate(frameName => {
+    document
+      .querySelector(`iframe[name="${frameName}"]`)
+      .contentDocument.location.reload();
+  }, name);
+  await navigated;
+  await waitForCollabFrame(page, name);
+}
+
+/**
  * @param {import('@playwright/test').Page} page
  * @param {Promise<never> | null} pageError a promise that rejects if the page
  *   throws an uncaught error, so a broken load fails fast instead of waiting
@@ -236,15 +286,7 @@ async function exposeLexicalEditor(page, pageError = null) {
     // boot/connect hiccup during setup doesn't fail the whole test.
     const waitForCollabFramesReady = () =>
       Promise.all(
-        ['left', 'right'].map(async name => {
-          const frameLocator = page.frameLocator(`[name="${name}"]`);
-          await expect(
-            frameLocator.locator('.action-button.connect'),
-          ).toHaveAttribute('title', /Disconnect/, {timeout: 15000});
-          await expect(
-            frameLocator.locator('[data-lexical-editor="true"] p'),
-          ).toBeVisible({timeout: 15000});
-        }),
+        ['left', 'right'].map(name => waitForCollabFrame(page, name)),
       );
     for (let attempt = 0; ; attempt++) {
       try {


### PR DESCRIPTION
## Description

`Collaboration.spec.mjs` has been intermittently failing on `collab-mac (24.x, webkit)`, at "Remove dangling text from YJS when there is no preceding text node".

Both "dangling text" tests end by reloading the left iframe and asserting that the content survived the refresh:

    await page.evaluate(() => {
      document
        .querySelector('iframe[name="left"]')
        .contentDocument.location.reload();
    });
    await assertHTML(page, html`...`);

`location.reload()` returns as soon as the navigation is *scheduled*, so `assertHTML`'s 5s polling budget also had to cover the bundle fetch, editor mount, websocket connect and initial Yjs sync. When that overran, the assertion failed while the frame was still booting and its contenteditable was not yet in the DOM -- an intermittent failure unrelated to what the test checks.

This adds a `reloadCollabFrame(page, name)` helper that registers a `framenavigated` listener, triggers the reload, then waits for the frame to navigate and come back up, so the assertion that follows measures the restored document rather than the page load. The readiness wait is extracted from the collab startup path in `exposeLexicalEditor` as `waitForCollabFrame`, now scoped with `.first()` since a reloaded frame can already hold several paragraphs where startup only ever saw one.

Both tests also undo a burst of typing and expect the whole burst to revert as a unit, without freezing the Yjs `UndoManager`'s 500ms wall-clock capture window. A stall between two keystrokes splits the burst across stack items and leaves a partial revert behind, so they now call `freezeCollabUndoGrouping` as the other tests in this file already do.

The agent-facing docs are adjusted too, because the rules in `AGENTS.md` were reachable but not actually reaching agents. `CLAUDE.md` described `AGENTS.md` in prose and linked to it, which lets a reader judge the file's relevance from a one-line summary and skip it; its contents are now just `@AGENTS.md`, the import form that inlines the file rather than pointing at it. Within `AGENTS.md`, the existing requirement that commit messages match `.github/pull_request_template.md` was a single bullet separated from the related hygiene section by "Build System"; it is expanded into a per-section breakdown -- how to build the subject line, what belongs under `## Description`, and that `## Test plan` needs real Before/After command output rather than a description of it -- and "Commit and PR Hygiene for Agents" moves up beneath "Commits and Pull Requests" so every commit-message rule lives in one place.

## Test plan

Run the spec against the collab playground:

    CI=true E2E_PORT=4000 E2E_EDITOR_MODE=rich-text-with-collab \
      pnpm exec concurrently -k -s first "pnpm run collab" \
      "pnpm exec cross-env E2E_BROWSER=chromium \
        E2E_EDITOR_MODE=rich-text-with-collab playwright test \
        --project=chromium --workers=4 --retries=0 --repeat-each=3 \
        packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs"

### Before

"Remove dangling text from YJS when there is no preceding text node" failed on every run, at the post-reload assertion (`Collaboration.spec.mjs:297`):

    Error: Timeout 5000ms exceeded while waiting on the predicate

       at packages/lexical-playground/__tests__/utils/index.mjs:394

      > 394 |   }).toPass({intervals: [100, 250, 500], timeout: 5000});
            |      ^
        at assertHTMLOnPageOrFrame (packages/.../utils/index.mjs:394:6)
        at assertHTML (packages/.../utils/index.mjs:426:5)
        at packages/.../e2e/Collaboration.spec.mjs:297:5

`CLAUDE.md` summarized `AGENTS.md` instead of importing it:

    $ cat CLAUDE.md
    # CLAUDE.md

    This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

    ## Agent Instructions

    For detailed architectural guidance, build commands, and development workflows, see **[AGENTS.md](./AGENTS.md)**.

### After

The full spec passes, 6 tests x 3 repeats, 4 workers, no retries:

    Running 18 tests using 4 workers
    ...
      18 passed (2.9m)

`AGENTS.md` is imported rather than described:

    $ cat CLAUDE.md
    @AGENTS.md

WebKit could not be exercised here (Playwright downloads it, but the Linux system libraries it needs are unavailable), so the runs above are Chromium only; the reload race is not browser specific.
