### PR TITLE
[lexical-link] Bug Fix: $toggleLink applies the title attribute for a NodeSelection

### DIFF
--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -787,8 +787,11 @@ export function $toggleLink(
           if (rel !== undefined) {
             existingLink.setRel(rel);
           }
+          if (title !== undefined) {
+            existingLink.setTitle(title);
+          }
         } else {
-          const linkNode = $createLinkNode(url, {rel, target});
+          const linkNode = $createLinkNode(url, {rel, target, title});
           node.insertBefore(linkNode);
           linkNode.append(node);
         }

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   $cloneWithProperties,
   $createLineBreakNode,
+  $createNodeSelection,
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
@@ -1638,6 +1639,102 @@ describe('LinkNode.extractWithChild (Issue #5046 — preserve link wrap across b
         },
         {discrete: true},
       );
+    });
+  });
+});
+
+describe('$toggleLink with a NodeSelection', () => {
+  const extension = defineExtension({
+    $initialEditorState: () => {
+      $getRoot()
+        .clear()
+        .append($createParagraphNode().append($createTextNode('hello')));
+    },
+    dependencies: [LinkExtension, RichTextExtension],
+    name: '[root-node-selection]',
+  });
+
+  function $selectTheTextNode(): void {
+    const textNode = $getRoot().getLastDescendant();
+    assert($isTextNode(textNode), 'Expected a TextNode');
+    const selection = $createNodeSelection();
+    selection.add(textNode.getKey());
+    $setSelection(selection);
+  }
+
+  function $getLink(): LinkNode {
+    const paragraph = $getRoot().getFirstChild();
+    assert($isParagraphNode(paragraph), 'Expected a ParagraphNode');
+    const link = paragraph.getFirstChild();
+    assert($isLinkNode(link), 'Expected a LinkNode');
+    return link;
+  }
+
+  it('applies the title when creating a link', () => {
+    using editor = buildEditorFromExtensions(extension);
+    editor.update(
+      () => {
+        $selectTheTextNode();
+        $toggleLink('https://lexical.dev/', {
+          rel: 'noopener',
+          target: '_blank',
+          title: 'Lexical',
+        });
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const link = $getLink();
+      expect(link.getURL()).toBe('https://lexical.dev/');
+      expect(link.getRel()).toBe('noopener');
+      expect(link.getTarget()).toBe('_blank');
+      expect(link.getTitle()).toBe('Lexical');
+    });
+  });
+
+  it('applies the title when updating an existing link', () => {
+    using editor = buildEditorFromExtensions(extension);
+    editor.update(
+      () => {
+        $selectTheTextNode();
+        $toggleLink('https://lexical.dev/', {title: 'First'});
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $selectTheTextNode();
+        $toggleLink('https://lexical.dev/docs', {title: 'Second'});
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const link = $getLink();
+      expect(link.getURL()).toBe('https://lexical.dev/docs');
+      expect(link.getTitle()).toBe('Second');
+    });
+  });
+
+  it('leaves an existing title alone when none is supplied', () => {
+    using editor = buildEditorFromExtensions(extension);
+    editor.update(
+      () => {
+        $selectTheTextNode();
+        $toggleLink('https://lexical.dev/', {title: 'Kept'});
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $selectTheTextNode();
+        $toggleLink('https://lexical.dev/docs');
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const link = $getLink();
+      expect(link.getURL()).toBe('https://lexical.dev/docs');
+      expect(link.getTitle()).toBe('Kept');
     });
   });
 });


### PR DESCRIPTION

## Description

`$toggleLink` documents its second argument as `{ target, rel, title }` and
destructures all three up front:

```ts
const {target, title} = attributes;
const rel = attributes.rel === undefined ? 'noreferrer' : attributes.rel;
```

The `RangeSelection` path honours all three — it calls `setTitle(title)` on an
existing link and passes `{rel, target, title}` to `$createLinkNode`. The
`NodeSelection` path handles only two of them:

```ts
if (existingLink) {
  existingLink.setURL(url);
  if (target !== undefined) { existingLink.setTarget(target); }
  if (rel !== undefined) { existingLink.setRel(rel); }
  // title is never applied
} else {
  const linkNode = $createLinkNode(url, {rel, target});   // title omitted
  ...
}
```

So `title` was silently dropped whenever the selection was a `NodeSelection` —
which is what you have after clicking a decorator node such as an image, a
video embed or a horizontal rule, the exact case where a link tooltip is most
useful. The same call with a text (range) selection produced `title="…"`; with
a node selection it produced no `title` at all.

Apply `title` in both branches, using the same `!== undefined` guard the
sibling `target`/`rel` lines use, so omitting it still leaves an existing
title untouched.

## Test plan

Three new cases in
`packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts`: creating a
link, updating an existing one, and confirming that omitting `title` does not
clear a title already on the node. Each also asserts `url`/`rel`/`target`, so
the two attributes that already worked stay pinned.

### Before

```
$ npx vitest run packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts

       × applies the title when creating a link 7ms
       × applies the title when updating an existing link 2ms
       × leaves an existing title alone when none is supplied 2ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected null to be 'Lexical' // Object.is equality
AssertionError: expected null to be 'Second' // Object.is equality
AssertionError: expected null to be 'Kept' // Object.is equality

      Tests  3 failed | 71 passed (74)
```

### After

```
$ npx vitest run packages/lexical-link packages/lexical-playground

 Test Files  23 passed (23)
      Tests  426 passed (426)
```

