### PR TITLE
[lexical-history] Bug Fix: undo/redo applies to the editor that changed with a shared HistoryState

### DIFF
--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -732,6 +732,57 @@ describe('HistoryExtension maxDepth', () => {
   });
 });
 
+describe('shared HistoryState across editors', () => {
+  function $setParagraphText(text: string) {
+    $getRoot().clear().append($createParagraphNodeWithText(text));
+  }
+  function $getText(target: LexicalEditor) {
+    return target.getEditorState().read(() => $getRoot().getTextContent());
+  }
+
+  // https://github.com/facebook/lexical/issues/8623
+  test('undo and redo apply to the editor that changed', async () => {
+    const parentEditor = createTestEditor({namespace: 'parent'});
+    const nestedEditor = createTestEditor({namespace: 'nested'});
+    // Give both editors content before registering history so that the edits
+    // below are changes rather than initialization.
+    for (const target of [parentEditor, nestedEditor]) {
+      target.update(() => $setParagraphText('initial'), {discrete: true});
+    }
+    const sharedHistory = createEmptyHistoryState();
+    registerHistory(parentEditor, sharedHistory, 0);
+    registerHistory(nestedEditor, sharedHistory, 0);
+
+    parentEditor.update(() => $setParagraphText('parent 1'), {discrete: true});
+    parentEditor.update(() => $setParagraphText('parent 2'), {discrete: true});
+    nestedEditor.update(() => $setParagraphText('nested 1'), {discrete: true});
+    expect(sharedHistory.undoStack).toHaveLength(2);
+    expect(sharedHistory.undoStack[0].editor).toBe(parentEditor);
+    expect(sharedHistory.undoStack[1].editor).toBe(nestedEditor);
+
+    // The most recent change was made in the nested editor, so that is the
+    // editor the undo has to apply to.
+    await nestedEditor.dispatchCommand(UNDO_COMMAND, undefined);
+    expect($getText(nestedEditor)).toBe('initial');
+    expect($getText(parentEditor)).toBe('parent 2');
+
+    // The next entry belongs to the parent editor.
+    await nestedEditor.dispatchCommand(UNDO_COMMAND, undefined);
+    expect($getText(nestedEditor)).toBe('initial');
+    expect($getText(parentEditor)).toBe('parent 1');
+    expect(sharedHistory.undoStack).toHaveLength(0);
+
+    await nestedEditor.dispatchCommand(REDO_COMMAND, undefined);
+    expect($getText(nestedEditor)).toBe('initial');
+    expect($getText(parentEditor)).toBe('parent 2');
+
+    await nestedEditor.dispatchCommand(REDO_COMMAND, undefined);
+    expect($getText(nestedEditor)).toBe('nested 1');
+    expect($getText(parentEditor)).toBe('parent 2');
+    expect(sharedHistory.redoStack).toHaveLength(0);
+  });
+});
+
 describe('SharedHistoryExtension', () => {
   test('can create a parent editor', async () => {
     const clock = Date.now();
@@ -828,7 +879,8 @@ describe('SharedHistoryExtension', () => {
       ).output.historyState.peek(),
     );
 
-    editor.dispatchCommand(UNDO_COMMAND);
+    // The last change was made in the child editor, so a single undo reverts
+    // it and leaves the parent alone.
     editor.dispatchCommand(UNDO_COMMAND);
     editor.read(() => {
       expect($getChildEditor().read(() => $getRoot().getTextContent())).toEqual(

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -376,6 +376,58 @@ function createMergeActionGetter(
   };
 }
 
+/**
+ * Build the entry that reverses `historyStateEntry` and belongs on the
+ * opposite stack.
+ *
+ * With a single editor this is always `current`, since `current` tracks the
+ * live state of that editor. With a shared {@link HistoryState} the stacks
+ * interleave entries from several editors, so `current` may belong to an
+ * editor that is *not* about to change — pushing it would record a no-op and
+ * lose the state we are about to overwrite. In that case read the live state
+ * off the entry's own editor instead.
+ */
+function getInverseEntry(
+  historyStateEntry: HistoryStateEntry,
+  current: null | HistoryStateEntry,
+): null | HistoryStateEntry {
+  if (current !== null && current.editor === historyStateEntry.editor) {
+    return current;
+  }
+  const {editor} = historyStateEntry;
+  const editorState = editor.getEditorState();
+  // An empty EditorState can not be restored (setEditorState throws), so
+  // there is nothing to reverse to.
+  return editorState.isEmpty() ? null : {editor, editorState};
+}
+
+/**
+ * Build the entry that an update from `editor` pushes onto the undo stack.
+ *
+ * `current` is the state to restore when this update is undone, but with a
+ * shared {@link HistoryState} it may belong to a different editor — one that
+ * is not changing here, so restoring it would be a no-op and the state that is
+ * about to be overwritten would never make it onto the stack. Record this
+ * editor's own pre-update state in that case.
+ */
+function getUndoEntry(
+  editor: LexicalEditor,
+  prevEditorState: EditorState,
+  current: null | HistoryStateEntry,
+): null | HistoryStateEntry {
+  if (current === null) {
+    return null;
+  }
+  if (current.editor === editor) {
+    return {...current};
+  }
+  // An empty EditorState can not be restored (setEditorState throws). Skipping
+  // it mirrors the way the first update of an editor is not undoable.
+  return prevEditorState.isEmpty()
+    ? null
+    : {editor, editorState: prevEditorState};
+}
+
 function redo(
   editor: LexicalEditor,
   historyState: HistoryState,
@@ -386,13 +438,16 @@ function redo(
 
   if (redoStack.length !== 0) {
     const current = historyState.current;
-
-    if (current !== null) {
-      undoStack.push(current);
-      editor.dispatchCommand(CAN_UNDO_COMMAND, true);
-    }
-
     const historyStateEntry = redoStack.pop();
+
+    if (historyStateEntry) {
+      const inverseEntry = getInverseEntry(historyStateEntry, current);
+
+      if (inverseEntry !== null) {
+        undoStack.push(inverseEntry);
+        editor.dispatchCommand(CAN_UNDO_COMMAND, true);
+      }
+    }
 
     if (redoStack.length === 0) {
       editor.dispatchCommand(CAN_REDO_COMMAND, false);
@@ -425,9 +480,13 @@ function undo(
     const current = historyState.current;
     const historyStateEntry = undoStack.pop();
 
-    if (current !== null) {
-      redoStack.push(current);
-      editor.dispatchCommand(CAN_REDO_COMMAND, true);
+    if (historyStateEntry) {
+      const inverseEntry = getInverseEntry(historyStateEntry, current);
+
+      if (inverseEntry !== null) {
+        redoStack.push(inverseEntry);
+        editor.dispatchCommand(CAN_REDO_COMMAND, true);
+      }
     }
 
     if (undoStack.length === 0) {
@@ -538,10 +597,10 @@ export function registerHistory(
         editor.dispatchCommand(CAN_REDO_COMMAND, false);
       }
 
-      if (current !== null) {
-        undoStack.push({
-          ...current,
-        });
+      const undoEntry = getUndoEntry(editor, prevEditorState, current);
+
+      if (undoEntry !== null) {
+        undoStack.push(undoEntry);
         const cap = readMaxDepth();
         if (cap !== null && undoStack.length > cap) {
           // FIFO-evict the oldest entries so the stack stays at `cap`.


### PR DESCRIPTION
Noting up front that you commented on the issue that this is working as designed. I'm sending it because the symptom is not just awkward semantics — history entries are lost — but close it if you'd rather redesign the entry model instead.

A shared `HistoryState` interleaves entries from several editors, but a push always recorded `historyState.current` — the state of whichever editor changed last. When the next change came from a different editor, the stack recorded a state that had not changed, so undo restored an editor to the state it was already in and the change that should have been undone was dropped from the history entirely. With two editors, editing A then B and pressing undo does nothing, empties the stack, and leaves both edits permanently unrecoverable.

This records the pre-update state of the editor that actually changed, and takes the inverse entry from that entry's own editor rather than from `current`, so undo and redo stay symmetric. An empty `EditorState` is skipped because it cannot be restored, mirroring the way an editor's first update is not undoable.

One existing test changed: `SharedHistoryExtension > can create a parent editor` previously needed two undos to revert one child edit. The extra press was the no-op entry described above, so it now needs one.

Fixes #8623
