### PR TITLE
[lexical-list] Bug Fix: keep the list's dir attribute in exported HTML

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -169,6 +169,13 @@ export class ListNode extends ElementNode {
       if (this.__listType === 'check') {
         element.setAttribute('__lexicalListType', 'check');
       }
+      // $convertListNode reads `dir` back off the <ol>/<ul>, so it has to be
+      // written here — this override does not call super.exportDOM, which is
+      // where ElementNode would otherwise emit it.
+      const direction = this.getDirection();
+      if (direction) {
+        element.dir = direction;
+      }
     }
     return {
       element,

--- a/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {$createLinkNode, $isLinkNode, type LinkNode} from '@lexical/link';
 import {
   $createListItemNode,
@@ -209,6 +210,39 @@ describe('LexicalListNode tests', () => {
         expect(domElement.outerHTML).toBe(
           '<ul class="my-ul-list-class my-ul-list-class-1"></ul>',
         );
+      });
+    });
+
+    test('ListNode.exportDOM() round-trips the dir attribute', async () => {
+      const {editor} = testEnv;
+
+      const parser = new DOMParser();
+      const input = html`
+        <ul dir="rtl">
+          <li dir="rtl">שלום</li>
+        </ul>
+      `;
+
+      await editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          root.append(
+            ...$generateNodesFromDOM(
+              editor,
+              parser.parseFromString(input, 'text/html'),
+            ),
+          );
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const listNode = $getRoot().getFirstChild();
+        assert($isListNode(listNode), 'expected a ListNode at the root');
+        // $convertListNode read it back off the <ul>
+        expect(listNode.getDirection()).toBe('rtl');
+        expect($generateHtmlFromNodes(editor)).toContain('<ul dir="rtl">');
       });
     });
 


### PR DESCRIPTION
## Description

Both list importers read `dir` off the `<ol>`/`<ul>`: `$convertListNode`
calls `$setDirectionFromDOM(node, domNode)`, and so does `ListRule` in the
`DOMImportExtension` pipeline. Nothing writes it back out.

`ElementNode.exportDOM` is what normally emits `element.dir` from
`getDirection()`, but `ListNode.exportDOM` builds its element with
`createDOM` and returns it directly without going through `super.exportDOM`,
so the direction is dropped. `ListItemNode.exportDOM`, right next to it, does
emit `element.dir`, so a copied RTL list currently exports as
`<ul><li dir="rtl">…</li></ul>` — the item keeps its direction and the list
that owns it silently loses it, and re-importing that HTML no longer produces
the node it came from.

This emits `dir` from `ListNode.exportDOM` when the node has an explicit
direction, matching `ListItemNode` and what the importers expect to read. A
node with no explicit direction is unaffected, so existing output is
unchanged.

## Test plan

`npx vitest run packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts`

### Before

```
 FAIL  |unit| packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts > LexicalListNode tests > ListNode.exportDOM() round-trips the dir attribute
AssertionError: expected '<ul><li value="1" dir="rtl"><span sty…' to contain '<ul dir="rtl">'

Expected: "<ul dir="rtl">"
Received: "<ul><li value="1" dir="rtl"><span style="white-space: pre-wrap;">שלום</span></li></ul>"

 Test Files  1 failed (1)
      Tests  1 failed | 18 passed (19)
```

### After

```
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

`npx vitest run packages/lexical-list packages/lexical-html packages/lexical-clipboard packages/lexical-markdown` is also green (25 files, 667 tests).

