### PR TITLE
[lexical-code-prism] Bug Fix: read the language maps as own properties

### DIFF
--- a/packages/lexical-code-prism/src/FacadePrism.ts
+++ b/packages/lexical-code-prism/src/FacadePrism.ts
@@ -83,13 +83,25 @@ export const CODE_LANGUAGE_MAP: Record<string, string> = {
   ts: 'typescript',
 };
 
+// The two maps above are plain objects, so a language whose name matches a
+// member of `Object.prototype` reads the inherited value: `CODE_LANGUAGE_MAP`
+// indexed with `constructor` hands back the `Object` function, not a string.
+// A code block's language comes from the document, so the name is not ours to
+// choose.
+function ownValue(
+  map: Record<string, string>,
+  key: string,
+): string | undefined {
+  return Object.prototype.hasOwnProperty.call(map, key) ? map[key] : undefined;
+}
+
 export function normalizeCodeLanguage(lang: string) {
-  return CODE_LANGUAGE_MAP[lang] || lang;
+  return ownValue(CODE_LANGUAGE_MAP, lang) || lang;
 }
 
 export function getLanguageFriendlyName(lang: string) {
   const _lang = normalizeCodeLanguage(lang);
-  return CODE_LANGUAGE_FRIENDLY_NAME_MAP[_lang] || _lang;
+  return ownValue(CODE_LANGUAGE_FRIENDLY_NAME_MAP, _lang) || _lang;
 }
 
 export const getCodeLanguages = (): string[] =>

--- a/packages/lexical-code-prism/src/__tests__/unit/CodePrismLanguageOptions.test.ts
+++ b/packages/lexical-code-prism/src/__tests__/unit/CodePrismLanguageOptions.test.ts
@@ -21,4 +21,28 @@ describe('Prism code language options', () => {
     expect(normalizeCodeLanguage('golang')).toBe('go');
     expect(isCodeLanguageLoaded('go')).toBe(true);
   });
+
+  test('returns a string for a language named after an Object member', () => {
+    // A markdown fence carries whatever the author typed, so these arrive as
+    // ordinary language names. Read off the prototype they come back as
+    // functions and reach the DOM as the source text of `Object`.
+    for (const lang of [
+      'constructor',
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'isPrototypeOf',
+      '__proto__',
+    ]) {
+      expect(normalizeCodeLanguage(lang)).toBe(lang);
+      expect(getLanguageFriendlyName(lang)).toBe(lang);
+    }
+  });
+
+  test('still maps and names the languages it knows', () => {
+    expect(normalizeCodeLanguage('javascript')).toBe('js');
+    expect(getLanguageFriendlyName('javascript')).toBe('JavaScript');
+    expect(normalizeCodeLanguage('rust')).toBe('rust');
+    expect(getLanguageFriendlyName('rust')).toBe('Rust');
+  });
 });


### PR DESCRIPTION
## Description

`normalizeCodeLanguage` and `getLanguageFriendlyName` are declared as returning a string, and for a handful of language names they return a function instead.

Both read their map with a plain index, and both maps are object literals:

```js
CODE_LANGUAGE_MAP[lang] || lang
CODE_LANGUAGE_FRIENDLY_NAME_MAP[_lang] || _lang
```

So a language whose name matches a member of `Object.prototype` resolves to the inherited value rather than falling through to `lang`:

```
normalizeCodeLanguage('constructor')     -> function Object
normalizeCodeLanguage('toString')        -> function toString
normalizeCodeLanguage('valueOf')         -> function valueOf
normalizeCodeLanguage('hasOwnProperty')  -> function hasOwnProperty
normalizeCodeLanguage('__proto__')       -> Object.prototype
```

The language of a code block is whatever the document carries, so the name is not ours to choose. The markdown transformer reads the info string of a fence and hands it straight to `$createCodeNode`:

```js
const language = startMatch[2] || undefined;
...
codeBlockNode = $createCodeNode(language);
```

so importing ` ```constructor ` is enough to reach it. From there the playground's `CodeActionMenuPlugin` renders `getLanguageFriendlyName(lang)` as the label and passes `normalizeCodeLanguage(...)` to `canBePrettier`, both of which now receive a function.

Worth mentioning because it is the thing that convinced me the fix belongs here rather than at the call sites: the sibling facade already gets this right. `normalizeCodeLanguage` in `@lexical/code-shiki` looks the name up with `bundledLanguagesInfo.find(...)`, an array search, so no name can reach a prototype member.

I kept both maps as plain objects, since they are exported and swapping them for a `Map` would be a breaking change for anyone reading or spreading them. The lookups go through a small helper that only accepts own properties, which leaves the `||` fallback behaving exactly as before for every language that is actually in the map.

## Test plan

Two tests added to `CodePrismLanguageOptions.test.ts`: one walks the six names above through both functions, and one asserts the ordinary mappings still work, so the guard cannot quietly swallow a real language.

### Before

The new test fails on the current code:

```
× returns a string for a language named after an Object member
  AssertionError: expected [Function Object] to be 'constructor'
```

### After

```
✓ Prism code language options > includes Go (#7704)
✓ Prism code language options > returns a string for a language named after an Object member
✓ Prism code language options > still maps and names the languages it knows

Test Files  1 passed (1)
     Tests  3 passed (3)
```

The wider suite is unchanged: `packages/lexical-code-prism`, `packages/lexical-code-shiki` and `packages/lexical-code-core` together give 10 files, 213 tests, all passing.
