### PR TITLE
[Breaking Change][lexical][lexical-utils][lexical-selection][lexical-website] Bug Fix: LexicalNode.replace no longer re-homes named slots

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSetBlocksTypeSlots.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSetBlocksTypeSlots.test.ts
@@ -20,6 +20,7 @@ import {
   $createTextNode,
   $getRoot,
   $getSlot,
+  $getSlotNames,
   $isParagraphNode,
   $setSlot,
 } from 'lexical';
@@ -75,6 +76,32 @@ describe('$setBlocksType and named slots', () => {
       expect(value).not.toBe(null);
       expect(value!.is(slotPara)).toBe(true);
       expect($isParagraphNode(value)).toBe(true);
+    });
+  });
+
+  // Slots are bound to their host node and are not necessarily portable
+  // across node types, so converting a slot host does not carry its slots
+  // onto the replacement block — they stay on (and are collected with) the
+  // replaced node. See the matching LexicalNode.replace semantics.
+  test('converting a slot host does not carry its slots onto the new block', () => {
+    runInEditor(() => {
+      const host = $createParagraphNode();
+      const bodyText = $createTextNode('body');
+      host.append(bodyText);
+      $getRoot().append(host);
+      const slotPara = $createParagraphNode().append($createTextNode('title'));
+      $setSlot(host, 'title', slotPara);
+      const selection = bodyText.select(0, 0);
+
+      $setBlocksType(selection, () => $createHeadingNode('h2'));
+
+      const heading = $getRoot().getLastChild();
+      expect($isHeadingNode(heading)).toBe(true);
+      expect(heading!.getTextContent()).toBe('body');
+      // The slots did not transfer; they remain on the detached host.
+      expect($getSlotNames(heading!)).toEqual([]);
+      expect(host.isAttached()).toBe(false);
+      expect($getSlot(host, 'title')!.is(slotPara)).toBe(true);
     });
   });
 

--- a/packages/lexical-utils/src/__tests__/unit/LexicalWrapNodeInElementSlots.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalWrapNodeInElementSlots.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$wrapNodeInElement} from '@lexical/utils';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSlot,
+  $getSlotHost,
+  $getSlotNames,
+  $isParagraphNode,
+  $setSlot,
+} from 'lexical';
+import {
+  $createTestShadowRootNode,
+  $isTestShadowRootNode,
+  TestShadowRootNode,
+} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
+
+// Regression for facebook/lexical#8936: $wrapNodeInElement is implemented as
+// `node.replace(wrapper); wrapper.append(node)`. replace() must not strip or
+// re-home named slots — they are bound to the node — so wrapping a slot host
+// preserves its slots.
+describe('$wrapNodeInElement and named slots', () => {
+  test('wrapping a slot host keeps its slots on the host', () => {
+    using editor = buildEditorFromExtensions({
+      $initialEditorState: () => {
+        const host = $createParagraphNode();
+        const slot = $createTestShadowRootNode();
+        slot.append($createParagraphNode().append($createTextNode('Title')));
+        $getRoot().append(host);
+        $setSlot(host, 'title', slot);
+      },
+      name: '[wrap-slots]',
+      nodes: [TestShadowRootNode],
+    });
+
+    editor.update(
+      () => {
+        const host = $getRoot().getFirstChildOrThrow();
+        const wrapper = $wrapNodeInElement(host, $createTestShadowRootNode);
+
+        // The wrapped host keeps its slot; the wrapper gains none.
+        expect(wrapper.getFirstChild()!.is(host)).toBe(true);
+        expect($getSlotNames(wrapper)).toEqual([]);
+        expect($getSlot(host, 'title')).not.toBe(null);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const wrapper = $getRoot().getFirstChildOrThrow();
+      assert($isTestShadowRootNode(wrapper));
+      const host = wrapper.getFirstChildOrThrow();
+      assert($isParagraphNode(host));
+      expect(host.isAttached()).toBe(true);
+      const slot = $getSlot(host, 'title');
+      expect(slot).not.toBe(null);
+      expect(slot!.getTextContent()).toBe('Title');
+      expect($getSlotHost(slot!)!.is(host)).toBe(true);
+    });
+  });
+});

--- a/packages/lexical-website/docs/concepts/named-slots.md
+++ b/packages/lexical-website/docs/concepts/named-slots.md
@@ -345,6 +345,17 @@ re-applying it from `updateDOM` so an editable toggle reaches the island.
   than replace it: the slot assignment is managed by the node or extension
   that owns the slot. Calling `LexicalNode.replace` directly on a slot value
   throws; reassign the slot with `$setSlot` on its host instead.
