### PR TITLE
[lexical][lexical-html] Bug Fix: restore the capitalization formats from text-transform on import

### DIFF
--- a/packages/lexical-html/src/__tests__/unit/Issue8915Repro.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/Issue8915Repro.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {
+  $generateHtmlFromNodes,
+  $generateNodesFromDOM,
+  $generateNodesFromDOMViaExtension,
+} from '@lexical/html';
+import {RichTextExtension} from '@lexical/rich-text';
+import {JSDOM} from 'jsdom';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isTextNode,
+  type LexicalEditor,
+  type LexicalNode,
+  type TextFormatType,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+// Reproduction for https://github.com/facebook/lexical/issues/8915
+//
+// TextNode.exportDOM writes `text-transform: uppercase|lowercase|capitalize`
+// for the three capitalization formats, but no importer read it back, so the
+// format was dropped on every HTML round trip.
+
+const CAPITALIZATION_FORMATS: TextFormatType[] = [
+  'lowercase',
+  'uppercase',
+  'capitalize',
+];
+
+const extension = defineExtension({
+  $initialEditorState: null,
+  dependencies: [RichTextExtension],
+  name: '[issue-8915]',
+});
+
+function buildEditor() {
+  return buildEditorFromExtensions(extension);
+}
+
+function $seed(format: TextFormatType) {
+  $getRoot()
+    .clear()
+    .append(
+      $createParagraphNode().append(
+        $createTextNode('Hello').toggleFormat(format),
+      ),
+    );
+}
+
+function exportHtml(editor: LexicalEditor): string {
+  return editor.read(() => $generateHtmlFromNodes(editor, null));
+}
+
+function parse(html: string): Document {
+  return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window
+    .document;
+}
+
+function firstTextNode(nodes: LexicalNode[]): LexicalNode {
+  const stack = [...nodes];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if ($isTextNode(node)) {
+      return node;
+    }
+    const children = (node as {getChildren?: () => LexicalNode[]}).getChildren;
+    if (typeof children === 'function') {
+      stack.unshift(...children.call(node));
+    }
+  }
+  assert(false, 'expected a TextNode');
+}
+
+describe('Issue #8915: text-transform survives an HTML round trip', () => {
+  test.each(CAPITALIZATION_FORMATS)(
+    'exportDOM writes text-transform for %s',
+    format => {
+      using editor = buildEditor();
+      editor.update(() => $seed(format), {discrete: true});
+      expect(exportHtml(editor)).toContain(`text-transform: ${format}`);
+    },
+  );
+
+  test.each(CAPITALIZATION_FORMATS)(
+    '$generateNodesFromDOM restores %s',
+    format => {
+      using editor = buildEditor();
+      editor.update(() => $seed(format), {discrete: true});
+      const html = exportHtml(editor);
+
+      editor.update(
+        () => {
+          const textNode = firstTextNode(
+            $generateNodesFromDOM(editor, parse(html)),
+          );
+          assert($isTextNode(textNode), 'expected a TextNode');
+          expect(textNode.hasFormat(format)).toBe(true);
+        },
+        {discrete: true},
+      );
+    },
+  );
+
+  test.each(CAPITALIZATION_FORMATS)(
+    '$generateNodesFromDOMViaExtension restores %s',
+    format => {
+      using editor = buildEditor();
+      editor.update(() => $seed(format), {discrete: true});
+      const html = exportHtml(editor);
+
+      editor.update(
+        () => {
+          const textNode = firstTextNode(
+            $generateNodesFromDOMViaExtension(parse(html)),
+          );
+          assert($isTextNode(textNode), 'expected a TextNode');
+          expect(textNode.hasFormat(format)).toBe(true);
+        },
+        {discrete: true},
+      );
+    },
+  );
+
+  test('an unrelated text-transform: none does not clear other formats', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        const nodes = $generateNodesFromDOM(
+          editor,
+          parse(
+            '<p><span style="font-weight: bold; text-transform: none;">Hello</span></p>',
+          ),
+        );
+        const textNode = firstTextNode(nodes);
+        assert($isTextNode(textNode), 'expected a TextNode');
+        expect(textNode.hasFormat('bold')).toBe(true);
+        expect(textNode.hasFormat('uppercase')).toBe(false);
+      },
+      {discrete: true},
+    );
+  });
+});

