### PR TITLE
[lexical] Bug Fix: collapseAtStart no longer discards a first paragraph that only starts blank

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1190,6 +1190,45 @@ test.describe('Selection', () => {
     );
   });
 
+  test('Backspace at the start of the first paragraph keeps content that follows a blank text node', async ({
+    page,
+    isPlainText,
+  }) => {
+    // Plain text uses line breaks instead of paragraphs for Enter.
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    // A blank first text node followed by a formatted one that carries the
+    // actual content.
+    await page.keyboard.type('  ');
+    await pressToggleBold(page);
+    await page.keyboard.type('hello');
+    await page.keyboard.press('Enter');
+    await pressToggleBold(page);
+    await page.keyboard.type('world');
+    await moveToEditorBeginning(page);
+
+    const expected = html`
+      <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+        <span data-lexical-text="true"></span>
+        <strong
+          class="PlaygroundEditorTheme__textBold"
+          data-lexical-text="true">
+          hello
+        </strong>
+      </p>
+      <p class="PlaygroundEditorTheme__paragraph" dir="auto">
+        <span data-lexical-text="true">world</span>
+      </p>
+    `;
+    await assertHTML(page, expected);
+
+    await page.keyboard.press('Backspace');
+
+    // The paragraph is not blank, so it must not be collapsed away.
+    await assertHTML(page, expected);
+  });
+
   test('Select all from Node selection #4658', async ({page, isPlainText}) => {
     // TODO selectAll is bad for Linux #4665
     test.skip(isPlainText || IS_LINUX);

--- a/packages/lexical/src/__tests__/unit/ParagraphCollapseAtStart.test.ts
+++ b/packages/lexical/src/__tests__/unit/ParagraphCollapseAtStart.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalEditor,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+const ext = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '[paragraph-collapse-at-start]',
+});
+
+function createEditor() {
+  const editor = buildEditorFromExtensions(ext);
+  const element = document.createElement('div');
+  element.contentEditable = 'true';
+  document.body.appendChild(element);
+  editor.setRootElement(element);
+  return editor;
+}
+
+/** The work Backspace does: KEY_BACKSPACE_COMMAND -> DELETE_CHARACTER_COMMAND. */
+function backspace(editor: LexicalEditor): void {
+  editor.update(
+    () => {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        selection.deleteCharacter(true);
+      }
+    },
+    {discrete: true},
+  );
+}
+
+function $blocks(): string[] {
+  return $getRoot()
+    .getChildren()
+    .map(child => child.getTextContent());
+}
+
+describe('ParagraphNode.collapseAtStart', () => {
+  test('keeps a first paragraph whose content follows a blank text node', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const first = $createParagraphNode();
+        const bold = $createTextNode('hello');
+        bold.toggleFormat('bold');
+        first.append($createTextNode('  '), bold);
+        const second = $createParagraphNode();
+        second.append($createTextNode('world'));
+        $getRoot().clear().append(first, second);
+        first.selectStart();
+      },
+      {discrete: true},
+    );
+
+    backspace(editor);
+
+    editor.read(() => {
+      expect($blocks()).toEqual(['  hello', 'world']);
+    });
+  });
+
+  test('keeps a first paragraph whose only other child is a line break', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const first = $createParagraphNode();
+        first.append($createTextNode(' '), $createLineBreakNode());
+        const second = $createParagraphNode();
+        second.append($createTextNode('world'));
+        $getRoot().clear().append(first, second);
+        first.selectStart();
+      },
+      {discrete: true},
+    );
+
+    backspace(editor);
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(2);
+    });
+  });
+
+  test('control: a blank first paragraph is still collapsed away', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const first = $createParagraphNode();
+        first.append($createTextNode('  '));
+        const second = $createParagraphNode();
+        second.append($createTextNode('world'));
+        $getRoot().clear().append(first, second);
+        first.selectStart();
+      },
+      {discrete: true},
+    );
+
+    backspace(editor);
+
+    editor.read(() => {
+      expect($blocks()).toEqual(['world']);
+    });
+  });
+
+  test('control: an empty first paragraph is still collapsed away', () => {
+    using editor = createEditor();
+    editor.update(
+      () => {
+        const first = $createParagraphNode();
+        const second = $createParagraphNode();
+        second.append($createTextNode('world'));
+        $getRoot().clear().append(first, second);
+        first.selectStart();
+      },
+      {discrete: true},
+    );
+
+    backspace(editor);
+
+    editor.read(() => {
+      expect($blocks()).toEqual(['world']);
+    });
+  });
+});

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -136,10 +136,13 @@ export class ParagraphNode extends ElementNode {
   collapseAtStart(): boolean {
     const children = this.getChildren();
     // If we have an empty (trimmed) first paragraph and try and remove it,
-    // delete the paragraph as long as we have another sibling to go to
+    // delete the paragraph as long as we have another sibling to go to.
+    // Every child has to be blank text: a paragraph that merely starts with
+    // blank text still has content to lose, and a non-text child (an inline
+    // decorator, a line break) is content even when it contributes no text.
     if (
       children.length === 0 ||
-      ($isTextNode(children[0]) && children[0].getTextContent().trim() === '')
+      (children.every($isTextNode) && this.getTextContent().trim() === '')
     ) {
       const nextSibling = this.getNextSibling();
       if (nextSibling !== null) {


### PR DESCRIPTION
`ParagraphNode.collapseAtStart` decided whether a paragraph was empty by inspecting `children[0]` alone. A first paragraph whose first text node is blank but whose later children carry the content — a leading space followed by a bold run, say — was treated as empty, so Backspace at its start removed the entire paragraph and the content was lost. A non-text child such as a line break was discarded the same way.

The fix requires every child to be a text node and the paragraph's whole text content to be blank before collapsing. Blank and empty first paragraphs still collapse exactly as before, so no existing test expectations change.

Tests: a unit test driving `RangeSelection.deleteCharacter(true)` (what `KEY_BACKSPACE_COMMAND` dispatches), plus a chromium e2e in `Selection.spec.mjs` that types the content in the playground and presses Backspace. Both fail on `main`; two control cases assert the existing collapse behaviour is unchanged and pass either way. Full unit suite 4071 passed; full chromium e2e 819 passed, 0 failed.

This does **not** change the behaviour reported in #6570 — a genuinely blank first paragraph is still collapsed away. That is a separate product decision, and I have explained on the issue why: prototyping the requested change breaks 12 chromium e2e tests, including one named "First paragraph backspace handling" that exists specifically to assert the current behaviour.

Refs #6570