+- **Slots stay bound to their host through `replace`.** Replacing a slot
+  *host* (`host.replace(other)`) does not transfer its slots to the
+  replacement — slots are not necessarily portable across node types, so the
+  slot map travels with the node, never with its position. If the replaced
+  host is reattached in the same update (the
+  [`$wrapNodeInElement`](/docs/api/modules/lexical_utils#wrapnodeinelement)
+  pattern) it keeps its slots; if it stays detached, its slot subtrees are
+  garbage-collected with it. The same applies to anything built on `replace`:
+  converting a slot host with `$setBlocksType` produces a slot-less
+  replacement block. Move a slot onto another host explicitly with
+  `$setSlot`.
 - **A NodeSelection of an element carries its children.** Copy and export
   of a whole-host NodeSelection (e.g. a chrome click that selects "the whole
   Card") include the host's body children even though they aren't in the

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -49,14 +49,9 @@ import {
 } from './LexicalSelection';
 import {
   $errorOnSlotCycleChild,
-  $getSlot,
   $getSlotHost,
   $getSlotHostKey,
-  $getSlotNames,
   $getSlotsTextContent,
-  $isSlotHost,
-  $removeSlot,
-  $setSlot,
 } from './LexicalSlot';
 import {
   errorOnReadOnly,
@@ -1623,6 +1618,12 @@ export class LexicalNode {
    * Replaces this LexicalNode with the provided node, optionally transferring the children
    * of the replaced node to the replacing node.
    *
+   * Named slots are bound to their host node and are never transferred: this
+   * node keeps its slot map, so if it is reattached elsewhere (as
+   * `$wrapNodeInElement` does) its slots come with it, and if it stays
+   * detached the slot subtrees are garbage-collected along with it. To move a
+   * slot value onto another host, use `$setSlot` explicitly.
+   *
    * @param replaceWith - The node to replace this one with.
    * @param includeChildren - Whether or not to transfer the children of this node to the replacing node.
    * */
@@ -1719,31 +1720,6 @@ export class LexicalNode {
         0,
         this.getChildren(),
       );
-    }
-    // Slots live in a separate Map keyed off __slotHost, not the child list,
-    // so the splice above (when includeChildren) never moves them — and
-    // decorator hosts skip that branch entirely. Re-home each slot onto the
-    // replacement regardless of includeChildren ($setSlot has move semantics;
-    // the explicit $removeSlot keeps the doomed host's map consistent before
-    // it is destroyed); otherwise they orphan and GC. Slot-less nodes have no
-    // names, so this is a no-op.
-    const slotNames = $getSlotNames(this);
-    if (slotNames.length > 0) {
-      if (!$isSlotHost(this) || !$isSlotHost(writableReplaceWith)) {
-        invariant(
-          false,
-          'replace: node %s has slots but %s cannot host them; only ElementNodes and DecoratorNodes can host slots.',
-          this.__key,
-          writableReplaceWith.__key,
-        );
-      }
-      for (const slotName of slotNames) {
-        const slot = $getSlot(this, slotName);
-        if (slot !== null) {
-          $removeSlot(this, slotName);
-          $setSlot(writableReplaceWith, slotName, slot);
-        }
-      }
     }
     if ($isRangeSelection(selection)) {
       $setSelection(selection);

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -1781,49 +1781,102 @@ describe('named-slots: core foundation', () => {
     expect(text).toContain('SLOTTEXT');
   });
 
-  test('replace(includeChildren) carries slots onto the replacement', () => {
+  // Slots are tightly bound to their host node, so replace() must not move
+  // them onto the replacement — the replaced host keeps its slot map, and when
+  // it stays detached the slot subtree is garbage-collected with it at commit
+  // (via the dual-channel slot GC).
+  test('replace(includeChildren) does not transfer slots; they GC with the replaced host', () => {
     using editor = createSlotEditor();
-    let survived = false;
+    let newHostKey = '';
+    let oldHostKey = '';
+    let slotKey = '';
     editor.update(
       () => {
         const host = $createParagraphNode();
         const slot = $slotContainer('SLOTTEXT');
         $getRoot().append(host);
         $setSlot(host, 'title', slot);
+        oldHostKey = host.getKey();
+        slotKey = slot.getKey();
         const newHost = $createParagraphNode();
         host.replace(newHost, true);
-        const got = $getSlot(newHost, 'title');
-        survived = got !== null && got.getTextContent() === 'SLOTTEXT';
+        newHostKey = newHost.getKey();
+        // The slot stays on the replaced host, not the replacement.
+        expect($getSlot(newHost, 'title')).toBe(null);
+        expect($getSlotNames(newHost)).toEqual([]);
+        expect($getSlot(host, 'title')!.is(slot)).toBe(true);
+        expect(host.isAttached()).toBe(false);
       },
       {discrete: true},
     );
-    expect(survived).toBe(true);
+    editor.read(() => {
+      // The detached host and its slot subtree were garbage-collected.
+      expect($getNodeByKey(oldHostKey)).toBe(null);
+      expect($getNodeByKey(slotKey)).toBe(null);
+      expect($getNodeByKey(newHostKey)!.isAttached()).toBe(true);
+    });
   });
 
-  // Decorator hosts can't carry children (includeChildren stays false), so the
-  // slot re-home must run independently of that gate; otherwise replacing a
-  // decorator host orphans its slots. Fails before the re-home left the
-  // includeChildren branch, passes after.
-  test('replace carries slots onto a decorator host without includeChildren', () => {
+  test('replace on a decorator host does not transfer slots; they GC with it', () => {
     using editor = createSlotEditor();
-    let survived = false;
-    let oldHostAttached = true;
+    let oldHostKey = '';
+    let slotKey = '';
     editor.update(
       () => {
         const host = $createTestDecoratorNode().setIsInline(false);
         const slot = $slotContainer('SLOTTEXT');
         $getRoot().append(host);
         $setSlot(host, 'media', slot);
+        oldHostKey = host.getKey();
+        slotKey = slot.getKey();
         const newHost = $createTestDecoratorNode().setIsInline(false);
         host.replace(newHost);
-        const got = $getSlot(newHost, 'media');
-        survived = got !== null && got.getTextContent() === 'SLOTTEXT';
-        oldHostAttached = host.isAttached();
+        expect($getSlot(newHost, 'media')).toBe(null);
+        expect($getSlot(host, 'media')!.is(slot)).toBe(true);
+        expect(host.isAttached()).toBe(false);
       },
       {discrete: true},
     );
-    expect(survived).toBe(true);
-    expect(oldHostAttached).toBe(false);
+    editor.read(() => {
+      expect($getNodeByKey(oldHostKey)).toBe(null);
+      expect($getNodeByKey(slotKey)).toBe(null);
+    });
+  });
+
+  // Regression for facebook/lexical#8936: $wrapNodeInElement is
+  // `node.replace(wrapper); wrapper.append(node)`. Because replace leaves the
+  // slot map on the node, the wrapped host keeps its slots when it is
+  // reattached in the same update.
+  test('a replaced host reattached in the same update keeps its slots (wrap pattern)', () => {
+    using editor = createSlotEditor();
+    let hostKey = '';
+    let slotKey = '';
+    editor.update(
+      () => {
+        const host = $createParagraphNode();
+        const slot = $slotContainer('SLOTTEXT');
+        $getRoot().append(host);
+        $setSlot(host, 'title', slot);
+        hostKey = host.getKey();
+        slotKey = slot.getKey();
+        // the $wrapNodeInElement pattern from @lexical/utils
+        const wrapper = $createTestShadowRootNode();
+        host.replace(wrapper);
+        wrapper.append(host);
+        expect($getSlot(host, 'title')!.is(slot)).toBe(true);
+        expect($getSlotNames(wrapper)).toEqual([]);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const host = $assertNodeType($getNodeByKey(hostKey), $isParagraphNode);
+      expect(host.isAttached()).toBe(true);
+      const slot = $getSlot(host, 'title');
+      expect(slot).not.toBe(null);
+      expect(slot!.getKey()).toBe(slotKey);
+      expect(slot!.getTextContent()).toBe('SLOTTEXT');
+      expect($getSlotHost(slot!)!.is(host)).toBe(true);
+    });
   });
 
   // Slots are a separate channel, so $destroyNode's child recursion doesn't


### PR DESCRIPTION
## Description

Previously, `LexicalNode.replace` moved the replaced node's named slots onto the replacement node. Slots are tightly bound to their host node and are not necessarily portable across node types, so this re-homing is removed: the replaced node keeps its slot map. If it is reattached in the same update (the `$wrapNodeInElement` pattern) its slots come with it, and if it stays detached its slot subtrees are garbage-collected with it via the existing dual-channel slot GC. Anything built on `replace()`, such as `$setBlocksType`, now produces a slot-less replacement block.

This also fixes the bug where `$wrapNodeInElement` stripped the wrapped node's slots, because `replace()` re-homed them onto the wrapper.

- Remove the re-home block (and its invariant) from `LexicalNode.replace`
- Repoint the LexicalSlot tests that pinned the re-home at the new semantics, and add a wrap-pattern regression test
- Add a `$wrapNodeInElement` slot-preservation test in `@lexical/utils`
- Pin the new `$setBlocksType` behavior (converted hosts drop slots)
- Document the node-bound slot lifecycle in the named-slots concepts doc

Closes #8936

## Test plan

### Before

`host.replace(other)` moved every named slot onto `other`; `$wrapNodeInElement(host, ...)` left the wrapped host slot-less. The tests `replace(includeChildren) carries slots onto the replacement` and `replace carries slots onto a decorator host without includeChildren` pinned that behavior.

### After

Slots stay on the replaced node. Covered by the updated LexicalSlot tests (no transfer + GC of the detached host's slots, wrap pattern keeps slots), the new `LexicalWrapNodeInElementSlots` regression test, and the new `$setBlocksType` slot-host test. Full unit suite, browser tests for core/utils/selection, tsc, eslint, and prettier all pass.
