### PR TITLE
[lexical-react] Bug Fix: Update the typeahead query during IME composition

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -285,9 +285,11 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
           return;
         }
 
-        if (editor.isComposing()) {
-          return;
-        }
+        const closeUnlessComposing = () => {
+          if (!editor.isComposing()) {
+            closeTypeahead();
+          }
+        };
 
         const editorWindow = editor._window || window;
         const range = editorWindow.document.createRange();
@@ -300,7 +302,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
           text === null ||
           range === null
         ) {
-          closeTypeahead();
+          closeUnlessComposing();
           return;
         }
 
@@ -328,7 +330,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
             return;
           }
         }
-        closeTypeahead();
+        closeUnlessComposing();
       });
     };
 

--- a/packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx
@@ -20,6 +20,10 @@ import {
 import {
   $createParagraphNode,
   $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  $setCompositionKey,
   DELETE_CHARACTER_COMMAND,
   type LexicalEditor,
   ParagraphNode,
@@ -496,6 +500,221 @@ describe('LexicalTypeaheadMenuPlugin', () => {
       });
 
       expect(callOrder).toEqual(['onClose']);
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(
+        document.querySelector('[data-testid="custom-typeahead"]'),
+      ).toBeNull();
+    });
+  });
+
+  describe('IME composition', () => {
+    beforeEach(() => {
+      class ResizeObserverMock {
+        constructor(_callback: unknown) {}
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+      vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    const menuRenderFn: MenuRenderFn<TestMenuOption> = (
+      anchorElementRef,
+      itemProps,
+      matchingString,
+    ) => {
+      return anchorElementRef.current && itemProps.options.length
+        ? ReactDOM.createPortal(
+            <div
+              className="custom-typeahead-menu"
+              data-testid="custom-typeahead">
+              <ul />
+              {matchingString != null && (
+                <span data-testid="matching-string">{matchingString}</span>
+              )}
+            </div>,
+            anchorElementRef.current,
+          )
+        : null;
+    };
+
+    function Harness({
+      onQueryChange = vi.fn(),
+      onClose,
+    }: {
+      onQueryChange?: (matchingString: string | null) => void;
+      onClose?: () => void;
+    }) {
+      const checkForTriggerMatch = useBasicTypeaheadTriggerMatch('/', {
+        minLength: 0,
+      });
+      const onSelectOption = useCallback(
+        (
+          _option: TestMenuOption,
+          _nodeToRemove: TextNode | null,
+          closeMenu: () => void,
+        ) => {
+          closeMenu();
+        },
+        [],
+      );
+      return (
+        <LexicalTypeaheadMenuPlugin<TestMenuOption>
+          onQueryChange={onQueryChange}
+          onSelectOption={onSelectOption}
+          triggerFn={checkForTriggerMatch}
+          options={TEST_OPTIONS}
+          menuRenderFn={menuRenderFn}
+          onClose={onClose}
+        />
+      );
+    }
+
+    function $insertTrigger(): void {
+      $getRoot()
+        .clear()
+        .append($createParagraphNode())
+        .select()
+        .insertText('/');
+    }
+
+    function $getQueryTextNode(): TextNode {
+      const textNode = $getRoot().getFirstDescendant();
+      if (!$isTextNode(textNode)) {
+        throw new Error('expected a text node holding the query');
+      }
+      return textNode;
+    }
+
+    function $compose(text: string): void {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) {
+        throw new Error('expected a range selection');
+      }
+      selection.insertText(text);
+      $setCompositionKey(selection.anchor.key);
+    }
+
+    function $dropTriggerWhileComposing(): void {
+      const textNode = $getQueryTextNode();
+      textNode.setTextContent('햄');
+      $setCompositionKey(textNode.getKey());
+    }
+
+    async function mountAndCompose(
+      props: React.ComponentProps<typeof Harness>,
+    ): Promise<LexicalEditor> {
+      const editorRef = React.createRef<LexicalEditor>();
+      const App = createApp(
+        <>
+          <EditorRefPlugin editorRef={editorRef} />
+          <Harness {...props} />
+        </>,
+        [ParagraphNode],
+      );
+
+      await act(async () => {
+        reactRoot.render(<App />);
+      });
+
+      const editor = editorRef.current;
+      if (editor === null) {
+        throw new Error('expected the editor ref to be populated');
+      }
+
+      await act(async () => {
+        editor.update($insertTrigger);
+      });
+
+      await act(async () => {
+        editor.update(() => $compose('햄'));
+      });
+
+      return editor;
+    }
+
+    it('reports the query while composing without closing the menu', async () => {
+      const onQueryChange = vi.fn();
+      const editorRef = React.createRef<LexicalEditor>();
+      const App = createApp(
+        <>
+          <EditorRefPlugin editorRef={editorRef} />
+          <Harness onQueryChange={onQueryChange} />
+        </>,
+        [ParagraphNode],
+      );
+
+      await act(async () => {
+        reactRoot.render(<App />);
+      });
+
+      const editor = editorRef.current;
+      expect(editor).not.toBeNull();
+
+      await act(async () => {
+        editor!.update($insertTrigger);
+      });
+
+      expect(
+        document.querySelector('[data-testid="custom-typeahead"]'),
+      ).not.toBeNull();
+
+      onQueryChange.mockClear();
+
+      await act(async () => {
+        editor!.update(() => $compose('햄'));
+      });
+
+      expect(editor!.isComposing()).toBe(true);
+      expect(onQueryChange).toHaveBeenCalledWith('햄');
+      expect(
+        document.querySelector('[data-testid="custom-typeahead"]'),
+      ).not.toBeNull();
+      expect(
+        document.querySelector('[data-testid="matching-string"]')?.textContent,
+      ).toBe('햄');
+    });
+
+    it('keeps the menu open when the trigger match is lost while composing', async () => {
+      const onClose = vi.fn();
+      const editor = await mountAndCompose({onClose});
+
+      await act(async () => {
+        editor.update($dropTriggerWhileComposing);
+      });
+
+      expect(editor.isComposing()).toBe(true);
+      expect(onClose).not.toHaveBeenCalled();
+      expect(
+        document.querySelector('[data-testid="custom-typeahead"]'),
+      ).not.toBeNull();
+    });
+
+    it('closes the menu once composition ends without a trigger match', async () => {
+      const onClose = vi.fn();
+      const editor = await mountAndCompose({onClose});
+
+      await act(async () => {
+        editor.update($dropTriggerWhileComposing);
+      });
+
+      expect(
+        document.querySelector('[data-testid="custom-typeahead"]'),
+      ).not.toBeNull();
+
+      await act(async () => {
+        editor.update(() => {
+          $setCompositionKey(null);
+          $getQueryTextNode().markDirty();
+        });
+        await Promise.resolve();
+      });
+
+      expect(editor.isComposing()).toBe(false);
       expect(onClose).toHaveBeenCalledTimes(1);
       expect(
         document.querySelector('[data-testid="custom-typeahead"]'),

--- a/packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx
@@ -170,7 +170,10 @@ describe('LexicalTypeaheadMenuPlugin', () => {
     reactRoot = createRoot(container);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await act(async () => {
+      reactRoot.unmount();
+    });
     document.body.removeChild(container);
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## Description
`LexicalTypeaheadMenuPlugin` does not update its query while an IME composition is in progress, so the menu keeps showing results for the text that preceded the composition. Typing `/한글` shows the results for `/`, and they only catch up once composition ends.

This is a follow-up to #7987 (fix for #7985). That PR stopped the menu from closing mid-composition by bailing out of the update listener entirely:

```ts
if (editor.isComposing()) {
  return;
}
```

The bail-out is wider than the problem it solves. Only the closing is undesirable during composition — the trigger match and onQueryChange are still meaningful, and skipping them is what leaves the menu stale.

### What changed

#### `packages/lexical-react`
- **Narrow the composition guard to the close paths**
    - `closeUnlessComposing()` replaces the early return, so `triggerFn` and `onQueryChange` run while composing and the menu filters as you type.
    - The menu still never closes mid-composition, which is what #7985 needed

## Test plan
- Unit tests for composing: query reported, menu kept open when the trigger match is lost, menu closed once composition ends
- Unmount the React root between tests — the menu portals into an anchor on `document.body`, so a test ending with it open leaked into later tests

### Before
- packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx — 1 failed | 10 passed.
-  Of the three new IME composition tests, `reports the query while composing without closing the menu` fails (`expected "vi.fn()" to be called with arguments: [ '햄' ]` / `Number of calls: 0`), because the update listener returns early while `editor.isComposing()` is true and never computes the query.
- The other two pass on `main` as well — they guard against the opposite regression, where the menu would close mid-composition.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/028d839e-61f0-4d19-888f-25c6f800ae76" />

### After
- packages/lexical-react/src/__tests__/unit/LexicalTypeaheadMenuPlugin.test.tsx — 11 passed.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/1cf0087e-dee6-454c-9716-e3f5564d7f39" />

Related: #7985, #7987