### PR TITLE
[lexical-selection] Bug Fix: don't throw reading the parent style of a slot value

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalComputedStyleSlots.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalComputedStyleSlots.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$getComputedStyleForParent, $isParentRTL} from '@lexical/selection';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getNodeByKeyOrThrow,
+  $getRoot,
+  $isRangeSelection,
+  $setSlot,
+  type ParagraphNode,
+} from 'lexical';
+import {
+  $createTestShadowRootNode,
+  TestShadowRootNode,
+} from 'lexical/src/__tests__/utils';
+import {afterEach, assert, describe, expect, test} from 'vitest';
+
+const mounted: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const element of mounted.splice(0)) {
+    element.remove();
+  }
+});
+
+// `build` runs in its own update so that the nodes are reconciled to the DOM
+// before `check` reads their computed styles.
+function runInEditor(build: () => void, check: () => void): void {
+  using editor = buildEditorFromExtensions({
+    name: '@computed-style-slots-test',
+    nodes: [TestShadowRootNode],
+  });
+  const rootElement = document.createElement('div');
+  document.body.appendChild(rootElement);
+  mounted.push(rootElement);
+  editor.setRootElement(rootElement);
+  editor.update(build, {discrete: true});
+  editor.update(check, {discrete: true});
+}
+
+// A named-slot value has no __parent — it links up to its host through
+// __slotHost. Reading the parent's computed style must not throw for it: the
+// arrow-key handlers in @lexical/rich-text call $isParentRTL on the anchor
+// node, and the anchor is the slot value itself whenever the caret sits in an
+// empty slot or next to a decorator inside one.
+// https://github.com/facebook/lexical/issues/8937
+describe('computed styles and named slots', () => {
+  test('$getComputedStyleForParent returns null for a bare-block slot value', () => {
+    let slotParaKey = '';
+    runInEditor(
+      () => {
+        const host = $createParagraphNode();
+        $getRoot().append(host);
+        const slotPara = $createParagraphNode();
+        slotParaKey = slotPara.getKey();
+        $setSlot(host, 'title', slotPara);
+      },
+      () => {
+        expect(
+          $getComputedStyleForParent($getNodeByKeyOrThrow(slotParaKey)),
+        ).toBe(null);
+      },
+    );
+  });
+
+  test('$isParentRTL is false for the anchor inside an empty bare-block slot value', () => {
+    let slotParaKey = '';
+    runInEditor(
+      () => {
+        const host = $createParagraphNode();
+        $getRoot().append(host);
+        const slotPara = $createParagraphNode();
+        slotParaKey = slotPara.getKey();
+        $setSlot(host, 'title', slotPara);
+      },
+      () => {
+        const slotPara = $getNodeByKeyOrThrow<ParagraphNode>(slotParaKey);
+        const selection = slotPara.select();
+        assert($isRangeSelection(selection));
+        expect($isParentRTL(selection.anchor.getNode())).toBe(false);
+      },
+    );
+  });
+
+  test('$getComputedStyleForParent still resolves the parent inside a slot', () => {
+    let slotParaKey = '';
+    let slotRootKey = '';
+    runInEditor(
+      () => {
+        const host = $createParagraphNode();
+        $getRoot().append(host);
+        const slotRoot = $createTestShadowRootNode();
+        const slotPara = $createParagraphNode().append(
+          $createTextNode('title'),
+        );
+        slotRoot.append(slotPara);
+        slotParaKey = slotPara.getKey();
+        slotRootKey = slotRoot.getKey();
+        $setSlot(host, 'title', slotRoot);
+      },
+      () => {
+        const slotPara = $getNodeByKeyOrThrow(slotParaKey);
+        // The paragraph is inside the slot but is not the slot value, so it
+        // has a parent and resolution is unchanged.
+        expect(slotPara.getParent()!.getKey()).toBe(slotRootKey);
+        expect($getComputedStyleForParent(slotPara)).not.toBe(null);
+      },
+    );
+  });
+});

--- a/packages/lexical-selection/src/__tests__/unit/LexicalComputedStyleSlots.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalComputedStyleSlots.test.ts
@@ -13,37 +13,31 @@ import {
   $createTextNode,
   $getNodeByKeyOrThrow,
   $getRoot,
-  $isRangeSelection,
+  $isParagraphNode,
   $setSlot,
-  type ParagraphNode,
 } from 'lexical';
 import {
+  $assertNodeType,
   $createTestShadowRootNode,
   TestShadowRootNode,
 } from 'lexical/src/__tests__/utils';
-import {afterEach, assert, describe, expect, test} from 'vitest';
-
-const mounted: HTMLElement[] = [];
-
-afterEach(() => {
-  for (const element of mounted.splice(0)) {
-    element.remove();
-  }
-});
+import {describe, expect, test} from 'vitest';
 
 // `build` runs in its own update so that the nodes are reconciled to the DOM
 // before `check` reads their computed styles.