--- a/packages/lexical-html/src/import/coreImportRules.ts
+++ b/packages/lexical-html/src/import/coreImportRules.ts
@@ -33,6 +33,7 @@ import {
   isOnlyChildInBlockNode,
   type LexicalNode,
   setNodeIndentFromDOM,
+  TEXT_TYPE_TO_FORMAT,
 } from 'lexical';
 
 import {contextValue} from '../ContextRecord';
@@ -90,6 +91,7 @@ interface FormatStyle {
   fontStyle?: string;
   textDecoration?: string;
   verticalAlign?: string;
+  textTransform?: string;
 }
 
 /**
@@ -124,6 +126,7 @@ function readElementFormatStyle(el: HTMLElement): FormatStyle {
     fontStyle: el.style.fontStyle,
     fontWeight: el.style.fontWeight,
     textDecoration: el.style.textDecoration,
+    textTransform: el.style.textTransform,
     verticalAlign: el.style.verticalAlign,
   };
 }
@@ -136,6 +139,7 @@ function mergeStyles(
     fontStyle: override.fontStyle || defaults.fontStyle,
     fontWeight: override.fontWeight || defaults.fontWeight,
     textDecoration: override.textDecoration || defaults.textDecoration,
+    textTransform: override.textTransform || defaults.textTransform,
     verticalAlign: override.verticalAlign || defaults.verticalAlign,
   };
 }
@@ -153,6 +157,7 @@ const FORMAT_BIT_STYLE_PROPS: ReadonlySet<string> = new Set([
   'font-weight',
   'font-style',
   'text-decoration',
+  'text-transform',
   'vertical-align',
 ]);
 
@@ -166,7 +171,8 @@ function styleFormatOverride(style: FormatStyle): FormatOverride {
   let set = 0;
   let clear = 0;
 
-  const {fontWeight, fontStyle, textDecoration, verticalAlign} = style;
+  const {fontWeight, fontStyle, textDecoration, textTransform, verticalAlign} =
+    style;
 
   if (fontWeight === '700' || fontWeight === 'bold') {
     set |= IS_BOLD;
@@ -191,6 +197,24 @@ function styleFormatOverride(style: FormatStyle): FormatOverride {
     if (parts.includes('none')) {
       clear |= IS_UNDERLINE | IS_STRIKETHROUGH;
     }
+  }
+
+  // TextNode.exportDOM writes exactly one of these three for the
+  // capitalization formats, and they are mutually exclusive (#8915).
+  if (textTransform === 'lowercase') {
+    set |= TEXT_TYPE_TO_FORMAT.lowercase;
+    clear |= TEXT_TYPE_TO_FORMAT.uppercase | TEXT_TYPE_TO_FORMAT.capitalize;
+  } else if (textTransform === 'uppercase') {
+    set |= TEXT_TYPE_TO_FORMAT.uppercase;
+    clear |= TEXT_TYPE_TO_FORMAT.lowercase | TEXT_TYPE_TO_FORMAT.capitalize;
+  } else if (textTransform === 'capitalize') {
+    set |= TEXT_TYPE_TO_FORMAT.capitalize;
+    clear |= TEXT_TYPE_TO_FORMAT.lowercase | TEXT_TYPE_TO_FORMAT.uppercase;
+  } else if (textTransform === 'none') {
+    clear |=
+      TEXT_TYPE_TO_FORMAT.lowercase |
+      TEXT_TYPE_TO_FORMAT.uppercase |
+      TEXT_TYPE_TO_FORMAT.capitalize;
   }
 
   if (verticalAlign === 'sub') {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1420,6 +1420,9 @@ function applyTextFormatFromStyle(
   const hasUnderlineTextDecoration = textDecoration.includes('underline');
   // Google Docs uses span tags + vertical-align to specify subscript and superscript
   const verticalAlign = style.verticalAlign;
+  // TextNode.exportDOM writes text-transform for the capitalization formats,
+  // so read it back here or they are lost on every HTML round trip (#8915).
+  const textTransform = style.textTransform;
 
   return (lexicalNode: LexicalNode) => {
     if (!$isTextNode(lexicalNode) && !$isInlineFormattable(lexicalNode)) {
@@ -1445,6 +1448,14 @@ function applyTextFormatFromStyle(
     }
     if (verticalAlign === 'super' && !lexicalNode.hasFormat('superscript')) {
       lexicalNode.toggleFormat('superscript');
+    }
+    if (
+      (textTransform === 'lowercase' ||
+        textTransform === 'uppercase' ||
+        textTransform === 'capitalize') &&
+      !lexicalNode.hasFormat(textTransform)
+    ) {
+      lexicalNode.toggleFormat(textTransform);
     }
 
     if (shouldApply && !lexicalNode.hasFormat(shouldApply)) {


### PR DESCRIPTION

## Description

Closes #8915

`TextNode.exportDOM` writes the three capitalization formats out as CSS:

```ts
// Add text-transform styles for capitalization formats
if (this.hasFormat('lowercase')) {
  element.style.textTransform = 'lowercase';
} else if (this.hasFormat('uppercase')) {
  element.style.textTransform = 'uppercase';
} else if (this.hasFormat('capitalize')) {
  element.style.textTransform = 'capitalize';
}
```

Nothing ever read `text-transform` back. `applyTextFormatFromStyle` (the legacy
`<span>` / `<b>` / `<em>` … converters) reads `fontWeight`, `textDecoration`,
`fontStyle` and `verticalAlign`; `readElementFormatStyle` /
`styleFormatOverride` in the `@lexical/html` rule pipeline read the same four.
So `IS_LOWERCASE` / `IS_UPPERCASE` / `IS_CAPITALIZE` were written on export and
silently dropped on import — copy/paste between editors, and any
`$generateHtmlFromNodes` -> `$generateNodesFromDOM` round trip, lost the format
while every other text format survived.

Read `text-transform` in both importers, mirroring how `vertical-align` is
already handled — including the mutual exclusion, since only one of the three
can apply. On the `@lexical/html` side, `text-transform: none` clears all three
(the same "explicit non-decorating value clears the bit" rule that
`font-weight: normal` and `vertical-align: baseline` already follow), and
`text-transform` joins `FORMAT_BIT_STYLE_PROPS` so the property is owned by the
format bit mask and does not also get materialized onto the node's inline
style.

## Test plan

New `packages/lexical-html/src/__tests__/unit/Issue8915Repro.test.ts`: for each
of the three formats, one export assertion (passes before and after — it is the
writer the readers are held to) plus a round trip through each of the two
import pipelines. A fourth case pins that an unrelated `text-transform: none`
alongside `font-weight: bold` neither sets a capitalization format nor disturbs
the bold one.

The test lives in its own `IssueNNNN Repro` file because
`LexicalTextNode.test.tsx` is already being edited by #8924.

### Before

```
$ npx vitest run packages/lexical-html/src/__tests__/unit/Issue8915Repro.test.ts

     ✓ exportDOM writes text-transform for lowercase 11ms
     ✓ exportDOM writes text-transform for uppercase 1ms
     ✓ exportDOM writes text-transform for capitalize 1ms
     × $generateNodesFromDOM restores lowercase 19ms
     × $generateNodesFromDOM restores uppercase 7ms
     × $generateNodesFromDOM restores capitalize 6ms
     × $generateNodesFromDOMViaExtension restores lowercase 7ms
     × $generateNodesFromDOMViaExtension restores uppercase 6ms
     × $generateNodesFromDOMViaExtension restores capitalize 6ms
     ✓ an unrelated text-transform: none does not clear other formats 6ms

AssertionError: expected false to be true // Object.is equality

      Tests  6 failed | 4 passed (10)
```

### After

```
$ npx vitest run packages/lexical-html packages/lexical/src packages/lexical-clipboard

 Test Files  79 passed (79)
      Tests  1469 passed | 1 skipped (1470)

$ npx vitest run packages/lexical-table packages/lexical-list packages/lexical-markdown packages/lexical-playground

 Test Files  40 passed (40)
      Tests  982 passed (982)
```

The real-world paste fixtures that carry `text-transform: none` (Slack, GitHub
and Facebook payloads in `HTMLCopyAndPaste.test.ts`, `CodeBlock.test.ts`,
`LexicalTableNode.test.tsx`) put it on block tags — `<p>`, `<ul>`, `<pre>`,
`<table>` — not on the inline-format tags these converters handle, and they all
still pass.

