### PR TITLE
[lexical] Bug Fix: delete the adjacent ElementNode from a block cursor

### DIFF
--- a/packages/lexical-playground/__tests__/unit/CardNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/CardNode.test.ts
@@ -329,6 +329,56 @@ describe('CardNode named slots', () => {
     });
   });
 
+  // A Card is a shadow root, so a caret placed between two of them renders a
+  // block cursor rather than a text position. Backspace there has to delete
+  // the Card it sits against — including its named slots — the same way it
+  // deletes an adjacent block DecoratorNode (#8939).
+  it.for([
+    {isBackward: true, survivor: 'B'},
+    {isBackward: false, survivor: 'A'},
+  ])(
+    'block cursor between two Cards deletes one (isBackward: $isBackward)',
+    ({isBackward, survivor}) => {
+      using editor = buildEditorFromExtensions(CardTestExtension);
+
+      editor.update(
+        () => {
+          const a = $createCardNode();
+          const b = $createCardNode();
+          for (const [card, label] of [
+            [a, 'A'],
+            [b, 'B'],
+          ] as const) {
+            const title = $getSlot(card, 'title');
+            assert($isParagraphNode(title), 'title slot must be a paragraph');
+            title.append($createTextNode(label));
+          }
+          $getRoot().clear().append(a, b);
+          // The block cursor sits between the two Cards.
+          $getRoot().select(1, 1);
+        },
+        {discrete: true},
+      );
+
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          assert($isRangeSelection(selection), 'Expected a RangeSelection');
+          selection.deleteCharacter(isBackward);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        expect($getRoot().getChildrenSize()).toBe(1);
+        const card = $getRoot().getFirstChild();
+        assert($isCardNode(card), 'The other Card must survive');
+        // The slot went with the deleted host, and the survivor kept its own.
+        expect($getSlot(card, 'title')?.getTextContent()).toBe(survivor);
+      });
+    },
+  );
+
   // Mid-text deletion inside the bare title value rides core's
   // deleteCharacter: $getNearestRootOrShadowRoot treats the slotted value as
   // its own scope root (the slot link is a virtual shadow root), so the

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -90,6 +90,7 @@ import {
   $isRootOrShadowRoot,
   $isSelectionCapturedInDecoratorInput,
   $isTokenOrSegmented,
+  $needsBlockCursorBeside,
   $setCompositionKey,
   doesContainSurrogatePair,
   getActiveElement,
@@ -1690,6 +1691,22 @@ export class RangeSelection implements BaseSelection {
           .getTextSlices()
           .every(slice => slice === null || slice.distance === 0)
       ) {
+        // The caret is an element point sitting directly beside a node that
+        // renders a block cursor ($needsBlockCursorBeside). There is no text
+        // position between the two, so the only thing the keystroke can mean
+        // is "delete that node", exactly as the DecoratorNode case below
+        // does. Decorators are left to that branch since it also honours
+        // isIsolated(); an ElementNode host (a shadow root such as a table or
+        // a slot-bearing card) has no such opt-out and was previously left
+        // untouched, because the loop below descends into it as a ChildCaret
+        // and bails out at the shadow root instead of deleting it.
+        if (anchor.type === 'element') {
+          const adjacent = initialCaret.getNodeAtCaret();
+          if ($isElementNode(adjacent) && $needsBlockCursorBeside(adjacent)) {
+            adjacent.remove();
+            return;
+          }
+        }
         // There's no text in the direction of the deletion so we can explore our options
         let state:
           | {type: 'initial'}

--- a/packages/lexical/src/__tests__/unit/Issue8939Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue8939Repro.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $needsBlockCursorBeside,
+  type LexicalNode,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+import {
+  $createTestDecoratorNode,
+  $createTestShadowRootNode,
+  TestDecoratorNode,
+  TestShadowRootNode,
+} from '../utils';
+
+const ext = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '[8939]',
+  nodes: [TestDecoratorNode, TestShadowRootNode],
+});
+
+function $blockDecorator(): LexicalNode {
+  return $createTestDecoratorNode().setIsInline(false);
+}
+
+function $shadowRoot(label: string): LexicalNode {
+  return $createTestShadowRootNode().append(
+    $createParagraphNode().append($createTextNode(label)),
+  );
+}
+
+// The block cursor is what Lexical renders when the selection is an element
+// point directly beside a node that `$needsBlockCursorBeside`. There is no
+// text position there, so Backspace/Delete can only mean "remove that node".
+// That already worked for a block DecoratorNode, but a shadow-root
+// ElementNode host (a table, or a slot-bearing card) was left untouched.
+describe('block cursor deletion beside an ElementNode (#8939)', () => {
+  test.for([
+    {isBackward: true, kind: 'decorator' as const},
+    {isBackward: false, kind: 'decorator' as const},
+    {isBackward: true, kind: 'shadowRoot' as const},
+    {isBackward: false, kind: 'shadowRoot' as const},
+  ])(
+    'deletes the adjacent $kind (isBackward: $isBackward)',
+    ({kind, isBackward}) => {
+      using editor = buildEditorFromExtensions(ext);
+      const $make =
+        kind === 'decorator' ? $blockDecorator : () => $shadowRoot('x');
+      let keyA = '';
+      let keyB = '';
+
+      editor.update(
+        () => {
+          const a = $make();
+          const b = $make();
+          keyA = a.getKey();
+          keyB = b.getKey();
+          $getRoot().clear().append(a, b);
+          // The block cursor position between the two nodes.
+          $getRoot().select(1, 1);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        // Both sides render a block cursor, so both must delete the same way.
+        expect($needsBlockCursorBeside($getRoot().getChildAtIndex(0))).toBe(
+          true,
+        );
+        expect($needsBlockCursorBeside($getRoot().getChildAtIndex(1))).toBe(
+          true,
+        );
+      });
+
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          assert($isRangeSelection(selection), 'Expected RangeSelection');
+          selection.deleteCharacter(isBackward);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        expect($getRoot().getChildrenSize()).toBe(1);
+        // Backspace removes the node before the cursor, Delete the one after.
+        expect($getRoot().getChildAtIndex(0)!.getKey()).toBe(
+          isBackward ? keyB : keyA,
+        );
+      });
+    },
+  );
+
+  test('Backspace after the last shadow root deletes it', () => {
+    using editor = buildEditorFromExtensions(ext);
+
+    editor.update(
+      () => {
+        $getRoot().clear().append($shadowRoot('A'), $shadowRoot('B'));
+        $getRoot().select(2, 2);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1);
+      expect($getRoot().getTextContent()).toBe('A');
+    });
+  });
+
+  // Guard the boundary of the new branch: an empty block whose caret merely
+  // sits next to a shadow root is not a block cursor, so the existing
+  // "remove the empty block, keep the shadow root" behaviour must survive.
+  test('Backspace in an empty block after a shadow root removes the block, not the shadow root', () => {
+    using editor = buildEditorFromExtensions(ext);
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().clear().append($shadowRoot('A'), paragraph);
+        paragraph.select(0, 0);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1);
+      expect($getRoot().getTextContent()).toBe('A');
+    });
+  });
+
+  // A plain paragraph never renders a block cursor, so it must not be
+  // removed as a unit.
+  test('a paragraph does not need a block cursor beside it', () => {
+    using editor = buildEditorFromExtensions(ext);
+
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('A')));
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($needsBlockCursorBeside($getRoot().getChildAtIndex(0))).toBe(
+        false,
+      );
+    });
+  });
+});


### PR DESCRIPTION
A block cursor is rendered whenever the selection is an element point next to a node that `$needsBlockCursorBeside` — a block `DecoratorNode`, or a non-inline shadow root such as a table or a slot-bearing card. There is no text position at that spot, so Backspace/Delete can only mean "remove that node".

`deleteCharacter` only did that for a decorator. For an `ElementNode` the caret walk descends into it as a `ChildCaret` and hits the "don't merge with a shadow root block" guard, which returns without deleting anything unless the anchor is an empty block — so a block cursor between two cards did nothing at all, in either direction.

This removes the adjacent node when the collapsed anchor is an element point beside a block-cursor `ElementNode`. Decorators keep going through the existing branch, which also honours `isIsolated()`.

Tests cover both directions against a decorator and a shadow root side by side (the decorator cases pin the behaviour that already worked), backspace after the last shadow root, and the two boundaries: an empty block next to a shadow root still removes the block, and a plain paragraph still merges.

Fixes #8939
