### PR TITLE
[lexical-link] Bug Fix: TOGGLE_LINK_COMMAND object payload no longer discards the configured attributes

### DIFF
--- a/packages/lexical-link/src/LexicalLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalLinkExtension.ts
@@ -83,13 +83,13 @@ export function registerLink(
           }
           return false;
         } else {
-          const {url, target, rel, title} = payload;
-          $toggleLink(url, {
-            ...attributes,
-            rel,
-            target,
-            title,
-          });
+          // Only the attributes the payload actually carries may override the
+          // configured defaults. Destructuring `rel`/`target`/`title` and
+          // spreading them unconditionally would write `undefined` over every
+          // configured value, since an explicit `undefined` still shadows a
+          // spread key.
+          const {url, ...payloadAttributes} = payload;
+          $toggleLink(url, {...attributes, ...payloadAttributes});
           return true;
         }
       },

--- a/packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts
@@ -19,6 +19,7 @@ import {
   $toggleLink,
   AutoLinkNode,
   LinkExtension,
+  TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
 import {RichTextExtension} from '@lexical/rich-text';
 import {
@@ -423,6 +424,97 @@ describe('Link', () => {
         assert($isLinkNode(link), 'Expected a LinkNode');
         expect(link.getURL()).toBe(pasteUrl);
         expect(link.getTextContent()).toBe('click here');
+      });
+    });
+  });
+
+  describe('TOGGLE_LINK_COMMAND with configured attributes', () => {
+    const configuredExtension = defineExtension({
+      $initialEditorState: () => {
+        const p = $createParagraphNode();
+        p.append($createTextNode('Hello'));
+        $getRoot().append(p);
+      },
+      dependencies: [
+        configExtension(LinkExtension, {
+          attributes: {
+            rel: 'noopener',
+            target: '_blank',
+            title: 'Configured title',
+          },
+        }),
+        RichTextExtension,
+      ],
+      name: '[root-attributes]',
+    });
+
+    function $selectHello() {
+      const textNode = $getRoot().getLastDescendant();
+      assert($isTextNode(textNode), 'Expected a TextNode');
+      textNode.select(0, textNode.getTextContentSize());
+    }
+
+    function $getLink() {
+      const p = $getRoot().getFirstChild();
+      assert($isParagraphNode(p), 'Expected a ParagraphNode');
+      const link = p.getFirstChild();
+      assert($isLinkNode(link), 'Expected a LinkNode');
+      return link;
+    }
+
+    it('applies the configured attributes for a string payload', () => {
+      using editor = buildEditorFromExtensions(configuredExtension);
+      editor.update(
+        () => {
+          $selectHello();
+          editor.dispatchCommand(TOGGLE_LINK_COMMAND, 'https://lexical.dev/');
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const link = $getLink();
+        expect(link.getRel()).toBe('noopener');
+        expect(link.getTarget()).toBe('_blank');
+        expect(link.getTitle()).toBe('Configured title');
+      });
+    });
+
+    it('applies the configured attributes for an object payload', () => {
+      using editor = buildEditorFromExtensions(configuredExtension);
+      editor.update(
+        () => {
+          $selectHello();
+          editor.dispatchCommand(TOGGLE_LINK_COMMAND, {
+            url: 'https://lexical.dev/',
+          });
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const link = $getLink();
+        expect(link.getRel()).toBe('noopener');
+        expect(link.getTarget()).toBe('_blank');
+        expect(link.getTitle()).toBe('Configured title');
+      });
+    });
+
+    it('lets the object payload override the configured attributes', () => {
+      using editor = buildEditorFromExtensions(configuredExtension);
+      editor.update(
+        () => {
+          $selectHello();
+          editor.dispatchCommand(TOGGLE_LINK_COMMAND, {
+            target: null,
+            url: 'https://lexical.dev/',
+          });
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const link = $getLink();
+        expect(link.getRel()).toBe('noopener');
+        expect(link.getTarget()).toBe(null);
+        expect(link.getTitle()).toBe('Configured title');
       });
     });
   });


### PR DESCRIPTION

## Description

`LinkConfig.attributes` is documented as "The default anchor tag attributes to
use for `TOGGLE_LINK_COMMAND`". The string-payload branch honours it
(`$toggleLink(payload, attributes)`), but the object-payload branch did not:

```ts
const {url, target, rel, title} = payload;
$toggleLink(url, {...attributes, rel, target, title});
```

`LinkAttributes` has exactly three members — `rel`, `target` and `title` — and
all three were destructured out of the payload and then written over the
spread. When the payload omits one, the destructured value is `undefined`, and
an explicit `undefined` still shadows a spread key, so `...attributes` was dead
code: every key it could carry was unconditionally erased.

The result was that the same intent produced two different links depending only
on the payload shape. With `attributes: {rel: 'noopener', target: '_blank',
title: 'Configured title'}` configured:

- `dispatchCommand(TOGGLE_LINK_COMMAND, 'https://lexical.dev/')` produced
  `rel="noopener" target="_blank" title="Configured title"`;
- `dispatchCommand(TOGGLE_LINK_COMMAND, {url: 'https://lexical.dev/'})` produced
  `rel="noreferrer"` (`$toggleLink`'s own fallback for a missing `rel`) and no
  `target` or `title` at all.

Spread the payload's own keys instead, so a key that the payload actually
carries (including an explicit `null`, which clears an attribute) wins and any
key it omits falls back to the configured default. The extension's internal
`PASTE_COMMAND` dispatch already pre-spreads `attributes` into the payload, so
it keeps working unchanged.

## Test plan

Three new cases in `packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts`:
the string payload (passes before and after — it is the reference behaviour),
the object payload, and an object payload that explicitly overrides one
attribute.

### Before

```
$ npx vitest run packages/lexical-link/src/__tests__/unit/LinkExtension.test.ts

 FAIL  |unit| .../LinkExtension.test.ts > Link > TOGGLE_LINK_COMMAND with configured attributes > applies the configured attributes for an object payload
AssertionError: expected 'noreferrer' to be 'noopener' // Object.is equality

Expected: "noopener"
Received: "noreferrer"

 FAIL  |unit| .../LinkExtension.test.ts > Link > TOGGLE_LINK_COMMAND with configured attributes > lets the object payload override the configured attributes
AssertionError: expected 'noreferrer' to be 'noopener' // Object.is equality

Expected: "noopener"
Received: "noreferrer"

 Test Files  1 failed (1)
      Tests  2 failed | 12 passed (14)
```

### After

```
$ npx vitest run packages/lexical-link

 Test Files  6 passed (6)
      Tests  155 passed (155)
```

