### PR TITLE
[lexical-utils] Bug Fix: positionNodeOnRange cleans up an invocation that lands after it was disposed of

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/positionNodeOnRange.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/positionNodeOnRange.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {positionNodeOnRange, selectionAlwaysOnDisplay} from '@lexical/utils';
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getRoot,
+  $setSelection,
+  type LexicalEditor,
+} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+// jsdom has no layout: give every Range a single 10px box so that
+// createRectsFromDOMRange() produces one rect and positionNodeOnRange()
+// actually builds its wrapper.
+Range.prototype.getClientRects = function (): DOMRectList {
+  const rect = {
+    bottom: 10,
+    height: 10,
+    left: 0,
+    right: 10,
+    top: 0,
+    width: 10,
+    x: 0,
+    y: 0,
+  };
+  const rects = [{...rect, toJSON: () => rect} as DOMRect];
+  return {
+    item: (i: number) => rects[i] || null,
+    length: rects.length,
+    [Symbol.iterator]: function* () {
+      yield* rects;
+    },
+  } as unknown as DOMRectList;
+};
+
+/**
+ * positionNodeOnRange() prepends exactly one `position: relative` wrapper div
+ * to the root element's parent per live invocation, so counting them across
+ * the document measures how many highlight overlays are currently attached.
+ */
+function countOverlays(): number {
+  return document.querySelectorAll('body div[style*="position: relative"]')
+    .length;
+}
+
+describe('positionNodeOnRange', () => {
+  let elements: HTMLElement[] = [];
+
+  function createRootElement(): HTMLDivElement {
+    const container = document.createElement('div');
+    const rootElement = document.createElement('div');
+    rootElement.contentEditable = 'true';
+    container.appendChild(rootElement);
+    document.body.appendChild(container);
+    elements.push(container);
+    return rootElement;
+  }
+
+  async function seed(editor: LexicalEditor): Promise<void> {
+    await editor.update(
+      () => {
+        const text = $createTextNode('hello');
+        $getRoot().clear().append($createParagraphNode().append(text));
+        const selection = $createRangeSelection();
+        selection.anchor.set(text.getKey(), 0, 'text');
+        selection.focus.set(text.getKey(), 5, 'text');
+        $setSelection(selection);
+      },
+      {discrete: true},
+    );
+  }
+
+  beforeEach(() => {
+    elements = [];
+  });
+
+  afterEach(() => {
+    for (const element of elements) {
+      element.remove();
+    }
+  });
+
+  it('removes the overlay of an invocation that lands after it was disposed of', () => {
+    const firstRootElement = createRootElement();
+    const secondRootElement = createRootElement();
+    const editor = createTestEditor();
+    editor.setRootElement(firstRootElement);
+
+    // An owner that shows a highlight and drops it whenever the root element
+    // changes -- the shape markSelection() has. The owner's root listener is
+    // registered first and the highlight is created later, so the highlight's
+    // own root listener sits after the owner's in the registry and is still
+    // invoked by the pass that unregisters it.
+    let removeHighlight: null | (() => void) = null;
+    const removeOwner = editor.registerRootListener(rootElement => {
+      if (rootElement === null) {
+        return;
+      }
+      return () => {
+        if (removeHighlight !== null) {
+          removeHighlight();
+          removeHighlight = null;
+        }
+      };
+    });
+
+    function showHighlight(): void {
+      const rootElement = editor.getRootElement()!;
+      const range = rootElement.ownerDocument.createRange();
+      range.selectNodeContents(rootElement);
+      removeHighlight = positionNodeOnRange(editor, range, () => {});
+    }
+
+    try {
+      showHighlight();
+      expect(countOverlays()).toBe(1);
+
+      editor.setRootElement(secondRootElement);
+      showHighlight();
+      expect(countOverlays()).toBe(1);
+    } finally {
+      removeOwner();
+      if (removeHighlight !== null) {
+        removeHighlight();
+      }
+    }
+
+    expect(countOverlays()).toBe(0);
+  });
+
+  it('leaves no overlay behind when the root element changed while marking', async () => {
+    const firstRootElement = createRootElement();
+    const secondRootElement = createRootElement();
+    const outside = document.createElement('div');
+    outside.appendChild(document.createTextNode('outside'));
+    document.body.appendChild(outside);
+    elements.push(outside);
+
+    const editor = createTestEditor();
+    editor.setRootElement(firstRootElement);
+    await seed(editor);
+
+    const selectOutsideOfTheEditor = () => {
+      const outsideText = outside.firstChild!;
+      document.getSelection()!.setBaseAndExtent(outsideText, 0, outsideText, 1);
+      document.dispatchEvent(new Event('selectionchange'));
+    };
+
+    const cleanup = selectionAlwaysOnDisplay(editor, vi.fn());
+    try {
+      selectOutsideOfTheEditor();
+      expect(countOverlays()).toBe(1);
+
+      // Re-mounting the editor on another element: a React re-render that
+      // swaps the contenteditable, StrictMode's double mount, a portal move.
+      editor.setRootElement(secondRootElement);
+      selectOutsideOfTheEditor();
+      expect(countOverlays()).toBe(1);
+    } finally {
+      cleanup();
+    }
+
+    expect(countOverlays()).toBe(0);
+  });
+});

