### PR TITLE
[lexical-table] Bug Fix: import the dir attribute in the DOMImportExtension table rules

### DIFF
--- a/packages/lexical-table/src/TableImportExtension.ts
+++ b/packages/lexical-table/src/TableImportExtension.ts
@@ -22,6 +22,7 @@ import {
   $isInlineElementOrDecoratorNode,
   $isLineBreakNode,
   $isTextNode,
+  $setDirectionFromDOM,
   IS_BOLD,
   IS_ITALIC,
   IS_STRIKETHROUGH,
@@ -154,6 +155,7 @@ const TableRule = /* @__PURE__ */ defineImportRule({
         node.setColWidths(columns);
       }
     }
+    $setDirectionFromDOM(node, el);
     return [
       node.splice(
         0,
@@ -171,8 +173,9 @@ const TableRowRule = /* @__PURE__ */ defineImportRule({
     const height = PIXEL_VALUE_REG_EXP.test(el.style.height)
       ? parseFloat(el.style.height)
       : undefined;
+    const node = $setDirectionFromDOM($createTableRowNode(height), el);
     return [
-      $createTableRowNode(height).splice(
+      node.splice(
         0,
         0,
         $descendantsMatching(ctx.$importChildren(el), $isTableCellNode),
@@ -216,6 +219,7 @@ const TableCellRule = /* @__PURE__ */ defineImportRule({
       }
     }
     const cell = $createTableCellNode(headerState, el.colSpan, width);
+    $setDirectionFromDOM(cell, el);
     cell.__rowSpan = el.rowSpan;
     const backgroundColor = el.style.backgroundColor;
     if (backgroundColor !== '') {

--- a/packages/lexical-table/src/__tests__/unit/TableImportExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/TableImportExtension.test.ts
@@ -126,6 +126,38 @@ describe('TableImportExtension', () => {
     });
   });
 
+  test('dir is imported for table, row, and cell', () => {
+    using editor = buildEditor();
+    importInto(
+      editor,
+      '<table dir="rtl"><tr dir="rtl"><td dir="rtl">a</td><th dir="ltr">b</th></tr></table>',
+    );
+    editor.read(() => {
+      const table = $rootTable();
+      expect(table.getDirection()).toBe('rtl');
+      const row = $rows(table)[0];
+      expect(row.getDirection()).toBe('rtl');
+      const cells = $cells(row);
+      expect(cells[0].getDirection()).toBe('rtl');
+      expect(cells[1].getDirection()).toBe('ltr');
+    });
+  });
+
+  test('an absent or invalid dir leaves the direction unset', () => {
+    using editor = buildEditor();
+    importInto(
+      editor,
+      '<table dir="auto"><tr><td dir="nonsense">a</td></tr></table>',
+    );
+    editor.read(() => {
+      const table = $rootTable();
+      expect(table.getDirection()).toBe(null);
+      const row = $rows(table)[0];
+      expect(row.getDirection()).toBe(null);
+      expect($cells(row)[0].getDirection()).toBe(null);
+    });
+  });
+
   test('deprecated TableImportExtension alias still imports tables', () => {
     using editor = buildEditorFromExtensions(
       defineExtension({


### PR DESCRIPTION
## Description

`$setDirectionFromDOM` reads an element's `dir` attribute and applies it to
the `ElementNode` being built. Every legacy table converter calls it —
`$convertTableElement`, `$convertTableRowElement`, and
`$convertTableCellNodeElement` all do — and so do the equivalent rules in the
new `DOMImportExtension` pipeline for the other packages
(`ListImportExtension` for `ol`/`ul`/`li`, `RichTextImportExtension` for
headings and quotes, `coreImportRules` for `p`).

The table rules in `TableImportExtension` are the exception: `TableRule`,
`TableRowRule`, and `TableCellRule` never read `dir`, so pasting
`<table dir="rtl">` through the new pipeline silently drops the explicit
direction that the legacy `importDOM` path preserves. The two
implementations of the same contract disagree.

This calls `$setDirectionFromDOM` from all three rules, matching the legacy
converters. An absent or invalid `dir` is still a no-op, so nothing else
changes.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/TableImportExtension.test.ts`

### Before

```
 FAIL  packages/lexical-table/src/__tests__/unit/TableImportExtension.test.ts > TableImportExtension > dir is imported for table, row, and cell
AssertionError: expected null to be 'rtl' // Object.is equality

- Expected:
"rtl"

+ Received:
null

 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

### After

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

