### PR TITLE
[lexical-html] Bug Fix: apply the after() replacement when exportDOM returns a DocumentFragment

### DIFF
--- a/packages/lexical-html/src/__tests__/unit/ExportAfterFragment.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/ExportAfterFragment.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {$generateHtmlFromNodes} from '@lexical/html';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $applyNodeReplacement,
+  $createTextNode,
+  $getDocument,
+  $getRoot,
+  type DOMExportOutput,
+  ElementNode,
+  type LexicalEditor,
+  type LexicalNode,
+} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+// DOMExportOutput.after may return a replacement element. When `element` is a
+// DocumentFragment the exporter appends it to the parent first, which moves
+// its children out and empties it — so the replacement written back into the
+// fragment afterwards never reaches the output.
+
+class FragmentExportNode extends ElementNode {
+  $config() {
+    return this.config('fragment-export', {extends: ElementNode});
+  }
+
+  createDOM(): HTMLElement {
+    return $getDocument().createElement('div');
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(_editor: LexicalEditor): DOMExportOutput {
+    const doc = $getDocument();
+    return {
+      after: () => {
+        const replacement = doc.createElement('section');
+        replacement.setAttribute('data-replaced', 'true');
+        return replacement;
+      },
+      element: doc.createDocumentFragment(),
+    };
+  }
+}
+
+function $createFragmentExportNode(): FragmentExportNode {
+  return $applyNodeReplacement(new FragmentExportNode());
+}
+
+class ElementExportNode extends ElementNode {
+  $config() {
+    return this.config('element-export', {extends: ElementNode});
+  }
+
+  createDOM(): HTMLElement {
+    return $getDocument().createElement('div');
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(_editor: LexicalEditor): DOMExportOutput {
+    const doc = $getDocument();
+    return {
+      after: () => {
+        const replacement = doc.createElement('section');
+        replacement.setAttribute('data-replaced', 'true');
+        return replacement;
+      },
+      element: doc.createElement('div'),
+    };
+  }
+}
+
+function $createElementExportNode(): ElementExportNode {
+  return $applyNodeReplacement(new ElementExportNode());
+}
+
+function buildEditor(factory: () => LexicalNode) {
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: () => {
+        $getRoot().clear().append(factory());
+      },
+      dependencies: [RichTextExtension],
+      name: '[after-fragment]',
+      nodes: [FragmentExportNode, ElementExportNode],
+    }),
+  );
+}
+
+describe('DOMExportOutput.after returning a replacement', () => {
+  it('applies the replacement when element is a DocumentFragment', () => {
+    using editor = buildEditor(() =>
+      $createFragmentExportNode().append($createTextNode('body')),
+    );
+    const html = editor.read(() => $generateHtmlFromNodes(editor, null));
+    expect(html).toContain('data-replaced="true"');
+  });
+
+  it('applies the replacement when element is an HTMLElement (control)', () => {
+    using editor = buildEditor(() =>
+      $createElementExportNode().append($createTextNode('body')),
+    );
+    const html = editor.read(() => $generateHtmlFromNodes(editor, null));
+    expect(html).toContain('data-replaced="true"');
+  });
+});

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -352,14 +352,25 @@ function $appendNodesToHTML(
         element.append(fragment);
       }
     }
-    parentElementAppend(element);
-
-    if (after) {
-      const newElement = after.call(target, element);
-      if (newElement) {
-        if (isDocumentFragment(element)) {
+    if (isDocumentFragment(element)) {
+      // Resolve `after` before handing the fragment to the parent: appending a
+      // DocumentFragment moves its children out and leaves it empty, so a
+      // replacement written into it afterwards would land in a detached,
+      // already-drained fragment and never reach the output.
+      if (after) {
+        const newElement = after.call(target, element);
+        if (newElement) {
           element.replaceChildren(newElement);
-        } else {
+        }
+      }
+      parentElementAppend(element);
+    } else {
+      // An HTMLElement has to be in the tree first so replaceWith() can swap
+      // it in place.
+      parentElementAppend(element);
+      if (after) {
+        const newElement = after.call(target, element);
+        if (newElement) {
           element.replaceWith(newElement);
         }
       }


### PR DESCRIPTION

## Description

`DOMExportOutput.after` may return a replacement element, and
`$appendNodesToHTML` has a dedicated branch for the case where the exported
`element` is a `DocumentFragment`:

```ts
parentElementAppend(element);

if (after) {
  const newElement = after.call(target, element);
  if (newElement) {
    if (isDocumentFragment(element)) {
      element.replaceChildren(newElement);
    } else {
      element.replaceWith(newElement);
    }
  }
}
```

The two lines are in the wrong order for a fragment. `parentElementAppend`
runs first, and appending a `DocumentFragment` **moves its children into the
parent and leaves the fragment empty and detached**. The subsequent
`element.replaceChildren(newElement)` therefore writes the replacement into a
fragment that is no longer connected to anything: the replacement is dropped
on the floor and the original children stay in the output. The `after` hook
silently does nothing.

The `HTMLElement` path is correct and depends on the current order —
`replaceWith` needs the element to already be in the tree — so the fix is to
split the two cases rather than move the call unconditionally: resolve `after`
*before* appending for a fragment, and leave the element path exactly as it
was.

## Test plan

New `packages/lexical-html/src/__tests__/unit/ExportAfterFragment.test.ts`
exports two custom nodes whose `after` returns a replacement — one returning a
`DocumentFragment` as `element`, one returning an `HTMLElement`. The element
case is the control: it passes before and after, and is the behaviour the
fragment case is held to.

### Before

```
$ npx vitest run packages/lexical-html/src/__tests__/unit/ExportAfterFragment.test.ts

     × applies the replacement when element is a DocumentFragment 15ms
     ✓ applies the replacement when element is an HTMLElement (control) 2ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected '<span style="white-space: pre-wrap;">…' to contain 'data-replaced="true"'
Expected: "data-replaced="true""
Received: "<span style="white-space: pre-wrap;">body</span>"

      Tests  1 failed | 1 passed (2)
```

### After

```
$ npx vitest run packages/lexical-html packages/lexical-clipboard packages/lexical-table packages/lexical-playground packages/lexical/src

 Test Files  107 passed (107)
      Tests  1889 passed | 1 skipped (1890)
```

