### PR TITLE
[lexical] Bug Fix: EditorState.clone() keeps the _parsed flag

### DIFF
--- a/packages/lexical/src/LexicalEditorState.ts
+++ b/packages/lexical/src/LexicalEditorState.ts
@@ -177,6 +177,12 @@ export class EditorState {
       this._slotsUsed,
     );
     editorState._readOnly = true;
+    // A clone describes the same content as this state, so it is still
+    // "parsed without running transforms" if this one was. Dropping the flag
+    // made `setEditorState(parsedState.clone(null))` — the documented way to
+    // apply a state without focusing the editor — skip the dirty-marking that
+    // lets transforms and hydrate-time normalization run.
+    editorState._parsed = this._parsed;
 
     return editorState;
   }

--- a/packages/lexical/src/__tests__/unit/Issue7876Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue7876Repro.test.ts
@@ -73,6 +73,30 @@ describe('Issue #7876: setEditorState triggers transforms on parsed state', () =
     );
   });
 
+  test('text-node transform fires for a cloned parsed state (the documented no-focus form)', () => {
+    using editor = buildEditor(node => {
+      const text = node.getTextContent();
+      if (text.includes('{{') && text !== TRANSFORMED_TEXT) {
+        node.setTextContent(TRANSFORMED_TEXT);
+      }
+    });
+
+    const parsed = editor.parseEditorState(makeParsedJSON(PARSED_TEXT));
+    expect(parsed._parsed).toBe(true);
+
+    // `editorState.clone(null)` is the form documented in
+    // docs/concepts/editor-state.md for applying a state without focusing
+    // the editor.
+    const cloned = parsed.clone(null);
+    expect(cloned._parsed).toBe(true);
+
+    editor.setEditorState(cloned);
+
+    expect(editor.read(() => $getRoot().getTextContent())).toBe(
+      TRANSFORMED_TEXT,
+    );
+  });
+
   test('setEditorState consumes the `_parsed` flag so re-applying the resulting state does not re-trigger transforms', () => {
     let transformCalls = 0;
     using editor = buildEditor(node => {


### PR DESCRIPTION

## Description

`EditorState._parsed` is documented as "True if this EditorState was parsed
without running transforms". `parseEditorState` sets it, and `setEditorState`
is its only consumer — when the state it is handed has `_parsed`, it dirty-marks
every node so registered node transforms (and the hydrate-time shadow-root
normalization) run against the freshly parsed content. That is the fix from
#7876.

`EditorState.clone()` carried `_nodeMap`, the selection and `_slotsUsed`, but
not `_parsed`, so the clone always reported `false`. `setEditorState` reads the
flag off its *argument*, which means the documented "apply a state without
focusing the editor" form silently lost the behaviour:

```js
// packages/lexical-website/docs/concepts/editor-state.md
// Passing `null` as a selection value to prevent focusing the editor
editor.setEditorState(editorState.clone(null));
```

`setEditorState(parsed)` ran the transforms; `setEditorState(parsed.clone(null))`
did not — the same content, applied two documented ways, with different results.

A clone describes the same content as the state it came from, so it is still
"parsed without running transforms" if the original was. Carry the flag.

This does not make transforms re-run later: `cloneEditorState` — the copy
`setEditorState` and every commit make internally — still starts a fresh state
with `_parsed === false`, which is where the flag is consumed. `clone()` has no
callers inside `packages/lexical`; it is a public API.

## Test plan

New case in `packages/lexical/src/__tests__/unit/Issue7876Repro.test.ts`,
alongside the existing direct-`setEditorState` case it mirrors.

### Before

```
$ npx vitest run packages/lexical/src/__tests__/unit/Issue7876Repro.test.ts

 FAIL  |unit| .../Issue7876Repro.test.ts > Issue #7876: setEditorState triggers transforms on parsed state > text-node transform fires for a cloned parsed state (the documented no-focus form)
AssertionError: expected false to be true // Object.is equality

- Expected
+ Received

- true
+ false

 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

### After

```
$ npx vitest run packages/lexical/src

 Test Files  65 passed (65)
      Tests  1348 passed | 1 skipped (1349)

$ npx vitest run packages/lexical-history packages/lexical-yjs packages/lexical-react

 Test Files  38 passed (38)
      Tests  285 passed (285)
```

