### PR TITLE
[lexical-code-core] Bug Fix: Alt+Arrow no longer merges two lines when a code block line is blank

### DIFF
--- a/packages/lexical-code-core/src/CodeIndentation.ts
+++ b/packages/lexical-code-core/src/CodeIndentation.ts
@@ -392,10 +392,15 @@ function $handleShiftLines(
     return true;
   }
 
+  // A LineBreakNode sibling means the adjacent line is blank, so it has no
+  // node of its own to anchor the move to — $getFirstCodeNodeOfLine /
+  // $getLastCodeNodeOfLine hand that linebreak straight back, and it belongs
+  // to a *different* line. Anchoring on it splices the moving line into the
+  // line on the far side of the blank one, merging the two.
+  const adjacentLineIsBlank = $isLineBreakNode(sibling);
   const maybeInsertionPoint =
-    $isCodeHighlightNode(sibling) ||
-    $isTabNode(sibling) ||
-    $isLineBreakNode(sibling)
+    !adjacentLineIsBlank &&
+    ($isCodeHighlightNode(sibling) || $isTabNode(sibling))
       ? arrowIsUp
         ? $getFirstCodeNodeOfLine(sibling)
         : $getLastCodeNodeOfLine(sibling)
@@ -404,7 +409,15 @@ function $handleShiftLines(
     maybeInsertionPoint != null ? maybeInsertionPoint : sibling;
   linebreak.remove();
   range.forEach(node => node.remove());
-  if (type === KEY_ARROW_UP_COMMAND) {
+  if (adjacentLineIsBlank) {
+    // The blank line's position is immediately after the sibling linebreak,
+    // in both directions.
+    range.forEach(node => {
+      insertionPoint.insertAfter(node);
+      insertionPoint = node;
+    });
+    insertionPoint.insertAfter(linebreak);
+  } else if (type === KEY_ARROW_UP_COMMAND) {
     range.forEach(node => insertionPoint.insertBefore(node));
     insertionPoint.insertBefore(linebreak);
   } else {

--- a/packages/lexical-code-core/src/__tests__/unit/CodeIndentation.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeIndentation.test.ts
@@ -14,6 +14,7 @@ import {
 import {buildEditorFromExtensions} from '@lexical/extension';
 import {RichTextExtension} from '@lexical/rich-text';
 import {
+  $createLineBreakNode,
   $createParagraphNode,
   $getRoot,
   $isParagraphNode,
@@ -23,6 +24,7 @@ import {
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_ARROW_UP_COMMAND,
+  type LexicalCommand,
 } from 'lexical';
 import {describe, expect, it} from 'vitest';
 
@@ -373,6 +375,65 @@ describe('CodeIndentExtension', () => {
         },
         {discrete: true},
       );
+    });
+  });
+
+  describe('shiftLines', () => {
+    // "A", "" and "B" — a blank line between two lines of code.
+    function buildBlankLineEditor(caretOnLastLine: boolean) {
+      const ext = defineExtension({
+        $initialEditorState: () => {
+          const codeNode = $createCodeNode('javascript');
+          const first = $createCodeHighlightNode('A');
+          const last = $createCodeHighlightNode('B');
+          codeNode.append(
+            first,
+            $createLineBreakNode(),
+            $createLineBreakNode(),
+            last,
+          );
+          $getRoot().append(codeNode);
+          (caretOnLastLine ? last : first).select(0, 0);
+        },
+        dependencies: [CodeIndentExtension, RichTextExtension],
+        name: '[root-shift-lines]',
+      });
+      return buildEditorFromExtensions(ext);
+    }
+
+    function shift(
+      editor: ReturnType<typeof buildBlankLineEditor>,
+      command: LexicalCommand<KeyboardEvent>,
+    ) {
+      const key = command === KEY_ARROW_UP_COMMAND ? 'ArrowUp' : 'ArrowDown';
+      editor.dispatchCommand(
+        command,
+        new KeyboardEvent('keydown', {altKey: true, key}),
+      );
+    }
+
+    it('moves a line up past a blank line without merging it into the line above', () => {
+      using editor = buildBlankLineEditor(true);
+
+      shift(editor, KEY_ARROW_UP_COMMAND);
+
+      editor.read(() => {
+        const codeNode = $getRoot().getFirstChildOrThrow();
+        expect($isCodeNode(codeNode)).toBe(true);
+        expect(codeNode.getTextContent()).toBe('A\nB\n');
+      });
+    });
+
+    it('moves a line down past a blank line without merging it into the line below', () => {
+      using editor = buildBlankLineEditor(false);
+
+      shift(editor, KEY_ARROW_DOWN_COMMAND);
+
+      editor.read(() => {
+        const codeNode = $getRoot().getFirstChildOrThrow();
+        expect($isCodeNode(codeNode)).toBe(true);
+        expect(codeNode.getTextContent()).toBe('\nA\nB');
+      });
     });
   });
 });


