### PR TITLE
[lexical-yjs] Bug Fix: Don't sync root textFormat/textStyle

### DIFF
--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -82,7 +82,11 @@ const elementExcludedProperties = new Set<string>([
   '__last',
   '__size',
 ]);
-const rootExcludedProperties = new Set<string>(['__cachedText']);
+const rootExcludedProperties = new Set<string>([
+  '__cachedText',
+  '__textFormat',
+  '__textStyle',
+]);
 const textExcludedProperties = new Set<string>(['__text']);
 
 // @experimental named-slots. Writes the slots Y.Map onto a host shared type.


### PR DESCRIPTION
## Description

`ElementNode.__textFormat` and `__textStyle` are synced for every element, including the root. On the root this produces a stream of pointless updates to the shared document.

The reconciler derives these from the first `TextNode` of an element's subtree (`reconcileTextFormat` / `reconcileTextStyle`), so an *empty* block remembers the formatting the next typed character inherits. 

The root can't be typed into, so the value serves no purpose there. It also never settles: the reconciler sets it from the first text node it meets while rendering, and a partial re-render only covers the part that changed. Loading the document sets the root from the first block, then editing a block further down replaces it with that block's formatting. Every flip is a Yjs update sent to every collaborator, and every client rewrites it on load.

It also isn't limited to users who can edit: `reconcileTextFormat` is gated on `!activeEditorStateReadOnly`, not `editor.isEditable()`, so read-only clients emit these updates too. This was how I found the issue - read-only clients attempting to edit docs and causing errors.

Lexical already treats the value as non-persistable on the root; `ElementNode.exportJSON` skips it there, and for any element with `TextNode` children, *"Only persist for cases when there are no TextNode children from which these would be set on reconcile (#7968)"*. This adds the two properties to `rootExcludedProperties` alongside `__cachedText` so the binding agrees. The reconciler still sets it locally, and existing documents keep their stored values, just ignored.

Blocks are unchanged: an empty block has no text to derive from, so its value is real state and still syncs.

Related: #7968, #7971

## Test plan

No automated test: `Collaboration.test.ts` can't reproduce it, because `activeEditorStateReadOnly` is true in that harness so the reconciler never derives the value. There's also no existing coverage of `rootExcludedProperties` to extend. Guidance welcome.

Verified in a browser. Open a document whose first text run is formatted, then edit a differently formatted block and reload.

### Before

```js
doc.get('root', Y.XmlElement).getAttributes()
// { __textFormat: 1, __textStyle: 'color: #00518F;' }
```

A new update every time the value flips.

### After

```js
doc.get('root', Y.XmlElement).getAttributes()
// {}
```

No updates. The root still holds the value locally, only the sharing is removed. Empty blocks still round-trip their `textFormat` / `textStyle`.