### PR TITLE
[lexical] Bug Fix: insert at the caret inside an inline ElementNode that cannot be split

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1179,7 +1179,7 @@ export class RangeSelection implements BaseSelection {
       if ('__language' in nodes[0]) {
         this.insertText(nodes[0].getTextContent());
       } else {
-        const index = $removeTextAndSplitBlock(this);
+        const [, index] = $removeTextAndSplitBlock(this);
         firstBlock.splice(index, 0, nodes);
         last.selectEnd();
       }
@@ -1197,8 +1197,15 @@ export class RangeSelection implements BaseSelection {
         firstNode.constructor.name,
         firstNode.getType(),
       );
-      const index = $removeTextAndSplitBlock(this);
-      firstBlock.splice(index, 0, nodes);
+      // The split walk normally ends on firstBlock, but it stops early on an
+      // inline ElementNode that cannot be split, which is the only position
+      // that preserves the caret for content pasted inside such a node
+      // (#6477).
+      const [container, index] = $removeTextAndSplitBlock(this, true);
+      const insertionParent = $isElementNode(container)
+        ? container
+        : firstBlock;
+      insertionParent.splice(index, 0, nodes);
       last.selectEnd();
       return;
     }
@@ -1210,7 +1217,7 @@ export class RangeSelection implements BaseSelection {
     // stripped like the input value sanitization strips newlines, and
     // block-only decorators are dropped, having no single-line form).
     if ($isElementNode(firstBlock) && $getSlotHostKey(firstBlock) !== null) {
-      const index = $removeTextAndSplitBlock(this);
+      const [, index] = $removeTextAndSplitBlock(this);
       const inlineNodes = $extractInlineFromBlocks(nodes);
       firstBlock.splice(index, 0, inlineNodes);
       const lastInserted = inlineNodes[inlineNodes.length - 1];
@@ -1263,7 +1270,7 @@ export class RangeSelection implements BaseSelection {
       !firstBlock.isParentRequired() &&
       !$isRootOrShadowRoot(firstBlock.getParentOrThrow())
     ) {
-      const index = $removeTextAndSplitBlock(this);
+      const [, index] = $removeTextAndSplitBlock(this);
       const inlineNodes = $extractInlineFromBlocks(nodes);
       firstBlock.splice(index, 0, inlineNodes);
       const lastInserted = inlineNodes[inlineNodes.length - 1];
@@ -1354,7 +1361,7 @@ export class RangeSelection implements BaseSelection {
       paragraph.select();
       return paragraph;
     }
-    const index = $removeTextAndSplitBlock(this);
+    const [, index] = $removeTextAndSplitBlock(this);
     const block = $findMatchingParent(this.anchor.getNode(), INTERNAL_$isBlock);
     if (block !== null && $getSlotHostKey(block) !== null) {
       // The block IS the slot value: its virtual shadow root holds exactly
@@ -4085,7 +4092,19 @@ function $extractInlineFromBlocks(nodes: LexicalNode[]): LexicalNode[] {
   return inlineNodes;
 }
 
-function $removeTextAndSplitBlock(selection: RangeSelection): number {
+/**
+ * Removes the selected text and splits the ancestor chain at the anchor up to
+ * the nearest block, returning the node the caller should insert into and the
+ * index within it.
+ *
+ * @param stopAtUnsplittableInline - when true, stop the walk on an inline
+ * ElementNode that cannot be split instead of continuing past it, see
+ * {@link $splitNodeAtPoint}.
+ */
+function $removeTextAndSplitBlock(
+  selection: RangeSelection,
+  stopAtUnsplittableInline = false,
+): [container: LexicalNode, offset: number] {
   let selection_ = selection;
   if (!selection.isCollapsed()) {
     selection_.removeText();
@@ -4113,18 +4132,33 @@ function $removeTextAndSplitBlock(selection: RangeSelection): number {
   // to the document root.
   while (!INTERNAL_$isBlock(node) && $getSlotHostKey(node) === null) {
     const prevNode = node;
-    [node, offset] = $splitNodeAtPoint(node, offset);
+    [node, offset] = $splitNodeAtPoint(node, offset, stopAtUnsplittableInline);
     if (prevNode.is(node)) {
       break;
     }
   }
 
-  return offset;
+  return [node, offset];
 }
 
+/**
+ * Splits `node` at `offset`, returning the parent that now holds the two
+ * halves and the index between them.
+ *
+ * @param stopAtUnsplittableInline - an ElementNode is split by moving the
+ * children after `offset` into the node returned by its `insertNewAfter()`,
+ * but that returns null for any ElementNode that does not implement it (the
+ * base class default). Such a node cannot be split, and continuing the walk
+ * would move the insertion point past the whole node, so inline content
+ * pasted with the caret inside it would land after it instead of at the caret
+ * (#6477). When this is true the unsplittable node itself is returned so the
+ * caller inserts into it at `offset`; when false the previous behavior of
+ * ascending to the parent is kept.
+ */
 function $splitNodeAtPoint(
   node: LexicalNode,
   offset: number,
+  stopAtUnsplittableInline = false,
 ): [parent: ElementNode, offset: number] {
   const parent = node.getParent();
   if (!parent) {
@@ -4160,6 +4194,8 @@ function $splitNodeAtPoint(
     const newElement = node.insertNewAfter(insertPoint) as ElementNode | null;
     if (newElement) {
       newElement.append(firstToAppend, ...firstToAppend.getNextSiblings());
+    } else if (stopAtUnsplittableInline) {
+      return [node, offset];
     }
   }
   return [parent, node.getIndexWithinParent() + 1];

--- a/packages/lexical/src/__tests__/unit/Issue6477Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue6477Repro.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {$insertDataTransferForRichText} from '@lexical/clipboard';
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {$createLinkNode, LinkNode} from '@lexical/link';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  type LexicalEditor,
+  type LexicalNode,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+import {
+  $createTestDecoratorNode,
+  $createTestInlineElementNode,
+  invariant,
+  TestDecoratorNode,
+  TestInlineElementNode,
+} from '../utils';
+
+const ext = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '[6477]',
+  nodes: [LinkNode, TestDecoratorNode, TestInlineElementNode],
+});
+
+/** A compact `type("text")` outline of the node tree. */
+function describeTree(node: LexicalNode): string {
+  if (!$isElementNode(node)) {
+    return `${node.getType()}("${node.getTextContent()}")`;
+  }
+  return `${node.getType()}(${node.getChildren().map(describeTree).join(' ')})`;
+}
+
+function $pasteHTML(editor: LexicalEditor, html: string): void {
+  const selection = $getSelection();
+  invariant($isRangeSelection(selection), 'Expected a RangeSelection');
+  const dataTransfer = new DataTransfer();
+  dataTransfer.setData('text/html', html);
+  $insertDataTransferForRichText(dataTransfer, selection, editor);
+}
+
+// A custom inline ElementNode does not implement insertNewAfter(), so it can
+// not be split. Content inserted with the caret inside it used to land after
+// the whole node instead of at the caret.
+describe('Insertion into a custom inline ElementNode (#6477)', () => {
+  test('pasted text is inserted at the caret inside the node', () => {
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const inner = $createTextNode('abcd');
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append(
+              $createTextNode('before'),
+              $createTestInlineElementNode().append(inner),
+              $createTextNode('after'),
+            ),
+          );
+        inner.select(2, 2);
+      },
+      {discrete: true},
+    );
+    editor.update(() => $pasteHTML(editor, '<b>XYZ</b>'), {discrete: true});
+    editor.read(() => {
+      expect(describeTree($getRoot())).toBe(
+        'root(paragraph(text("before") test_inline_block(text("ab") text("XYZ") text("cd")) text("after")))',
+      );
+    });
+  });
+
+  test('an inline node inserted at the caret goes inside the node', () => {
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const inner = $createTextNode('abcd');
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append(
+              $createTestInlineElementNode().append(inner),
+            ),
+          );
+        inner.select(2, 2);
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected a RangeSelection');
+        selection.insertNodes([$createTestDecoratorNode()]);
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      expect(describeTree($getRoot())).toBe(
+        'root(paragraph(test_inline_block(text("ab") test_decorator("Hello world") text("cd"))))',
+      );
+    });
+  });
+
+  // Control: a LinkNode implements insertNewAfter(), so it is split around the
+  // pasted content. This assertion holds both with and without the fix.
+  test('control: a splittable inline ElementNode is still split', () => {
+    using editor = buildEditorFromExtensions(ext);
+    editor.update(
+      () => {
+        const inner = $createTextNode('abcd');
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append(
+              $createLinkNode('https://lexical.dev').append(inner),
+            ),
+          );
+        inner.select(2, 2);
+      },
+      {discrete: true},
+    );
+    editor.update(() => $pasteHTML(editor, '<b>XYZ</b>'), {discrete: true});
+    editor.read(() => {
+      expect(describeTree($getRoot())).toBe(
+        'root(paragraph(link(text("ab")) text("XYZ") link(text("cd"))))',
+      );
+    });
+  });
+});


### PR DESCRIPTION
`RangeSelection.insertNodes` splits the ancestor chain from the anchor up to the nearest block before splicing inline content in. An `ElementNode` is split by moving the children after the caret into the node returned by its `insertNewAfter()`, which returns `null` for any `ElementNode` that does not implement it — the base class default. `$splitNodeAtPoint` ignored that `null` and still reported the position after the whole node, so content pasted with the caret inside a custom inline `ElementNode` landed after the node while typing the same text inserted it in place.

Stop the split walk on an unsplittable inline element and splice into it at the caret.

Nodes that implement `insertNewAfter` — `LinkNode`, `MarkNode`, `ListItemNode`, `CodeNode` — are unaffected and still split. `$removeTextAndSplitBlock` now returns the container alongside the index, but only the one affected call site opts into the new walk; `insertParagraph` and the code-block and slot paste paths take the index alone and are unchanged.

Reverting the product file fails 2 of the 3 new tests with the reported symptom — `text("abcd")) text("XYZ")` instead of `text("ab") text("XYZ") text("cd")`. The third is a control.

Fixes #6477
