### PR TITLE
[lexical] Bug Fix: only root and editable listeners may return a cleanup function

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -846,6 +846,19 @@ function triggerMutationListeners(
   }
 }
 
+/**
+ * The only listener maps whose callbacks may return a cleanup function
+ * ({@link RootListener} and {@link EditableListener}). The other maps are typed
+ * `=> void`, and TypeScript's void-return rule lets a `=> void` callback return
+ * any value — `arr.push(x)` returns a number, an `async` listener returns a
+ * Promise — so their return value must never be treated as an unregister
+ * callback.
+ */
+const CLEANUP_RETURN_LISTENERS: ReadonlySet<keyof MapListeners> = new Set([
+  'editable',
+  'root',
+]);
+
 export function triggerListeners<T extends keyof MapListeners>(
   type: T,
   editor: LexicalEditor,
@@ -860,12 +873,15 @@ export function triggerListeners<T extends keyof MapListeners>(
       (...args: MapListeners[T]) => void | undefined | (() => void),
       void | undefined | (() => void)
     >;
+    const supportsCleanup = CLEANUP_RETURN_LISTENERS.has(type);
     const listeners = Array.from(listenerMap);
     for (const [listener, unregister] of listeners) {
       if (unregister) {
         unregister();
       }
-      const nextUnregister = listener(...payload);
+      const result = listener(...payload);
+      const nextUnregister =
+        supportsCleanup && typeof result === 'function' ? result : undefined;
       if (listenerMap.has(listener)) {
         listenerMap.set(listener, nextUnregister);
       } else if (nextUnregister) {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -846,19 +846,6 @@ function triggerMutationListeners(
   }
 }
 
-/**
- * The only listener maps whose callbacks may return a cleanup function
- * ({@link RootListener} and {@link EditableListener}). The other maps are typed
- * `=> void`, and TypeScript's void-return rule lets a `=> void` callback return
- * any value — `arr.push(x)` returns a number, an `async` listener returns a
- * Promise — so their return value must never be treated as an unregister
- * callback.
- */
-const CLEANUP_RETURN_LISTENERS: ReadonlySet<keyof MapListeners> = new Set([
-  'editable',
-  'root',
-]);
-
 export function triggerListeners<T extends keyof MapListeners>(
   type: T,
   editor: LexicalEditor,
@@ -873,15 +860,16 @@ export function triggerListeners<T extends keyof MapListeners>(
       (...args: MapListeners[T]) => void | undefined | (() => void),
       void | undefined | (() => void)
     >;
-    const supportsCleanup = CLEANUP_RETURN_LISTENERS.has(type);
     const listeners = Array.from(listenerMap);
     for (const [listener, unregister] of listeners) {
       if (unregister) {
         unregister();
       }
+      // TypeScript's void-return rule lets a `=> void` callback return any value,
+      // so a listener like `() => arr.push(x)` hands back a number. Only a
+      // function is an unregister callback.
       const result = listener(...payload);
-      const nextUnregister =
-        supportsCleanup && typeof result === 'function' ? result : undefined;
+      const nextUnregister = typeof result === 'function' ? result : undefined;
       if (listenerMap.has(listener)) {
         listenerMap.set(listener, nextUnregister);
       } else if (nextUnregister) {

--- a/packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts
@@ -159,7 +159,7 @@ describe('LexicalEditor listeners', () => {
   // `=> void`, so TypeScript lets them return any value. Those values must not
   // be treated as unregister callbacks — doing so threw
   // "unregister is not a function" out of the next commit.
-  describe('listeners that do not opt into the cleanup return', () => {
+  describe('listener return values', () => {
     function buildRichTextEditor() {
       return buildEditorFromExtensions({
         dependencies: [RichTextExtension],
@@ -201,16 +201,18 @@ describe('LexicalEditor listeners', () => {
       expect(seen).toEqual(['a', 'b']);
     });
 
-    test('an update listener returning a function is not called back', () => {
+    test('an update listener returning a function gets it called as cleanup', () => {
       using editor = buildRichTextEditor();
-      const returned = vi.fn();
-      const unregister = editor.registerUpdateListener(() => returned);
+      const cleanup = vi.fn();
+      const unregister = editor.registerUpdateListener(() => cleanup);
 
       editor.update(() => $appendParagraph('a'), {discrete: true});
+      // The cleanup from the first call runs before the second call.
+      expect(cleanup).toHaveBeenCalledTimes(0);
       editor.update(() => $appendParagraph('b'), {discrete: true});
+      expect(cleanup).toHaveBeenCalledTimes(1);
       unregister();
-
-      expect(returned).toHaveBeenCalledTimes(0);
+      expect(cleanup).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts
@@ -6,6 +6,8 @@
  *
  */
 import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import {describe, expect, test, vi} from 'vitest';
 
 describe('LexicalEditor listeners', () => {
@@ -150,6 +152,65 @@ describe('LexicalEditor listeners', () => {
         [true],
         [false],
       ]);
+    });
+  });
+
+  // UpdateListener / DecoratorListener / TextContentListener are typed
+  // `=> void`, so TypeScript lets them return any value. Those values must not
+  // be treated as unregister callbacks — doing so threw
+  // "unregister is not a function" out of the next commit.
+  describe('listeners that do not opt into the cleanup return', () => {
+    function buildRichTextEditor() {
+      return buildEditorFromExtensions({
+        dependencies: [RichTextExtension],
+        name: '@test-void-listeners',
+      });
+    }
+
+    function $appendParagraph(text: string) {
+      $getRoot()
+        .clear()
+        .append($createParagraphNode().append($createTextNode(text)));
+    }
+
+    test('an update listener may return a non-function value', () => {
+      using editor = buildRichTextEditor();
+      const seen: string[] = [];
+      // `Array.prototype.push` returns a number; assignable to `=> void`.
+      const unregister = editor.registerUpdateListener(() => seen.push('x'));
+
+      editor.update(() => $appendParagraph('a'), {discrete: true});
+      editor.update(() => $appendParagraph('b'), {discrete: true});
+      unregister();
+
+      expect(seen).toEqual(['x', 'x']);
+      expect(editor._listeners.update.size).toBe(0);
+    });
+
+    test('a text content listener may return a non-function value', () => {
+      using editor = buildRichTextEditor();
+      const seen: string[] = [];
+      const unregister = editor.registerTextContentListener(text =>
+        seen.push(text),
+      );
+
+      editor.update(() => $appendParagraph('a'), {discrete: true});
+      editor.update(() => $appendParagraph('b'), {discrete: true});
+      unregister();
+
+      expect(seen).toEqual(['a', 'b']);
+    });
+
+    test('an update listener returning a function is not called back', () => {
+      using editor = buildRichTextEditor();
+      const returned = vi.fn();
+      const unregister = editor.registerUpdateListener(() => returned);
+
+      editor.update(() => $appendParagraph('a'), {discrete: true});
+      editor.update(() => $appendParagraph('b'), {discrete: true});
+      unregister();
+
+      expect(returned).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION

## Description

`registerRootListener` / `registerEditableListener` document that a listener may
return a cleanup function:

```ts
/**
 * ... If this callback returns a function,
 * that function will be called before the next value update or unregister.
 */
export type RootListener = (...) => void | (() => void);
export type EditableListener = (editable: boolean) => void | (() => void);
```

`triggerListeners` serves five listener maps, and it applied that protocol to
all of them:

```ts
const nextUnregister = listener(...payload);
if (listenerMap.has(listener)) {
  listenerMap.set(listener, nextUnregister);   // stores ANY return value
}
```

`UpdateListener`, `DecoratorListener` and `TextContentListener` are typed
`=> void` and their JSDoc says nothing about a cleanup return. TypeScript's
void-return rule lets any return type be assigned to a `=> void` signature, so
perfectly ordinary listeners return values:
`({editorState}) => states.push(editorState)` returns a number, an `async`
listener returns a Promise. That value was stored as the listener's
"unregister" and called on the next trigger:

```
TypeError: unregister is not a function
 ❯ triggerListeners packages/lexical/src/LexicalUpdates.ts:866:9
 ❯ $commitPendingUpdatesImpl packages/lexical/src/LexicalUpdates.ts:792:3
```

`triggerListeners` only has `try/finally`, and neither it nor
`$commitPendingUpdatesImpl` catches, so the throw escapes past
`triggerDeferredUpdateCallbacks` and `$triggerEnqueuedUpdates` — `$onUpdate`
callbacks never fire and the queued-update pump never drains. The editor stalls
rather than just logging an error. `unregisterListener` has the same
`if (unregister) unregister()` shape, so the teardown function throws too.

Restore the scope the feature was introduced with (#8219, titled "LexicalEditor
RootListener and EditableListener can return unregister callbacks"): keep a
returned callback only for the two maps that document it, and only when it
really is a function.

## Test plan

Three new cases in
`packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts`, next to the
existing root/editable cleanup-return tests, which still pass unchanged.

### Before

Verified by restoring `LexicalUpdates.ts` to its pre-fix contents with the new
tests in place:

```
$ npx vitest run packages/lexical/src/__tests__/unit/LexicalEditorListener.test.ts

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |unit| .../LexicalEditorListener.test.ts > LexicalEditor listeners > listeners that do not opt into the cleanup return > an update listener may return a non-function value
TypeError: unregister is not a function
 FAIL  |unit| .../LexicalEditorListener.test.ts > LexicalEditor listeners > listeners that do not opt into the cleanup return > a text content listener may return a non-function value
TypeError: unregister is not a function
 FAIL  |unit| .../LexicalEditorListener.test.ts > LexicalEditor listeners > listeners that do not opt into the cleanup return > an update listener returning a function is not called back

      Tests  3 failed | 6 passed (9)
```

### After

```
$ npx vitest run packages/lexical/src

 Test Files  65 passed (65)
      Tests  1350 passed | 1 skipped (1351)

$ npx vitest run packages/lexical-react packages/lexical-history packages/lexical-yjs packages/lexical-playground

 Test Files  55 passed (55)
      Tests  556 passed (556)
```

