### PR TITLE
[lexical-yjs] Bug Fix: sync unknown node state when a node is first created

### DIFF
--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -637,7 +637,11 @@ function syncNodeStateFromLexical(
       : [undefined, new Map()];
   if (unknown) {
     for (const [k, v] of Object.entries(unknown)) {
-      if (prevUnknown && v !== prevUnknown[k]) {
+      // `prevUnknown` is undefined when there is no previous state at all (the
+      // node is being created) and also when the previous state only had known
+      // keys. Both mean "nothing was synced yet", so every entry is new — the
+      // known loop below expresses the same thing with its empty-Map default.
+      if (!prevUnknown || v !== prevUnknown[k]) {
         stateMap.set(k, v);
       }
     }

--- a/packages/lexical-yjs/src/__tests__/unit/NodeStateSyncUnknown.test.ts
+++ b/packages/lexical-yjs/src/__tests__/unit/NodeStateSyncUnknown.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import type { XmlText} from 'yjs';
+
+import {
+  buildEditorFromExtensions,
+  type LexicalEditorWithDispose,
+} from '@lexical/extension';
+import {createBinding, type Provider} from '@lexical/yjs';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getWritableNodeState,
+  $setState,
+  createState,
+  defineExtension,
+  type LexicalEditor,
+} from 'lexical';
+import {afterEach, assert, describe, expect, test} from 'vitest';
+import {Doc, Map as YMap} from 'yjs';
+
+// A state key that IS registered on the node type, used as a control: known
+// state already syncs correctly on the create path.
+const knownFlagState = createState('knownFlag', {
+  parse: v => (typeof v === 'string' ? v : ''),
+});
+
+describe('collab-v1 node state: unknown keys', () => {
+  const editors: LexicalEditorWithDispose[] = [];
+  afterEach(() => {
+    for (const editor of editors) {
+      editor.dispose();
+    }
+    editors.length = 0;
+  });
+
+  function buildBinding() {
+    const editor = buildEditorFromExtensions(
+      defineExtension({
+        $initialEditorState: null,
+        name: '[node-state-unknown]',
+      }),
+    );
+    editors.push(editor);
+    const doc = new Doc();
+    const docMap = new Map<string, Doc>([['node-state-unknown', doc]]);
+    const binding = createBinding(
+      editor,
+      null as unknown as Provider,
+      'node-state-unknown',
+      doc,
+      docMap,
+    );
+    return {binding, doc, editor};
+  }
+
+  function serialize(
+    editor: LexicalEditor,
+    binding: ReturnType<typeof createBinding>,
+  ) {
+    editor.read(() => {
+      binding.doc.transact(() => {
+        binding.root.syncChildrenFromLexical(
+          binding,
+          $getRoot(),
+          null,
+          null,
+          null,
+        );
+      });
+    });
+  }
+
+  function paragraphStateMap(binding: ReturnType<typeof createBinding>) {
+    const collab = binding.root._children[0];
+    assert('_xmlText' in collab);
+    const xmlText = collab._xmlText as XmlText;
+    const state = xmlText.getAttribute('__state') as unknown;
+    assert(state instanceof YMap);
+    return state as YMap<unknown>;
+  }
+
+  test('unknown state on a newly created node is written to the shared doc', () => {
+    const {binding, editor} = buildBinding();
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('hello'));
+        $getRoot().clear().append(paragraph);
+        // State written by a plugin that this build does not have registered.
+        $getWritableNodeState(paragraph).updateFromUnknown('pluginKey', 42);
+      },
+      {discrete: true},
+    );
+
+    serialize(editor, binding);
+
+    expect(paragraphStateMap(binding).get('pluginKey')).toBe(42);
+  });
+
+  test('known state on a newly created node is written to the shared doc', () => {
+    const {binding, editor} = buildBinding();
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('hello'));
+        $getRoot().clear().append(paragraph);
+        $setState(paragraph, knownFlagState, 'on');
+      },
+      {discrete: true},
+    );
+
+    serialize(editor, binding);
+
+    expect(paragraphStateMap(binding).get('knownFlag')).toBe('on');
+  });
+
+  test('several unknown keys all reach the shared doc', () => {
+    const {binding, editor} = buildBinding();
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('hello'));
+        $getRoot().clear().append(paragraph);
+        const state = $getWritableNodeState(paragraph);
+        state.updateFromUnknown('a', 1);
+        state.updateFromUnknown('b', 'two');
+      },
+      {discrete: true},
+    );
+
+    serialize(editor, binding);
+
+    const stateMap = paragraphStateMap(binding);
+    expect(stateMap.get('a')).toBe(1);
+    expect(stateMap.get('b')).toBe('two');
+  });
+});


### PR DESCRIPTION
## Description

`syncNodeStateFromLexical` writes a node's state into the shared doc in two
loops — one for unknown keys (state whose `StateConfig` this build has not
registered) and one for known keys. They disagree about how to treat "there is
no previous state":

```js
const [prevUnknown, prevKnown] =
  prevState && stateMap.doc
    ? prevState.getInternalState()
    : [undefined, new Map()];
if (unknown) {
  for (const [k, v] of Object.entries(unknown)) {
    if (prevUnknown && v !== prevUnknown[k]) {
      stateMap.set(k, v);
    }
  }
}
for (const [stateConfig, v] of known) {
  if (prevKnown.get(stateConfig) !== v) {
    stateMap.set(stateConfig.key, stateConfig.unparse(v));
  }
}
```

The known loop deliberately falls back to an empty `Map`, so on the create path
every entry compares unequal and is written. The unknown loop falls back to
`undefined` and then short-circuits on it, so **nothing** is written.

`NodeState.getInternalState()` returns `[UnknownStateRecord | undefined, ...]`,
so `prevUnknown` is also `undefined` whenever the previous state carried only
known keys — not just on creation. Either way the guard means "nothing was
synced yet", which is exactly when the entries *should* be written.

The create path is the common one: `$createCollabNodeFromLexicalNode` calls
`syncPropertiesFromLexical(..., null, node)`, so `prevLexicalNode` is `null`.
The unknown keys of a newly created node therefore never reach the shared
document, and because later updates only write *changed* keys, a value dropped
at creation stays dropped forever. Peers never receive it.

This matters precisely for the case unknown state exists to serve — as
`NodeState.unknownState` documents, it is what stops "an old version of your
code" from erasing metadata written by a newer version. Under collab that
metadata is dropped instead of preserved.

Making the unknown loop use the same "no previous state means everything is
new" rule as the known loop fixes it.

## Test plan

New unit test `packages/lexical-yjs/src/__tests__/unit/NodeStateSyncUnknown.test.ts`.
It serializes a paragraph carrying unknown state through a real binding and
asserts the `__state` Y.Map contains it. A third case sets *known* state the
same way as a control — that one passes before and after, which is what pins
the asymmetry.

### Before

```
$ npx vitest run packages/lexical-yjs/src/__tests__/unit/NodeStateSyncUnknown.test.ts

     × unknown state on a newly created node is written to the shared doc 10ms
     × several unknown keys all reach the shared doc 1ms

AssertionError: expected undefined to be 42 // Object.is equality
AssertionError: expected undefined to be 1 // Object.is equality

      Tests  2 failed | 1 passed (3)
```

### After

```
$ npx vitest run packages/lexical-yjs

 Test Files  6 passed (6)
      Tests  81 passed (81)

$ npx vitest run packages/lexical-react

 Test Files  31 passed (31)
      Tests  182 passed (182)
```
