### PR TITLE
[lexical-utils] Bug Fix: no extra paragraph when $insertNodeToNearestRoot splits at the end of a block

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
@@ -89,6 +89,37 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
       selectionPath: [0, 0],
     },
     {
+      // The empty paragraph created by splitting at the end of a block is
+      // only useful when nothing follows it, otherwise it is spurious (#5433)
+      _: 'insert in the end of paragraph that is followed by another block',
+      expectedHtml:
+        '<p><span style="white-space: pre-wrap;">Hello world</span></p>' +
+        '<test-decorator></test-decorator>' +
+        '<p><span style="white-space: pre-wrap;">Second</span></p>',
+      initialHtml: '<p>Hello world</p><p>Second</p>',
+      selectionOffset: 'Hello world'.length,
+      selectionPath: [0, 0],
+    },
+    {
+      _: 'insert in the end of the last nested list item',
+      expectedHtml:
+        '<ul>' +
+        '<li><span style="white-space: pre-wrap;">Before</span><ul><li><span style="white-space: pre-wrap;">Hello</span></li></ul></li>' +
+        '</ul>' +
+        '<test-decorator></test-decorator>' +
+        '<ul>' +
+        '<li><span style="white-space: pre-wrap;">After</span></li>' +
+        '</ul>',
+      initialHtml:
+        '<ul>' +
+        '<li><span>Before</span></li>' +
+        '<ul><li><span>Hello</span></li></ul>' +
+        '<li><span>After</span></li>' +
+        '</ul>',
+      selectionOffset: 'Hello'.length,
+      selectionPath: [0, 1, 0, 0, 0],
+    },
+    {
       _: 'insert in the beginning of paragraph',
       expectedHtml:
         '<p><br></p>' +

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -753,6 +753,25 @@ export function $restoreEditorState(
 }
 
 /**
+ * Determine whether anything follows the given caret before the end of its
+ * nearest root (see {@link lexical!$isRootOrShadowRoot}).
+ */
+function $hasContentAfter(caret: PointCaret<'next'>): boolean {
+  let nodeCaret: NodeCaret<'next'>;
+  if ($isTextPointCaret(caret)) {
+    if (caret.offset < caret.origin.getTextContentSize()) {
+      return true;
+    }
+    nodeCaret = caret.getSiblingCaret();
+  } else {
+    nodeCaret = caret;
+  }
+  return (
+    $getAdjacentSiblingOrParentSiblingCaret(nodeCaret, 'shadowRoot') !== null
+  );
+}
+
+/**
  * If the selected insertion area is the root/shadow root node (see {@link lexical!$isRootOrShadowRoot}),
  * the node will be appended there, otherwise, it will be inserted before the insertion area.
  * If there is no selection where the node is to be inserted, it will be appended after any current nodes
@@ -779,7 +798,18 @@ export function $insertNodeToNearestRoot<T extends LexicalNode>(node: T): T {
         .getFlipped()
         .insert($createParagraphNode());
   }
-  const insertCaret = $insertNodeToNearestRootAtCaret(node, initialCaret);
+  // Splitting at the end of a block would otherwise leave an empty copy of
+  // that block after the inserted node. That empty block is only useful when
+  // the insertion point is at the very end of its nearest root, where it is
+  // the only place left for the selection to go. Anywhere else it is a
+  // spurious extra paragraph (#5433).
+  const insertCaret = $insertNodeToNearestRootAtCaret(
+    node,
+    initialCaret,
+    $hasContentAfter(initialCaret)
+      ? {$shouldSplit: (_node, edge) => edge !== 'last'}
+      : undefined,
+  );
   const adjacent = $getAdjacentChildCaret(insertCaret);
   const selectionCaret = $isChildCaret(adjacent)
     ? $normalizeCaret(adjacent)


### PR DESCRIPTION
`$insertNodeToNearestRoot` splits the enclosing blocks at the selection focus and inserts the node between the two halves. When the focus sits at the end of a block, the right-hand half is empty, so an empty paragraph — or list item, etc. — is left behind after the inserted node. Inserting a layout, horizontal rule or embed at the end of a line in the middle of a document therefore adds a stray blank block.

That empty block is only wanted when the insertion point is at the very end of its nearest root, where it is the only place left for the selection to go — which is what the empty-editor horizontal rule flow depends on. Anywhere else it is spurious, so `$insertNodeToNearestRoot` now passes a `$shouldSplit` that declines the empty `'last'` split when content still follows the caret inside its nearest root.

Only the selection-driven wrapper changes. `$insertNodeToNearestRootAtCaret` keeps its documented `$alwaysSplit` default, so the `@lexical/list` and `@lexical/link` callers are unaffected.

Two cases added to the existing suite; the eight existing expectations are unchanged and pass either way as controls. `lexical-utils` 227 passed, full unit project 4075 passed.

Fixes #5433
