### PR TITLE
[lexical-playground] Bug Fix: keep mention style and text formats in exported HTML

### DIFF
--- a/packages/lexical-playground/__tests__/unit/MentionHTML.test.ts
+++ b/packages/lexical-playground/__tests__/unit/MentionHTML.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $generateHtmlFromNodes,
+  $generateNodesFromDOMViaExtension,
+} from '@lexical/html';
+import {$patchStyleText} from '@lexical/selection';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $insertNodes,
+  $isElementNode,
+  $selectAll,
+  $setSelection,
+  defineExtension,
+  type LexicalNode,
+} from 'lexical';
+import {expectHtmlToBeEqual, html} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, it} from 'vitest';
+
+import {$createMentionNode, $isMentionNode} from '../../src/nodes/MentionNode';
+import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
+import {MentionsExtension} from '../../src/plugins/MentionsExtension';
+
+const MentionTestExtension = defineExtension({
+  $initialEditorState: null,
+  dependencies: [PlaygroundImportExtension, MentionsExtension],
+  name: '[test]',
+});
+
+function $findFirst(
+  predicate: (node: LexicalNode) => boolean,
+): LexicalNode | null {
+  const stack: LexicalNode[] = [...$getRoot().getChildren()];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if (predicate(node)) {
+      return node;
+    }
+    if ($isElementNode(node)) {
+      stack.push(...node.getChildren());
+    }
+  }
+  return null;
+}
+
+/**
+ * Insert a mention, then apply `$patchStyleText` / `formatText` to the whole
+ * document the way the playground toolbar's font-size dropdown and format
+ * buttons do, and return the HTML the editor exports.
+ */
+function exportMentionHtml(
+  patch: Record<string, string> | null,
+  formats: readonly ('bold' | 'italic' | 'underline' | 'strikethrough')[],
+): string {
+  using editor = buildEditorFromExtensions(MentionTestExtension);
+  editor.update(
+    () => {
+      const paragraph = $createParagraphNode();
+      $getRoot().clear().append(paragraph);
+      paragraph.selectStart();
+      $insertNodes([$createMentionNode('Luke Skywalker')]);
+      const selection = $selectAll();
+      if (patch !== null) {
+        $patchStyleText(selection, patch);
+      }
+      for (const format of formats) {
+        selection.formatText(format);
+      }
+      $setSelection(null);
+    },
+    {discrete: true},
+  );
+  return editor.read(() => $generateHtmlFromNodes(editor, null));
+}
+
+describe('MentionNode HTML export', () => {
+  // Control: this passes with and without the exportDOM fix, and guards the
+  // markup the `span[data-lexical-mention]` import rule matches on.
+  it('exports a plain mention as a data-lexical-mention span', () => {
+    expectHtmlToBeEqual(
+      exportMentionHtml(null, []),
+      html`
+        <p><span data-lexical-mention="true">Luke Skywalker</span></p>
+      `,
+    );
+  });
+
+  it('exports the font-size applied to a mention (#6453)', () => {
+    expectHtmlToBeEqual(
+      exportMentionHtml({'font-size': '20px'}, []),
+      html`
+        <p>
+          <span style="font-size: 20px;" data-lexical-mention="true">
+            Luke Skywalker
+          </span>
+        </p>
+      `,
+    );
+  });
+
+  it('exports the text formats applied to a mention (#6453)', () => {
+    expectHtmlToBeEqual(
+      exportMentionHtml(null, ['bold', 'italic', 'underline']),
+      html`
+        <p>
+          <u>
+            <i>
+              <b><span data-lexical-mention="true">Luke Skywalker</span></b>
+            </i>
+          </u>
+        </p>
+      `,
+    );
+  });
+
+  // Control: passes with and without the exportDOM fix. It pins down that the
+  // format wrappers added around the mention span do not stop the
+  // `span[data-lexical-mention]` import rule from recognizing it again.
+  it('still imports a formatted mention back as a MentionNode', () => {
+    using editor = buildEditorFromExtensions(MentionTestExtension);
+    const htmlString = exportMentionHtml({'font-size': '20px'}, ['bold']);
+    editor.update(
+      () => {
+        $getRoot().clear().select();
+        const dom = new DOMParser().parseFromString(htmlString, 'text/html');
+        $insertNodes($generateNodesFromDOMViaExtension(dom));
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const node = $findFirst($isMentionNode);
+      assert($isMentionNode(node), 'expected a MentionNode');
+      expect(node.getTextContent()).toBe('Luke Skywalker');
+    });
+  });
+});

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -15,8 +15,18 @@ import {
   type NodeKey,
   type SerializedTextNode,
   type Spread,
+  type TextFormatType,
   TextNode,
 } from 'lexical';
+
+// The element TextNode.exportDOM wraps its output with, one per text format,
+// innermost first.
+const FORMAT_WRAPPER_TAGS: readonly (readonly [TextFormatType, string])[] = [
+  ['bold', 'b'],
+  ['italic', 'i'],
+  ['strikethrough', 's'],
+  ['underline', 'u'],
+];
 
 export type SerializedMentionNode = Spread<
   {
@@ -64,13 +74,30 @@ export class MentionNode extends TextNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = $getDocument().createElement('span');
+    const document = $getDocument();
+    const element = document.createElement('span');
     element.setAttribute('data-lexical-mention', 'true');
     if (this.__text !== this.__mention) {
       element.setAttribute('data-lexical-mention-name', this.__mention);
     }
     element.textContent = this.__text;
-    return {element};
+    // Carry the inline style (e.g. a font-size applied from the toolbar) and
+    // the text formats onto the exported markup the way TextNode.exportDOM
+    // does, otherwise they are silently dropped from the HTML. The mention
+    // itself stays a <span> so the `span[data-lexical-mention]` import rule
+    // keeps matching it.
+    if (this.__style !== '') {
+      element.style.cssText = this.__style;
+    }
+    let wrapped: HTMLElement = element;
+    for (const [format, tag] of FORMAT_WRAPPER_TAGS) {
+      if (this.hasFormat(format)) {
+        const wrapper = document.createElement(tag);
+        wrapper.appendChild(wrapped);
+        wrapped = wrapper;
+      }
+    }
+    return {element: wrapped};
   }
 
   isTextEntity(): true {


### PR DESCRIPTION
`MentionNode.exportDOM()` created a bare `<span data-lexical-mention>` from `this.__text` and ignored the node's `__style` and `__format`. Applying a font size from the toolbar dropdown to a selection containing a mention updates the editor state correctly (`style: "font-size: 20px;"`), but the mention is exported as an unstyled span — the symptom in #6453, visible in the playground's Tree View "Export DOM" panel. Text formats were dropped the same way.

The export now carries the inline style onto the span and wraps it in the same `<b>`/`<i>`/`<s>`/`<u>` elements `TextNode.exportDOM` uses. The mention element itself stays a `<span>` so the `span[data-lexical-mention]` import rule still matches it and mentions keep round-tripping.

Adds `MentionHTML.test.ts`: two tests for the reported symptom, plus two controls — the unchanged plain-mention export shape, and an export-import round trip confirming the format wrappers don't break mention recognition.

One adjacent bug I found and deliberately left alone: the mention *import* rule in `MentionsExtension/index.tsx` does not read `ctx.get(ImportTextFormat)` / `ImportTextStyle` the way the core `#text` rule does, so a bold mention pasted back in loses its bold. That is independent of this change — before it, there was nothing exported to lose — and it belongs in its own PR.

Fixes #6453
