### PR TITLE
[lexical] Bug Fix: undo from a control outside the editor no longer runs the browser's native history over the editor DOM

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -17,6 +17,7 @@ import {
   selectCharacters,
   STANDARD_KEYPRESS_DELAY_MS,
   toggleBold,
+  undo,
 } from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
@@ -2368,6 +2369,55 @@ test.describe('Links', () => {
       `,
       undefined,
       {ignoreClasses: false},
+    );
+  });
+
+  test('Undo from the link URL input undoes in the editor rather than natively (#6714)', async ({
+    page,
+    browserName,
+    isCollab,
+  }) => {
+    // Firefox keeps the undo scoped to the focused control and never
+    // dispatches `beforeinput`/`historyUndo` on the editor root, so there is
+    // nothing for the editor to mishandle.
+    test.skip(browserName === 'firefox' || isCollab);
+    await focusEditor(page);
+    await page.keyboard.type('Hello world ');
+    await withExclusiveClipboardAccess(async () => {
+      await pasteFromClipboard(page, {'text/plain': 'https://lexical.dev'});
+    });
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Hello world</span>
+          <a class="PlaygroundEditorTheme__link" href="https://lexical.dev">
+            <span data-lexical-text="true">https://lexical.dev</span>
+          </a>
+        </p>
+      `,
+    );
+
+    // Open the URL field of the link popup, which moves focus out of the
+    // editor and leaves the editor without a selection.
+    await click(page, '.link-edit');
+    await focus(page, '.link-input');
+
+    // Chromium and WebKit exhaust the URL field's own (empty) undo stack and
+    // then dispatch the undo at the editor root. Nothing has been typed into
+    // the URL field, so this is the very first undo the user presses.
+    await undo(page);
+
+    // The pasted link is undone. Before the fix the browser ran its native
+    // undo over the editor's DOM instead, producing "Hhttps://lexical.dev":
+    // a state that was never in Lexical's history.
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+          <span data-lexical-text="true">Hello world</span>
+        </p>
+      `,
     );
   });
 });

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -979,6 +979,23 @@ function $handleBeforeInput(event: InputEvent): boolean {
   }
 
   if (!$isRangeSelection(selection)) {
+    if (inputType === 'historyUndo' || inputType === 'historyRedo') {
+      // Chromium and WebKit walk up the browser's undo scope, so they
+      // dispatch history undo/redo at the editor root when the focused
+      // control is outside of it and has exhausted its own history — e.g. the
+      // URL field of a floating link toolbar (#6714) — at which point the
+      // editor no longer has a selection. Returning without preventing the
+      // default lets the browser run its native history over a
+      // Lexical-managed contenteditable, rewriting the DOM behind the
+      // editor's back; the editor state is then rebuilt from that DOM into a
+      // document that was never in Lexical's history. `@lexical/history`
+      // restores a whole editor state, so it does not need a selection.
+      event.preventDefault();
+      dispatchCommand(
+        editor,
+        inputType === 'historyUndo' ? UNDO_COMMAND : REDO_COMMAND,
+      );
+    }
     return true;
   }
 


### PR DESCRIPTION
Chromium and WebKit walk up the browser's undo scope, so when the focused control sits outside the editor and has exhausted its own history — the URL field of the playground's floating link toolbar, for example — they dispatch `beforeinput`/`historyUndo` at the editor root. The editor has no selection at that point, so `$handleBeforeInput` returned at its range-selection guard without calling `preventDefault`, and the browser ran its native undo over the Lexical-managed contenteditable. The state was then rebuilt from the mangled DOM: pasting a link after "Hello world " and pressing undo from the URL field produced `Hhttps://lexical.dev`, a document that was never in Lexical's history.

Handle `historyUndo`/`historyRedo` in that branch: prevent the default and dispatch `UNDO_COMMAND`/`REDO_COMMAND`. `@lexical/history` restores a whole editor state, so it does not need a selection, and undo now removes the pasted link as the user expects. The change is additive — the range-selection path is untouched and the existing switch cases are unchanged.

I traced this rather than inferring it: instrumenting `$handleBeforeInput` captures `historyUndo selection=null activeEl=link-input`, and the retarget only happens once the input's own undo stack is exhausted — typing into the URL field first makes the same keystroke undo inside the input instead.

e2e added to `Links.spec.mjs`, chromium and webkit. Firefox keeps the undo scoped to the focused control and never dispatches the event, so it is skipped with a comment saying why.

Fixes #6714
