### PR TITLE
[lexical-playground] Bug Fix: a closed collapsible container no longer exports as open

### DIFF
--- a/packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts
@@ -7,7 +7,10 @@
  */
 
 import {buildEditorFromExtensions} from '@lexical/extension';
-import {$generateNodesFromDOMViaExtension} from '@lexical/html';
+import {
+  $generateHtmlFromNodes,
+  $generateNodesFromDOMViaExtension,
+} from '@lexical/html';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -446,5 +449,58 @@ describe('CollapsibleExtension transforms', () => {
       );
       expect($isParagraphNode(children[2])).toBe(true);
     });
+  });
+});
+
+describe('CollapsibleContainerNode open round trip', () => {
+  function buildEditor() {
+    return buildEditorFromExtensions(CollapsibleImportTestExtension);
+  }
+
+  function $seed(open: boolean): void {
+    $getRoot()
+      .clear()
+      .append(
+        $createCollapsibleContainerNode(open).append(
+          $createCollapsibleTitleNode().append($createTextNode('Title')),
+          $createCollapsibleContentNode().append(
+            $createParagraphNode().append($createTextNode('Body')),
+          ),
+        ),
+      );
+  }
+
+  function $getContainerOpen(): boolean {
+    const container = $getRoot().getFirstChild();
+    assert($isCollapsibleContainerNode(container), 'expected a container');
+    return container.getOpen();
+  }
+
+  it.each([true, false])('round-trips open=%s through HTML', open => {
+    using editor = buildEditor();
+    editor.update(() => $seed(open), {discrete: true});
+
+    const html = editor.read(() => $generateHtmlFromNodes(editor, null));
+
+    using target = buildEditor();
+    target.update(
+      () => {
+        $getRoot().clear().select();
+        $importHtml(html);
+      },
+      {discrete: true},
+    );
+
+    expect(target.read($getContainerOpen)).toBe(open);
+  });
+
+  it('does not write a value for the boolean open attribute', () => {
+    using editor = buildEditor();
+    editor.update(() => $seed(false), {discrete: true});
+
+    const html = editor.read(() => $generateHtmlFromNodes(editor, null));
+    // `open` is an HTML boolean attribute: any value, including "false",
+    // means open. A closed container must omit it entirely.
+    expect(html).not.toContain('open=');
   });
 });

--- a/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsibleExtension/CollapsibleContainerNode.ts
@@ -137,7 +137,13 @@ export class CollapsibleContainerNode extends ElementNode {
   exportDOM(): DOMExportOutput {
     const element = $getDocument().createElement('details');
     element.classList.add('Collapsible__container');
-    element.setAttribute('open', this.__open.toString());
+    // `open` is an HTML boolean attribute — its presence is what makes the
+    // <details> open, whatever its value. Writing `open="false"` on a closed
+    // container reads back (and renders) as open, so omit it instead. This
+    // matches createDOM/updateDOM, which already set '' / removeAttribute.
+    if (this.__open) {
+      element.setAttribute('open', '');
+    }
     return {element};
   }
 


### PR DESCRIPTION

## Description

`CollapsibleContainerNode.exportDOM` stringifies the open flag into the
attribute value:

```ts
element.setAttribute('open', this.__open.toString());
```

`open` is an HTML **boolean** attribute: the element is open because the
attribute is *present*, whatever its value. `open="false"` is therefore open —
in every browser, in jsdom, and in `HTMLDetailsElement.open`. A collapsed
container exported to HTML came back expanded, and rendered expanded anywhere
the exported markup was viewed.

The import rule reads the property, so it sees exactly that:

```ts
return [$createCollapsibleContainerNode(el.open).append(titleNode, contentNode)];
```

`createDOM` and `updateDOM` in the same class already get this right —
`setAttribute('open', '')` when opening and `removeAttribute('open')` when
closing. Only `exportDOM` stringified. Emit the attribute only when the
container is open, matching them.

`exportJSON` is unaffected (it serializes a real boolean), so this is purely
the HTML path — copy/paste of a collapsed container between editors, and any
`$generateHtmlFromNodes` output.

## Test plan

Three new cases in
`packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts`:
an `open=true` / `open=false` round trip (the `true` case passes before and
after — it is the control the `false` case is held to), plus a direct
assertion on the exported markup.

The existing import tests feed hand-written HTML (`<details open>`,
`open="true"`, or the attribute absent), so none of them ever exercised the
`open="false"` string this code produced.

### Before

```
$ npx vitest run packages/lexical-playground/__tests__/unit/CollapsibleContainerNode.test.ts

     ✓ round-trips open=true through HTML 9ms
     × round-trips open=false through HTML 6ms
     × does not write a value for the boolean open attribute 3ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected true to be false // Object.is equality
AssertionError: expected '<details class="Collapsible__containe…' not to contain 'open='
Expected: "open="
```

### After

```
$ npx vitest run packages/lexical-playground

 Test Files  17 passed (17)
      Tests  274 passed (274)
```

