### PR TITLE
[lexical-playground] Bug Fix: toggle the column header of the clicked cell's grid column

### DIFF
--- a/packages/lexical-playground/__tests__/regression/7266-column-header-merged-cells.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/7266-column-header-merged-cells.spec.mjs
@@ -8,11 +8,14 @@
 import {
   assertTableHTML as assertHTML,
   click,
+  expect,
   focusEditor,
+  getPageOrFrame,
   html,
   initialize,
   insertTable,
   mergeTableCells,
+  selectCellFromTableCoord,
   selectCellsFromTableCords,
   test,
   toggleColumnHeader,
@@ -169,6 +172,53 @@ test.describe('Regression test #7266', () => {
         </p>
       `,
     );
+  });
+
+  test('toggling column header applies to the grid column of the clicked cell, not its index among its row children', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await initialize({isCollab, page});
+
+    await focusEditor(page);
+
+    await insertTable(page, 3, 4);
+
+    // Merge grid columns 1 and 2 of row 1 into one cell, so the cells after it
+    // in that row sit one grid column to the right of their child index.
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 1},
+      {x: 2, y: 1},
+      false,
+      false,
+    );
+    await mergeTableCells(page);
+
+    // The last cell of row 1 is now the third child of its row but still
+    // occupies grid column 3.
+    await selectCellFromTableCoord(page, {x: 2, y: 1}, false);
+    await toggleColumnHeader(page);
+
+    // Read back which grid columns are headers, per row.
+    const headerGrid = await getPageOrFrame(page).evaluate(() => {
+      const table = document.querySelector('table');
+      return Array.from(table.querySelectorAll(':scope > tr')).map(row =>
+        Array.from(row.children).flatMap(cell =>
+          Array.from({length: cell.colSpan}, () => cell.tagName),
+        ),
+      );
+    });
+
+    expect(headerGrid).toEqual([
+      ['TH', 'TH', 'TH', 'TH'],
+      ['TH', 'TD', 'TD', 'TH'],
+      ['TH', 'TD', 'TD', 'TH'],
+    ]);
   });
 
   test('toggling row header with merged row cells should only apply row header to the selected row', async ({

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -15,7 +15,6 @@ import {
   $deleteTableRowAtSelection,
   $getNodeTriplet,
   $getTableCellNodeFromLexicalNode,
-  $getTableColumnIndexFromTableCellNode,
   $getTableNodeFromLexicalNodeOrThrow,
   $getTableRowIndexFromTableCellNode,
   $insertTableColumnAtSelection,
@@ -364,7 +363,16 @@ function TableActionMenu({
   const toggleTableColumnIsHeader = useCallback(() => {
     editor.update(() => {
       const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
-      const columnIndex = $getTableColumnIndexFromTableCellNode(tableCellNode);
+      // $setTableColumnIsHeader indexes the table grid, so the cell's position
+      // has to come from the table map rather than from its index among its
+      // row's children — the two diverge once an earlier cell in the row spans
+      // more than one column.
+      const [, cellMap] = $computeTableMap(
+        tableNode,
+        tableCellNode,
+        tableCellNode,
+      );
+      const columnIndex = cellMap.startColumn;
       const isHeader = !tableCellNode.hasHeaderState(
         TableCellHeaderStates.COLUMN,
       );


### PR DESCRIPTION
## Description

`$setTableColumnIsHeader(tableNode, columnIndex, isHeader)` indexes the table
grid — it walks `gridMap[row][columnIndex]`. The table action menu feeds it
`$getTableColumnIndexFromTableCellNode`, which returns the cell's index among
its row's children:

```ts
export function $getTableColumnIndexFromTableCellNode(
  tableCellNode: TableCellNode,
): number {
  const tableRowNode = $getTableRowNodeFromTableCellNodeOrThrow(tableCellNode);
  return tableRowNode.getChildren().findIndex(n => n.is(tableCellNode));
}
```

Those two numbers are the same only while every cell in the row has
`colSpan === 1`. Once an earlier cell in the row spans more than one column,
each cell after it sits one or more grid columns to the right of its child
index, so "Toggle column header" applies the header to a column to the left of
the one the user clicked — and can hit the spanning cell itself.

The row toggle right above it is unaffected: rows and row indices are always
1:1, so `$getTableRowIndexFromTableCellNode` is already a grid row index.

This computes the column from the table map instead (`cellMap.startColumn`),
which is the same index `$setTableColumnIsHeader` walks. Nothing changes for
tables without horizontal merges.

## Test plan

Playground dev server running on :3000, then:

`E2E_BROWSER=chromium npx playwright test --project=chromium 7266-column-header-merged-cells.spec.mjs --reporter=line`

The new case merges grid columns 1–2 of row 1, clicks the last cell of that
row (child index 2, grid column 3) and toggles the column header.

### Before

```
  1) [chromium] › .../7266-column-header-merged-cells.spec.mjs:177:3 › Regression test #7266 › toggling column header applies to the grid column of the clicked cell, not its index among its row children

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 3
    + Received  + 3

    @@ -5,16 +5,16 @@
          "TH",
          "TH",
        ],
        Array [
          "TH",
    -     "TD",
    -     "TD",
    +     "TH",
          "TH",
    +     "TD",
        ],
        Array [
          "TH",
          "TD",
    -     "TD",
          "TH",
    +     "TD",
        ],
      ]

  1 failed
  2 passed (6.4s)
```

### After

```
Running 3 tests using 3 workers
  3 passed (4.0s)
```

Only chromium was exercised locally; the change is DOM-independent (it is a
node-tree index computation), so firefox/webkit were not run.

