### PR TITLE
[lexical-playground] Bug Fix: keep the Excalidraw drawing and its size across a node clone

### DIFF
--- a/packages/lexical-playground/__tests__/unit/ExcalidrawNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/ExcalidrawNode.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $isElementNode,
+  defineExtension,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+import {
+  $createExcalidrawNode,
+  $isExcalidrawNode,
+  ExcalidrawNode,
+} from '../../src/nodes/ExcalidrawNode';
+
+const ExcalidrawTestExtension = defineExtension({
+  $initialEditorState: null,
+  name: '[test-excalidraw]',
+  nodes: [ExcalidrawNode],
+});
+
+const DATA = '[{"type":"rectangle","id":"a"}]';
+
+function $getExcalidrawNodes(): ExcalidrawNode[] {
+  const paragraph = $getRoot().getFirstChild();
+  assert($isElementNode(paragraph), 'expected a paragraph');
+  return paragraph.getChildren().filter($isExcalidrawNode);
+}
+
+function $getExcalidrawNode(): ExcalidrawNode {
+  const [node] = $getExcalidrawNodes();
+  assert($isExcalidrawNode(node), 'expected an ExcalidrawNode');
+  return node;
+}
+
+describe('ExcalidrawNode', () => {
+  it('keeps the drawing data when the node is resized', () => {
+    using editor = buildEditorFromExtensions(ExcalidrawTestExtension);
+    editor.update(
+      () => {
+        $getRoot().append(
+          $createParagraphNode().append($createExcalidrawNode(DATA, 100, 200)),
+        );
+      },
+      {discrete: true},
+    );
+
+    // Resizing calls setWidth/setHeight, each of which goes through
+    // getWritable() and therefore through the node's clone.
+    editor.update(
+      () => {
+        $getExcalidrawNode().setWidth(300).setHeight(400);
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $getExcalidrawNode().exportJSON())).toMatchObject({
+      data: DATA,
+      height: 400,
+      width: 300,
+    });
+  });
+
+  it('keeps the dimensions when the drawing data is saved', () => {
+    using editor = buildEditorFromExtensions(ExcalidrawTestExtension);
+    editor.update(
+      () => {
+        $getRoot().append(
+          $createParagraphNode().append($createExcalidrawNode('[]', 100, 200)),
+        );
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        $getExcalidrawNode().setData(DATA);
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $getExcalidrawNode().exportJSON())).toMatchObject({
+      data: DATA,
+      height: 200,
+      width: 100,
+    });
+  });
+
+  it('keeps the drawing data when the node is moved', () => {
+    using editor = buildEditorFromExtensions(ExcalidrawTestExtension);
+    editor.update(
+      () => {
+        $getRoot().append(
+          $createParagraphNode().append(
+            $createExcalidrawNode(DATA, 100, 200),
+            $createExcalidrawNode('[]'),
+          ),
+        );
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const [first, second] = $getExcalidrawNodes();
+        // insertAfter() writes to both nodes, cloning each of them.
+        second.insertAfter(first);
+      },
+      {discrete: true},
+    );
+
+    expect(
+      editor.read(() => $getExcalidrawNodes().map(node => node.exportJSON())),
+    ).toMatchObject([{data: '[]'}, {data: DATA, height: 200, width: 100}]);
+  });
+});

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -43,6 +43,16 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
     return this.config('excalidraw', {extends: DecoratorNode});
   }
 
+  // Every constructor argument has a default, so `$config` synthesizes the
+  // static `clone` as `new ExcalidrawNode()` — the drawing and its dimensions
+  // have to be carried over here or every `getWritable()` resets them.
+  afterCloneFrom(prevNode: this): void {
+    super.afterCloneFrom(prevNode);
+    this.__data = prevNode.__data;
+    this.__width = prevNode.__width;
+    this.__height = prevNode.__height;
+  }
+
   static importJSON(serializedNode: SerializedExcalidrawNode): ExcalidrawNode {
     return new ExcalidrawNode(
       serializedNode.data,


### PR DESCRIPTION

## Description

`ExcalidrawNode` declares `__data`, `__width` and `__height`, and its
constructor gives every argument a default. That means `$config()` synthesizes
the static `clone` as `new ExcalidrawNode()` and relies on `afterCloneFrom` to
carry the node's own properties over — but `ExcalidrawNode` never implemented
`afterCloneFrom`, so the base implementation runs and the three properties are
silently reset to their constructor defaults on every clone.

Every mutation goes through `getWritable()`, which clones, so the writes that
the Excalidraw UI performs destroy each other:

- resizing (`setWidth`/`setHeight`, dispatched by `ImageResizer`) wipes the
  drawing back to `'[]'` — the picture disappears;
- saving the drawing (`setData`, dispatched when the modal is closed) resets the
  width and height back to `'inherit'`;
- any unrelated write to the node (moving it, `insertAfter`, …) clears all three.

Implement `afterCloneFrom` to copy `__data`, `__width` and `__height`, matching
what every other node in the repo with extra properties does (e.g.
`TableRowNode`, which has the same all-defaults constructor).

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/ExcalidrawNode.test.ts`
covering the three cases above.

### Before

```
$ npx vitest run packages/lexical-playground/__tests__/unit/ExcalidrawNode.test.ts

 FAIL  |unit| .../ExcalidrawNode.test.ts > ExcalidrawNode > keeps the drawing data when the node is resized
 FAIL  |unit| .../ExcalidrawNode.test.ts > ExcalidrawNode > keeps the dimensions when the drawing data is saved
 FAIL  |unit| .../ExcalidrawNode.test.ts > ExcalidrawNode > keeps the drawing data when the node is moved

AssertionError: expected { type: 'excalidraw', ... } to match object { data: '[{"type":"rectangle","id":"a"}]', height: 400, width: 300 }

- Expected
+ Received

  {
-   "data": "[{\"type\":\"rectangle\",\"id\":\"a\"}]",
-   "height": 400,
-   "width": 300,
+   "data": "[]",
+   "height": undefined,
+   "width": undefined,
  }

 Test Files  1 failed (1)
      Tests  3 failed (3)
```

### After

```
$ npx vitest run packages/lexical-playground/__tests__/unit/ExcalidrawNode.test.ts

 ✓ |unit| packages/lexical-playground/__tests__/unit/ExcalidrawNode.test.ts (3 tests) 13ms

 Test Files  1 passed (1)
      Tests  3 passed (3)

$ npx vitest run packages/lexical-playground

 Test Files  18 passed (18)
      Tests  274 passed (274)
```

