### PR TITLE
[lexical-link] Bug Fix: AutoLinkNode.insertNewAfter keeps the node's own properties

### DIFF
--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -559,19 +559,12 @@ export class AutoLinkNode extends LinkNode {
     };
   }
 
-  insertNewAfter(
-    _: RangeSelection,
-    restoreSelection = true,
-  ): null | ElementNode {
-    const linkNode = $createAutoLinkNode(this.__url, {
-      isUnlinked: this.__isUnlinked,
-      rel: this.__rel,
-      target: this.__target,
-      title: this.__title,
-    });
-    this.insertAfter(linkNode, restoreSelection);
-    return linkNode;
-  }
+  // insertNewAfter is deliberately not overridden: LinkNode's implementation
+  // uses $copyNode, which runs clone() + afterCloneFrom() and so carries the
+  // element props (format/indent/style/dir/textFormat/textStyle) and NodeState
+  // as well as the link attributes. Enumerating properties by hand here
+  // dropped all of those, and rebuilt the node as a base AutoLinkNode even for
+  // a subclass. AutoLinkNode.afterCloneFrom already carries __isUnlinked.
 }
 
 /**

--- a/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts
@@ -18,7 +18,10 @@ import {
   $createParagraphNode,
   $createRangeSelection,
   $getRoot,
+  $getState,
   $selectAll,
+  $setState,
+  createState,
   ParagraphNode,
   type SerializedParagraphNode,
   TextNode,
@@ -525,6 +528,67 @@ describe('LexicalAutoAutoLinkNode tests', () => {
         expect(paragraph.getChildrenSize()).toBe(2);
         // No new paragraph should be created
         expect(root.getChildrenSize()).toBe(1);
+      });
+    });
+  });
+});
+
+const autoLinkTestState = createState('autoLinkTestState', {
+  parse: (v: unknown) => (typeof v === 'string' ? v : ''),
+});
+
+describe('AutoLinkNode.insertNewAfter carries the node over', () => {
+  initializeUnitTest(testEnv => {
+    function $seed() {
+      const root = $getRoot();
+      root.clear();
+      const paragraph = $createParagraphNode();
+      const autoLink = $createAutoLinkNode('https://example.com', {
+        isUnlinked: true,
+        rel: 'noopener',
+        target: '_blank',
+        title: 'Example',
+      });
+      autoLink.setStyle('color: red');
+      autoLink.setTextStyle('font-size: 20px');
+      autoLink.setTextFormat(1);
+      $setState(autoLink, autoLinkTestState, 'carried');
+      autoLink.append(new TextNode('https://example.com'));
+      paragraph.append(autoLink);
+      root.append(paragraph);
+      return autoLink;
+    }
+
+    test('keeps the element style, text style and text format', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const next = $seed().insertNewAfter($createRangeSelection(), false);
+        expect($isAutoLinkNode(next)).toBe(true);
+        expect(next!.getStyle()).toBe('color: red');
+        expect(next!.getTextStyle()).toBe('font-size: 20px');
+        expect(next!.getTextFormat()).toBe(1);
+      });
+    });
+
+    test('keeps the NodeState', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const next = $seed().insertNewAfter($createRangeSelection(), false);
+        expect($getState(next!, autoLinkTestState)).toBe('carried');
+      });
+    });
+
+    test('keeps the link attributes (control)', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const next = $seed().insertNewAfter($createRangeSelection(), false);
+        expect($isAutoLinkNode(next)).toBe(true);
+        const autoLink = next as AutoLinkNode;
+        expect(autoLink.getURL()).toBe('https://example.com');
+        expect(autoLink.getRel()).toBe('noopener');
+        expect(autoLink.getTarget()).toBe('_blank');
+        expect(autoLink.getTitle()).toBe('Example');
+        expect(autoLink.getIsUnlinked()).toBe(true);
       });
     });
   });


### PR DESCRIPTION

## Description

`LinkNode.insertNewAfter` produces the trailing half of a split with
`$copyNode`, which runs `constructor.clone(node)` followed by
`afterCloneFrom(node)`:

```ts
insertNewAfter(_: RangeSelection, restoreSelection = true): null | ElementNode {
  const linkNode = $copyNode(this);
  this.insertAfter(linkNode, restoreSelection);
  return linkNode;
}
```

`AutoLinkNode` overrode it with a hand-rolled constructor call that enumerated
four properties:

```ts
const linkNode = $createAutoLinkNode(this.__url, {
  isUnlinked: this.__isUnlinked,
  rel: this.__rel,
  target: this.__target,
  title: this.__title,
});
```

Everything else the clone contract carries was dropped:

- `__format`, `__indent`, `__style`, `__dir`, `__textFormat`, `__textStyle`,
  carried by `ElementNode.afterCloneFrom`;
- `__state` — the entire NodeState, i.e. every `createState`/`$setState` value,
  carried by `LexicalNode.afterCloneFrom`;
- the concrete class: `$copyNode` goes through `node.constructor.clone`, while
  `$createAutoLinkNode` hardcodes `new AutoLinkNode(...)`, so a subclass of
  `AutoLinkNode` came back as a base `AutoLinkNode`.

The production path is `$splitNodeAtPoint`
(`packages/lexical/src/LexicalSelection.ts`, `node.insertNewAfter(insertPoint)`),
so splitting an autolink while inserting or pasting produced a trailing half
that had silently lost its node state and element props — while the identical
operation on a plain `LinkNode` preserved them.

The override is also redundant: `AutoLinkNode.afterCloneFrom` already carries
`__isUnlinked`, and `LinkNode.afterCloneFrom` carries url/rel/target/title. So
the fix is to delete it and inherit the correct implementation.

## Test plan

Three new cases in
`packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts`. The
third is a control that passes before and after — it pins the four attributes
the override did handle, so removing it cannot regress them.

The existing `AutoLinkNode.insertNewAfter does not create new paragraph` test
asserts only node type and sibling counts, all of which still hold.

### Before

```
$ npx vitest run packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts

     × keeps the element style, text style and text format 6ms
     × keeps the NodeState 2ms
     ✓ keeps the link attributes (control) 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected '' to be 'color: red' // Object.is equality
AssertionError: expected '' to be 'carried' // Object.is equality

      Tests  2 failed | 29 passed (31)
```

### After

```
$ npx vitest run packages/lexical-link packages/lexical-playground packages/lexical/src

 Test Files  88 passed (88)
      Tests  1773 passed | 1 skipped (1774)
```

`npx tsc -p tsconfig.json --noEmit` and `npx eslint` on the changed file are
both clean.

Note: this touches `LexicalLinkNode.ts`, as does #8993, but a different method
(`AutoLinkNode.insertNewAfter` vs the `$toggleLink` NodeSelection branch). The
two apply cleanly in either order.

