### PR TITLE
[lexical][lexical-headless] Bug Fix: make deleteCharacter work in a headless editor

### DIFF
--- a/packages/lexical-headless/src/__tests__/unit/Issue4210Repro.test.ts
+++ b/packages/lexical-headless/src/__tests__/unit/Issue4210Repro.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalEditor,
+} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+import {createHeadlessEditor} from '../..';
+
+function $setUp(text: string, offset: number): void {
+  const paragraph = $createParagraphNode();
+  const textNode = $createTextNode(text);
+  paragraph.append(textNode);
+  $getRoot().clear().append(paragraph);
+  textNode.select(offset, offset);
+}
+
+function buildEditor(text: string, offset: number): LexicalEditor {
+  const editor = createHeadlessEditor({
+    namespace: 'Issue4210Repro',
+    onError: error => {
+      throw error;
+    },
+  });
+  editor.update(() => $setUp(text, offset), {discrete: true});
+  return editor;
+}
+
+function $deleteCharacter(isBackward: boolean): void {
+  const selection = $getSelection();
+  if ($isRangeSelection(selection)) {
+    selection.deleteCharacter(isBackward);
+  }
+}
+
+describe('deleteCharacter in a headless editor (#4210)', () => {
+  it('deletes the character before a collapsed caret', () => {
+    const editor = buildEditor('hello', 5);
+    editor.update(() => $deleteCharacter(true), {discrete: true});
+    expect(
+      editor.getEditorState().read(() => $getRoot().getTextContent()),
+    ).toBe('hell');
+  });
+
+  it('deletes the character after a collapsed caret', () => {
+    const editor = buildEditor('hello', 0);
+    editor.update(() => $deleteCharacter(false), {discrete: true});
+    expect(
+      editor.getEditorState().read(() => $getRoot().getTextContent()),
+    ).toBe('ello');
+  });
+
+  it('deletes a whole code point rather than half a surrogate pair', () => {
+    // '🙂' is two UTF-16 code units, so extending by one unit and deleting it
+    // would leave a lone surrogate behind.
+    const editor = buildEditor('a🙂', 3);
+    editor.update(() => $deleteCharacter(true), {discrete: true});
+    expect(
+      editor.getEditorState().read(() => $getRoot().getTextContent()),
+    ).toBe('a');
+  });
+
+  it('leaves the text alone at the start of the only block', () => {
+    const editor = buildEditor('hello', 0);
+    editor.update(() => $deleteCharacter(true), {discrete: true});
+    expect(
+      editor.getEditorState().read(() => $getRoot().getTextContent()),
+    ).toBe('hello');
+  });
+
+  it('does not throw for word deletion, which has no model equivalent', () => {
+    const editor = buildEditor('hello world', 11);
+    expect(() =>
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            selection.deleteWord(true);
+          }
+        },
+        {discrete: true},
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2353,6 +2353,50 @@ function $shrinkSelectionToRoot(
  * unresolvable anchor — the selection is left collapsed, so the deletion
  * becomes a no-op for that keystroke.
  */
+/**
+ * Model-only stand-in for the native caret measurement, used when the editor has
+ * no window (a headless editor).
+ *
+ * Only `character` is handled: a single code unit within the focus's own text
+ * node, which `$updateCaretSelectionForUnicodeCharacter` then widens to a whole
+ * code point in `deleteCharacter`. Word and line boundaries depend on the
+ * engine's text segmentation and have no model equivalent, and crossing a block
+ * boundary is left to `$collapseAtStart`, which already owns that merge.
+ */
+function $extendSelectionForDeletionInModel(
+  selection: RangeSelection,
+  isBackward: boolean,
+  granularity: 'character' | 'word' | 'lineboundary',
+): void {
+  if (granularity !== 'character') {
+    return;
+  }
+  const focus = selection.focus;
+  if (focus.type !== 'text') {
+    return;
+  }
+  const text = focus.getNode().getTextContent();
+  const offset = focus.offset;
+  let nextOffset = isBackward ? offset - 1 : offset + 1;
+  if (nextOffset < 0 || nextOffset > text.length) {
+    return;
+  }
+  // Step over a whole surrogate pair rather than splitting one, which would
+  // leave a lone surrogate in the text.
+  if (isBackward) {
+    const code = text.charCodeAt(nextOffset);
+    if (code >= 0xdc00 && code <= 0xdfff && nextOffset > 0) {
+      nextOffset -= 1;
+    }
+  } else {
+    const code = text.charCodeAt(nextOffset - 1);
+    if (code >= 0xd800 && code <= 0xdbff && nextOffset < text.length) {
+      nextOffset += 1;
+    }
+  }
+  focus.set(focus.key, nextOffset, 'text');
+}
+
 function $extendSelectionForDeletion(
   selection: RangeSelection,
   isBackward: boolean,
@@ -2370,7 +2414,15 @@ function $extendSelectionForDeletion(
     return;
   }
   const editor = getActiveEditor();
-  const domSelection = getDOMSelection(getWindow(editor));
+  const editorWindow = editor._window;
+  if (editorWindow === null) {
+    // A headless editor has no window, so there is no native caret to measure
+    // against. `getWindow` would throw here, which is why `deleteCharacter`
+    // was unusable outside the browser (#4210). Extend in the model instead.
+    $extendSelectionForDeletionInModel(selection, isBackward, granularity);
+    return;
+  }
+  const domSelection = getDOMSelection(editorWindow);
   if (!domSelection || typeof domSelection.modify !== 'function') {
     return;
   }


### PR DESCRIPTION
## Description

`selection.deleteCharacter()` throws `window object not found` in a headless
editor, so the whole deletion API is unusable outside the browser.

`deleteCharacter` extends the selection by one character before removing the
text, and that extension measures the native caret: it calls `getWindow(editor)`
to reach `document.getSelection().modify()`. A headless editor has no window,
and `getWindow` raises an invariant rather than returning null, so the call
fails before any of the surrounding logic runs.

Extending is now done in the model when the editor has no window. The fallback
covers `character` only: a single code unit in the focus's own text node,
stepping over a surrogate pair rather than splitting one. Word and line
boundaries depend on the engine's text segmentation and have no model
equivalent, so they return without extending, which turns `deleteWord` and
`deleteLine` from a crash into a no-op. Crossing a block boundary is left to
`$collapseAtStart`, which already owns that merge.

The fallback is reached only when `editor._window` is null, so editors with a
DOM keep measuring the native caret exactly as before.

Refs #4210

## Test plan

`packages/lexical-headless/src/__tests__/unit/Issue4210Repro.test.ts` covers
backward and forward deletion, a surrogate pair, the start-of-block no-op, and
`deleteWord` not throwing.

### Before

```
$ npx vitest run packages/lexical-headless
 × deletes the character before a collapsed caret
 × deletes the character after a collapsed caret
 × deletes a whole code point rather than half a surrogate pair
 × leaves the text alone at the start of the only block
 × does not throw for word deletion, which has no model equivalent
Error: window object not found
```

### After

```
$ npx vitest run packages/lexical-headless
 Test Files  2 passed (2)
      Tests  13 passed (13)

$ npx vitest run packages/lexical/src/__tests__ packages/lexical-headless \
    packages/lexical-selection packages/lexical-rich-text packages/lexical-list
 Test Files  89 passed (89)
      Tests  1518 passed | 1 skipped (1519)
```

Browser matrix not exercised: this path is reached only when there is no
window, so the DOM behavior is unchanged by construction.

