### PR TITLE
[lexical-code-core] Bug Fix: restore the code block theme from data-theme on import

### DIFF
--- a/packages/lexical-code-core/src/CodeImportExtension.ts
+++ b/packages/lexical-code-core/src/CodeImportExtension.ts
@@ -23,6 +23,7 @@ import {
 import {$createCodeNode} from './CodeNode';
 
 const LANGUAGE_DATA_ATTRIBUTE = 'data-language';
+const THEME_DATA_ATTRIBUTE = 'data-theme';
 
 /**
  * True for elements whose `font-family` mentions `monospace` — the
@@ -63,11 +64,10 @@ const GitHubCodeTableOverlayRules = /* @__PURE__ */ defineOverlayRules([
 
 const PreRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => [
-    $createCodeNode(el.getAttribute(LANGUAGE_DATA_ATTRIBUTE)).splice(
-      0,
-      0,
-      ctx.$importChildren(el),
-    ),
+    $createCodeNode(
+      el.getAttribute(LANGUAGE_DATA_ATTRIBUTE),
+      el.getAttribute(THEME_DATA_ATTRIBUTE),
+    ).splice(0, 0, ctx.$importChildren(el)),
   ],
   match: sel.tag('pre'),
   name: '@lexical/code/pre',
@@ -87,11 +87,10 @@ const MultilineCodeRule = /* @__PURE__ */ defineImportRule({
       return $next();
     }
     return [
-      $createCodeNode(el.getAttribute(LANGUAGE_DATA_ATTRIBUTE)).splice(
-        0,
-        0,
-        ctx.$importChildren(el),
-      ),
+      $createCodeNode(
+        el.getAttribute(LANGUAGE_DATA_ATTRIBUTE),
+        el.getAttribute(THEME_DATA_ATTRIBUTE),
+      ).splice(0, 0, ctx.$importChildren(el)),
     ];
   },
   match: sel.tag('code'),

--- a/packages/lexical-code-core/src/CodeNode.ts
+++ b/packages/lexical-code-core/src/CodeNode.ts
@@ -417,7 +417,10 @@ export function $isCodeNode(
 
 function $convertPreElement(domNode: HTMLElement): DOMConversionOutput {
   const language = domNode.getAttribute(LANGUAGE_DATA_ATTRIBUTE);
-  return {node: $createCodeNode(language)};
+  // exportDOM writes data-theme next to data-language, so read it back here
+  // too — otherwise the theme is dropped on every HTML round trip.
+  const theme = domNode.getAttribute(THEME_DATA_ATTRIBUTE);
+  return {node: $createCodeNode(language, theme)};
 }
 
 function $convertDivElement(domNode: Node): DOMConversionOutput {

--- a/packages/lexical-code-core/src/__tests__/unit/CodeImportExtension.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeImportExtension.test.ts
@@ -83,6 +83,32 @@ describe('CodeImportExtension', () => {
     });
   });
 
+  test('<pre data-theme="poimandres"> restores the theme', () => {
+    using editor = buildEditor();
+    importInto(
+      editor,
+      '<pre data-language="ts" data-theme="poimandres">x</pre>',
+    );
+    editor.read(() => {
+      const node = $rootCode();
+      expect(node.getLanguage()).toBe('ts');
+      expect(node.getTheme()).toBe('poimandres');
+    });
+  });
+
+  test('multi-line <code data-theme> restores the theme', () => {
+    using editor = buildEditor();
+    importInto(
+      editor,
+      '<code data-language="ts" data-theme="poimandres">a\nb</code>',
+    );
+    editor.read(() => {
+      const node = $rootCode();
+      expect(node.getLanguage()).toBe('ts');
+      expect(node.getTheme()).toBe('poimandres');
+    });
+  });
+
   test('multi-line <code> imports as CodeNode (not inline)', () => {
     using editor = buildEditor();
     importInto(editor, '<code>line1\nline2</code>');

--- a/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts
@@ -6,10 +6,11 @@
  *
  */
 
-import {$createCodeNode} from '@lexical/code-core';
+import {$createCodeNode, $isCodeNode, CodeNode} from '@lexical/code-core';
+import {$generateNodesFromDOM} from '@lexical/html';
 import {$getRoot, type EditorConfig} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
-import {describe, expect, it} from 'vitest';
+import {assert, describe, expect, it} from 'vitest';
 
 const editorConfig = {
   namespace: '',
@@ -68,10 +69,37 @@ describe('CodeNode', () => {
         expect(exportedElement!.style.padding).toBe('1px');
         expect(exportedElement!.style.color).toBe('blue');
       });
+
+      it('round-trips the theme through exportDOM/importDOM', async () => {
+        const {editor} = testEnv;
+
+        let exportedElement!: HTMLElement;
+
+        await editor.update(() => {
+          const codeNode = $createCodeNode('javascript', 'poimandres');
+          $getRoot().append(codeNode);
+          exportedElement = codeNode.exportDOM(editor).element as HTMLElement;
+        });
+
+        expect(exportedElement.getAttribute('data-language')).toBe(
+          'javascript',
+        );
+        expect(exportedElement.getAttribute('data-theme')).toBe('poimandres');
+
+        const doc = document.implementation.createHTMLDocument();
+        doc.body.append(exportedElement);
+
+        await editor.update(() => {
+          const [node] = $generateNodesFromDOM(editor, doc);
+          assert($isCodeNode(node), 'expected a CodeNode');
+          expect(node.getLanguage()).toBe('javascript');
+          expect(node.getTheme()).toBe('poimandres');
+        });
+      });
     },
     {
       namespace: 'test',
-      nodes: [],
+      nodes: [CodeNode],
       theme: editorConfig.theme,
     },
   );


### PR DESCRIPTION

## Description

`CodeNode.exportDOM` writes the theme next to the language:

```ts
const language = this.getLanguage();
if (language) {
  element.setAttribute(LANGUAGE_DATA_ATTRIBUTE, language);
  ...
}
const theme = this.getTheme();
if (theme) {
  element.setAttribute(THEME_DATA_ATTRIBUTE, theme);   // 'data-theme'
}
```

but nothing ever read `data-theme` back. `$convertPreElement` (used for both
`<pre>` and multi-line `<code>` on the legacy path) and the `PreRule` /
`MultilineCodeRule` import rules on the `@lexical/html` path all built the node
with `$createCodeNode(el.getAttribute(LANGUAGE_DATA_ATTRIBUTE))` and dropped the
theme. A repo-wide grep for `data-theme` found only writers, no readers.

`CodeNode` has had a `theme` since the two-argument `$createCodeNode(language,
theme)`; it is part of `SerializedCodeNode` and survives JSON round-trips, and
`@lexical/code-shiki` sets it on real documents. Only the HTML round trip lost
it, so copy/pasting a code block between editors — or
`$generateHtmlFromNodes` -> `$generateNodesFromDOM` — silently reverted the
block to the default theme while keeping its language.

Read `data-theme` in all three converters, mirroring how `data-language` is
already handled. The heuristic converters for pasted third-party code
(`<div style="font-family: monospace">`, GitHub code tables) are untouched —
they never carry a Lexical `data-theme`.

## Test plan

Two new cases in
`packages/lexical-code-core/src/__tests__/unit/CodeImportExtension.test.ts`
(the `@lexical/html` rule pipeline) and one export -> import round trip in
`packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts` (the legacy
`importDOM` path). The round trip asserts the export side too, so it pins both
halves of the contract.

### Before

Verified by restoring `CodeNode.ts` and `CodeImportExtension.ts` to their
pre-fix contents with the new tests in place:

```
$ npx vitest run packages/lexical-code-core/src/__tests__/unit/CodeNode.test.ts \
    packages/lexical-code-core/src/__tests__/unit/CodeImportExtension.test.ts

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |unit| .../CodeImportExtension.test.ts > CodeImportExtension > <pre data-theme="poimandres"> restores the theme
 FAIL  |unit| .../CodeImportExtension.test.ts > CodeImportExtension > multi-line <code data-theme> restores the theme
 FAIL  |unit| .../CodeNode.test.ts > CodeNode > round-trips the theme through exportDOM/importDOM

AssertionError: expected undefined to be 'poimandres' // Object.is equality

- Expected:
"poimandres"

+ Received:
undefined

      Tests  3 failed | 14 passed (17)
```

### After

```
$ npx vitest run packages/lexical-code-core packages/lexical-code

 Test Files  11 passed (11)
      Tests  271 passed | 1 skipped (272)
```

