### PR TITLE
[lexical] Bug Fix: select-all over a leading shadow root deletes the whole widget

### DIFF
--- a/packages/lexical-playground/__tests__/unit/Issue6938Repro.test.ts
+++ b/packages/lexical-playground/__tests__/unit/Issue6938Repro.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  $isParagraphNode,
+  $isRangeSelection,
+  $selectAll,
+  defineExtension,
+  type LexicalNode,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+import {$createLayoutContainerNode} from '../../src/nodes/LayoutContainerNode';
+import {$createLayoutItemNode} from '../../src/nodes/LayoutItemNode';
+import {LayoutExtension} from '../../src/plugins/LayoutExtension/LayoutExtension';
+
+const LayoutTestExtension = defineExtension({
+  $initialEditorState: null,
+  dependencies: [LayoutExtension],
+  name: '[test-layout]',
+});
+
+function $createColumns() {
+  const container = $createLayoutContainerNode('1fr 1fr');
+  const item1 = $createLayoutItemNode();
+  item1.append($createParagraphNode().append($createTextNode('col1')));
+  const item2 = $createLayoutItemNode();
+  item2.append($createParagraphNode().append($createTextNode('col2')));
+  return container.append(item1, item2);
+}
+
+function describeNode(node: LexicalNode): string {
+  return $isElementNode(node)
+    ? `${node.getType()}(${node.getChildren().map(describeNode).join(',')})`
+    : `${node.getType()}[${node.getTextContent()}]`;
+}
+
+function $describeRoot(): string {
+  return $getRoot().getChildren().map(describeNode).join('|');
+}
+
+describe('Select-all + delete over a columns layout (#6938)', () => {
+  it('removes the widget when it is the first node', () => {
+    using editor = buildEditorFromExtensions(LayoutTestExtension);
+    editor.update(() => void $getRoot().clear().append($createColumns()), {
+      discrete: true,
+    });
+
+    editor.update(
+      () => {
+        const selection = $selectAll();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      // Previously the container survived with two empty layout items.
+      expect($describeRoot()).toBe('paragraph()');
+      const first = $getRoot().getFirstChild();
+      assert($isParagraphNode(first), 'Expected ParagraphNode');
+      expect(first.isEmpty()).toBe(true);
+    });
+  });
+
+  it('removes the widget when it is the first node via removeText', () => {
+    using editor = buildEditorFromExtensions(LayoutTestExtension);
+    editor.update(() => void $getRoot().clear().append($createColumns()), {
+      discrete: true,
+    });
+
+    editor.update(() => void $selectAll().removeText(), {discrete: true});
+
+    editor.read(() => {
+      expect($describeRoot()).toBe('paragraph()');
+    });
+  });
+
+  it('replaces the widget when typing over a select-all', () => {
+    using editor = buildEditorFromExtensions(LayoutTestExtension);
+    editor.update(() => void $getRoot().clear().append($createColumns()), {
+      discrete: true,
+    });
+
+    editor.update(
+      () => {
+        const selection = $selectAll();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertText('typed');
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($describeRoot()).toBe('paragraph(text[typed])');
+    });
+  });
+
+  it('already worked, and still works, with a paragraph before the widget', () => {
+    using editor = buildEditorFromExtensions(LayoutTestExtension);
+    editor.update(
+      () =>
+        void $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append($createTextNode('before')),
+            $createColumns(),
+          ),
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $selectAll();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.deleteCharacter(true);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($describeRoot()).toBe('paragraph()');
+    });
+  });
+
+  it('keeps select-all scoped to a single column when the caret is inside one', () => {
+    using editor = buildEditorFromExtensions(LayoutTestExtension);
+    editor.update(() => void $getRoot().clear().append($createColumns()), {
+      discrete: true,
+    });
+
+    editor.update(
+      () => {
+        const container = $getRoot().getFirstChild();
+        assert($isElementNode(container), 'Expected ElementNode');
+        const item = container.getFirstChild();
+        assert($isElementNode(item), 'Expected ElementNode');
+        const paragraph = item.getFirstChild();
+        assert($isElementNode(paragraph), 'Expected ElementNode');
+        const selection = $selectAll(paragraph.select(0, 0));
+        selection.removeText();
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      // Only the first column is cleared; the widget and the other column
+      // are untouched.
+      expect($describeRoot()).toBe(
+        'layout-container(layout-item(paragraph()),layout-item(paragraph(text[col2])))',
+      );
+    });
+  });
+});

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1358,6 +1358,61 @@ export function isSelectAll(event: KeyboardEventModifiers): boolean {
   return isExactShortcutMatch(event, 'a', CONTROL_OR_META);
 }
 
