### PR TITLE
[lexical-code-core] Bug Fix: Shift+Tab outdents a code line when the caret is at column 0

### DIFF
--- a/packages/lexical-code-core/src/CodeIndentation.ts
+++ b/packages/lexical-code-core/src/CodeIndentation.ts
@@ -206,6 +206,32 @@ function $handleTab(shiftKey: boolean): null | LexicalCommand<void> {
   return indentOrOutdent;
 }
 
+/**
+ * Outdent the single line the collapsed caret sits on.
+ *
+ * `$getCodeLines` drops a trailing line when the selection ends exactly at its
+ * start — for a collapsed caret that is always true, so the caret's own line
+ * never reaches the outdent loop and the line has to be resolved from the
+ * anchor here. Applies the same rule as that loop: strip a leading TabNode, or
+ * `tabSize` leading spaces when the extension is configured for them.
+ */
+function $outdentLineAtCaret(
+  selection: RangeSelection,
+  tabSize: number | undefined,
+): void {
+  const anchorNode = selection.anchor.getNode();
+  // An element point (e.g. the caret on a blank line) has no line to outdent.
+  if (!$isCodeHighlightNode(anchorNode) && !$isTabNode(anchorNode)) {
+    return;
+  }
+  const firstOfLine = $getFirstCodeNodeOfLine(anchorNode);
+  if ($isTabNode(firstOfLine)) {
+    firstOfLine.remove();
+  } else if (tabSize !== undefined && $isCodeHighlightNode(firstOfLine)) {
+    $outdentLeadingSpaces(firstOfLine, tabSize, selection);
+  }
+}
+
 function $handleMultilineIndent(
   type: LexicalCommand<void>,
   tabSize?: number,
@@ -223,6 +249,8 @@ function $handleMultilineIndent(
   if (codeLinesLength === 0 && selection.isCollapsed()) {
     if (type === INDENT_CONTENT_COMMAND) {
       selection.insertNodes([$createTabNode()]);
+    } else {
+      $outdentLineAtCaret(selection, tabSize);
     }
     return true;
   }

--- a/packages/lexical-code-core/src/__tests__/unit/CodeOutdentCollapsedAtLineStart.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeOutdentCollapsedAtLineStart.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createCodeHighlightNode,
+  $createCodeNode,
+  $isCodeNode,
+  CodeIndentExtension,
+} from '@lexical/code';
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createTabNode,
+  $getRoot,
+  $isTabNode,
+  configExtension,
+  defineExtension,
+  OUTDENT_CONTENT_COMMAND,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+// Shift+Tab (OUTDENT_CONTENT_COMMAND) with a *collapsed* caret at column 0 of
+// an indented code line silently did nothing: $getCodeLines drops a trailing
+// line when the selection ends exactly at its start, which for a collapsed
+// caret is the only line, so the outdent loop had nothing to work on.
+
+function buildEditor(tabSize?: number) {
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: () => {
+        const code = $createCodeNode('javascript');
+        code.append($createTabNode(), $createCodeHighlightNode('hello'));
+        $getRoot().append(code);
+      },
+      dependencies: [
+        tabSize === undefined
+          ? CodeIndentExtension
+          : configExtension(CodeIndentExtension, {tabSize}),
+        RichTextExtension,
+      ],
+      name: '[root-outdent]',
+    }),
+  );
+}
+
+function $codeText(): string {
+  const code = $getRoot().getFirstChildOrThrow();
+  assert($isCodeNode(code), 'expected a CodeNode');
+  return code.getTextContent();
+}
+
+describe('OUTDENT_CONTENT_COMMAND at the start of a code line', () => {
+  it('outdents when the caret is collapsed at column 0 (on the TabNode)', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const tab = $getRoot().getFirstDescendant();
+        assert($isTabNode(tab), 'expected a TabNode');
+        tab.select(0, 0);
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+
+    expect(editor.read($codeText)).toBe('hello');
+  });
+
+  it('outdents when the caret is collapsed at column 0 of the code text', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const text = $getRoot().getLastDescendant();
+        assert(text !== null, 'expected a text node');
+        text.selectStart();
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+
+    expect(editor.read($codeText)).toBe('hello');
+  });
+
+  it('still outdents from a non-zero column (unchanged behaviour)', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const text = $getRoot().getLastDescendant();
+        assert(text !== null, 'expected a text node');
+        text.select(1, 1);
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+
+    expect(editor.read($codeText)).toBe('hello');
+  });
+
+  it('strips a space indent from column 0 when tabSize is configured', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        $initialEditorState: () => {
+          const code = $createCodeNode('javascript');
+          code.append($createCodeHighlightNode('  hello'));
+          $getRoot().append(code);
+        },
+        dependencies: [
+          configExtension(CodeIndentExtension, {tabSize: 2}),
+          RichTextExtension,
+        ],
+        name: '[root-outdent-spaces]',
+      }),
+    );
+
+    editor.update(
+      () => {
+        const text = $getRoot().getLastDescendant();
+        assert(text !== null, 'expected a text node');
+        text.selectStart();
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+
+    expect(editor.read($codeText)).toBe('hello');
+  });
+
+  it('is still a no-op on an unindented line', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        $initialEditorState: () => {
+          const code = $createCodeNode('javascript');
+          code.append($createCodeHighlightNode('hello'));
+          $getRoot().append(code);
+        },
+        dependencies: [CodeIndentExtension, RichTextExtension],
+        name: '[root-outdent-flat]',
+      }),
+    );
+
+    editor.update(
+      () => {
+        const text = $getRoot().getLastDescendant();
+        assert(text !== null, 'expected a text node');
+        text.selectStart();
+      },
+      {discrete: true},
+    );
+    editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+
+    expect(editor.read($codeText)).toBe('hello');
+  });
+});


