### PR TITLE
[lexical-playground] Bug Fix: $createMentionNode keeps the display text it is given

### DIFF
--- a/packages/lexical-playground/__tests__/unit/MentionTextContent.test.ts
+++ b/packages/lexical-playground/__tests__/unit/MentionTextContent.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $generateHtmlFromNodes,
+  $generateNodesFromDOMViaExtension,
+} from '@lexical/html';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $insertNodes,
+  defineExtension,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+import {$createMentionNode, $isMentionNode} from '../../src/nodes/MentionNode';
+import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
+import {MentionsExtension} from '../../src/plugins/MentionsExtension';
+
+// MentionNode carries a display text that may differ from the mention name;
+// exportDOM encodes the split as data-lexical-mention-name and the import rule
+// decodes it and passes both values to $createMentionNode.
+
+const MentionTestExtension = defineExtension({
+  $initialEditorState: null,
+  dependencies: [MentionsExtension, PlaygroundImportExtension],
+  name: '[test-mention-text]',
+});
+
+function $importHtml(html: string): void {
+  const parser = new DOMParser();
+  const dom = parser.parseFromString(html, 'text/html');
+  $insertNodes($generateNodesFromDOMViaExtension(dom));
+}
+
+function $getMention() {
+  const paragraph = $getRoot().getFirstChild();
+  assert(paragraph !== null, 'expected a first child');
+  const mention = (
+    paragraph as ReturnType<typeof $createParagraphNode>
+  ).getFirstChild();
+  assert($isMentionNode(mention), 'expected a MentionNode');
+  return mention;
+}
+
+describe('MentionNode display text', () => {
+  it('$createMentionNode honours an explicit textContent', () => {
+    using editor = buildEditorFromExtensions(MentionTestExtension);
+    editor.update(
+      () => {
+        const mention = $createMentionNode('luke_skywalker', 'Luke Skywalker');
+        expect(mention.getTextContent()).toBe('Luke Skywalker');
+      },
+      {discrete: true},
+    );
+  });
+
+  it('$createMentionNode defaults textContent to the mention name', () => {
+    using editor = buildEditorFromExtensions(MentionTestExtension);
+    editor.update(
+      () => {
+        expect($createMentionNode('Luke').getTextContent()).toBe('Luke');
+      },
+      {discrete: true},
+    );
+  });
+
+  it('round-trips a display text that differs from the mention name', () => {
+    using editor = buildEditorFromExtensions(MentionTestExtension);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append(
+              $createMentionNode('luke_skywalker', 'Luke Skywalker'),
+            ),
+          );
+      },
+      {discrete: true},
+    );
+
+    const html = editor.read(() => $generateHtmlFromNodes(editor, null));
+    expect(html).toContain('data-lexical-mention-name="luke_skywalker"');
+
+    using target = buildEditorFromExtensions(MentionTestExtension);
+    target.update(
+      () => {
+        $getRoot().clear().select();
+        $importHtml(html);
+      },
+      {discrete: true},
+    );
+
+    target.read(() => {
+      const mention = $getMention();
+      expect(mention.getTextContent()).toBe('Luke Skywalker');
+      expect(mention.exportJSON().mentionName).toBe('luke_skywalker');
+    });
+  });
+});

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -90,7 +90,7 @@ export function $createMentionNode(
   mentionName: string,
   textContent?: string,
 ): MentionNode {
-  const mentionNode = new MentionNode(mentionName, (textContent = mentionName));
+  const mentionNode = new MentionNode(mentionName, textContent);
   mentionNode.setMode('segmented').toggleDirectionless();
   return $applyNodeReplacement(mentionNode);
 }


### PR DESCRIPTION

## Description

`$createMentionNode` assigned to its own parameter before using it:

```ts
export function $createMentionNode(
  mentionName: string,
  textContent?: string,
): MentionNode {
  const mentionNode = new MentionNode(mentionName, (textContent = mentionName));
  ...
```

`(textContent = mentionName)` overwrites the caller's argument and passes
`mentionName` through, so the `textContent` parameter was dead — a mention's
display text was always forced to equal its mention name.

Two other sites cooperate to preserve exactly that distinction, so this
silently defeated both. `MentionNode.exportDOM` goes out of its way to encode
it:

```ts
if (this.__text !== this.__mention) {
  element.setAttribute('data-lexical-mention-name', this.__mention);
}
element.textContent = this.__text;
```

and the import rule in `MentionsExtension` decodes it and passes both values
back:

```ts
const textContent = el.textContent ?? '';
const mentionName = el.getAttribute('data-lexical-mention-name') ?? textContent;
return [$createMentionNode(mentionName, textContent)];
```

With the factory discarding the second argument, importing
`<span data-lexical-mention="true" data-lexical-mention-name="luke_skywalker">Luke Skywalker</span>`
produced a mention that renders as `luke_skywalker`. It also made
`exportDOM`'s `this.__text !== this.__mention` branch unreachable for anything
the factory built, so the attribute was never written in the first place and
the encode/decode pair could never round-trip.

`MentionNode`'s constructor already defaults correctly
(`super(text ?? mentionName, key)`), so passing the parameter straight through
preserves the single-argument behaviour exactly.

## Test plan

New `packages/lexical-playground/__tests__/unit/MentionTextContent.test.ts`:
the explicit-text case, a control for the single-argument default (passes
before and after), and a full export -> import round trip.

The test lives in its own file because `MentionHTML.test.ts` is already being
edited by #8969. This change is in the same file as #8969 but a different
function (`$createMentionNode` vs `exportDOM`/imports); the two apply cleanly
in either order.

The existing mention coverage is unaffected either way:
`PlaygroundNodeImporters.test.ts` calls `$createMentionNode('Luke')` with one
argument, and `Mentions.spec.mjs` pastes a `<span data-lexical-mention="true">`
with no `data-lexical-mention-name`, so `mentionName === textContent` in both.

### Before

```
$ npx vitest run packages/lexical-playground/__tests__/unit/MentionTextContent.test.ts

     × $createMentionNode honours an explicit textContent 9ms
     ✓ $createMentionNode defaults textContent to the mention name 1ms
     × round-trips a display text that differs from the mention name 4ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected 'luke_skywalker' to be 'Luke Skywalker' // Object.is equality
Expected: "Luke Skywalker"
Received: "luke_skywalker"

AssertionError: expected '<p><span data-lexical-mention="true">…' to contain 'data-lexical-mention-name="luke_skywa…'
Expected: "data-lexical-mention-name="luke_skywalker""
Received: "<p><span data-lexical-mention="true">luke_skywalker</span></p>"

      Tests  2 failed | 1 passed (3)
```

### After

```
$ npx vitest run packages/lexical-playground

 Test Files  18 passed (18)
      Tests  274 passed (274)
```

