### PR TITLE
[lexical-mdast] Bug Fix: block shortcuts typed inside a blockquote

### DIFF
--- a/packages/lexical-mdast/src/MdastShortcuts.ts
+++ b/packages/lexical-mdast/src/MdastShortcuts.ts
@@ -17,7 +17,12 @@ import {
   $isListItemNode,
   $isListNode,
 } from '@lexical/list';
-import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
+import {
+  $createHeadingNode,
+  $createQuoteNode,
+  $isQuoteNode,
+  type QuoteNode,
+} from '@lexical/rich-text';
 import {
   $addUpdateTag,
   $getNodeByKey,
@@ -69,8 +74,23 @@ function $stripLeading(element: ElementNode, n: number): void {
 }
 
 /**
+ * Installs `block` in place of `container`, except for an inline-content quote
+ * (see {@link $isShortcutQuote}) which keeps its identity and adopts the block
+ * as a child instead.
+ */
+function $placeBlock(container: ElementNode, block: ElementNode): void {
+  if ($isQuoteNode(container)) {
+    container.append(block);
+  } else {
+    container.replace(block);
+  }
+}
+
+/**
  * Replaces `paragraph` with the block construct described by `match`, keeping
- * the content that followed the marker.
+ * the content that followed the marker. `paragraph` is the shortcut container:
+ * a ParagraphNode, or an inline-content QuoteNode that adopts the new block
+ * rather than being replaced by it.
  */
 function $applyBlock(paragraph: ElementNode, match: MdastBlockMatch): boolean {
   // Capture the fence before the marker is stripped from the paragraph.
@@ -91,7 +111,7 @@ function $applyBlock(paragraph: ElementNode, match: MdastBlockMatch): boolean {
       $setState(code, codeMetaState, match.node.meta);
     }
     $append(code, remaining);
-    paragraph.replace(code);
+    $placeBlock(paragraph, code);
     code.selectStart();
     return true;
   }
@@ -128,7 +148,7 @@ function $applyBlock(paragraph: ElementNode, match: MdastBlockMatch): boolean {
     selectInto = item;
   }
 
-  paragraph.replace(target);
+  $placeBlock(paragraph, target);
   selectInto.selectStart();
   return true;
 }
