### PR TITLE
[lexical-markdown] Bug Fix: block shortcuts no longer discard the enclosing block quote

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -381,6 +381,18 @@ export function $createMarkdownLineBreakNode(
   return lineBreakNode;
 }
 
+/**
+ * Block-level shortcuts convert by replacing the enclosing block, which
+ * discards it. A QuoteNode holds inline content, so there is nowhere to nest
+ * the new block and the quote would simply be lost. Import already refuses:
+ * `$convertFromMarkdownString('> # x')` keeps the quote and leaves `# x` as
+ * literal text, so the shortcut declines too rather than dropping the quote
+ * out from under the caret. See #7407.
+ */
+function $isUnreplaceableBlock(parentNode: ElementNode): boolean {
+  return $isQuoteNode(parentNode);
+}
+
 const createBlockNode = (
   createNode: (match: string[]) => ElementNode,
 ): ElementTransformer['replace'] => {
@@ -417,7 +429,10 @@ function getIndent(whitespaces: string): number {
 
 const listReplace = (listType: ListType): ElementTransformer['replace'] => {
   return (parentNode, children, match, isImport) => {
-    if ($isHeadingNode(parentNode)) {
+    if (
+      $isHeadingNode(parentNode) ||
+      (!isImport && $isUnreplaceableBlock(parentNode))
+    ) {
       return false;
     }
 
@@ -536,6 +551,11 @@ const $listExport = (
   return output.join('\n');
 };
 
+const $replaceWithHeading = createBlockNode(match => {
+  const tag = ('h' + match[1].length) as HeadingTagType;
+  return $createHeadingNode(tag);
+});
+
 export const HEADING: ElementTransformer = {
   dependencies: [HeadingNode],
   export: (node, exportChildren) => {
@@ -546,10 +566,12 @@ export const HEADING: ElementTransformer = {
     return '#'.repeat(level) + ' ' + exportChildren(node);
   },
   regExp: HEADING_REGEX,
-  replace: createBlockNode(match => {
-    const tag = ('h' + match[1].length) as HeadingTagType;
-    return $createHeadingNode(tag);
-  }),
+  replace: (parentNode, children, match, isImport) => {
+    if (!isImport && $isUnreplaceableBlock(parentNode)) {
+      return false;
+    }
+    return $replaceWithHeading(parentNode, children, match, isImport);
+  },
   triggerOnEnter: true,
   type: 'element',
 };

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -36,6 +36,7 @@ import {
   $createHeadingNode,
   $createQuoteNode,
   $isHeadingNode,
+  $isQuoteNode,
   HeadingNode,
   QuoteNode,
 } from '@lexical/rich-text';
@@ -1148,6 +1149,55 @@ describe('Markdown', () => {
         const heading = $getRoot().getFirstChild();
         expect($isHeadingNode(heading)).toBe(true);
         expect(heading?.getTextContent()).toBe(
+          `${shortcut}Welcome to the playground`,
+        );
+      });
+    },
+  );
+
+  it.each(['# ', '## ', '###### ', '1. ', '- ', '* ', '+ '])(
+    'should preserve a quote when typing the "%s" shortcut (#7407)',
+    shortcut => {
+      const editor = createHeadlessEditor({
+        nodes: [
+          HeadingNode,
+          ListNode,
+          ListItemNode,
+          QuoteNode,
+          CodeNode,
+          LinkNode,
+        ],
+      });
+
+      registerMarkdownShortcuts(editor, TRANSFORMERS);
+
+      editor.update(
+        () => {
+          const quote = $createQuoteNode();
+          const text = $createTextNode('Welcome to the playground');
+          quote.append(text);
+          $getRoot().append(quote);
+          text.select(0, 0);
+        },
+        {discrete: true},
+      );
+
+      for (const character of shortcut) {
+        editor.update(
+          () => {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) {
+              selection.insertText(character);
+            }
+          },
+          {discrete: true},
+        );
+      }
+
+      editor.read(() => {
+        const quote = $getRoot().getFirstChild();
+        expect($isQuoteNode(quote)).toBe(true);
+        expect(quote?.getTextContent()).toBe(
           `${shortcut}Welcome to the playground`,
         );
       });


### PR DESCRIPTION
Typing `# `, `## `, `- ` or `1. ` at the start of an existing block quote replaced the `QuoteNode` with the new block, silently discarding the quote. The `> ` and ` ``` ` shortcuts were already safe; heading and list shortcuts were not. That is broader than the report, which only mentions headings.

A `QuoteNode` holds inline content, so there is nowhere to nest the new block — exporting a heading nested in a quote loses the level (`> H2`). Import already declines: `$convertFromMarkdownString('> # x')` keeps the quote and leaves `# x` as literal text. The shortcut now agrees rather than dropping the quote out from under the caret. This mirrors the guard `listReplace` already has for `HeadingNode`.

Import is untouched (the check is gated on `!isImport`); only the typed-shortcut path changes.

Adds 7 tests over `# `, `## `, `###### `, `1. `, `- `, `* `, `+ `.

If you would rather the marker actually take effect inside the quote, `@lexical/mdast` already supports that tree shape and I have a companion change for its shortcuts — happy to send it if this direction is wrong.

Fixes #7407
