### PR TITLE
[lexical-playground] Bug Fix: triple click selects the paragraph before an embed block

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/BlockWithAlignableContents.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/BlockWithAlignableContents.spec.mjs
@@ -9,6 +9,8 @@
 import {selectAll} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
+  assertSelection,
+  createHumanReadableSelection,
   focusEditor,
   html,
   initialize,
@@ -127,6 +129,42 @@ test.describe('BlockWithAlignableContents', () => {
       `,
       undefined,
       {ignoreClasses: true},
+    );
+  });
+
+  // #7618: an unfocused embed block must not opt out of user selection, or the
+  // browser refuses to extend a triple click to the end of the paragraph that
+  // precedes it and collapses the selection to the start of that paragraph.
+  test('Can triple click to select a paragraph followed by an embed block', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+    const text = 'Hello world';
+    await page.keyboard.type(text);
+    await insertYouTubeEmbed(page, YOUTUBE_SAMPLE_URL);
+    await page
+      .locator('div[contenteditable="true"] > p')
+      .first()
+      .click({clickCount: 3, delay: 50});
+    await assertSelection(
+      page,
+      createHumanReadableSelection('the whole first paragraph', {
+        anchorOffset: {desc: 'start of the text', value: 0},
+        anchorPath: [
+          {desc: 'first paragraph', value: 0},
+          {desc: 'first span', value: 0},
+          {desc: 'Text node', value: 0},
+        ],
+        focusOffset: {desc: 'end of the text', value: text.length},
+        focusPath: [
+          {desc: 'first paragraph', value: 0},
+          {desc: 'first span', value: 0},
+          {desc: 'Text node', value: 0},
+        ],
+      }),
     );
   });
 });

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -635,7 +635,14 @@
   background: rgba(255, 212, 0, 0.7);
   border-bottom: 2px solid rgba(255, 212, 0, 0.7);
 }
-.PlaygroundEditorTheme__embedBlock {
+/*
+  Keep the embed's contents unselectable, but leave the decorator host and this
+  wrapper itself selectable: a browser will not extend a triple click past an
+  unselectable block, so an unselectable wrapper collapses the selection when
+  the paragraph before the embed is triple clicked (#7618). `user-select` is
+  inherited, so scoping it to the children still covers the whole embed.
+*/
+.PlaygroundEditorTheme__embedBlock > * {
   user-select: none;
 }
 .PlaygroundEditorTheme__embedBlockFocus {


### PR DESCRIPTION
Triple-clicking a paragraph that is immediately followed by an embed collapsed the selection to the start of that paragraph instead of selecting the line.

The cause is `user-select: none` on `.PlaygroundEditorTheme__embedBlock`, as @etrepum identified on the issue. A browser will not extend a triple click past an unselectable block, and here the unselectable element is the decorator's own wrapper.

That rule was not always unconditional, which answers the question about what it was for. #1895 added it as `.embed-block.focused { user-select: none }` — focused state only. #2387 moved it to the always-on base class while migrating embeds to the theme, so the unconditional form looks like a side effect of that refactor rather than a deliberate requirement.

`user-select` is inherited, so scoping the rule to `.PlaygroundEditorTheme__embedBlock > *` keeps the embed contents unselectable while leaving the decorator host and the wrapper selectable.

Adds an e2e regression test to `BlockWithAlignableContents.spec.mjs`. It fails on chromium before the change (focusOffset 0 instead of 11) and passes after; webkit and firefox were unaffected either way, so on those engines it is a control. Full chromium e2e: 825 passed, 22 skipped.

Fixes #7618
