### PR TITLE
[lexical] Bug Fix: refresh pending format and style when removeText moves the caret to another node

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1068,8 +1068,29 @@ export class RangeSelection implements BaseSelection {
    */
   removeText(): void {
     const isCurrentSelection = $getSelection() === this;
+    const previousAnchorKey = this.anchor.key;
     const newRange = $removeTextFromCaretRange($caretRangeFromSelection(this));
     $updateRangeSelectionFromCaretRange(this, newRange);
+    // The caret can end up in a node it did not start in, e.g. backspacing
+    // an empty paragraph merges the caret into the end of the previous
+    // block. The pending format and style describe the node the caret left,
+    // so re-derive them from the node it landed on. This matches what
+    // $internalCreateRangeSelection does when a selection change resolves to
+    // a different anchor.
+    if (this.anchor.key !== previousAnchorKey && this.isCollapsed()) {
+      const anchorNode = this.anchor.getNode();
+      const format = $isTextNode(anchorNode)
+        ? anchorNode.getFormat()
+        : anchorNode.getTextFormat();
+      const style = $isTextNode(anchorNode)
+        ? anchorNode.getStyle()
+        : anchorNode.getTextStyle();
+      if (this.format !== format || this.style !== style) {
+        this.format = format;
+        this.style = style;
+        this.dirty = true;
+      }
+    }
     if (isCurrentSelection && $getSelection() !== this) {
       $setSelection(this);
     }

--- a/packages/lexical/src/__tests__/unit/Issue6781Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue6781Repro.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $isTextNode,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+import {IS_BOLD, IS_ITALIC} from '../../LexicalConstants';
+import {initializeUnitTest} from '../utils';
+
+describe('Backspacing an empty block updates the pending format (#6781)', () => {
+  initializeUnitTest(testEnv => {
+    test('merging into the previous block adopts that block text format and style', async () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          const text = $createTextNode('hello');
+          text.setFormat(IS_BOLD);
+          text.setStyle('color: red');
+          paragraph.append(text);
+          // The empty paragraph the caret sits in carries its own pending
+          // format and style, as it would after the toolbar is used on an
+          // empty line.
+          const emptyParagraph = $createParagraphNode();
+          emptyParagraph.setTextFormat(IS_ITALIC);
+          emptyParagraph.setTextStyle('color: blue');
+          $getRoot().clear().append(paragraph, emptyParagraph);
+          const selection = emptyParagraph.select(0, 0);
+          selection.setFormat(IS_ITALIC);
+          selection.setStyle('color: blue');
+        },
+        {discrete: true},
+      );
+
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          assert($isRangeSelection(selection), 'Expected RangeSelection');
+          selection.deleteCharacter(true);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        expect(selection.format).toBe(IS_BOLD);
+        expect(selection.style).toBe('color: red');
+      });
+
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          assert($isRangeSelection(selection), 'Expected RangeSelection');
+          selection.insertText('X');
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const root = $getRoot();
+        expect(root.getTextContent()).toBe('helloX');
+        const text = root.getLastDescendant();
+        assert($isTextNode(text), 'Expected TextNode');
+        expect(text.getFormat()).toBe(IS_BOLD);
+        expect(text.getStyle()).toBe('color: red');
+        // The inserted text merges into the existing node rather than
+        // starting a differently styled one.
+        const paragraph = root.getFirstChild();
+        assert($isElementNode(paragraph), 'Expected ElementNode');
+        expect(paragraph.getChildrenSize()).toBe(1);
+      });
+    });
+
+    test('backspacing inside a block leaves the pending format alone', async () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          const text = $createTextNode('hello');
+          text.setFormat(IS_BOLD);
+          text.setStyle('color: red');
+          paragraph.append(text);
+          $getRoot().clear().append(paragraph);
+          const selection = text.select(5, 5);
+          selection.setFormat(IS_ITALIC);
+          selection.setStyle('color: blue');
+        },
+        {discrete: true},
+      );
+
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          assert($isRangeSelection(selection), 'Expected RangeSelection');
+          selection.deleteCharacter(true);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        // The caret never left the text node, so the format the user chose
+        // for the next keystroke is preserved.
+        expect(selection.format).toBe(IS_ITALIC);
+        expect(selection.style).toBe('color: blue');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Backspacing away an empty paragraph merges the caret into the end of the previous block, but `RangeSelection.removeText()` only moved the anchor and focus. The pending `format`/`style` still described the paragraph that was just deleted, so the next keystroke was inserted with the wrong formatting and split off into its own text node.

`removeText()` now re-derives `format` and `style` from the anchor when the caret ends up in a different node than it started in — `getFormat`/`getStyle` for a TextNode, `getTextFormat`/`getTextStyle` for an ElementNode. This is the same rule `$internalCreateRangeSelection` applies when a selection change resolves to a new anchor. When the caret stays put the pending format is left alone, so a format chosen for the next keystroke still survives an ordinary backspace. `insertText` already snapshots and restores these values around its own `removeText()` call, so that path is unchanged.

Adds a unit test covering the reported case and a control for the same-node case.

Fixes #6781
