### PR TITLE
[lexical-markdown] Bug Fix: hashtag no longer blocks the heading shortcut

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -27,6 +27,7 @@ import {
   type LexicalEditor,
   type LexicalNode,
   mergeRegister,
+  type PointType,
   TEXT_TYPE_TO_FORMAT,
   type TextNode,
 } from 'lexical';
@@ -418,6 +419,40 @@ function getOpenTagStartIndex(
   return -1;
 }
 
+/**
+ * Offset of a text point measured from the start of its parent element rather
+ * than from the start of its own node.
+ *
+ * The "did the user type exactly one character?" heuristic compares the anchor
+ * offset before and after an update, but node transforms (hashtags, autolinks,
+ * ...) can split or merge the leaves around the caret within that same update.
+ * The anchor then lands in a different node and the two raw offsets are no
+ * longer comparable, so a single typed character can look like a large jump and
+ * the shortcut is skipped (#5366). Rebasing both offsets on the parent element
+ * keeps them comparable; when the leaves around the caret are unchanged this is
+ * the previous offset plus a constant on both sides, so the comparison is
+ * unaffected.
+ */
+function $getOffsetInParent(point: PointType): number {
+  const node = point.getNode();
+
+  if (!$isTextNode(node)) {
+    return point.offset;
+  }
+
+  let offset = point.offset;
+
+  for (
+    let sibling = node.getPreviousSibling();
+    sibling !== null;
+    sibling = sibling.getPreviousSibling()
+  ) {
+    offset += sibling.getTextContentSize();
+  }
+
+  return offset;
+}
+
 function isEqualSubString(
   stringA: string,
   aStart: number,
@@ -574,12 +609,18 @@ export function registerMarkdownShortcuts(
 
         const anchorNode = editorState._nodeMap.get(anchorKey);
 
+        if (!$isTextNode(anchorNode) || !dirtyLeaves.has(anchorKey)) {
+          return;
+        }
+
         if (
-          !$isTextNode(anchorNode) ||
-          !dirtyLeaves.has(anchorKey) ||
-          (!isCompositionEnd &&
-            anchorOffset !== 1 &&
-            anchorOffset > prevSelection.anchor.offset + 1)
+          !isCompositionEnd &&
+          anchorOffset !== 1 &&
+          editorState.read(() => $getOffsetInParent(selection.anchor)) >
+            prevEditorState.read(() =>
+              $getOffsetInParent(prevSelection.anchor),
+            ) +
+              1
         ) {
           return;
         }

--- a/packages/lexical-markdown/src/__tests__/unit/Issue5366Repro.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/Issue5366Repro.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {CodeNode} from '@lexical/code';
+import {HashtagNode, registerLexicalHashtag} from '@lexical/hashtag';
+import {createHeadlessEditor} from '@lexical/headless';
+import {LinkNode} from '@lexical/link';
+import {ListItemNode, ListNode} from '@lexical/list';
+import {registerMarkdownShortcuts, TRANSFORMERS} from '@lexical/markdown';
+import {$isHeadingNode, HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+// https://github.com/facebook/lexical/issues/5366
+describe('Issue #5366: hashtags block the heading shortcut', () => {
+  it.each([
+    ['# ', 'h1'],
+    ['## ', 'h2'],
+    ['### ', 'h3'],
+    ['#### ', 'h4'],
+    ['##### ', 'h5'],
+    ['###### ', 'h6'],
+  ])(
+    'transforms with the "%s" shortcut typed before existing text',
+    (shortcut, tag) => {
+      const editor = createHeadlessEditor({
+        nodes: [
+          HeadingNode,
+          ListNode,
+          ListItemNode,
+          QuoteNode,
+          CodeNode,
+          LinkNode,
+          HashtagNode,
+        ],
+        onError: error => {
+          throw error;
+        },
+      });
+
+      // The hashtag entity turns the leading "#" of "##Welcome" into its own
+      // node, which moves the caret to a different leaf while the shortcut is
+      // being typed.
+      registerLexicalHashtag(editor);
+      registerMarkdownShortcuts(editor, TRANSFORMERS);
+
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          const text = $createTextNode('Welcome to the playground');
+          paragraph.append(text);
+          $getRoot().append(paragraph);
+          text.select(0, 0);
+        },
+        {discrete: true},
+      );
+
+      for (const character of shortcut) {
+        editor.update(
+          () => {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) {
+              selection.insertText(character);
+            }
+          },
+          {discrete: true},
+        );
+      }
+
+      editor.read(() => {
+        const heading = $getRoot().getFirstChild();
+        expect($isHeadingNode(heading)).toBe(true);
+        expect($isHeadingNode(heading) && heading.getTag()).toBe(tag);
+        expect(heading?.getTextContent()).toBe('Welcome to the playground');
+      });
+    },
+  );
+});

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -9,6 +9,7 @@
 import {
   moveLeft,
   moveRight,
+  moveToLineBeginning,
   redo,
   selectAll,
   selectCharacters,
@@ -1058,6 +1059,25 @@ test.describe('Markdown', () => {
       focusOffset: 0,
       focusPath: [0, 2, 0],
     });
+  });
+
+  // The hashtag entity claims the "#Welcome" inside "##Welcome", which moves
+  // the caret into a different leaf while the shortcut is being typed.
+  test('can type a heading shortcut in front of existing text (#5366)', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Welcome to the playground');
+    await moveToLineBeginning(page);
+    await page.keyboard.type('## ');
+    await assertHTML(
+      page,
+      html`
+        <h2 class="PlaygroundEditorTheme__h2" dir="auto">
+          <span data-lexical-text="true">Welcome to the playground</span>
+        </h2>
+      `,
+    );
   });
 
   test('keep list marker on its own items', async ({page}) => {


### PR DESCRIPTION
Typing `## ` in front of existing text leaves the literal `## ` in a paragraph instead of producing an `h2`.

`registerMarkdownShortcuts` only runs its transformers when the update looks like a single typed character, which it checks by comparing the anchor offset against the previous anchor offset. A node transform can split or merge the leaves around the caret inside that same update, which moves the anchor into a different node and makes the two raw offsets incomparable.

`##Welcome` is exactly that: the hashtag entity claims `#Welcome`, so the caret ends up at offset 1 of the hashtag node. Typing the space breaks the hashtag and merges everything back into one text node at offset 3, which reads as a two-character jump, and the heading transformer never runs. `# ` works; `## ` through `###### ` do not. That matches the reporter's own analysis in the thread.

Rebase both offsets on the parent element before comparing them. When the leaves around the caret are unchanged this adds the same constant to both sides, so the existing comparison is unaffected — it only changes the case where a node transform moved the caret into a different leaf.

Adds a headless unit test covering `# ` through `###### ` with the hashtag entity registered, and a playground e2e for the reported repro. The `# ` case passes either way and is a control.

Fixes #5366
