### PR TITLE
[lexical-mark] Bug Fix: keep the markOverlap class in sync for every id-count change

### DIFF
--- a/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
+++ b/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
@@ -6,12 +6,17 @@
  *
  */
 import {$generateNodesFromDOM} from '@lexical/html';
-import {$isMarkNode, $wrapSelectionInMarkNode} from '@lexical/mark';
+import {
+  $createMarkNode,
+  $isMarkNode,
+  $wrapSelectionInMarkNode,
+} from '@lexical/mark';
 import {$insertNodeIntoLeaf} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
+  $getNodeByKey,
   $getRoot,
   $isElementNode,
   $isParagraphNode,
@@ -293,4 +298,54 @@ describe('LexicalMarkNode tests', () => {
       });
     });
   });
+});
+
+describe('MarkNode overlap theme class', () => {
+  initializeUnitTest(
+    testEnv => {
+      function markElement(ids: string[], nextIds?: string[]): HTMLElement {
+        const {editor} = testEnv;
+        let key = '';
+        editor.update(
+          () => {
+            const markNode = $createMarkNode(ids);
+            markNode.append($createTextNode('marked'));
+            key = markNode.getKey();
+            $getRoot().clear().append($createParagraphNode().append(markNode));
+          },
+          {discrete: true},
+        );
+        if (nextIds) {
+          editor.update(
+            () => {
+              const markNode = $getNodeByKey(key);
+              assert($isMarkNode(markNode), 'Expected a MarkNode');
+              markNode.setIDs(nextIds);
+            },
+            {discrete: true},
+          );
+        }
+        const element = editor.getElementByKey(key);
+        assert(element !== null, 'Expected a rendered MarkNode');
+        return element;
+      }
+
+      test('createDOM adds the overlap class for more than one id', () => {
+        expect(markElement(['a', 'b', 'c']).className).toContain('mk-overlap');
+      });
+
+      test('updateDOM adds the overlap class when going from 1 to 3 ids', () => {
+        expect(markElement(['a'], ['a', 'b', 'c']).className).toContain(
+          'mk-overlap',
+        );
+      });
+
+      test('updateDOM removes the overlap class when going from 2 to 0 ids', () => {
+        expect(markElement(['a', 'b'], []).className).not.toContain(
+          'mk-overlap',
+        );
+      });
+    },
+    {namespace: 'test', theme: {mark: 'mk', markOverlap: 'mk-overlap'}},
+  );
 });

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -82,12 +82,15 @@ export class MarkNode extends ElementNode {
     const nextIDsCount = nextIDs.length;
     const overlapTheme = config.theme.markOverlap;
 
-    if (prevIDsCount !== nextIDsCount) {
-      if (prevIDsCount === 1) {
-        if (nextIDsCount === 2) {
-          addClassNamesToElement(element, overlapTheme);
-        }
-      } else if (nextIDsCount === 1) {
+    // Mirror createDOM's rule (`ids.length > 1` carries the overlap class)
+    // rather than enumerating transitions: only 1 -> 2 and N -> 1 used to be
+    // handled, so e.g. 1 -> 3 never gained the class and 2 -> 0 never lost it.
+    const hadOverlap = prevIDsCount > 1;
+    const hasOverlap = nextIDsCount > 1;
+    if (hadOverlap !== hasOverlap) {
+      if (hasOverlap) {
+        addClassNamesToElement(element, overlapTheme);
+      } else {
         removeClassNamesFromElement(element, overlapTheme);
       }
     }


### PR DESCRIPTION

## Description

`MarkNode.createDOM` states the rule plainly — a mark carries
`theme.markOverlap` when it has more than one id:

```ts
if (this.__ids.length > 1) {
  addClassNamesToElement(element, config.theme.markOverlap);
}
```

`updateDOM` enumerated transitions instead of re-applying that rule, and only
covered two of them:

```ts
if (prevIDsCount !== nextIDsCount) {
  if (prevIDsCount === 1) {
    if (nextIDsCount === 2) { addClassNamesToElement(element, overlapTheme); }
  } else if (nextIDsCount === 1) {
    removeClassNamesFromElement(element, overlapTheme);
  }
}
```

So any other crossing of the `> 1` boundary desynced the DOM from the rule:

- `1 -> 3` (or `0 -> 2`, `1 -> 4`, …) crosses into overlap but the class is
  never added — the inner `nextIDsCount === 2` check fails and the `else if` is
  unreachable;
- `2 -> 0` crosses out of overlap but the class is never removed, leaving
  `markOverlap` on a mark with no ids.

`1 -> 3` is reachable from the shipped playground comment feature: merging
nested marks does `from.getIDs().forEach(id => to.addID(id))`
(`CommentPlugin/index.tsx`), so merging a 2-id mark into a 1-id mark lands on 3
ids in a single update and the overlap styling is silently lost. Re-creating
the same node from scratch does style it, which is the contradiction.

Compute the overlap state from the same `> 1` rule `createDOM` uses and toggle
the class only when that state changes.

## Test plan

Three new cases in `packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts`
under a theme that defines `mark`/`markOverlap`. The `createDOM` case passes
before and after — it is the reference the two `updateDOM` cases are held to.

### Before

```
$ npx vitest run packages/lexical-mark

 FAIL  |unit| .../LexicalMarkNode.test.ts > MarkNode overlap theme class > updateDOM adds the overlap class when going from 1 to 3 ids
AssertionError: expected 'mk' to contain 'mk-overlap'

 FAIL  |unit| .../LexicalMarkNode.test.ts > MarkNode overlap theme class > updateDOM removes the overlap class when going from 2 to 0 ids
AssertionError: expected 'mk mk-overlap' not to contain 'mk-overlap'

Expected: "mk-overlap"
Received: "mk mk-overlap"

 Test Files  1 failed | 2 passed (3)
      Tests  2 failed | 437 passed (439)
```

### After

```
$ npx vitest run packages/lexical-mark

 Test Files  3 passed (3)
      Tests  439 passed (439)
```