--- a/packages/lexical-utils/src/positionNodeOnRange.ts
+++ b/packages/lexical-utils/src/positionNodeOnRange.ts
@@ -155,7 +155,19 @@ export default function mlcPositionNodeOnRange(
     position();
   }
 
-  const removeRootListener = editor.registerRootListener(restart);
+  // Returning stop() hands the teardown to the root listener registry.
+  // registerRootListener runs the previous invocation's cleanup before it
+  // re-invokes the listener, and runs it again when the listener is
+  // unregistered, so the wrapper element and the MutationObserver never
+  // outlive the invocation of restart() that created them. Without a cleanup
+  // to call, an invocation that lands after this positionNodeOnRange has
+  // already been disposed of (root listeners are triggered from a snapshot of
+  // the registry, so a listener removed mid-pass is still called) would leave
+  // its wrapper element in the document with nothing left to remove it.
+  const removeRootListener = editor.registerRootListener(() => {
+    restart();
+    return stop;
+  });
 
   return () => {
     removeRootListener();


### PR DESCRIPTION

## Description

`positionNodeOnRange` registers `restart` as a root listener but returns nothing from it, so Lexical is given no way to undo what an invocation did:

```ts
const removeRootListener = editor.registerRootListener(restart);
```

`restart()` is not side effect free — it prepends a wrapper element to the root element's parent and starts a `MutationObserver`. The only thing that undoes that is the `stop()` in the closure `positionNodeOnRange` returns to *its* caller.

That is fine while the two stay in step, but root listeners are triggered from a snapshot of the registry:

```ts
const listeners = Array.from(listenerMap);
for (const [listener, unregister] of listeners) {
  if (unregister) { unregister(); }
  const nextUnregister = listener(...payload);
  if (listenerMap.has(listener)) {
    listenerMap.set(listener, nextUnregister);
  } else if (nextUnregister) {
    nextUnregister();          // <- the escape hatch, unusable without a cleanup
  }
}
```

So a listener that an *earlier* listener in the same pass unregistered is still invoked once more. Lexical already handles that: it calls `nextUnregister()` for a listener that is no longer registered. `restart` returns `undefined`, so there is nothing to call, and the wrapper element it just attached stays in the document with nothing left that can remove it.

This is reachable straight from `selectionAlwaysOnDisplay`, which is the shipped consumer of this pattern (`@lexical/react`'s `SelectionAlwaysOnDisplay` plugin, and the playground's `selectionAlwaysOnDisplay` setting). Its root listener is registered first and its `markSelection` — and therefore its `positionNodeOnRange` — is created later from a `selectionchange` event, so the two sit in exactly that order in the registry. Change the editor's root element while the selection is being marked (a React re-render that swaps the contenteditable, `StrictMode`'s double mount, moving the editor into a portal) and the pass tears the mark down, re-invokes the orphaned listener, and leaves a stray `Highlight`-coloured overlay welded to the container. It never repositions, never clears, and survives the cleanup returned by `selectionAlwaysOnDisplay`; each subsequent root change adds another one.

The fix is to return `stop` from the root listener, which is what the `RootListener` contract is for. `registerRootListener` runs the previous invocation's cleanup before re-invoking the listener and again when the listener is unregistered, so the wrapper and the observer are now owned by the invocation that created them in every path, including the disposed-mid-pass one. No API or serialization change.

## Test plan

New unit test `packages/lexical-utils/src/__tests__/unit/positionNodeOnRange.test.tsx`, covering both the direct contract and the `selectionAlwaysOnDisplay` symptom. Both count the overlays attached to the document.

### Before

```
 ❯ packages/lexical-utils/src/__tests__/unit/positionNodeOnRange.test.tsx (2 tests | 2 failed)
   × removes the overlay of an invocation that lands after it was disposed of
     AssertionError: expected 2 to be 1 // Object.is equality
   × leaves no overlay behind when the root element changed while marking
     AssertionError: expected 2 to be 1 // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Full package suites are unchanged:

```
$ npx vitest run packages/lexical-utils
 Test Files  16 passed (16)
      Tests  227 passed (227)

$ npx vitest run packages/lexical-react
 Test Files  31 passed (31)
      Tests  182 passed (182)
```
