### PR TITLE
[lexical] Bug Fix: refresh selection format and style on a programmatic move

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3438,6 +3438,48 @@ export function $internalCreateRangeSelection(
   return newSelection;
 }
 
+/**
+ * Re-reads the format and style that a collapsed insertion would use from the
+ * selection's anchor, after a programmatic move has repointed it at a
+ * different node.
+ *
+ * {@link $internalCreateSelection} already does this for every selection
+ * change that originates in the DOM (a click, an arrow key), which is why
+ * those keep the toolbar in sync. Moving the selection through the node APIs
+ * bypassed it, so the format and style of the old position leaked into the new
+ * one (#8817).
+ *
+ * Landing on the same node is not a move: a format toggled on a collapsed
+ * caret is armed for the next insertion and is deliberately not backed by the
+ * node yet, so it must survive being re-selected in place.
+ *
+ * @internal
+ */
+export function $internalRefreshSelectionFormatAndStyle(
+  selection: RangeSelection,
+  previousAnchorKey: NodeKey,
+): void {
+  const anchor = selection.anchor;
+  if (anchor.key === previousAnchorKey) {
+    return;
+  }
+  const anchorNode = anchor.getNode();
+  let format = 0;
+  let style = '';
+  if ($isTextNode(anchorNode)) {
+    format = anchorNode.getFormat();
+    style = anchorNode.getStyle();
+  } else if ($isElementNode(anchorNode)) {
+    format = anchorNode.getTextFormat();
+    style = anchorNode.getTextStyle();
+  }
+  if (selection.format !== format || selection.style !== style) {
+    selection.format = format;
+    selection.style = style;
+    selection.dirty = true;
+  }
+}
+
 function $validatePoint(name: 'anchor' | 'focus', point: PointType): void {
   const node = $getNodeByKey(point.key);
   invariant(

--- a/packages/lexical/src/__tests__/unit/Issue8817Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue8817Repro.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {$patchStyleText} from '@lexical/selection';
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $setSelection,
+  type TextNode,
+} from 'lexical';
+import {initializeUnitTest, invariant} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+/**
+ * Builds `<p>Hello</p><p>World</p>` and returns both text nodes. "Hello" is
+ * always left plain so it can stand in for an unformatted destination.
+ */
+function $setUpTwoParagraphs(): {first: TextNode; second: TextNode} {
+  const root = $getRoot();
+  root.clear();
+  const firstParagraph = $createParagraphNode();
+  const first = $createTextNode('Hello');
+  firstParagraph.append(first);
+  const secondParagraph = $createParagraphNode();
+  const second = $createTextNode('World');
+  secondParagraph.append(second);
+  root.append(firstParagraph, secondParagraph);
+  return {first, second};
+}
+
+/** Places a collapsed caret at `offset` inside `node`, with no format/style. */
+function $placeFreshCaret(node: TextNode, offset: number): void {
+  const selection = $createRangeSelection();
+  selection.anchor.set(node.getKey(), offset, 'text');
+  selection.focus.set(node.getKey(), offset, 'text');
+  $setSelection(selection);
+}
+
+describe('Programmatically moving a Selection updates format and style (#8817)', () => {
+  initializeUnitTest(testEnv => {
+    test('selectStart() drops the format of the old position', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const {second} = $setUpTwoParagraphs();
+        $placeFreshCaret(second, 0);
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.focus.set(
+          second.getKey(),
+          second.getTextContentSize(),
+          'text',
+        );
+        selection.formatText('bold');
+        expect(selection.hasFormat('bold')).toBe(true);
+      });
+
+      await editor.update(() => {
+        // Move the caret to the start of the (plain) first paragraph.
+        $getRoot().selectStart();
+      });
+
+      editor.read(() => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        // "Hello" is not bold, so neither is a caret sitting inside it.
+        expect(selection.hasFormat('bold')).toBe(false);
+      });
+    });
+
+    test('selectEnd() picks up the format of the new position', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const {first, second} = $setUpTwoParagraphs();
+        second.setFormat('bold');
+        // A fresh caret in the plain first paragraph: format starts at 0.
+        $placeFreshCaret(first, 0);
+      });
+
+      await editor.update(() => {
+        // Move it into the bold second paragraph.
+        $getRoot().selectEnd();
+      });
+
+      editor.read(() => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        expect(selection.hasFormat('bold')).toBe(true);
+      });
+    });
+
+    test('selectStart() drops the style of the old position', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const {second} = $setUpTwoParagraphs();
+        // A collapsed caret is what arms selection.style for the next
+        // insertion, which is the value the report observes.
+        $placeFreshCaret(second, second.getTextContentSize());
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        $patchStyleText(selection, {color: 'rgb(255, 0, 0)'});
+        expect(selection.style).toBe('color: rgb(255, 0, 0);');
+      });
+
+      await editor.update(() => {
+        $getRoot().selectStart();
+      });
+
+      editor.read(() => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        // "Hello" carries no inline style.
+        expect(selection.style).toBe('');
+      });
+    });
+
+    test('selectEnd() picks up the style of the new position', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const {first, second} = $setUpTwoParagraphs();
+        second.setStyle('color: rgb(255, 0, 0);');
+        $placeFreshCaret(first, 0);
+      });
+
+      await editor.update(() => {
+        $getRoot().selectEnd();
+      });
+
+      editor.read(() => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        expect(selection.style).toBe('color: rgb(255, 0, 0);');
+      });
+    });
+
+    // Controls: these must hold both before and after the fix.
+    test('an armed format survives a move within the same node', async () => {
+      const {editor} = testEnv;
+      let text: TextNode;
+
+      await editor.update(() => {
+        const {first} = $setUpTwoParagraphs();
+        text = first;
+        $placeFreshCaret(first, 5);
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        // Toggling bold on a collapsed caret arms the format for the next
+        // insertion even though the node itself is not bold.
+        selection.formatText('bold');
+        expect(selection.hasFormat('bold')).toBe(true);
+      });
+
+      await editor.update(() => {
+        // Re-selecting the same node must not disarm it.
+        text.select(5, 5);
+      });
+
+      editor.read(() => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        expect(selection.hasFormat('bold')).toBe(true);
+      });
+    });
+
+    test('an armed style survives a move within the same node', async () => {
+      const {editor} = testEnv;
+      let text: TextNode;
+
+      await editor.update(() => {
+        const {first} = $setUpTwoParagraphs();
+        text = first;
+        $placeFreshCaret(first, 5);
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        $patchStyleText(selection, {color: 'rgb(0, 0, 255)'});
+      });
+
+      await editor.update(() => {
+        text.select(5, 5);
+      });
+
+      editor.read(() => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected RangeSelection');
+        expect(selection.style).toBe('color: rgb(0, 0, 255);');
+      });
+    });
+  });
+});

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -37,6 +37,7 @@ import {
 import {
   $getSelection,
   $internalMakeRangeSelection,
+  $internalRefreshSelectionFormatAndStyle,
   $isRangeSelection,
   type BaseSelection,
   moveSelectionPointToSibling,
@@ -606,9 +607,11 @@ export class ElementNode
         'element',
       );
     } else {
+      const previousAnchorKey = selection.anchor.key;
       selection.anchor.set(key, anchorOffset, 'element');
       selection.focus.set(key, focusOffset, 'element');
       selection.dirty = true;
+      $internalRefreshSelectionFormatAndStyle(selection, previousAnchorKey);
     }
     return selection;
   }

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -50,6 +50,7 @@ import {
   $generateNodesFromRawText,
   $getSelection,
   $internalMakeRangeSelection,
+  $internalRefreshSelectionFormatAndStyle,
   $isRangeSelection,
   $updateElementSelectionOnCreateDeleteNode,
   adjustPointOffsetForMergedSibling,
@@ -894,7 +895,9 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
       ) {
         $setCompositionKey(key);
       }
+      const previousAnchorKey = selection.anchor.key;
       selection.setTextNodeRange(this, anchorOffset, this, focusOffset);
+      $internalRefreshSelectionFormatAndStyle(selection, previousAnchorKey);
     }
     return selection;
   }


### PR DESCRIPTION
Moving the selection through the node APIs (`selectStart`, `selectEnd`, `select`, `selectPrevious`, `selectNext`) repointed the anchor but left `format` and `style` holding the values of the old position, so `hasFormat` and the style helpers kept reporting the formatting of wherever the selection used to be.

`$internalCreateSelection` already re-reads `format` and `style` from the anchor whenever a DOM-driven selection change lands on a different node, which is why clicking or arrowing keeps a toolbar in sync. The node `select()` paths never did, so they were the only way to move a selection and keep stale state.

Both `TextNode.select` and `ElementNode.select` now run the same refresh, and only when the anchor actually changes node: a format toggled on a collapsed caret is armed for the next insertion rather than backed by the node, so re-selecting the same node must leave it alone. Tests cover both directions for format and style, plus the two armed-in-place controls.

Fixes #8817
