### PR TITLE
[lexical-markdown] Bug Fix: don't emit a dangling closing tag when a selection slices a format to whitespace

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -545,7 +545,17 @@ function exportTextFormat(
     }
 
     // dedup applied formats
-    if (checkHasFormat(node, format) && !applied.has(format)) {
+    // `checkHasFormat` reads the node's whole text, but the text being
+    // exported may be a selection slice of it. When the slice is entirely
+    // whitespace the tags are dropped by the early return below, so
+    // registering them here would leave an unclosed tag for a later node to
+    // close. In the full-document path `checkHasFormat` already rejects
+    // whitespace-only nodes, so this guard only affects sliced content.
+    if (
+      !isWhitespaceOnly &&
+      checkHasFormat(node, format) &&
+      !applied.has(format)
+    ) {
       applied.add(format);
 
       // append the tag to openingTags, if it's not applied to the previous nodes,

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -3193,3 +3193,31 @@ describe('$generateNodesFromMarkdownString', () => {
     expect(nodes[0].getType()).toBe('paragraph');
   });
 });
+
+describe('$convertSelectionToMarkdownString whitespace slices', () => {
+  it('does not emit a dangling closing tag when the selection slices a format down to whitespace', () => {
+    const editor = createHeadlessEditor({nodes: [LinkNode]});
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const first = $createTextNode('a  ');
+        first.toggleFormat('bold');
+        first.setStyle('color: red');
+        const second = $createTextNode('b');
+        second.toggleFormat('bold');
+        root.append($createParagraphNode().append(first, second));
+        $setSelectionFromCaretRange(
+          $getCaretRange(
+            $getTextPointCaret(first, 'next', 1),
+            $getTextPointCaret(second, 'next', 1),
+          ),
+        );
+      },
+      {discrete: true},
+    );
+    const result = editor.read('latest', () =>
+      $convertSelectionToMarkdownString(TRANSFORMERS, $getSelection()),
+    );
+    expect(result).toBe('  **b**');
+  });
+});


### PR DESCRIPTION
## Description

`exportTextFormat` decides two different things from two different strings, and a selection export can make them disagree.

Whether the node carries a format comes from `checkHasFormat`, which reads the node's **whole** text and rejects nodes that are entirely whitespace:

```ts
if (n && /^\s*$/.test(n.getTextContent())) {
  return false;
}
```

Whether the tags are actually emitted comes from `isWhitespaceOnly`, computed from the `textContent` argument, which on the selection path is the node sliced down to the selected range:

```ts
if (isWhitespaceOnly && !node.hasFormat('code')) {
  return closingTagsBefore + output;
}
```

When a selection slices a formatted node down to whitespace, the first check passes and the second one fires. The tag is pushed onto `unclosedTags` but the opening tag is thrown away by the early return, so the next node closes a tag that was never opened.

Two bold text nodes, `'a  '` and `'b'`, with the selection running from offset 1 of the first through the second:

```ts
$convertSelectionToMarkdownString(TRANSFORMERS, $getSelection())
// '  b**', expected '  **b**'
```

The `**` at the end has no opener, so the output is not valid markdown.

The opening-tag registration is now skipped when the exported text is whitespace-only. The early return already discards those tags, so registering them had no effect other than corrupting the shared `unclosedTags` list. The following node then sees no pending `**`, opens its own, and closes it.

This does not change the full-document path: there `textContent` is the node's whole text, so `isWhitespaceOnly` can only be true when `checkHasFormat` already returned false for every format.

## Test plan

### Before

```
FAIL packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
  > $convertSelectionToMarkdownString whitespace slices
    > does not emit a dangling closing tag when the selection slices a format down to whitespace

AssertionError: expected '  b**' to be '  **b**'
```

### After

```
Test Files  1 passed (1)
     Tests  417 passed (417)
```

Full `vitest run`: 5251 passed, 2 skipped. The two failures are in `scripts/__tests__/unit/childProcess.test.ts` and are about shell env forwarding on Windows. They reproduce on a clean `main` with this change stashed, so they are not related to it.

`pnpm run prettier` and `pnpm run tsc` are clean.
