### PR TITLE
[lexical-markdown] Bug Fix: keep a blank first line of a fenced code block

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -658,10 +658,12 @@ export const CODE: MultilineElementTransformer = {
         const endMatch = line.match(multilineEndRegex);
         const linesInBetween = lines.slice(startLineIndex + 1, i);
 
-        const afterFullMatch = currentLine.slice(startMatch[0].length);
-        if (afterFullMatch.length > 0) {
-          linesInBetween.unshift(afterFullMatch);
-        }
+        // `replace` follows the default $importMultiline contract, where
+        // linesInBetween[0] is always the remainder of the opening fence line
+        // and is discarded when blank. Unshift it unconditionally so a code
+        // block that genuinely starts with a blank line keeps that line
+        // instead of having it mistaken for this (empty) remainder.
+        linesInBetween.unshift(currentLine.slice(startMatch[0].length));
 
         CODE.replace(
           rootNode,
@@ -676,10 +678,7 @@ export const CODE: MultilineElementTransformer = {
     }
 
     const linesInBetween = lines.slice(startLineIndex + 1);
-    const afterFullMatch = currentLine.slice(startMatch[0].length);
-    if (afterFullMatch.length > 0) {
-      linesInBetween.unshift(afterFullMatch);
-    }
+    linesInBetween.unshift(currentLine.slice(startMatch[0].length));
 
     CODE.replace(rootNode, null, startMatch, null, linesInBetween, true);
     return [true, lines.length - 1];

--- a/packages/lexical-markdown/src/__tests__/unit/CodeBlockLeadingBlankLine.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/CodeBlockLeadingBlankLine.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$isCodeNode, CodeNode} from '@lexical/code-core';
+import {createHeadlessEditor} from '@lexical/headless';
+import {LinkNode} from '@lexical/link';
+import {ListItemNode, ListNode} from '@lexical/list';
+import {
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
+  TRANSFORMERS,
+} from '@lexical/markdown';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {$getRoot} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+function createEditor() {
+  return createHeadlessEditor({
+    nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, CodeNode, LinkNode],
+    onError: error => {
+      throw error;
+    },
+  });
+}
+
+function importCodeText(markdown: string): string {
+  const editor = createEditor();
+  let text: string | null = null;
+  editor.update(
+    () => {
+      $convertFromMarkdownString(markdown, TRANSFORMERS);
+      const first = $getRoot().getFirstChild();
+      text = $isCodeNode(first) ? first.getTextContent() : null;
+    },
+    {discrete: true},
+  );
+  return text as unknown as string;
+}
+
+function roundTrip(markdown: string): string {
+  const editor = createEditor();
+  editor.update(
+    () => {
+      $convertFromMarkdownString(markdown, TRANSFORMERS);
+    },
+    {discrete: true},
+  );
+  return editor.read(() => $convertToMarkdownString(TRANSFORMERS));
+}
+
+describe('code block leading blank lines', () => {
+  it('keeps a blank first line of a fenced code block', () => {
+    expect(importCodeText('```js\n\ncode\n```')).toBe('\ncode');
+  });
+
+  it('keeps several blank first lines', () => {
+    expect(importCodeText('```js\n\n\na\nb\n```')).toBe('\n\na\nb');
+  });
+
+  it('round trips a code block that starts with a blank line', () => {
+    const markdown = '```js\n\ncode\n```';
+    expect(roundTrip(markdown)).toBe(markdown);
+  });
+
+  it('still drops nothing from a code block without leading blank lines', () => {
+    expect(importCodeText('```js\ncode\n```')).toBe('code');
+    expect(roundTrip('```js\ncode\n```')).toBe('```js\ncode\n```');
+  });
+
+  it('still treats text after the opening fence as content', () => {
+    expect(importCodeText('``` code\nmore\n```')).toBe('code\nmore');
+    expect(importCodeText('```javascript Incomplete tag')).toBe(
+      'Incomplete tag',
+    );
+  });
+});


### PR DESCRIPTION
## Description

`MultilineElementTransformer.replace` documents `linesInBetween` as the lines
between the start and end matches. The default `$importMultiline` path builds
it so that `linesInBetween[0]` is always the *remainder of the opening fence
line* — it pushes `lines[startLineIndex].slice(startMatch[0].length)` even when
that remainder is empty. `CODE.replace` relies on that contract and drops a
blank first entry:

```js
if (linesInBetween[0].trim().length === 0) {
  linesInBetween.shift();
}
```

`CODE.handleImportAfterStartMatch` builds `linesInBetween` itself, and only
unshifted the fence-line remainder when it was non-empty. For the common
` ```js ` fence the remainder *is* empty, so index 0 became the first real line
of code instead. When that line is blank, `replace` mistakes it for the
fence-line remainder and deletes it.

The result is that a code block starting with a blank line silently loses it on
import, and markdown -> editor -> markdown is not idempotent: export writes
exactly one newline after the fence, so every extra round trip eats one more
blank line.

```
```\n\n\ncode\n```   ->   ```\n\ncode\n```   ->   ```\ncode\n```
```

This unshifts the remainder unconditionally, so `linesInBetween[0]` means the
same thing in both import paths. Text that follows the opening fence on the
same line is still treated as content (` ``` code `), unterminated fences are
unchanged, and trailing blank lines are still trimmed as before.

## Test plan

New unit test `packages/lexical-markdown/src/__tests__/unit/CodeBlockLeadingBlankLine.test.ts`.

### Before

```
$ npx vitest run packages/lexical-markdown/src/__tests__/unit/CodeBlockLeadingBlankLine.test.ts

     × keeps a blank first line of a fenced code block 7ms
     × keeps several blank first lines 1ms
     × round trips a code block that starts with a blank line 1ms

AssertionError: expected 'code' to be '\ncode' // Object.is equality
AssertionError: expected '\na\nb' to be '\n\na\nb' // Object.is equality
AssertionError: expected '```js\ncode\n```' to be '```js\n\ncode\n```' // Object.is equality

      Tests  3 failed | 2 passed (5)
```

### After

```
$ npx vitest run packages/lexical-markdown/src/__tests__/unit/CodeBlockLeadingBlankLine.test.ts

 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npx vitest run packages/lexical-markdown packages/lexical-code-core packages/lexical-code-prism packages/lexical-code-shiki

 Test Files  13 passed (13)
      Tests  643 passed (643)
```
