### PR TITLE
[lexical-code-prism][lexical-code-shiki] Bug Fix: don't drag the caret into a code block while highlighting

### DIFF
--- a/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
@@ -218,6 +218,17 @@ function $updateAndRetainSelection(
   }
 
   const anchor = selection.anchor;
+  // The selection is restored by walking this code node's children, so it can
+  // only be retained when it actually points inside this code node. When the
+  // selection lives elsewhere there is nothing to retain and restoring would
+  // drag the caret into the code block instead of leaving it where the user
+  // put it.
+  const anchorNode = anchor.getNode();
+  if (anchorNode !== node && !node.isParentOf(anchorNode)) {
+    updateFn();
+    return;
+  }
+
   const anchorOffset = anchor.offset;
   const isNewLineAnchor =
     anchor.type === 'element' &&
@@ -226,7 +237,6 @@ function $updateAndRetainSelection(
 
   // Calculating previous text offset (all text node prior to anchor + anchor own text offset)
   if (!isNewLineAnchor) {
-    const anchorNode = anchor.getNode();
     textOffset =
       anchorOffset +
       anchorNode.getPreviousSiblings().reduce((offset, _node) => {

--- a/packages/lexical-code-prism/src/__tests__/unit/CodePrismRetainSelection.test.ts
+++ b/packages/lexical-code-prism/src/__tests__/unit/CodePrismRetainSelection.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createCodeNode, $isCodeNode} from '@lexical/code-core';
+import {CodePrismExtension} from '@lexical/code-prism';
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$convertFromMarkdownString, TRANSFORMERS} from '@lexical/markdown';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  defineExtension,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+function createEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [RichTextExtension, CodePrismExtension],
+      name: 'code-prism-retain-selection-test',
+    }),
+  );
+}
+
+/**
+ * Describes where the caret ended up, in terms that survive the highlighter
+ * splitting a code block's text into CodeHighlightNodes.
+ */
+function $describeCaret() {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) {
+    return {selection: String(selection)};
+  }
+  const anchorNode = selection.anchor.getNode();
+  return {
+    blocks: $getRoot()
+      .getChildren()
+      .map(child => child.getType()),
+    inCodeBlock:
+      $isCodeNode(anchorNode) || anchorNode.getParents().some($isCodeNode),
+    offset: selection.anchor.offset,
+    text: anchorNode.getTextContent(),
+  };
+}
+
+/**
+ * $convertFromMarkdownString only moves the caret when there already is one,
+ * which is the case when a user pastes markdown into a focused editor.
+ */
+function $seedSelection(): void {
+  const paragraph = $createParagraphNode();
+  $getRoot().clear().append(paragraph);
+  paragraph.selectEnd();
+}
+
+describe('Prism highlighting only retains a selection it owns (#6305)', () => {
+  test('importing markdown that ends in a code block leaves the caret at the document start', () => {
+    using editor = createEditor();
+
+    editor.update($seedSelection, {discrete: true});
+    editor.update(
+      () => {
+        $convertFromMarkdownString(
+          'hello world\n\n```\necho hello world\n```',
+          TRANSFORMERS,
+        );
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read($describeCaret)).toEqual({
+      blocks: ['paragraph', 'code'],
+      inCodeBlock: false,
+      offset: 0,
+      text: 'hello world',
+    });
+  });
+
+  test('the caret is not dragged into the last of several imported code blocks', () => {
+    using editor = createEditor();
+
+    editor.update($seedSelection, {discrete: true});
+    editor.update(
+      () => {
+        $convertFromMarkdownString(
+          'hello world\n\n```\nfirst\n```\n\nmiddle\n\n```\nlast\n```',
+          TRANSFORMERS,
+        );
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read($describeCaret)).toEqual({
+      blocks: ['paragraph', 'code', 'paragraph', 'code'],
+      inCodeBlock: false,
+      offset: 0,
+      text: 'hello world',
+    });
+  });
+
+  // Control: this selection really is inside the code block, so it passes with
+  // and without the fix. It guards against "fixing" #6305 by never restoring.
+  test('a caret inside the code block is still retained across highlighting', () => {
+    using editor = createEditor();
+
+    editor.update(
+      () => {
+        const codeNode = $createCodeNode('javascript');
+        const textNode = $createTextNode('const x = 1;');
+        codeNode.append(textNode);
+        $getRoot().clear().append(codeNode);
+        // 'const ' — the caret sits inside what becomes a token boundary.
+        textNode.select(6, 6);
+      },
+      {discrete: true},
+    );
+
+    const caret = editor.read($describeCaret);
+    expect(caret.inCodeBlock).toBe(true);
+    // The highlighter split the single TextNode into tokens, so the caret
+    // rides along to the token that now holds text offset 6.
+    expect(caret.text).toBe(' x ');
+    expect(caret.offset).toBe(1);
+  });
+});

--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -243,6 +243,17 @@ function $updateAndRetainSelection(
   }
 
   const anchor = selection.anchor;
+  // The selection is restored by walking this code node's children, so it can
+  // only be retained when it actually points inside this code node. When the
+  // selection lives elsewhere there is nothing to retain and restoring would
+  // drag the caret into the code block instead of leaving it where the user
+  // put it.
+  const anchorNode = anchor.getNode();
+  if (anchorNode !== node && !node.isParentOf(anchorNode)) {
+    updateFn();
+    return;
+  }
+
   const anchorOffset = anchor.offset;
   const isNewLineAnchor =
     anchor.type === 'element' &&
@@ -251,7 +262,6 @@ function $updateAndRetainSelection(
 
   // Calculating previous text offset (all text node prior to anchor + anchor own text offset)
   if (!isNewLineAnchor) {
-    const anchorNode = anchor.getNode();
     textOffset =
       anchorOffset +
       anchorNode.getPreviousSiblings().reduce((offset, _node) => {

--- a/packages/lexical-code-shiki/src/__tests__/unit/CodeShikiRetainSelection.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/CodeShikiRetainSelection.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$isCodeNode} from '@lexical/code-core';
+import {
+  CodeShikiExtension,
+  loadCodeLanguage,
+  loadCodeTheme,
+} from '@lexical/code-shiki';
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$convertFromMarkdownString, TRANSFORMERS} from '@lexical/markdown';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  defineExtension,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+function createEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [RichTextExtension, CodeShikiExtension],
+      name: 'code-shiki-retain-selection-test',
+    }),
+  );
+}
+
+/**
+ * Shiki loads grammars and themes asynchronously, so the highlight transform
+ * that rewrites the code block's children only runs once those settle.
+ */
+async function settleHighlighting(): Promise<void> {
+  await loadCodeLanguage('javascript');
+  await loadCodeTheme('one-light');
+  await Promise.resolve();
+}
+
+function $describeCaret() {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) {
+    return {selection: String(selection)};
+  }
+  const anchorNode = selection.anchor.getNode();
+  return {
+    blocks: $getRoot()
+      .getChildren()
+      .map(child => child.getType()),
+    inCodeBlock:
+      $isCodeNode(anchorNode) || anchorNode.getParents().some($isCodeNode),
+    offset: selection.anchor.offset,
+    text: anchorNode.getTextContent(),
+  };
+}
+
+/**
+ * $convertFromMarkdownString only moves the caret when there already is one,
+ * which is the case when a user pastes markdown into a focused editor.
+ */
+function $seedSelection(): void {
+  const paragraph = $createParagraphNode();
+  $getRoot().clear().append(paragraph);
+  paragraph.selectEnd();
+}
+
+describe('Shiki highlighting only retains a selection it owns (#6305)', () => {
+  test('importing markdown that ends in a code block leaves the caret at the document start', async () => {
+    using editor = createEditor();
+
+    editor.update($seedSelection, {discrete: true});
+    editor.update(
+      () => {
+        $convertFromMarkdownString(
+          'hello world\n\n```\necho hello world\n```',
+          TRANSFORMERS,
+        );
+      },
+      {discrete: true},
+    );
+    await settleHighlighting();
+
+    expect(editor.read($describeCaret)).toEqual({
+      blocks: ['paragraph', 'code'],
+      inCodeBlock: false,
+      offset: 0,
+      text: 'hello world',
+    });
+  });
+
+  test('the caret is not dragged into the last of several imported code blocks', async () => {
+    using editor = createEditor();
+
+    editor.update($seedSelection, {discrete: true});
+    editor.update(
+      () => {
+        $convertFromMarkdownString(
+          'hello world\n\n```\nfirst\n```\n\nmiddle\n\n```\nlast\n```',
+          TRANSFORMERS,
+        );
+      },
+      {discrete: true},
+    );
+    await settleHighlighting();
+
+    expect(editor.read($describeCaret)).toEqual({
+      blocks: ['paragraph', 'code', 'paragraph', 'code'],
+      inCodeBlock: false,
+      offset: 0,
+      text: 'hello world',
+    });
+  });
+});


### PR DESCRIPTION
`$updateAndRetainSelection` restores the selection by walking the highlighted code node's children. That is only meaningful when the selection was inside that code node, but it ran for every `RangeSelection`, so a selection anywhere else in the document was moved into the code block.

`$convertFromMarkdownString` leaves the caret at the start of the document (`root.selectStart()`). The highlight transform then immediately pulled it into the imported code block — and with several code blocks, into the last one, scrolling long documents down to it.

The fix skips the retain/restore when the anchor is not inside the code node being highlighted; the highlighting itself still runs. Both the Prism and Shiki highlighters carry the same copy of this function, so both are fixed.

Tests: new unit tests in each package import the exact markdown from the issue and assert the caret stays at the start of the first paragraph, plus a control asserting a caret genuinely inside the code block is still retained across tokenization. Reverting the two product files fails 4 of the 5.

Fixes #6305