### PR DESCRIPTION

## Description

`$getCodeLines` deliberately discards a trailing line when the selection ends
exactly at its start:

```ts
// Discard the last line if the selection ends exactly at the
// start of the line (no real selection)
const lastPoint = $createPoint(lastLine[0].getKey(), 0, 'text');
if (!selectionEnd.is(lastPoint)) {
  lines.push(lastLine);
}
```

For a **collapsed** caret at column 0 that condition is always true, and the
caret's line is the only line — so `codeLines` comes back empty and control
falls into the collapsed special case, which only ever handles indent:

```ts
if (codeLinesLength === 0 && selection.isCollapsed()) {
  if (type === INDENT_CONTENT_COMMAND) {
    selection.insertNodes([$createTabNode()]);
  }
  return true;   // OUTDENT: returns handled, having done nothing
}
```

So Shift+Tab with the caret at the very start of an indented code line silently
did nothing, while the identical keystroke one column to the right outdented
normally. It also returns `true`, so the command is reported as handled and no
lower-priority handler gets a chance.

Column 0 is the position the caret naturally lands on — `Home`, `ArrowUp` from
the line below, or clicking the left gutter — so this is the common case, not
an edge one.

Resolve the caret's own line from the anchor in that branch and apply the same
rule the outdent loop uses: strip a leading `TabNode`, or `tabSize` leading
spaces when the extension is configured for space indentation. An element-typed
anchor (the caret on a blank line) has no line to outdent and still no-ops.

The existing coverage steps around this: `can outdent at arbitrary points in
the line (with tabs)` uses `codeText.select(1, 1)`, and the outdent half of
`can indent/outdent with collapsed selection at start of line (with tabs)`
builds a *non-collapsed* selection spanning the tab, despite its name.

## Test plan

New `packages/lexical-code-core/src/__tests__/unit/CodeOutdentCollapsedAtLineStart.test.ts`
— a separate file rather than `CodeIndentation.test.ts`, which #8986 is already
editing. This PR is independent of #8986: it touches a different function in
`CodeIndentation.ts` and the two apply cleanly in either order.

Two cases pin the fix; two are controls that pass before and after (outdent
from a non-zero column, and the no-op on an unindented line with no `tabSize`).

### Before

Verified by restoring `CodeIndentation.ts` to its pre-fix contents with the new
tests in place:

```
$ npx vitest run packages/lexical-code-core/src/__tests__/unit/CodeOutdentCollapsedAtLineStart.test.ts

     × outdents when the caret is collapsed at column 0 (on the TabNode) 10ms
     × outdents when the caret is collapsed at column 0 of the code text 1ms
     ✓ still outdents from a non-zero column (unchanged behaviour) 1ms
     × strips a space indent from column 0 when tabSize is configured 1ms
     ✓ is still a no-op on an unindented line 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected '\thello' to be 'hello' // Object.is equality
AssertionError: expected '\thello' to be 'hello' // Object.is equality
AssertionError: expected '  hello' to be 'hello' // Object.is equality

      Tests  3 failed | 2 passed (5)
```

### After

```
$ npx vitest run packages/lexical-code-core packages/lexical-code packages/lexical-code-prism packages/lexical-code-shiki

 Test Files  12 passed (12)
      Tests  273 passed | 1 skipped (274)
```