### PR DESCRIPTION

## Description

`$handleShiftLines` moves the selected code-block line(s) past the adjacent
line. It anchors the move on `sibling` — the node just past the linebreak that
separates the moving line from its neighbour — and resolves that to the
neighbour line's boundary node:

```ts
const maybeInsertionPoint =
  $isCodeHighlightNode(sibling) || $isTabNode(sibling) || $isLineBreakNode(sibling)
    ? arrowIsUp ? $getFirstCodeNodeOfLine(sibling) : $getLastCodeNodeOfLine(sibling)
    : null;
```

When the neighbour line is **blank**, `sibling` is itself a `LineBreakNode` —
the one that terminates the line on the *far* side of the blank line.
`$getFirstCodeNodeOfLine` / `$getLastCodeNodeOfLine` only walk over
`CodeHighlightNode`/`TabNode`, so for a `LineBreakNode` anchor they return it
unchanged. The moving line is then spliced against a linebreak that belongs to
another line, which appends it to that line — the two lines merge and the text
is corrupted, not merely misplaced.

With a code block containing `A`, a blank line, and `B`:

- Alt+ArrowUp on `B` produced `AB\n\n` instead of `A\nB\n`;
- Alt+ArrowDown on `A` produced `\n\nAB` instead of `\nA\nB`.

A blank `LineBreakNode` sibling has no node of its own to anchor to, so treat
it as its own case: drop the moving line (and its linebreak) immediately after
that sibling, which is exactly the blank line's position. That is the same
insertion for both directions. Lines whose neighbour is not blank keep taking
the existing code path unchanged.

## Test plan

Two new cases in
`packages/lexical-code-core/src/__tests__/unit/CodeIndentation.test.ts`.

### Before

```
$ npx vitest run packages/lexical-code-core/src/__tests__/unit/CodeIndentation.test.ts

 FAIL  |unit| .../CodeIndentation.test.ts > CodeIndentExtension > shiftLines > moves a line up past a blank line without merging it into the line above
AssertionError: expected 'AB\n\n' to be 'A\nB\n' // Object.is equality

 FAIL  |unit| .../CodeIndentation.test.ts > CodeIndentExtension > shiftLines > moves a line down past a blank line without merging it into the line below
AssertionError: expected '\n\nAB' to be '\nA\nB' // Object.is equality

- Expected
+ Received

-
- A
- B
+
+ AB

 Test Files  1 failed (1)
      Tests  2 failed | 18 passed (20)
```

### After

```
$ npx vitest run packages/lexical-code-core packages/lexical-code

 Test Files  11 passed (11)
      Tests  270 passed | 1 skipped (271)
```

The existing `code blocks can shift lines (with tab)` /
`code blocks can shift multiple lines (with tab)` unit tests and the
`can move around code block with arrow keys` e2e spec use no blank lines, so
their `sibling` is a `CodeHighlightNode` and they take the unchanged path.

