### PR TITLE
[lexical-playground] Bug Fix: keep the floating format toolbar aligned under CSS scale

### DIFF
--- a/packages/lexical-playground/src/__tests__/browser/FloatingElemScale.test.ts
+++ b/packages/lexical-playground/src/__tests__/browser/FloatingElemScale.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {describe, expect, onTestFinished, test} from 'vitest';
+
+import {setFloatingElemPosition} from '../../utils/setFloatingElemPosition';
+
+const VERTICAL_GAP = 10;
+const HORIZONTAL_OFFSET = 5;
+
+// Where the floating element should end up, in on-screen pixels: the CSS gaps
+// are authored in the scaled coordinate space, so they shrink with the scale.
+function build(scale: number) {
+  const outer = document.createElement('div');
+  outer.style.transform = `scale(${scale})`;
+  outer.style.transformOrigin = '0 0';
+  outer.style.width = '800px';
+
+  const scroller = document.createElement('div');
+  scroller.style.position = 'relative';
+  scroller.style.width = '800px';
+  scroller.style.height = '600px';
+
+  const anchor = document.createElement('div');
+  anchor.style.position = 'relative';
+  anchor.style.width = '800px';
+  anchor.style.height = '600px';
+
+  const floating = document.createElement('div');
+  floating.style.position = 'absolute';
+  floating.style.top = '0';
+  floating.style.left = '0';
+  floating.style.width = '200px';
+  floating.style.height = '40px';
+
+  const target = document.createElement('div');
+  target.style.position = 'absolute';
+  target.style.top = '300px';
+  target.style.left = '120px';
+  target.style.width = '90px';
+  target.style.height = '20px';
+
+  anchor.append(floating, target);
+  scroller.append(anchor);
+  outer.append(scroller);
+  document.body.append(outer);
+  onTestFinished(() => outer.remove());
+
+  // The helpers inspect the DOM selection to detect end-aligned text; keep it
+  // empty so that branch stays out of the way.
+  window.getSelection()?.removeAllRanges();
+
+  return {anchor, floating, scroller, target};
+}
+
+function measure(scale: number) {
+  const {anchor, floating, target} = build(scale);
+  return {
+    anchor,
+    floating,
+    // The accumulated on-screen scale of the anchor's coordinate space.
+    realScale: anchor.getBoundingClientRect().width / anchor.offsetWidth,
+    target,
+    targetRect: target.getBoundingClientRect(),
+  };
+}
+
+describe('floating element positioning under CSS scale (#6748)', () => {
+  for (const scale of [1, 0.5, 2]) {
+    // scale 1 is the control: it must keep behaving exactly as before.
+    test(`setFloatingElemPosition places the toolbar above the target at scale ${scale}`, () => {
+      const {anchor, floating, targetRect, realScale} = measure(scale);
+      expect(realScale).toBeCloseTo(scale, 5);
+
+      setFloatingElemPosition(targetRect, floating, anchor);
+
+      const rect = floating.getBoundingClientRect();
+      expect(rect.bottom).toBeCloseTo(
+        targetRect.top - VERTICAL_GAP * realScale,
+        1,
+      );
+      expect(rect.left).toBeCloseTo(
+        targetRect.left - HORIZONTAL_OFFSET * realScale,
+        1,
+      );
+    });
+  }
+});

--- a/packages/lexical-playground/src/utils/getElementScale.ts
+++ b/packages/lexical-playground/src/utils/getElementScale.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * The on-screen scale of `element`'s own coordinate space, accumulated over
+ * every CSS `transform` / `scale` between it and the viewport.
+ *
+ * `getBoundingClientRect()` reports on-screen pixels, but a `translate()`
+ * written back to `style.transform` is applied in the element's own — still
+ * unscaled — coordinate space. Any offset derived from client rects therefore
+ * has to be divided by this scale first, and any constant expressed in the
+ * element's own pixels has to be multiplied by it before being mixed into
+ * client-rect arithmetic.
+ *
+ * Falls back to 1 for either axis that has no layout box to measure against.
+ */
+export function getElementScale(element: HTMLElement): {x: number; y: number} {
+  const {height, width} = element.getBoundingClientRect();
+  const {offsetHeight, offsetWidth} = element;
+  const x = offsetWidth > 0 ? width / offsetWidth : 1;
+  const y = offsetHeight > 0 ? height / offsetHeight : 1;
+  return {
+    x: Number.isFinite(x) && x > 0 ? x : 1,
+    y: Number.isFinite(y) && y > 0 ? y : 1,
+  };
+}

