### PR TITLE
[lexical] Bug Fix: don't leave empty class/style attributes in the editor DOM

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
@@ -200,7 +200,7 @@ test.describe('Clear All Formatting', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello World Test</span>
         </p>
       `,
@@ -221,7 +221,7 @@ test.describe('Clear All Formatting', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello World Test</span>
         </p>
       `,
@@ -242,7 +242,7 @@ test.describe('Clear All Formatting', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello World Test</span>
         </p>
       `,
@@ -269,7 +269,7 @@ test.describe('Clear All Formatting', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello World Test</span>
         </p>
       `,
@@ -288,7 +288,7 @@ test.describe('Clear All Formatting', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">Hello World</span>
         </p>
       `,

--- a/packages/lexical-playground/__tests__/e2e/Indentation.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Indentation.spec.mjs
@@ -404,13 +404,13 @@ test.describe('Identation', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">foo</span>
         </p>
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">bar</span>
         </p>
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">yar</span>
         </p>
         <ul class="PlaygroundEditorTheme__ul" dir="auto">
@@ -434,7 +434,7 @@ test.describe('Identation', () => {
           data-gutter="1">
           <span data-lexical-text="true">code</span>
         </code>
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <br data-lexical-managed-linebreak="true" />
         </p>
         <table
@@ -447,13 +447,13 @@ test.describe('Identation', () => {
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader PlaygroundEditorTheme__tableCellSelected"
               dir="auto">
-              <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+              <p class="PlaygroundEditorTheme__paragraph" dir="auto">
                 <span data-lexical-text="true">foo</span>
               </p>
             </th>
           </tr>
         </table>
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <br data-lexical-managed-linebreak="true" />
         </p>
       `,

--- a/packages/lexical-playground/__tests__/e2e/KeyboardShortcuts.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/KeyboardShortcuts.spec.mjs
@@ -371,7 +371,7 @@ test.describe('Keyboard shortcuts', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph" dir="auto" style="">
+        <p class="PlaygroundEditorTheme__paragraph" dir="auto">
           <span data-lexical-text="true">abc</span>
         </p>
       `,

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -54,6 +54,7 @@ import {
   $markSlotEditable,
   cloneDecorators,
   getElementByKeyOrThrow,
+  removeEmptyDOMAttribute,
   setDOMUnmanaged,
   setMutatedNode,
   setNodeKeyOnDOMNode,
@@ -393,6 +394,8 @@ function setElementIndent(dom: HTMLElement, indent: number): void {
       ? ''
       : `calc(${indent} * var(--lexical-indent-base-value, ${DEFAULT_INDENT_VALUE}))`,
   );
+  removeEmptyDOMAttribute(dom, 'class');
+  removeEmptyDOMAttribute(dom, 'style');
 }
 
 function setElementFormat(dom: HTMLElement, format: number): void {
@@ -413,6 +416,7 @@ function setElementFormat(dom: HTMLElement, format: number): void {
   } else if (format === IS_ALIGN_END) {
     setTextAlign(domStyle, 'end');
   }
+  removeEmptyDOMAttribute(dom, 'style');
 }
 
 export function $getReconciledDirection(

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1413,6 +1413,24 @@ export function $selectAll(selection?: RangeSelection | null): RangeSelection {
   }
 }
 
+/**
+ * Removes `class` or `style` from the element when the attribute is present
+ * but has an empty value.
+ *
+ * `classList.remove(...)` and `style.setProperty(prop, '')` do not remove the
+ * attribute once every token/declaration is gone, so clearing the last theme
+ * class or the last inline declaration leaves `class=""` / `style=""` behind
+ * in the editor DOM.
+ */
+export function removeEmptyDOMAttribute(
+  dom: HTMLElement,
+  attributeName: 'class' | 'style',
+): void {
+  if (dom.getAttribute(attributeName) === '') {
+    dom.removeAttribute(attributeName);
+  }
+}
+
 export function getCachedClassNameArray(
   classNamesTheme: EditorThemeClasses,
   classNameThemeType: string,

--- a/packages/lexical/src/__tests__/unit/Issue5307Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue5307Repro.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $isTextNode,
+  $selectAll,
+  type ElementNode,
+  type TextNode,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+import {initializeUnitTest} from '../utils';
+
+const EMPTY_ATTRIBUTES_HTML =
+  '<p dir="auto"><span data-lexical-text="true">abc</span></p>';
+
+function $getParagraph(): ElementNode {
+  const paragraph = $getRoot().getFirstChildOrThrow();
+  if (!$isElementNode(paragraph)) {
+    throw new Error('Expected a ParagraphNode');
+  }
+  return paragraph;
+}
+
+function $getText(): TextNode {
+  const textNode = $getParagraph().getFirstChild();
+  if (!$isTextNode(textNode)) {
+    throw new Error('Expected a TextNode');
+  }
+  return textNode;
+}
+
+// Regression tests for #5307. `classList.remove()` and
+// `style.setProperty(prop, '')` leave the attribute behind with an empty
+// value, so clearing the last theme class / inline declaration used to render
+// `<span class="">` and `<p style="">`.
+describe('Issue 5307: empty style attribute', () => {
+  initializeUnitTest(testEnv => {
+    test('clearing an element format removes the style attribute', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('abc')));
+        },
+        {discrete: true},
+      );
+      editor.update(() => $getParagraph().setFormat('center'), {
+        discrete: true,
+      });
+      expect(testEnv.innerHTML).toBe(
+        '<p dir="auto" style="text-align: center;">' +
+          '<span data-lexical-text="true">abc</span></p>',
+      );
+
+      editor.update(() => $getParagraph().setFormat(''), {discrete: true});
+      expect(testEnv.innerHTML).toBe(EMPTY_ATTRIBUTES_HTML);
+    });
+
+    test('clearing an element indent removes the style attribute', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('abc')));
+        },
+        {discrete: true},
+      );
+      editor.update(() => $getParagraph().setIndent(1), {discrete: true});
+      expect(testEnv.innerHTML).toContain('padding-inline-start');
+
+      editor.update(() => $getParagraph().setIndent(0), {discrete: true});
+      expect(testEnv.innerHTML).toBe(EMPTY_ATTRIBUTES_HTML);
+    });
+
+    test('clearing a text style removes the style attribute', () => {
+      const {editor} = testEnv;
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('abc')));
+        },
+        {discrete: true},
+      );
+      editor.update(() => $getText().setStyle('color: red'), {discrete: true});
+      expect(testEnv.innerHTML).toContain('color: red');
+
+      editor.update(() => $getText().setStyle(''), {discrete: true});
+      expect(testEnv.innerHTML).toBe(EMPTY_ATTRIBUTES_HTML);
+    });
+  });
+});
+
+describe('Issue 5307: empty class attribute', () => {
+  initializeUnitTest(
+    testEnv => {
+      test('clearing the last text format removes the class attribute', () => {
+        const {editor} = testEnv;
+        editor.update(
+          () => {
+            $getRoot()
+              .clear()
+              .append($createParagraphNode().append($createTextNode('abc')));
+            $selectAll();
+          },
+          {discrete: true},
+        );
+        editor.update(
+          () => {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) {
+              selection.formatText('underline');
+            }
+          },
+          {discrete: true},
+        );
+        expect(testEnv.innerHTML).toBe(
+          '<p dir="auto">' +
+            '<span data-lexical-text="true" class="my-underline">abc</span></p>',
+        );
+
+        editor.update(
+          () => {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) {
+              selection.formatText('underline');
+            }
+          },
+          {discrete: true},
+        );
+        expect(testEnv.innerHTML).toBe(EMPTY_ATTRIBUTES_HTML);
+      });
+    },
+    {namespace: 'test', theme: {text: {underline: 'my-underline'}}},
+  );
+});

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -70,6 +70,7 @@ import {
   isDOMTextNode,
   isHTMLElement,
   isInlineDomNode,
+  removeEmptyDOMAttribute,
   toggleTextFormatType,
 } from '../LexicalUtils';
 import {setDOMStyleFromCSS} from '../utils/setDOMStyle';
@@ -198,6 +199,7 @@ function setTextThemeClassNames(
       }
     }
   }
+  removeEmptyDOMAttribute(dom, 'class');
 }
 
 function diffComposedText(a: string, b: string): [number, number, string] {
@@ -650,6 +652,7 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
     const nextStyle = this.__style;
     if (prevStyle !== nextStyle) {
       setDOMStyleFromCSS(dom.style, nextStyle, prevStyle);
+      removeEmptyDOMAttribute(dom, 'style');
     }
     return false;
   }


### PR DESCRIPTION
`classList.remove()` and `style.setProperty(prop, '')` keep the attribute in place with an empty value, so clearing the last theme class or the last inline declaration renders `<span class="">` / `<p style="">`.

Repro: `p.setFormat('center')` then `p.setFormat('')` gives `<p style="">`; toggling `selection.formatText('underline')` twice with a `theme.text.underline` class gives `<span class="">`.

Adds an internal `removeEmptyDOMAttribute(dom, 'class' | 'style')`, which drops the attribute when `getAttribute` returns `''`, and calls it from the three reconcile paths that can drop the final token: element format (`text-align`), element indent (`padding-inline-start` plus the indent theme class), and `TextNode.updateDOM` (theme classes and `__style`). It is not exported from `index.ts`, so there is no public API or flow change.

Four unit tests, all failing on `main` with the exact `style=""` / `class=""` output.

Three e2e files had recorded the leftover attribute and are updated — `ClearFormatting` (5), `Indentation` (6), `KeyboardShortcuts` (1). Their purpose is unchanged; only the stale attribute is gone, and I confirmed in Chromium beforehand that the received HTML differed from the expectation by exactly `style=""`.

`DraggableBlock.spec.mjs` keeps its four `style=""` assertions on purpose: that one comes from `LexicalDraggableBlockPlugin` writing `element.style.transform` directly and restoring it, not from the reconciler. Same cosmetic class, plugin-owned DOM, worth its own fix.

Noting @acywatson's "we could probably change this, but I'm not sure it's a bug" from the thread — happy to close this if the answer is still that it isn't worth the churn.

Fixes #5307
