### PR TITLE
[lexical-react] Bug Fix: CollaborationPlugin recreates the provider when providerFactory changes

### DIFF
--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -80,7 +80,15 @@ export function CollaborationPlugin({
   rootName,
 }: CollaborationPluginProps): JSX.Element {
   const isBindingInitialized = useRef(false);
-  const isProviderInitialized = useRef(false);
+  // The inputs that produced the current Provider. A ref rather than the effect
+  // deps alone because the effect must be idempotent: React StrictMode (and
+  // React 18+ remounts in general) re-runs the effect with unchanged inputs and
+  // must not create a second Provider.
+  const providerInputs = useRef<null | {
+    id: string;
+    providerFactory: ProviderFactory;
+    yjsDocMap: Map<string, Doc>;
+  }>(null);
 
   const collabContext = useCollaborationContext(username, cursorColor);
   const {yjsDocMap, name, color} = collabContext;
@@ -93,11 +101,17 @@ export function CollaborationPlugin({
   const [doc, setDoc] = useState<Doc>();
 
   useEffect(() => {
-    if (isProviderInitialized.current) {
+    const prevInputs = providerInputs.current;
+    if (
+      prevInputs !== null &&
+      prevInputs.id === id &&
+      prevInputs.providerFactory === providerFactory &&
+      prevInputs.yjsDocMap === yjsDocMap
+    ) {
       return;
     }
 
-    isProviderInitialized.current = true;
+    providerInputs.current = {id, providerFactory, yjsDocMap};
 
     const newProvider = providerFactory(id, yjsDocMap);
     setProvider(newProvider);

--- a/packages/lexical-react/src/__tests__/unit/LexicalCollaborationPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalCollaborationPlugin.test.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {Provider} from '@lexical/yjs';
+
 import {LexicalCollaboration} from '@lexical/react/LexicalCollaborationContext';
 import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
@@ -17,6 +19,37 @@ import {act} from 'react';
 import {createRoot, type Root} from 'react-dom/client';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 import * as Y from 'yjs';
+
+type TestProvider = Provider & {
+  _connectCount: number;
+  _disconnectCount: number;
+};
+
+/** A minimal in-memory {@link Provider} that records connect/disconnect calls. */
+function createTestProvider(): TestProvider {
+  const provider: TestProvider = {
+    _connectCount: 0,
+    _disconnectCount: 0,
+    awareness: {
+      getLocalState: () => null,
+      getStates: () => new Map(),
+      off: () => {},
+      on: () => {},
+      setLocalState: () => {},
+      setLocalStateField: () => {},
+    },
+    connect: () => {
+      provider._connectCount++;
+    },
+    disconnect: () => {
+      provider._disconnectCount++;
+    },
+    off: () => {},
+    on: () => {},
+  };
+
+  return provider;
+}
 
 describe(`LexicalCollaborationPlugin`, () => {
   let container: HTMLDivElement;
@@ -97,5 +130,60 @@ describe(`LexicalCollaborationPlugin`, () => {
     });
 
     expect(providerFactory).toHaveBeenCalledTimes(1);
+  });
+
+  // https://github.com/facebook/lexical/issues/7136
+  test(`provider is replaced when providerFactory changes`, () => {
+    const doc = new Y.Doc();
+    const providerA = createTestProvider();
+    const providerB = createTestProvider();
+
+    const factoryA = vi.fn((id: string, yjsDocMap: Map<string, Y.Doc>) => {
+      yjsDocMap.set(id, doc);
+      return providerA;
+    });
+    const factoryB = vi.fn((id: string, yjsDocMap: Map<string, Y.Doc>) => {
+      yjsDocMap.set(id, doc);
+      return providerB;
+    });
+
+    function App({
+      providerFactory,
+    }: {
+      providerFactory: (id: string, yjsDocMap: Map<string, Y.Doc>) => Provider;
+    }) {
+      return (
+        <LexicalCollaboration>
+          <LexicalComposer initialConfig={editorConfig}>
+            <CollaborationPlugin
+              id="main"
+              providerFactory={providerFactory}
+              shouldBootstrap={false}
+            />
+            <RichTextPlugin
+              contentEditable={<ContentEditable />}
+              placeholder={<></>}
+              ErrorBoundary={LexicalErrorBoundary}
+            />
+          </LexicalComposer>
+        </LexicalCollaboration>
+      );
+    }
+
+    act(() => {
+      reactRoot.render(<App providerFactory={factoryA} />);
+    });
+
+    expect(factoryA).toHaveBeenCalledTimes(1);
+    expect(providerA._connectCount).toBe(1);
+
+    act(() => {
+      reactRoot.render(<App providerFactory={factoryB} />);
+    });
+
+    expect(factoryB).toHaveBeenCalledTimes(1);
+    expect(providerB._connectCount).toBe(1);
+    // The superseded provider is torn down.
+    expect(providerA._disconnectCount).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
`CollaborationPlugin` guards provider creation with an `isProviderInitialized` ref that is set on first run and never reset, so the effect's `[id, providerFactory, yjsDocMap]` dependencies never take effect — the provider is created exactly once for the lifetime of the component. Changing `providerFactory` afterwards does nothing, which makes it impossible to reconnect with refreshed connection parameters such as a rotated auth token.

The guard exists so that a StrictMode/remount re-run with unchanged inputs does not create a second provider. This replaces it with a ref that remembers the inputs the current provider was built from, and short-circuits only when all of them are identical. The effect stays idempotent for re-runs, but a genuine change now tears down the old provider and creates a new one.

The binding is intentionally left alone: it is keyed to the Yjs document, which the documented `getDocFromMap` factory pattern preserves across a provider re-create.

Adds a unit test that re-renders with a new factory and asserts the new provider is created and connected and the old one disconnected; it fails on `main`.

Fixes #7136
