### PR TITLE
[lexical-table] Bug Fix: ArrowUp from the block cursor below a table returns to the last row

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -14,6 +14,7 @@ import invariant from '@lexical/internal/invariant';
 import {objectKlassEquals} from '@lexical/utils';
 import {
   $caretFromPoint,
+  $comparePointCaretNext,
   $createParagraphNode,
   $createRangeSelectionFromDom,
   $createTextNode,
@@ -21,6 +22,7 @@ import {
   $findMatchingParent,
   $getAdjacentChildCaret,
   $getChildCaret,
+  $getCommonAncestor,
   $getNearestNodeFromDOMNode,
   $getNodeByKey,
   $getNodeByKeyOrThrow,
@@ -2100,6 +2102,27 @@ function $findNextTableCell<D extends CaretDirection>(
   return null;
 }
 
+/**
+ * True when the selection focus sits before `tableNode` in document order —
+ * the only side an ArrowDown can move the caret into the table from.
+ */
+function $isSelectionBeforeTable(
+  selection: null | BaseSelection,
+  tableNode: TableNode,
+): boolean {
+  if (!$isRangeSelection(selection)) {
+    return false;
+  }
+  const focusCaret = $caretFromPoint(selection.focus, 'next');
+  // A ChildCaret is ordered at the table's 'enter' (pre-order) position, so
+  // any caret strictly before it is outside of and above the table.
+  const tableCaret = $getChildCaret(tableNode, 'next');
+  return (
+    $getCommonAncestor(focusCaret.origin, tableCaret.origin) !== null &&
+    $comparePointCaretNext(focusCaret, tableCaret) < 0
+  );
+}
+
 function $handleArrowKey(
   editor: LexicalEditor,
   event: KeyboardEvent,
@@ -2287,7 +2310,17 @@ function $handleArrowKey(
         }
       }
     }
-    if (direction === 'down' && $isScrollableTablesActive(editor)) {
+    if (
+      direction === 'down' &&
+      $isScrollableTablesActive(editor) &&
+      // Only arm the workaround when ArrowDown could actually move the caret
+      // into the table. From a caret after the table (e.g. the block cursor
+      // below a trailing table) ArrowDown moves nothing, so the flag would
+      // survive to be consumed by an unrelated later selection change — an
+      // ArrowUp back into the last row would then be snapped to the first
+      // cell.
+      $isSelectionBeforeTable(selection, tableNode)
+    ) {
       // Enable Firefox workaround
       tableObservers.setShouldCheckSelectionForTable(tableNode.getKey());
     }

--- a/packages/lexical-table/src/__tests__/browser/Issue6822BlockCursorArrowKeys.test.ts
+++ b/packages/lexical-table/src/__tests__/browser/Issue6822BlockCursorArrowKeys.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createTableNodeWithDimensions,
+  $isTableCellNode,
+  $isTableRowNode,
+  TableExtension,
+} from '@lexical/table';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  defineExtension,
+  type LexicalEditor,
+} from 'lexical';
+import {describe, expect, onTestFinished, test} from 'vitest';
+import {userEvent} from 'vitest/browser';
+
+// Regression tests for #6822.
+//
+// A table that is the first or last child of the root gets a block cursor
+// beside it when the caret steps off its edge. Getting back into the table
+// from that block cursor is native caret movement, so these tests run in a
+// real browser (see the `browser` project in vitest.config.mts) against real
+// layout — jsdom has neither a caret nor line boxes to move it between.
+//
+// The theme mirrors the playground's block cursor and table CSS because the
+// engine's vertical caret movement is layout-driven; an approximation of the
+// real stylesheet lands the caret in different cells.
+const PLAYGROUND_CSS = `
+.test-blockCursor { display: block; pointer-events: none; position: absolute; }
+.test-blockCursor:after { content: ''; display: block; position: absolute; top: -2px; width: 20px; border-top: 1px solid black; }
+.test-scrollWrapper { overflow-x: auto; margin: 0px 0px 5px 0px; scrollbar-width: none; }
+.test-scrollWrapper > .test-table { margin-top: 0; margin-bottom: 0; }
+.test-table { border-collapse: collapse; border-spacing: 0; table-layout: fixed; width: fit-content; margin-top: 25px; margin-bottom: 30px; }
+.test-cell { border: 1px solid #bbb; width: 75px; vertical-align: top; text-align: start; padding: 6px 8px; position: relative; outline: none; overflow: auto; }
+.test-cell > * { overflow: inherit; }
+.test-cellHeader { background-color: #f2f3f5; text-align: start; }
+`;
+
+const THEME = {
+  blockCursor: 'test-blockCursor',
+  table: 'test-table',
+  tableCell: 'test-cell',
+  tableCellHeader: 'test-cellHeader',
+  tableScrollableWrapper: 'test-scrollWrapper',
+};
+
+/**
+ * A 3x3 table whose cells read "c1".."c9" in document order, so an assertion
+ * on the anchor's text content names the cell the caret landed in.
+ */
+function $createNumberedTable() {
+  const table = $createTableNodeWithDimensions(3, 3, true);
+  let n = 0;
+  for (const row of table.getChildren()) {
+    if (!$isTableRowNode(row)) {
+      continue;
+    }
+    for (const cell of row.getChildren()) {
+      if (!$isTableCellNode(cell)) {
+        continue;
+      }
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode(`c${++n}`));
+      cell.clear().append(paragraph);
+    }
+  }
+  return table;
+}
+
+function setUpEditor($initialEditorState: () => void): LexicalEditor {
+  const style = document.createElement('style');
+  style.textContent = PLAYGROUND_CSS;
+  document.head.appendChild(style);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const editor = buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState,
+      afterRegistration(builtEditor) {
+        const rootElement = document.createElement('div');
+        rootElement.contentEditable = 'true';
+        container.appendChild(rootElement);
+        builtEditor.setRootElement(rootElement);
+        return () => {
+          document.body.removeChild(container);
+          document.head.removeChild(style);
+        };
+      },
+      // hasHorizontalScroll defaults on, which is what arms the Firefox
+      // scroll workaround under test.
+      dependencies: [RichTextExtension, TableExtension],
+      name: '[6822-browser]',
+      theme: THEME,
+    }),
+  );
+  onTestFinished(() => editor.dispose());
+  return editor;
+}
+
+async function press(key: string): Promise<void> {
+  await userEvent.keyboard(key);
+  // Let the engine's selectionchange (and Lexical's reconcile of it) settle.
+  await new Promise(resolve => setTimeout(resolve, 60));
+}
+
+/** The text of the node the caret is anchored in, or a description of a
+ * non-text anchor (`block cursor` for a collapsed element point on the root). */
+function anchorText(editor: LexicalEditor): string {
+  return editor.getEditorState().read(() => {
+    const selection = $getSelection();
+    if (!$isRangeSelection(selection)) {
+      return `not a RangeSelection: ${String(selection)}`;
+    }
+    const anchor = selection.anchor;
+    return anchor.type === 'text'
+      ? anchor.getNode().getTextContent()
+      : `element point on ${anchor.getNode().getType()}@${anchor.offset}`;
+  });
+}
+
+function hasBlockCursor(editor: LexicalEditor): boolean {
+  return editor._blockCursorElement !== null;
+}
+
+describe('block cursor beside a table (#6822)', () => {
+  test('ArrowUp from the block cursor below a trailing table returns to the last row', async () => {
+    const editor = setUpEditor(() => {
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode('before'));
+      $getRoot().clear().append(paragraph, $createNumberedTable());
+    });
+    editor.update(
+      () => {
+        // The last descendant of the root is the text in the table's last
+        // cell in both layouts under test.
+        $getRoot().getLastDescendant()!.selectEnd();
+      },
+      {discrete: true},
+    );
+    editor.focus();
+    await new Promise(resolve => setTimeout(resolve, 60));
+    expect(anchorText(editor)).toBe('c9');
+
+    // Step off the bottom edge: the caret becomes a block cursor after the
+    // table (an element point on the root).
+    await press('{ArrowDown}');
+    expect(hasBlockCursor(editor)).toBe(true);
+    expect(anchorText(editor)).toBe('element point on root@2');
+
+    // A second ArrowDown moves nothing — there is nothing below the table.
+    await press('{ArrowDown}');
+    expect(hasBlockCursor(editor)).toBe(true);
+    expect(anchorText(editor)).toBe('element point on root@2');
+
+    // ArrowUp must step back into the row the caret left, not jump to the
+    // top-left cell.
+    await press('{ArrowUp}');
+    expect(hasBlockCursor(editor)).toBe(false);
+    expect(anchorText(editor)).toBe('c9');
+
+    await press('z');
+    expect(
+      editor.getEditorState().read(() => $getRoot().getTextContent()),
+    ).toBe('before\n\nc1\n\nc2\n\nc3\n\nc4\n\nc5\n\nc6\n\nc7\n\nc8\n\nc9z');
+  });
+
+  test('ArrowUp from the block cursor below a table that is the only root child returns to the last row', async () => {
+    const editor = setUpEditor(() => {
+      $getRoot().clear().append($createNumberedTable());
+    });
+    editor.update(
+      () => {
+        // The last descendant of the root is the text in the table's last
+        // cell in both layouts under test.
+        $getRoot().getLastDescendant()!.selectEnd();
+      },
+      {discrete: true},
+    );
+    editor.focus();
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    await press('{ArrowDown}');
+    expect(hasBlockCursor(editor)).toBe(true);
+    await press('{ArrowDown}');
+    expect(hasBlockCursor(editor)).toBe(true);
+    await press('{ArrowUp}');
+    expect(anchorText(editor)).toBe('c9');
+  });
+
+  test('ArrowDown from the block cursor above a leading table still enters the first cell', async () => {
+    // A control: this passes with and without the fix, because in this engine
+    // the native ArrowDown lands in the first cell on its own. It is here to
+    // pin the direction the Firefox scroll workaround is gated to — entering
+    // the table from above must keep working.
+    const editor = setUpEditor(() => {
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode('after'));
+      $getRoot().clear().append($createNumberedTable(), paragraph);
+    });
+    editor.update(
+      () => {
+        $getRoot().getFirstDescendant()!.selectStart();
+      },
+      {discrete: true},
+    );
+    editor.focus();
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    await press('{ArrowUp}');
+    expect(hasBlockCursor(editor)).toBe(true);
+    expect(anchorText(editor)).toBe('element point on root@0');
+
+    await press('{ArrowDown}');
+    expect(hasBlockCursor(editor)).toBe(false);
+    expect(anchorText(editor)).toBe('c1');
+
+    await press('z');
+    expect(
+      editor.getEditorState().read(() => $getRoot().getTextContent()),
+    ).toBe('zc1\n\nc2\n\nc3\n\nc4\n\nc5\n\nc6\n\nc7\n\nc8\n\nc9\n\nafter');
+  });
+});


### PR DESCRIPTION
When a table is the last block in the editor, stepping the caret off its bottom edge shows a block cursor after the table. Pressing ArrowDown there moves nothing — but it still armed the Firefox scrollable-table workaround (`setShouldCheckSelectionForTable`). Because that ArrowDown produces no selection change, the flag survived and was consumed by the *next* selection change instead: the following ArrowUp correctly walked the caret back into the table's last row, and was then immediately snapped to the table's first cell.

`$handleArrowKey` now arms the workaround only when the selection focus is before the table in document order — the only side an ArrowDown can enter a table from.

The regression test lives in the vitest `browser` project (real Chromium) because this is native caret movement over real layout, which jsdom cannot model; the theme mirrors the playground's block-cursor and table CSS, since an approximation lands the caret in different cells. Two tests fail on main with `expected 'c1' to be 'c9'` and pass with the fix; a third is a control pinning the direction the workaround still applies to.

`lexical-table`: 153/153 unit, 7/7 browser.

Fixes #6822