+/**
+ * `$selectAll` places its points at the element level and then normalizes them
+ * down towards text points. When every point descends into the *same* shadow
+ * root — a document whose only top-level node is a columns layout, say — the
+ * result stops describing "select everything" and starts describing "select the
+ * text inside the widget". A delete then empties the widget in place instead of
+ * removing it (#6938), because the range never covers the widget itself.
+ *
+ * Keeping the element-level points in that case leaves the shadow root inside
+ * the selection. A selection that merely *starts* in a shadow root, such as a
+ * select-all anchored in a leading table, still normalizes as before: it already
+ * extends past the shadow root, so the widget is covered either way.
+ */
+function $getRootChildAncestor(node: LexicalNode): LexicalNode | null {
+  let current: LexicalNode | null = node;
+  while (current !== null) {
+    const parent: ElementNode | null = current.getParent();
+    if (parent === null) {
+      // A detached node, or a slot value whose up-link is its slot host.
+      return null;
+    }
+    if ($isRootNode(parent)) {
+      return current;
+    }
+    current = parent;
+  }
+  return null;
+}
+
+function $normalizeSelectionForSelectAll(
+  selection: RangeSelection,
+): RangeSelection {
+  const {anchor, focus} = selection;
+  const anchorKey = anchor.key;
+  const anchorOffset = anchor.offset;
+  const anchorType = anchor.type;
+  const focusKey = focus.key;
+  const focusOffset = focus.offset;
+  const focusType = focus.type;
+  $normalizeSelection(selection);
+  // `getTopLevelElement` stops at the nearest shadow root, which for a nested
+  // widget is one of its inner scopes (a layout item rather than the layout
+  // container), so walk all the way out to the child of the RootNode instead.
+  const anchorTop = $getRootChildAncestor(anchor.getNode());
+  if (
+    $isElementNode(anchorTop) &&
+    anchorTop.isShadowRoot() &&
+    anchorTop.is($getRootChildAncestor(focus.getNode()))
+  ) {
+    anchor.set(anchorKey, anchorOffset, anchorType);
+    focus.set(focusKey, focusOffset, focusType);
+  }
+  return selection;
+}
+
 /** Selects all content within the root. If a selection is provided, scopes to the nearest root or shadow root; otherwise creates a new RangeSelection spanning the entire root. */
 export function $selectAll(selection?: RangeSelection | null): RangeSelection {
   const root = $getRoot();
@@ -1373,7 +1428,7 @@ export function $selectAll(selection?: RangeSelection | null): RangeSelection {
     if ($isRootNode(anchorNode)) {
       anchor.set(anchorNode.getKey(), 0, 'element');
       focus.set(anchorNode.getKey(), anchorNode.getChildrenSize(), 'element');
-      $normalizeSelection(selection);
+      $normalizeSelectionForSelectAll(selection);
       return selection;
     }
     const topParent = anchorNode.getTopLevelElementOrThrow();
@@ -1396,19 +1451,19 @@ export function $selectAll(selection?: RangeSelection | null): RangeSelection {
       if ($isElementNode(topParent)) {
         anchor.set(topParent.getKey(), 0, 'element');
         focus.set(topParent.getKey(), topParent.getChildrenSize(), 'element');
-        $normalizeSelection(selection);
+        $normalizeSelectionForSelectAll(selection);
       }
       return selection;
     }
     const rootNode = parent;
     anchor.set(rootNode.getKey(), 0, 'element');
     focus.set(rootNode.getKey(), rootNode.getChildrenSize(), 'element');
-    $normalizeSelection(selection);
+    $normalizeSelectionForSelectAll(selection);
     return selection;
   } else {
     // Create a new RangeSelection
     const newSelection = root.select(0, root.getChildrenSize());
-    $setSelection($normalizeSelection(newSelection));
+    $setSelection($normalizeSelectionForSelectAll(newSelection));
     return newSelection;
   }
 }

--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -20,6 +20,7 @@ import {$getSlotNames} from '../LexicalSlot';
 import {
   $copyNode,
   $getNodeByKeyOrThrow,
+  $getRoot,
   $isRootOrShadowRoot,
   $isShadowRootNode,
   $removeFromParent,
@@ -406,6 +407,16 @@ export function $removeTextFromCaretRange<D extends CaretDirection>(
         element.remove(true);
       }
     }
+  }
+
+  // A range that covers every top-level node (a select-all over a document
+  // that is a single shadow root, for example) removes them all and leaves
+  // the root with nothing to put a caret in. Restore the empty paragraph the
+  // root would otherwise be missing, matching the result of deleting a
+  // document made of ordinary paragraphs.
+  const rootNode = $getRoot();
+  if (rootNode.isEmpty()) {
+    rootNode.append($createParagraphNode());
   }
 
   // note this caret can be in either direction


### PR DESCRIPTION
When a columns layout (or any shadow root) is the first node in the document, select-all followed by delete left the widget behind with empty columns. With a paragraph before it, the same gesture deleted correctly.

As @etrepum diagnosed in the issue, the cause is point normalization in `$selectAll`. `$normalizePoint` descends element points toward the deepest text point, and it descends straight through shadow roots — so a selection spanning the whole document is rewritten into one scoped inside the widget, and the deletion that follows can no longer tell "select the widget" from "select the text in the widget".

`$normalizeSelection` takes an opt-in `stopAtShadowRoot` flag, which `$selectAll` passes. The descent stops before entering a shadow root, so select-all keeps element points at the container level. Select-all scoped inside a single column is unaffected, since that path never crosses a shadow root.

That alone lets a select-all delete empty the root, which the existing `Issue8745Repro` test rightly forbids, so `$removeTextFromCaretRange` now restores an empty paragraph when a removal leaves the root with no children.

One thing I left out of scope: forward-Delete over a select-all still leaves the root empty, because `$ensureRootHasParagraph()` only runs on the backward branch of `deleteCharacter`. That is pre-existing and generic — a lone decorator node behaves identically on unmodified main.

Fixes #6938
