### PR TITLE
[lexical-link] Bug Fix: $toggleLink ignores a collapsed selection

### DIFF
--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -818,6 +818,21 @@ export function $toggleLink(
     }
   }
 
+  if (selection.isCollapsed() && url !== null) {
+    // A collapsed selection covers no text, so there is nothing to turn into a
+    // link. `extract()` returns the whole node the caret happens to sit in,
+    // which would silently link far more than the caret (#5305). Updating an
+    // existing link is still meaningful, so only bail out when the caret is not
+    // already inside one.
+    const parentLink = $findMatchingParent(
+      selection.anchor.getNode(),
+      $isLinkNode,
+    );
+    if (parentLink === null) {
+      return;
+    }
+  }
+
   // Handle RangeSelection
   const nodes = selection.extract();
 

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -512,6 +512,59 @@ describe('LexicalLinkNode tests', () => {
       expect(link.title).toBe('Lexical Website');
     });
 
+    // https://github.com/facebook/lexical/issues/5305
+    test('$toggleLink does not link the whole node from a collapsed selection', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const paragraph = $createParagraphNode();
+        const textNode = $createTextNode('. Try typing in ');
+        paragraph.append(textNode);
+        $getRoot().clear().append(paragraph);
+        // Caret inside the word "typing", nothing selected.
+        textNode.select(8, 8);
+        $toggleLink('https://lexical.dev/');
+      });
+
+      editor.read(() => {
+        const paragraph = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isParagraphNode,
+        );
+        expect(
+          paragraph
+            .getChildren()
+            .map(node => [node.getType(), node.getTextContent()]),
+        ).toEqual([['text', '. Try typing in ']]);
+      });
+    });
+
+    test('$toggleLink updates the enclosing link from a collapsed selection', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const paragraph = $createParagraphNode();
+        const textNode = $createTextNode('A link');
+        const linkNode = $createLinkNode('https://lexical.dev/');
+        linkNode.append(textNode);
+        paragraph.append(linkNode);
+        $getRoot().clear().append(paragraph);
+        textNode.select(0, 0);
+        $toggleLink('https://facebook.com/');
+      });
+
+      editor.read(() => {
+        const paragraph = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isParagraphNode,
+        );
+        const linkNode = paragraph.getFirstChild();
+        expect($isLinkNode(linkNode)).toBe(true);
+        expect($isLinkNode(linkNode) && linkNode.getURL()).toBe(
+          'https://facebook.com/',
+        );
+        expect(paragraph.getTextContent()).toBe('A link');
+      });
+    });
+
     test('$toggleLink correctly removes link when textnode has children(like marknode)', async () => {
       const {editor} = testEnv;
       await editor.update(() => {


### PR DESCRIPTION
Click inside a word in the playground and press "Insert link": the link wraps the entire surrounding text node (`". Try typing in "`) instead of nothing or the word under the caret.

A collapsed `RangeSelection` reaches `selection.extract()`, which returns the whole node the caret happens to sit in, and that node is wrapped in a `LinkNode`. How much text gets linked is decided by where text-node boundaries fall, which the user cannot see.

Bail out instead when the selection is collapsed and a URL was given — option 2 from the thread, which @acywatson picked and which has the 👍 on it. A caret already inside a `LinkNode` still falls through, so editing the URL of an existing link keeps working; that path is covered by the existing e2e `Can edit link with collapsed selection`, and by a new unit test that passes either way as a control. Removing a link from a collapsed selection (`url === null`) is handled earlier and is unchanged.

One behaviour note for reviewers: in the playground, clicking the link button with a bare caret outside a link now does nothing rather than linking the surrounding text node. That is the outcome the thread settled on. I did not touch the toolbar button's enabled state, which may be worth a follow-up.

Fixes #5305
