### PR TITLE
[lexical-list] Bug Fix: DOMImportExtension list normalization uses ListNode.createListItemNode()

### DIFF
--- a/packages/lexical-list/src/ListImportExtension.ts
+++ b/packages/lexical-list/src/ListImportExtension.ts
@@ -29,7 +29,7 @@ import {
   $isListItemNode,
   type ListItemNode,
 } from './LexicalListItemNode';
-import {$createListNode, $isListNode} from './LexicalListNode';
+import {$createListNode, $isListNode, type ListNode} from './LexicalListNode';
 
 /**
  * Mirrors the legacy `isDomChecklist` heuristic from
@@ -47,8 +47,15 @@ function isDomChecklist(domNode: HTMLElement): boolean {
  * Lift nested `ListNode`s out of `ListItemNode`s into sibling
  * `ListItemNode`s (the legacy `$normalizeChildren` shape). Also wraps any
  * non-`ListItemNode` children in a new `ListItemNode`.
+ *
+ * The wrapper items come from `listNode.createListItemNode()` — the same
+ * subclass hook the legacy `$normalizeChildren` uses — so a `ListNode`
+ * subclass gets its own item type here too.
  */
-function $normalizeListChildren(children: LexicalNode[]): ListItemNode[] {
+function $normalizeListChildren(
+  children: LexicalNode[],
+  listNode: ListNode,
+): ListItemNode[] {
   const out: ListItemNode[] = [];
   for (const child of children) {
     if ($isListItemNode(child)) {
@@ -57,12 +64,12 @@ function $normalizeListChildren(children: LexicalNode[]): ListItemNode[] {
       if (innerChildren.length > 1) {
         for (const inner of innerChildren) {
           if ($isListNode(inner)) {
-            out.push($createListItemNode().append(inner));
+            out.push(listNode.createListItemNode().append(inner));
           }
         }
       }
     } else {
-      out.push($createListItemNode().append(child));
+      out.push(listNode.createListItemNode().append(child));
     }
   }
   return out;
@@ -89,7 +96,7 @@ const ListRule = /* @__PURE__ */ defineImportRule({
         0,
         0,
         $propagateTextAlignToBlockChildren(
-          $normalizeListChildren(ctx.$importChildren(el)),
+          $normalizeListChildren(ctx.$importChildren(el), node),
           el,
         ),
       ),

--- a/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
@@ -30,8 +30,8 @@ import {
   $isListNode,
   ListExtension,
   ListImportExtension,
-  type ListItemNode,
-  type ListNode,
+  ListItemNode,
+  ListNode,
 } from '@lexical/list';
 import {JSDOM} from 'jsdom';
 import {
@@ -44,6 +44,21 @@ import {
   type LexicalNode,
 } from 'lexical';
 import {assert, describe, expect, test} from 'vitest';
+
+class CustomListItemNode extends ListItemNode {
+  $config() {
+    return this.config('custom-listitem', {extends: ListItemNode});
+  }
+}
+
+class CustomListNode extends ListNode {
+  $config() {
+    return this.config('custom-list', {extends: ListNode});
+  }
+  createListItemNode(): ListItemNode {
+    return new CustomListItemNode();
+  }
+}
 
 function buildEditor() {
   return buildEditorFromExtensions(
@@ -149,6 +164,39 @@ describe('ListImportExtension', () => {
       expect(items.some(i => i.getTextContent().includes('real item'))).toBe(
         true,
       );
+    });
+  });
+
+  test('wrapper items come from ListNode.createListItemNode()', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [ListExtension],
+        name: 'custom-list-host',
+        nodes: [
+          CustomListNode,
+          CustomListItemNode,
+          {
+            replace: ListNode,
+            with: (node: ListNode) =>
+              new CustomListNode(node.getListType(), node.getStart()),
+            withKlass: CustomListNode,
+          },
+        ],
+      }),
+    );
+    // Both $normalizeListChildren branches: the nested <ul> is lifted into a
+    // wrapper item, and the stray text is wrapped in one.
+    importInto(editor, '<ul>stray<li>parent<ul><li>child</li></ul></li></ul>');
+    editor.read(() => {
+      const list = $rootList();
+      expect(list.getType()).toBe('custom-list');
+      const wrappers = $items(list).filter(
+        item => !item.getTextContent().startsWith('parent'),
+      );
+      expect(wrappers.length).toBeGreaterThanOrEqual(2);
+      for (const wrapper of wrappers) {
+        expect(wrapper.getType()).toBe('custom-listitem');
+      }
     });
   });
 


### PR DESCRIPTION
## Description

`ListNode.createListItemNode()` was added in #8427 ("Add the
`createListItemNode` method to the ListNode and use it for children
normalization") precisely so a `ListNode` subclass controls the item type its
normalization synthesizes. The legacy converter honours it —
`$normalizeChildren` does `listNode.createListItemNode.bind(listNode)` — and
so does `ListNode.splice`.

The `DOMImportExtension` port of that normalization,
`$normalizeListChildren` in `ListImportExtension`, does not: it calls the
module-level `$createListItemNode()` instead, so a subclassed list imported
through the new pipeline gets plain `ListItemNode` wrappers for both of its
synthesized-item cases (a nested list lifted into a sibling item, and a
non-item child wrapped into one). The two implementations of the same
normalization disagree.

This threads the `ListNode` being built into `$normalizeListChildren` and
uses `listNode.createListItemNode()`, matching `$normalizeChildren`. The
default `ListNode.createListItemNode()` returns `$createListItemNode()`, so
nothing changes for unsubclassed lists.

## Test plan

`npx vitest run packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts`

### Before

```
 FAIL  |unit| packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts > ListImportExtension > wrapper items come from ListNode.createListItemNode()
AssertionError: expected 'listitem' to be 'custom-listitem' // Object.is equality

Expected: "custom-listitem"
Received: "listitem"

 Test Files  1 failed (1)
      Tests  1 failed | 11 passed (12)
```

### After

```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

`npx vitest run packages/lexical-list` is green (10 files, 126 tests).

