### PR TITLE
[Breaking Change][lexical-clipboard] Bug Fix: the Lexical clipboard payload asks excludeFromCopy for the clone destination

### DIFF
--- a/packages/lexical-clipboard/src/__tests__/unit/MarkClipboardJSON.test.ts
+++ b/packages/lexical-clipboard/src/__tests__/unit/MarkClipboardJSON.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $generateJSONFromSelectedNodes,
+  $generateNodesFromSerializedNodes,
+} from '@lexical/clipboard';
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {$createMarkNode, $isMarkNode, MarkNode} from '@lexical/mark';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $selectAll,
+  type LexicalNode,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+// MarkNode.excludeFromCopy() is `destination !== 'clone'` — keep me in the
+// internal clone payload, drop me from HTML. $appendNodesToJSON builds the
+// `application/x-lexical-editor` clone payload but asked with 'html', so marks
+// were stripped from it.
+
+const extension = defineExtension({
+  $initialEditorState: () => {
+    $getRoot()
+      .clear()
+      .append(
+        $createParagraphNode().append(
+          $createMarkNode(['comment-1']).append($createTextNode('marked')),
+        ),
+      );
+  },
+  dependencies: [RichTextExtension],
+  name: '[mark-clipboard]',
+  nodes: [MarkNode],
+});
+
+function hasMark(nodes: LexicalNode[]): boolean {
+  const stack = [...nodes];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if ($isMarkNode(node)) {
+      return true;
+    }
+    if ($isElementNode(node)) {
+      stack.unshift(...node.getChildren());
+    }
+  }
+  return false;
+}
+
+describe('$generateJSONFromSelectedNodes with a MarkNode', () => {
+  it('keeps the MarkNode in the clone payload', () => {
+    using editor = buildEditorFromExtensions(extension);
+
+    editor.update(
+      () => {
+        $selectAll();
+        const {nodes} = $generateJSONFromSelectedNodes(editor, $getSelection());
+        const rebuilt = $generateNodesFromSerializedNodes(nodes);
+
+        expect(hasMark(rebuilt)).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+
+  it('keeps the mark ids on the round trip', () => {
+    using editor = buildEditorFromExtensions(extension);
+
+    editor.update(
+      () => {
+        $selectAll();
+        const {nodes} = $generateJSONFromSelectedNodes(editor, $getSelection());
+        const rebuilt = $generateNodesFromSerializedNodes(nodes);
+
+        const stack = [...rebuilt];
+        let ids: string[] | null = null;
+        while (stack.length > 0) {
+          const node = stack.shift()!;
+          if ($isMarkNode(node)) {
+            ids = node.getIDs();
+            break;
+          }
+          if ($isElementNode(node)) {
+            stack.unshift(...node.getChildren());
+          }
+        }
+        assert(ids !== null, 'expected a MarkNode');
+        expect(ids).toEqual(['comment-1']);
+      },
+      {discrete: true},
+    );
+  });
+
+  it('still carries the marked text', () => {
+    using editor = buildEditorFromExtensions(extension);
+
+    editor.update(
+      () => {
+        $selectAll();
+        const {nodes} = $generateJSONFromSelectedNodes(editor, $getSelection());
+        const rebuilt = $generateNodesFromSerializedNodes(nodes);
+
+        expect(rebuilt.map(node => node.getTextContent()).join('')).toContain(
+          'marked',
+        );
+      },
+      {discrete: true},
+    );
+  });
+});

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -512,8 +512,13 @@ function $appendNodesToJSON(
 ): boolean {
   let shouldInclude =
     selection !== null ? currentNode.isSelected(selection) : true;
+  // 'clone', not 'html': this builds the internal
+  // `application/x-lexical-editor` payload, the same destination the
+  // $sliceSelectedTextNodeContent and extractWithChild calls below already
+  // pass. Asking with 'html' dropped nodes that opt out of HTML export while
+  // asking to survive a clone (e.g. MarkNode).
   const shouldExclude =
-    $isElementNode(currentNode) && currentNode.excludeFromCopy('html');
+    $isElementNode(currentNode) && currentNode.excludeFromCopy('clone');
   let target = currentNode;
 
   if (selection !== null && $isTextNode(target)) {


### PR DESCRIPTION

## Description

`$appendNodesToJSON` builds the `application/x-lexical-editor` payload — the
serialized-node form used by copy/cut and by `$generateJSONFromSelectedNodes`.
Its destination is `'clone'`, and the other two destination-aware calls in the
very same function say so:

```ts
target = $sliceSelectedTextNodeContent(selection, target, 'clone');
...
currentNode.extractWithChild(childNode, selection, 'clone')
```

The `excludeFromCopy` call in between asked for the wrong one:

```ts
const shouldExclude =
  $isElementNode(currentNode) && currentNode.excludeFromCopy('html');
```

The genuine HTML path has its own, correct call site —
`packages/lexical/src/LexicalEditor.ts:927` passes `'html'` to
`$appendNodesToHTML`'s `$shouldExclude` — so this one was simply asking the
wrong question.

The parameter exists precisely so a node can answer differently per
destination, and `MarkNode` is the in-repo node that does:

```ts
excludeFromCopy(destination: 'clone' | 'html'): boolean {
  return destination !== 'clone';
}
```

"Drop me from HTML export, keep me in the internal clone payload." Asking with
`'html'` inverted that: `shouldExclude` came back `true`, the `MarkNode` was
never pushed, and its children were spliced up into the parent. **Copying a
commented / highlighted range and pasting it back into Lexical silently lost
the mark** — text intact, mark and its ids gone. Any third-party node using
the same `destination === 'html'` idiom was broken the same way.

Nodes that return `true` unconditionally (the common case, including the
repo's own test helpers) are unaffected — they still exclude.

## Test plan

New `packages/lexical-clipboard/src/__tests__/unit/MarkClipboardJSON.test.ts`
round-trips a marked range through `$generateJSONFromSelectedNodes` ->
`$generateNodesFromSerializedNodes`: the mark survives, its ids survive, and
the text still comes through (that third case passes before and after — it is
what made the loss silent).

### Before

```
$ npx vitest run packages/lexical-clipboard/src/__tests__/unit/MarkClipboardJSON.test.ts

     × keeps the MarkNode in the clone payload 12ms
     × keeps the mark ids on the round trip 1ms
     ✓ still carries the marked text 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected false to be true // Object.is equality
AssertionError: expected a MarkNode

      Tests  2 failed | 1 passed (3)
```

### After

```
$ npx vitest run packages/lexical-clipboard packages/lexical-mark packages/lexical-playground packages/lexical/src

 Test Files  89 passed (89)
      Tests  2080 passed | 1 skipped (2081)
```