-function runInEditor(build: () => void, check: () => void): void {
+function runInEditor($build: () => void, $check: () => void): void {
   using editor = buildEditorFromExtensions({
+    $initialEditorState: $build,
+    afterRegistration: editor_ => {
+      const rootElement = document.createElement('div');
+      document.body.appendChild(rootElement);
+      editor_.setRootElement(rootElement);
+      return () => rootElement.remove();
+    },
     name: '@computed-style-slots-test',
     nodes: [TestShadowRootNode],
   });
-  const rootElement = document.createElement('div');
-  document.body.appendChild(rootElement);
-  mounted.push(rootElement);
-  editor.setRootElement(rootElement);
-  editor.update(build, {discrete: true});
-  editor.update(check, {discrete: true});
+  editor.update($check, {discrete: true});
 }
 
 // A named-slot value has no __parent — it links up to its host through
@@ -65,7 +59,12 @@ describe('computed styles and named slots', () => {
       },
       () => {
         expect(
-          $getComputedStyleForParent($getNodeByKeyOrThrow(slotParaKey)),
+          $getComputedStyleForParent(
+            $assertNodeType(
+              $getNodeByKeyOrThrow(slotParaKey),
+              $isParagraphNode,
+            ),
+          ),
         ).toBe(null);
       },
     );
@@ -82,9 +81,11 @@ describe('computed styles and named slots', () => {
         $setSlot(host, 'title', slotPara);
       },
       () => {
-        const slotPara = $getNodeByKeyOrThrow<ParagraphNode>(slotParaKey);
+        const slotPara = $assertNodeType(
+          $getNodeByKeyOrThrow(slotParaKey),
+          $isParagraphNode,
+        );
         const selection = slotPara.select();
-        assert($isRangeSelection(selection));
         expect($isParentRTL(selection.anchor.getNode())).toBe(false);
       },
     );
@@ -107,7 +108,10 @@ describe('computed styles and named slots', () => {
         $setSlot(host, 'title', slotRoot);
       },
       () => {
-        const slotPara = $getNodeByKeyOrThrow(slotParaKey);
+        const slotPara = $assertNodeType(
+          $getNodeByKeyOrThrow(slotParaKey),
+          $isParagraphNode,
+        );
         // The paragraph is inside the slot but is not the slot value, so it
         // has a parent and resolution is unchanged.
         expect(slotPara.getParent()!.getKey()).toBe(slotRootKey);

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -234,7 +234,7 @@ export function $getComputedStyleForParent(
   // parentless too. Treat both like a missing DOM element rather than
   // throwing; every caller already handles null.
   const parent = $isRootNode(node) ? node : node.getParent();
-  return parent === null ? null : $getComputedStyleForElement(parent);
+  return parent && $getComputedStyleForElement(parent);
 }
 
 /**

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -223,13 +223,18 @@ export function $getComputedStyleForElement(
 /**
  * Gets the computed DOM styles of the parent of the node.
  * @param node - The node to check its parent's styles for.
- * @returns the computed styles of the node or null if there is no DOM element or no default view for the document.
+ * @returns the computed styles of the node, or null if the node has no parent,
+ * there is no DOM element, or there is no default view for the document.
  */
 export function $getComputedStyleForParent(
   node: LexicalNode,
 ): CSSStyleDeclaration | null {
-  const parent = $isRootNode(node) ? node : node.getParentOrThrow();
-  return $getComputedStyleForElement(parent);
+  // A named-slot value has no parent — it links up to its host through
+  // __slotHost — so there is no parent element to measure. Detached nodes are
+  // parentless too. Treat both like a missing DOM element rather than
+  // throwing; every caller already handles null.
+  const parent = $isRootNode(node) ? node : node.getParent();
+  return parent === null ? null : $getComputedStyleForElement(parent);
 }
 
 /**


### PR DESCRIPTION
`$getComputedStyleForParent` called `getParentOrThrow`, but a named-slot value has no parent — it links up to its host through `__slotHost`. The arrow-key handlers in `@lexical/rich-text` call `$isParentRTL` on the selection anchor, and the anchor is the slot value itself whenever the caret sits in an emptied slot or beside a decorator inside one. Moving between two adjacent slots therefore threw `Expected node N to have a parent.` and left the editor unable to accept typed input.

Reproduced with the playground document from the issue (a pullquote host whose `attribution` slot is a bare paragraph containing an image): ArrowLeft/ArrowRight across the slot boundary throws on every press.

This resolves the parent with `getParent()` and returns `null` when there is none — the same result the function already produces for a node with no DOM element, which every caller handles.

Fixes #8937
