### PR TITLE
[lexical] Bug Fix: SKIP_DOM_SELECTION_TAG applies to the initial mount

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -58,6 +58,7 @@ import {
 import {
   FOCUS_TAG,
   HISTORY_MERGE_TAG,
+  SKIP_DOM_SELECTION_TAG,
   type UpdateTag,
 } from './LexicalUpdateTags';
 import {
@@ -1151,6 +1152,16 @@ export class LexicalEditor {
   _normalizedNodes: Set<NodeKey>;
   /** @internal */
   _updateTags: Set<UpdateTag>;
+  /**
+   * `true` when an update carrying {@link SKIP_DOM_SELECTION_TAG} was
+   * committed while the editor had no root element. Such a commit only
+   * reconciles to an EditorState, so the DOM selection is never touched and
+   * the tag is cleared with the rest of `_updateTags`. Remembering the request
+   * lets the first commit that does have a root element honor it — notably an
+   * `$initialEditorState` update, which always runs before `setRootElement`.
+   * @internal
+   */
+  _deferredSkipDOMSelection: boolean;
   /** @internal */
   _observer: null | MutationObserver;
   /** @internal */
@@ -1236,6 +1247,7 @@ export class LexicalEditor {
     this._dirtyElements = new Map();
     this._normalizedNodes = new Set();
     this._updateTags = new Set();
+    this._deferredSkipDOMSelection = false;
     // Handling of DOM mutations
     this._observer = null;
     // Used for identifying owning editors
@@ -1651,6 +1663,11 @@ export class LexicalEditor {
         initMutationObserver(this);
 
         this._updateTags.add(HISTORY_MERGE_TAG);
+        if (this._deferredSkipDOMSelection) {
+          // An update that ran before the editor was mounted asked not to
+          // move the DOM selection; this is the commit that would do it.
+          this._updateTags.add(SKIP_DOM_SELECTION_TAG);
+        }
 
         $commitPendingUpdates(this);
 

--- a/packages/lexical/src/LexicalUpdateTags.ts
+++ b/packages/lexical/src/LexicalUpdateTags.ts
@@ -54,6 +54,11 @@ export const SKIP_SCROLL_INTO_VIEW_TAG = 'skip-scroll-into-view';
 /**
  * Indicates that the update should skip updating the DOM selection
  * This is useful when you want to make updates without changing the selection or focus
+ *
+ * An update that runs before the editor has a root element (such as an
+ * `$initialEditorState` initializer) is reconciled to an EditorState only, so
+ * the tag is applied to the later commit that first reconciles that state to
+ * the DOM.
  */
 export const SKIP_DOM_SELECTION_TAG = 'skip-dom-selection';
 

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -700,6 +700,14 @@ function $commitPendingUpdatesImpl(
   // reconciles) would inherit the COLLABORATION tag and be skipped by
   // syncLexicalUpdateToYjs, desyncing the peers.
   editor._updateTags = new Set();
+  // Without a root element this commit reconciles to an EditorState only, so
+  // the DOM selection block below never runs and a SKIP_DOM_SELECTION_TAG
+  // would be cleared before the DOM ever sees this state. Carry the request
+  // over to the first commit that does have a root element — the one that
+  // reconciles an $initialEditorState into a freshly mounted contenteditable.
+  editor._deferredSkipDOMSelection =
+    rootElement === null &&
+    (editor._deferredSkipDOMSelection || tags.has(SKIP_DOM_SELECTION_TAG));
   $garbageCollectDetachedDecorators(editor, pendingEditorState);
 
   // ======

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -4214,5 +4214,42 @@ describe('LexicalEditor tests', () => {
       expect(range.endOffset).toBe(text.length);
       expect(onError).not.toHaveBeenCalled();
     });
+    // https://github.com/facebook/lexical/issues/8610
+    it('does not update the DOM selection on mount with skip-dom-selection', async () => {
+      const onError = vi.fn();
+      const newEditor = createTestEditor({
+        onError: onError,
+      });
+      const outside = document.createElement('div');
+      outside.textContent = 'outside the editor';
+      document.body.appendChild(outside);
+      const outsideText = outside.firstChild as Text;
+      const selection = getDOMSelection(window) as Selection;
+      selection.setBaseAndExtent(outsideText, 0, outsideText, 0);
+      try {
+        const text = 'initial content';
+        let textNode!: TextNode;
+        // This is the shape of an $initialEditorState update: it is committed
+        // before the editor has a root element, so the DOM selection is only
+        // ever applied by the setRootElement commit below.
+        await newEditor.update(
+          () => {
+            textNode = $createTextNode(text);
+            $getRoot().append($createParagraphNode().append(textNode));
+            textNode.select();
+          },
+          {tag: SKIP_DOM_SELECTION_TAG},
+        );
+        await newEditor.setRootElement(container);
+        expect(newEditor.getElementByKey(textNode.getKey())).not.toBe(null);
+        expect(selection.rangeCount).toBe(1);
+        const range = selection.getRangeAt(0);
+        expect(range.startContainer).toBe(outsideText);
+        expect(range.endContainer).toBe(outsideText);
+        expect(onError).not.toHaveBeenCalled();
+      } finally {
+        document.body.removeChild(outside);
+      }
+    });
   });
 });


### PR DESCRIPTION
An update that runs before the editor has a root element — notably an `$initialEditorState` initializer, or the `editorState` of an initial config — is reconciled to an `EditorState` only. The DOM-selection block is never reached and the update tags are cleared at the end of that commit, so by the time `setRootElement` reconciles that state into the contenteditable there is no `SKIP_DOM_SELECTION_TAG` left. Initializing content with `$insertNodes` therefore moved the DOM selection and scrolled the page to the end of the content even though the tag was set.

This remembers the request across the un-mounted commit and re-applies the tag on the first commit that has a root element, so the tag means the same thing during initialization as it does afterwards. The `$setSelection(null)` workaround keeps working; the tag's doc comment now describes the mount case.

Fixes #8610
