### PR TITLE
[lexical-clipboard] Bug Fix: $insertDataTransferForRichText ignores its selection argument for text/plain

### DIFF
--- a/packages/lexical-clipboard/src/ClipboardImportExtension.ts
+++ b/packages/lexical-clipboard/src/ClipboardImportExtension.ts
@@ -20,6 +20,7 @@ import {
   $getEditor,
   $getSelection,
   $isRangeSelection,
+  $setSelection,
   type BaseSelection,
   defineExtension,
   type RangeSelection,
@@ -238,6 +239,19 @@ const $defaultPlainTextImporter: ImportMimeTypeFunction = (data, selection) => {
   if (!$isRangeSelection(selection)) {
     selection.insertRawText(data);
     return true;
+  }
+  // Each insertion below reports the caret position that follows it by
+  // writing to the editor's selection — a node replacement can even swap
+  // the selection object outright (#5954) — so the loop has to re-read
+  // $getSelection() between tokens instead of holding a reference that
+  // goes stale after the first one. Honoring a caller-supplied selection
+  // (#6278) therefore means promoting it to the editor's selection first;
+  // otherwise every token lands wherever the editor happens to point.
+  // Insertion leaves the selection after the inserted content, which is
+  // what the text/html and application/x-lexical-editor handlers already
+  // do via $insertGeneratedNodes.
+  if (selection !== $getSelection()) {
+    $setSelection(selection);
   }
   const withCurrentRange = (fn: (cur: RangeSelection) => void) => {
     const cur = $getSelection();

--- a/packages/lexical-clipboard/src/__tests__/unit/ClipboardImportExtension.test.ts
+++ b/packages/lexical-clipboard/src/__tests__/unit/ClipboardImportExtension.test.ts
@@ -24,6 +24,7 @@ import {
 } from '@lexical/html';
 import {
   $createParagraphNode,
+  $createRangeSelection,
   $createTextNode,
   $getEditor,
   $getRoot,
@@ -40,6 +41,12 @@ function $initialEditorState(): void {
 function dataTransferWithHtml(html: string): DataTransfer {
   const dt = new DataTransfer();
   dt.setData('text/html', html);
+  return dt as unknown as DataTransfer;
+}
+
+function dataTransferWithPlainText(text: string): DataTransfer {
+  const dt = new DataTransfer();
+  dt.setData('text/plain', text);
   return dt as unknown as DataTransfer;
 }
 
@@ -266,5 +273,104 @@ describe('ClipboardImportExtension', () => {
       assert($isParagraphNode(lastChild), 'expected paragraph');
       expect(lastChild.getTextContent()).toBe('via new pipeline');
     });
+  });
+});
+
+describe('$insertDataTransferForRichText selection argument (#6278)', () => {
+  // Two paragraphs, with the *editor's* selection parked at the end of the
+  // second one so that inserting at the current selection is distinguishable
+  // from inserting at the supplied one.
+  function makeEditor() {
+    return buildEditorFromExtensions(
+      defineExtension({
+        $initialEditorState() {
+          const second = $createTextNode('second');
+          $getRoot()
+            .clear()
+            .append(
+              $createParagraphNode().append($createTextNode('first')),
+              $createParagraphNode().append(second),
+            );
+          second.select();
+        },
+        name: 'host',
+      }),
+    );
+  }
+
+  function $insertOverFirstParagraph(
+    editor: ReturnType<typeof buildEditorFromExtensions>,
+    dataTransfer: DataTransfer,
+  ) {
+    editor.update(
+      () => {
+        const [firstParagraph] = $getRoot().getChildren();
+        const selection = $createRangeSelection();
+        selection.anchor.set(firstParagraph.getKey(), 0, 'element');
+        selection.focus.set(firstParagraph.getKey(), 1, 'element');
+        $insertDataTransferForRichText(dataTransfer, selection, editor);
+      },
+      {discrete: true},
+    );
+  }
+
+  function paragraphTexts(
+    editor: ReturnType<typeof buildEditorFromExtensions>,
+  ): string[] {
+    return editor.read(() =>
+      $getRoot()
+        .getChildren()
+        .map(node => node.getTextContent()),
+    );
+  }
+
+  test('text/plain is inserted at the supplied selection', () => {
+    using editor = makeEditor();
+    $insertOverFirstParagraph(editor, dataTransferWithPlainText('replacement'));
+    expect(paragraphTexts(editor)).toEqual(['replacement', 'second']);
+  });
+
+  test('multi-line text/plain is inserted at the supplied selection', () => {
+    using editor = makeEditor();
+    $insertOverFirstParagraph(editor, dataTransferWithPlainText('one\ntwo'));
+    expect(paragraphTexts(editor)).toEqual(['one', 'two', 'second']);
+  });
+
+  test('text/uri-list is inserted at the supplied selection', () => {
+    using editor = makeEditor();
+    const dt = new DataTransfer();
+    dt.setData('text/uri-list', 'https://lexical.dev');
+    $insertOverFirstParagraph(editor, dt as unknown as DataTransfer);
+    expect(paragraphTexts(editor)).toEqual(['https://lexical.dev', 'second']);
+  });
+
+  test('text/html is inserted at the supplied selection', () => {
+    // Control: the text/html handler already honored the argument before
+    // this fix, so this passes with or without it.
+    using editor = makeEditor();
+    $insertOverFirstParagraph(
+      editor,
+      dataTransferWithHtml('<p>replacement</p>'),
+    );
+    expect(paragraphTexts(editor)).toEqual(['replacement', 'second']);
+  });
+
+  test('text/plain still lands at the caret on the ordinary paste path', () => {
+    // Control: when the argument *is* the editor's selection (every paste
+    // and drop), behaviour is unchanged. Passes with or without the fix.
+    using editor = makeEditor();
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'expected RangeSelection');
+        $insertDataTransferForRichText(
+          dataTransferWithPlainText('!'),
+          selection,
+          editor,
+        );
+      },
+      {discrete: true},
+    );
+    expect(paragraphTexts(editor)).toEqual(['first', 'second!']);
   });
 });


### PR DESCRIPTION
The default `text/plain` importer re-read `$getSelection()` for every token it inserted, so plain-text (and `text/uri-list`) payloads always landed at the editor's current selection instead of the `selection` argument that `$insertDataTransferForRichText` documents as the insertion point. A caller that builds its own `RangeSelection` — a find-and-replace pass, say — had its content inserted at the caret.

The re-read exists for a reason: each insertion reports its trailing caret position through the editor's selection, and a node replacement can swap the selection object outright (#5954), so a held reference goes stale after the first token. Rather than drop the argument, promote it to the editor's selection before the loop. When the argument already *is* the editor's selection — every paste and drop — the behaviour is byte-for-byte unchanged, and insertion leaves the selection after the inserted content exactly as the `text/html` and `application/x-lexical-editor` handlers already do via `$insertGeneratedNodes`.

Five tests. Three fail without the change (`text/plain` single-line, multi-line, `text/uri-list`); two are marked in-source as controls that pass either way — `text/html`, which already honoured the argument, and the ordinary paste path where the argument is the current selection.

Fixes #6278
