### PR TITLE
[lexical-text] Bug Fix: replace a text entity match that ends a TextNode

### DIFF
--- a/packages/lexical-text/src/__tests__/unit/Issue5466Repro.test.ts
+++ b/packages/lexical-text/src/__tests__/unit/Issue5466Repro.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $applyNodeReplacement,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type ElementNode,
+  TextNode,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+import {type EntityMatch, registerLexicalTextEntity} from '../..';
+
+class TestEntityNode extends TextNode {
+  $config() {
+    return this.config('test-entity-5466', {extends: TextNode});
+  }
+
+  isTextEntity(): true {
+    return true;
+  }
+}
+
+function $createTestEntityNode(text: string): TestEntityNode {
+  return $applyNodeReplacement(new TestEntityNode(text));
+}
+
+// Matches `${…}` placeholders, as in the report.
+function getMatch(text: string): null | EntityMatch {
+  const match = /\$\{[^}]*\}/.exec(text);
+  return match === null
+    ? null
+    : {end: match.index + match[0].length, start: match.index};
+}
+
+/**
+ * Renders the paragraph children as `E:"…"` for entity nodes and `T:"…"` for
+ * plain text nodes.
+ */
+function $describeParagraph(): string {
+  return ($getRoot().getFirstChild() as ElementNode)
+    .getChildren<TextNode>()
+    .map(
+      node =>
+        `${node instanceof TestEntityNode ? 'E' : 'T'}:${JSON.stringify(
+          node.getTextContent(),
+        )}`,
+    )
+    .join(' ');
+}
+
+describe('registerLexicalTextEntity (#5466)', () => {
+  initializeUnitTest(
+    testEnv => {
+      // The second text node is bold so that it is not normalized into the first
+      // one. That leaves the match at the end of a text node that still has a
+      // TextNode sibling, which is the shape produced by $insertNodes.
+      const cases: [string, string, string, string][] = [
+        [
+          'x ${A}',
+          ' tail',
+          'T:"x " E:"${A}" T:" tail"',
+          'replaces a match that ends the node and does not start at offset 0',
+        ],
+        [
+          'x ${A} y ${B}',
+          ' tail',
+          'T:"x " E:"${A}" T:" y " E:"${B}" T:" tail"',
+          'replaces the last of several matches in the same node',
+        ],
+        [
+          '${A} ${B} ${C}',
+          ' tail',
+          'E:"${A}" T:" " E:"${B}" T:" " E:"${C}" T:" tail"',
+          'replaces every match when the first one starts at offset 0',
+        ],
+        [
+          'x ${A} y',
+          ' tail',
+          'T:"x " E:"${A}" T:" y" T:" tail"',
+          'replaces a match that does not end the node (control)',
+        ],
+        [
+          'x ${A',
+          'B} tail',
+          'T:"x ${A" T:"B} tail"',
+          'leaves a match that only completes inside the sibling (control)',
+        ],
+      ];
+
+      for (const [first, second, expected, description] of cases) {
+        test(description, async () => {
+          const {editor} = testEnv;
+          registerLexicalTextEntity(
+            editor,
+            getMatch,
+            TestEntityNode,
+            textNode => $createTestEntityNode(textNode.getTextContent()),
+          );
+
+          await editor.update(() => {
+            const paragraph = $createParagraphNode();
+            paragraph.append(
+              $createTextNode(first),
+              $createTextNode(second).toggleFormat('bold'),
+            );
+            $getRoot().clear().append(paragraph);
+          });
+
+          editor.getEditorState().read(() => {
+            expect($describeParagraph()).toBe(expected);
+          });
+        });
+      }
+    },
+    {namespace: 'test', nodes: [TestEntityNode], theme: {}},
+  );
+});

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -104,17 +104,23 @@ export function registerLexicalTextEntity<T extends TextNode>(
     let prevMatchLengthToSkip = 0;
 
     while (true) {
-      match = getMatch(text);
-      let nextText = match === null ? '' : text.slice(match.end);
+      const remainingText = text;
+      match = getMatch(remainingText);
+      const nextText = match === null ? '' : remainingText.slice(match.end);
       text = nextText;
 
       if (nextText === '') {
         const nextSibling = currentNode.getNextSibling();
 
         if ($isTextNode(nextSibling)) {
-          nextText =
-            currentNode.getTextContent() + nextSibling.getTextContent();
-          const nextMatch = getMatch(nextText);
+          // The match ends where this node ends, so the next sibling's text may
+          // extend, shorten or invalidate it. Re-run getMatch over the text that
+          // is still to be processed plus the sibling's text and bail out unless
+          // the same match is found at the same offset. Matches that were
+          // already replaced (or skipped) are excluded from `remainingText`, so
+          // the comparison is against `match.start` rather than 0.
+          const combinedText = remainingText + nextSibling.getTextContent();
+          const nextMatch = getMatch(combinedText);
 
           if (nextMatch === null) {
             if (isTargetNode(nextSibling)) {
@@ -124,7 +130,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
             }
 
             return;
-          } else if (nextMatch.start !== 0) {
+          } else if (match === null || nextMatch.start !== match.start) {
             return;
           }
         }


### PR DESCRIPTION
## Description

`registerLexicalTextEntity` silently skips a match when the match **ends at the end of its TextNode** and does not start at offset 0. In #5466 the reporter's `${Tenant.Zip}` and `${Facility.Zip}` never became `VariableNode`s, and they found the tell themselves: excluding the trailing `}` from the selection made the transform work, and the problem only ever hit the last match in a node when that match also ended the node.

The transform walks a node replacing matches one at a time. Once a match is consumed, the loop keeps a `text` cursor holding only the text still to be processed. When the remaining text runs out, the node's match might be continued by the next sibling — a `${Tenant.` in one node and `Zip}` in the next — so the code re-runs `getMatch` over the combined text and requires the result to line up before replacing.

Two things were wrong with that check:

- it re-ran `getMatch` over `currentNode.getTextContent() + nextSibling.getTextContent()`, the **whole** node text, rather than the text still to be processed, and
- it then required `nextMatch.start === 0`.

Those only agree when the match starts at offset 0 of the node. For any later match, `nextMatch.start` is the offset within the full node text, never 0, so the function returned early and left the match untransformed. The combined text is now built from the remaining text, and the check compares against `match.start`, which is the same coordinate space.

Closes #5466

## Test plan

`packages/lexical-text/src/__tests__/unit/Issue5466Repro.test.ts` registers a `${...}` entity, matching the reporter's plugin, and covers the three broken shapes plus two controls that must keep working: a match that does not end the node, and a match that only completes inside the sibling (which must still be left alone).

### Before

```
$ npx vitest run packages/lexical-text
 × replaces a match that ends the node and does not start at offset 0
 × replaces the last of several matches in the same node
 × replaces every match when the first one starts at offset 0
 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

### After

```
$ npx vitest run packages/lexical-text
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npx vitest run packages/lexical-text packages/lexical-react packages/lexical/src/__tests__
 Test Files  88 passed (88)
      Tests  1120 passed | 1 skipped (1121)
```

Unit tests only — this is a text-transform path with no e2e coverage of its own.
