### PR TITLE
[lexical-markdown] Bug Fix: don't prefix a newline when a selection starts below the first block

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -113,10 +113,13 @@ export function createSelectionMarkdownExport(
 
   return selection => {
     const output = [];
-    const children = $getRoot().getChildren();
+    // The separator depends on the previously *emitted* block, not on the
+    // previous root child: unselected children produce no output, so keying
+    // off the child index would prefix a newline to the first emitted block
+    // whenever the selection starts below the top of the document.
+    let previousExported: LexicalNode | null = null;
 
-    for (let i = 0; i < children.length; i++) {
-      const child = children[i];
+    for (const child of $getRoot().getChildren()) {
       const {shouldInclude, markdown} = $processNodeForSelection(
         child,
         selection,
@@ -129,12 +132,13 @@ export function createSelectionMarkdownExport(
       if (shouldInclude && markdown != null) {
         output.push(
           isNewlineDelimited &&
-            i > 0 &&
+            previousExported !== null &&
             !isEmptyParagraph(child) &&
-            !isEmptyParagraph(children[i - 1])
+            !isEmptyParagraph(previousExported)
             ? '\n'.concat(markdown)
             : markdown,
         );
+        previousExported = child;
       }
     }
     return output.join('\n');

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -2704,6 +2704,34 @@ describe('$convertSelectionToMarkdownString', () => {
     expect(result).toBe('Hello **Bold**');
   });
 
+  it('does not prefix a newline when the selection starts after the first block', () => {
+    const editor = createTestEditor();
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const firstText = $createTextNode('First');
+        const secondText = $createTextNode('Second');
+        const thirdText = $createTextNode('Third');
+        root.append(
+          $createParagraphNode().append(firstText),
+          $createParagraphNode().append(secondText),
+          $createParagraphNode().append(thirdText),
+        );
+        $setSelectionFromCaretRange(
+          $getCaretRange(
+            $getTextPointCaret(secondText, 'next', 0),
+            $getTextPointCaret(thirdText, 'next', 5),
+          ),
+        );
+      },
+      {discrete: true},
+    );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
+    expect(result).toBe('Second\n\nThird');
+  });
+
   it('returns empty string for null selection', () => {
     const result = $convertSelectionToMarkdownString(TRANSFORMERS, null);
     expect(result).toBe('');


### PR DESCRIPTION
## Description

`$convertSelectionToMarkdownString` decides whether to prefix a block with `\n` by looking at the block's index among the root's children:

```ts
isNewlineDelimited &&
  i > 0 &&
  !isEmptyParagraph(child) &&
  !isEmptyParagraph(children[i - 1])
```

Unselected children emit nothing, so the index is not the position in the output. When the selection starts below the top of the document, the first block that does get emitted still has `i > 0`, and a newline is prefixed to it. The returned markdown then opens with a blank line.

With three paragraphs and a selection covering only the last two:

```ts
$convertSelectionToMarkdownString(TRANSFORMERS, $getSelection())
// '\nSecond\n\nThird', expected 'Second\n\nThird'
```

The separator now tracks the previously emitted block instead of the previous child. When every child is selected, the previously emitted block is `children[i - 1]`, so nothing changes for the existing cases.

`createMarkdownExport` has the same shape but not the same bug: `$exportTopLevelElements` only returns `null` for a node that is neither an element nor a decorator, which a root child never is, so every child there contributes to the output.

## Test plan

### Before

```
FAIL packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
  > $convertSelectionToMarkdownString
    > does not prefix a newline when the selection starts after the first block

AssertionError: expected '\nSecond\n\nThird' to be 'Second\n\nThird'
```

### After

```
Test Files  1 passed (1)
     Tests  417 passed (417)
```

`pnpm run prettier` and `pnpm run tsc` are both clean.
