### PR TITLE
[lexical-markdown] Bug Fix: strip the fence indentation from an indented code block

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -381,6 +381,19 @@ export function $createMarkdownLineBreakNode(
   return lineBreakNode;
 }
 
+/**
+ * CommonMark: "If the leading code fence is indented N spaces, then up to N
+ * spaces of indentation are removed from each line of the content (if
+ * present)." https://spec.commonmark.org/0.31.2/#fenced-code-blocks
+ */
+function stripFenceIndent(line: string, indent: number): string {
+  let index = 0;
+  while (index < indent && (line[index] === ' ' || line[index] === '\t')) {
+    index++;
+  }
+  return line.slice(index);
+}
+
 const createBlockNode = (
   createNode: (match: string[]) => ElementNode,
 ): ElementTransformer['replace'] => {
@@ -704,12 +717,16 @@ export const CODE: MultilineElementTransformer = {
 
     const fence = startMatch[1] ? startMatch[1].trim() : '```';
     const language = startMatch[2] || undefined;
+    // `startMatch[1]` keeps the whitespace that precedes the opening fence.
+    const fenceIndent = startMatch[1]
+      ? startMatch[1].length - startMatch[1].trimStart().length
+      : 0;
 
     if (!children && linesInBetween) {
       if (linesInBetween.length === 1) {
         if (endMatch) {
           codeBlockNode = $createCodeNode(language);
-          code = linesInBetween[0];
+          code = stripFenceIndent(linesInBetween[0], fenceIndent);
         } else {
           codeBlockNode = $createCodeNode(language);
           code = linesInBetween[0].startsWith(' ')
@@ -734,7 +751,9 @@ export const CODE: MultilineElementTransformer = {
           linesInBetween.pop();
         }
 
-        code = linesInBetween.join('\n');
+        code = linesInBetween
+          .map(line => stripFenceIndent(line, fenceIndent))
+          .join('\n');
       }
 
       $setState(codeBlockNode, codeFenceState, fence);

--- a/packages/lexical-markdown/src/__tests__/unit/CodeBlockFenceIndent.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/CodeBlockFenceIndent.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$isCodeNode, CodeNode} from '@lexical/code-core';
+import {createHeadlessEditor} from '@lexical/headless';
+import {LinkNode} from '@lexical/link';
+import {ListItemNode, ListNode} from '@lexical/list';
+import {$convertFromMarkdownString, TRANSFORMERS} from '@lexical/markdown';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {$getRoot} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+function importCodeText(markdown: string): string | null {
+  const editor = createHeadlessEditor({
+    nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, CodeNode, LinkNode],
+    onError: error => {
+      throw error;
+    },
+  });
+  let text: string | null = null;
+  editor.update(
+    () => {
+      $convertFromMarkdownString(markdown, TRANSFORMERS);
+      const first = $getRoot().getFirstChild();
+      text = $isCodeNode(first) ? first.getTextContent() : null;
+    },
+    {discrete: true},
+  );
+  return text;
+}
+
+describe('indented code fences', () => {
+  it('removes the fence indentation from the content', () => {
+    expect(importCodeText('  ```js\n  code\n  ```')).toBe('code');
+  });
+
+  it('preserves indentation relative to the fence', () => {
+    expect(importCodeText('   ```\n   a\n     b\n   ```')).toBe('a\n  b');
+  });
+
+  it('removes at most the fence indentation', () => {
+    expect(importCodeText('  ```\ncode\n  ```')).toBe('code');
+    expect(importCodeText('  ```\n a\n  b\n  ```')).toBe('a\nb');
+  });
+
+  it('handles a tab-indented fence', () => {
+    expect(importCodeText('\t```\n\tcode\n\t```')).toBe('code');
+  });
+
+  it('keeps content indentation when the fence is not indented', () => {
+    expect(importCodeText('```js\n  code\n```')).toBe('  code');
+    expect(importCodeText('```js\ncode\n```')).toBe('code');
+  });
+});


### PR DESCRIPTION
## Description

An opening code fence may be indented by up to three spaces. CommonMark then
requires that indentation to be removed from the block's content:

> If the leading code fence is indented N spaces, then up to N spaces of
> indentation are removed from each line of the content (if present).
> https://spec.commonmark.org/0.31.2/#fenced-code-blocks

`CODE_START_REGEX` already accepts a leading-whitespace run and captures it as
part of `startMatch[1]`, and `CODE_END_REGEX` accepts an indented closing
fence, so an indented block is imported as a code block. But `CODE.replace`
only ever used `startMatch[1].trim()` to derive the fence string and never
looked at the indentation, so every content line kept it:

```
  ```js
  code
  ```
```

imported as a code block whose text is `"  code"` rather than `"code"`. The
indentation is dropped from the fence lines on export but kept in the content,
so the block also comes back wider on every markdown round trip.

This computes the fence indent from the whitespace `startMatch[1]` already
carries, and removes up to that many leading space/tab characters from each
content line. "Up to" matters: content indented less than the fence is left
alone rather than having non-whitespace removed, and indentation *relative* to
the fence is preserved. A fence with no indentation is unaffected, so code
blocks that intentionally start with indented lines still keep it.

## Test plan

New unit test `packages/lexical-markdown/src/__tests__/unit/CodeBlockFenceIndent.test.ts`.

### Before

```
$ npx vitest run packages/lexical-markdown/src/__tests__/unit/CodeBlockFenceIndent.test.ts

     × removes the fence indentation from the content 7ms
     × preserves indentation relative to the fence 1ms
     × removes at most the fence indentation 1ms
     × handles a tab-indented fence 1ms

AssertionError: expected '  code' to be 'code' // Object.is equality
AssertionError: expected '  a\n     b' to be 'a\n  b' // Object.is equality
AssertionError: expected 'a\n  b' to be 'a\nb' // Object.is equality
AssertionError: expected '\tcode' to be 'code' // Object.is equality

      Tests  4 failed | 1 passed (5)
```

### After

```
$ npx vitest run packages/lexical-markdown/src/__tests__/unit/CodeBlockFenceIndent.test.ts

 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npx vitest run packages/lexical-markdown packages/lexical-code-core packages/lexical-code-prism packages/lexical-code-shiki

 Test Files  13 passed (13)
      Tests  643 passed (643)
```