@@ -257,6 +277,37 @@ function $isShortcutParagraph(
 }
 
 /**
+ * A blockquote imported by the default handler holds inline content directly,
+ * so a block marker typed at its start has no enclosing paragraph to convert.
+ * The marker still has to take effect, because import already produces the
+ * nested shape: `> ## H2` imports as a QuoteNode holding a HeadingNode. Only
+ * the leading text is eligible, so a quote that already starts with a block is
+ * left alone. Shadow root quotes are excluded — they hold paragraphs, which
+ * {@link $isShortcutParagraph} already accepts. See #7407.
+ */
+function $isShortcutQuote(
+  node: LexicalNode,
+  anchorNode: TextNode,
+): node is QuoteNode {
+  return (
+    $isQuoteNode(node) &&
+    !node.isShadowRoot() &&
+    $isRootOrShadowRoot(node.getParent()) &&
+    node.getFirstChild() === anchorNode
+  );
+}
+
+/** The element a block marker typed at `anchorNode` may convert. */
+function $isShortcutContainer(
+  node: LexicalNode,
+  anchorNode: TextNode,
+): boolean {
+  return (
+    $isShortcutParagraph(node, anchorNode) || $isShortcutQuote(node, anchorNode)
+  );
+}
+
+/**
  * Registers streaming Markdown shortcuts on `editor` from the
  * {@link CompiledMdast} registry. As the user types, the current line/inline
  * buffer is fed back through micromark (the same parser as full-document
@@ -264,6 +315,8 @@ function $isShortcutParagraph(
  *
  * - Block markers (`# `, `> `, `- `, `1. `, `- [ ] `) convert the paragraph
  *   into the matching Lexical block as soon as the trailing space is typed.
+ *   Typed at the start of a blockquote they nest the block inside the quote,
+ *   matching what import produces for `> ## H2`.
  * - A marker-only line (`` ```lang ``, `## `, `- `) converts on
  *   <kbd>Enter</kbd>.
  * - Inline constructs (`*em*`, `**strong**`, `` `code` ``, `~~del~~`,
@@ -378,7 +431,7 @@ export function registerMarkdownShortcuts(
               transformed = true;
             } else if (
               anchorOffset <= MAX_BLOCK_MARKER_LENGTH &&
-              $isShortcutParagraph(parent, node)
+              $isShortcutContainer(parent, node)
             ) {
               // The marker must end exactly at the caret, so scanning the
               // prefix is sufficient (and cheaper than the whole line).
@@ -422,7 +475,7 @@ export function registerMarkdownShortcuts(
         if (
           parent === null ||
           $isCodeNode(parent) ||
-          !$isShortcutParagraph(parent, anchorNode) ||
+          !$isShortcutContainer(parent, anchorNode) ||
           anchorOffset !== anchorNode.getTextContentSize()
         ) {
           return false;

--- a/packages/lexical-mdast/src/__tests__/unit/MdastShortcuts.test.ts
+++ b/packages/lexical-mdast/src/__tests__/unit/MdastShortcuts.test.ts
@@ -168,6 +168,76 @@ describe('@lexical/mdast streaming shortcuts', () => {
     });
   });
 
+  // `> ## H2` imports as a QuoteNode holding a HeadingNode, so typing the
+  // same markers has to build the same tree instead of leaving the marker as
+  // literal text inside the quote.
+  describe('block shortcuts inside a quote (#7407)', () => {
+    it('## -> heading nested in the quote', () => {
+      using editor = createEditor();
+      type(editor, ['>', ' ', '#', '#', ' ', 'H2']);
+      editor.read(() => {
+        const quote = $assertNodeType($getRoot().getFirstChild(), $isQuoteNode);
+        const heading = $assertNodeType(quote.getFirstChild(), $isHeadingNode);
+        expect(heading.getTag()).toBe('h2');
+        expect(heading.getTextContent()).toBe('H2');
+        expect(quote.getChildrenSize()).toBe(1);
+      });
+    });
+
+    it('- -> bullet list nested in the quote', () => {
+      using editor = createEditor();
+      type(editor, ['>', ' ', '-', ' ', 'a']);
+      editor.read(() => {
+        const quote = $assertNodeType($getRoot().getFirstChild(), $isQuoteNode);
+        const list = $assertNodeType(quote.getFirstChild(), $isListNode);
+        expect(list.getListType()).toBe('bullet');
+        expect(list.getTextContent()).toBe('a');
+      });
+    });
+
+    it('1. -> ordered list nested in the quote', () => {
+      using editor = createEditor();
+      type(editor, ['>', ' ', '1', '.', ' ', 'a']);
+      editor.read(() => {
+        const quote = $assertNodeType($getRoot().getFirstChild(), $isQuoteNode);
+        const list = $assertNodeType(quote.getFirstChild(), $isListNode);
+        expect(list.getListType()).toBe('number');
+        expect(list.getTextContent()).toBe('a');
+      });
+    });
+
+    it('```js + Enter -> code block nested in the quote', () => {
+      using editor = createEditor();
+      type(editor, ['>', ' ', '```js']);
+      editor.dispatchCommand(KEY_ENTER_COMMAND, null);
+      editor.read(() => {
+        const quote = $assertNodeType($getRoot().getFirstChild(), $isQuoteNode);
+        const code = $assertNodeType(quote.getFirstChild(), $isCodeNode);
+        expect(code.getLanguage()).toBe('js');
+        expect(code.getTextContent()).toBe('');
+      });
+    });
+
+    it('leaves the quote alone once it holds a block', () => {
+      using editor = createEditor();
+      type(editor, ['>', ' ', '#', ' ', 'A']);
+      editor.read(() => {
+        const quote = $assertNodeType($getRoot().getFirstChild(), $isQuoteNode);
+        $assertNodeType(quote.getFirstChild(), $isHeadingNode);
+      });
+      // The caret sits in the heading, which is not the quote's leading text,
+      // so a second marker must stay literal rather than restructure anything.
+      type(editor, [' ', '#', '#', ' ']);
+      editor.read(() => {
+        const quote = $assertNodeType($getRoot().getFirstChild(), $isQuoteNode);
+        expect(quote.getChildrenSize()).toBe(1);
+        const heading = $assertNodeType(quote.getFirstChild(), $isHeadingNode);
+        expect(heading.getTag()).toBe('h1');
+        expect(heading.getTextContent()).toBe('A ## ');
+      });
+    });
+  });
+
   describe('inline shortcuts (on closing delimiter)', () => {
     function inlineFormats(editor: LexicalEditor): number[] {
       return editor.read(() => {


### PR DESCRIPTION
`@lexical/mdast` already supports block children inside a blockquote: `> ## H2` imports as a `QuoteNode` holding a `HeadingNode` and round-trips exactly, as do `> - a`, `> 1. a`, `> > x` and a fenced block. Typing the same markers did nothing — the marker was left as literal text — because a quote from the default handler holds inline content directly, so the caret's parent is the `QuoteNode` and the shortcut only recognized a `ParagraphNode` container.

This accepts an inline-content quote as a shortcut container and appends the new block to it instead of replacing it, so typing builds the tree import builds. Only the quote's leading text is eligible, so a quote that already starts with a block is untouched. Shadow root quotes are unaffected — they hold paragraphs, which already qualified. Import, export, and the paragraph path are unchanged.

Adds 5 tests covering heading, bullet list, ordered list, fenced code on Enter, and the leading-text guard.

Companion to the `@lexical/markdown` change for the same report: that package cannot nest a block in a quote, so it declines the shortcut instead; this one can, so it performs it. They are independent — take either, both, or neither.

Refs #7407