--- a/packages/lexical-playground/src/utils/setFloatingElemPosition.ts
+++ b/packages/lexical-playground/src/utils/setFloatingElemPosition.ts
@@ -7,6 +7,8 @@
  */
 import {getDOMSelection, getDOMSelectionRange, getParentElement} from 'lexical';
 
+import {getElementScale} from './getElementScale';
+
 const VERTICAL_GAP = 10;
 const HORIZONTAL_OFFSET = 5;
 
@@ -30,8 +32,15 @@ export function setFloatingElemPosition(
   const anchorElementRect = anchorElem.getBoundingClientRect();
   const editorScrollerRect = scrollerElem.getBoundingClientRect();
 
-  let top = targetRect.top - floatingElemRect.height - verticalGap;
-  let left = targetRect.left - horizontalOffset;
+  // Every rect above is in on-screen pixels, so the gaps — which are authored
+  // in the anchor's own coordinate space — have to be scaled to match before
+  // they are mixed in. The result is converted back at the end.
+  const scale = getElementScale(anchorElem);
+  const verticalGapPx = verticalGap * scale.y;
+  const horizontalOffsetPx = horizontalOffset * scale.x;
+
+  let top = targetRect.top - floatingElemRect.height - verticalGapPx;
+  let left = targetRect.left - horizontalOffsetPx;
 
   // Check if text is end-aligned.
   const domSelection = getDOMSelection(anchorElem.ownerDocument.defaultView);
@@ -47,7 +56,7 @@ export function setFloatingElemPosition(
 
       if (textAlign === 'right' || textAlign === 'end') {
         // For end-aligned text, position the toolbar relative to the text end
-        left = targetRect.right - floatingElemRect.width + horizontalOffset;
+        left = targetRect.right - floatingElemRect.width + horizontalOffsetPx;
       }
     }
   }
@@ -57,19 +66,20 @@ export function setFloatingElemPosition(
     top +=
       floatingElemRect.height +
       targetRect.height +
-      verticalGap * (isLink ? 9 : 2);
+      verticalGapPx * (isLink ? 9 : 2);
   }
 
   if (left + floatingElemRect.width > editorScrollerRect.right) {
-    left = editorScrollerRect.right - floatingElemRect.width - horizontalOffset;
+    left =
+      editorScrollerRect.right - floatingElemRect.width - horizontalOffsetPx;
   }
 
   if (left < editorScrollerRect.left) {
-    left = editorScrollerRect.left + horizontalOffset;
+    left = editorScrollerRect.left + horizontalOffsetPx;
   }
 
-  top -= anchorElementRect.top;
-  left -= anchorElementRect.left;
+  top = (top - anchorElementRect.top) / scale.y;
+  left = (left - anchorElementRect.left) / scale.x;
 
   floatingElem.style.opacity = '1';
   floatingElem.style.transform = `translate(${left}px, ${top}px)`;


### PR DESCRIPTION
`setFloatingElemPosition` mixes two coordinate spaces. Every rect it reads (target, floating element, anchor, scroller) is in on-screen pixels, but the `translate()` it writes back is resolved in the anchor's own — unscaled — coordinate space. Under a CSS `scale()` on any ancestor those differ by the scale factor, so the floating format toolbar is placed at the wrong offset from the selection, and the 10px/5px gap constants are applied at the wrong size.

The gap constants are now scaled into on-screen pixels for the arithmetic, and the final offset is divided back into the anchor's space. At scale 1 both factors are 1, so the computation is byte-for-byte unchanged — covered by a scale-1 control test.

Reproduced in the vitest browser project (real Chromium): at scale 0.5 the toolbar lands at 80 where 145 is expected, at scale 2 at 1100 where 580 is expected.

Two scope notes. `@lexical/react`'s `LexicalDraggableBlockPlugin` has the same class of defect, but it already divides by `calculateZoomLevel` for CSS `zoom`, and reconciling that with transform scale needs cross-browser verification of the `zoom`/`offsetWidth` interaction — left for a follow-up rather than guessed at here. `setFloatingElemPositionForLinkEditor` has the same maths but is dead code since the link editor moved to `@floating-ui/react`, so it is untouched.

Marking this `Refs` rather than `Fixes`: the report's screenshots point at the floating format toolbar, which this covers, but "floating elements" may be read more broadly.

Refs #6748
