### PR TITLE
[lexical-playground] Bug Fix: a keyword keeps the text format it was typed with

### DIFF
--- a/packages/lexical-playground/__tests__/unit/KeywordNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/KeywordNode.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type EditorThemeClasses,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
+
+import {$createKeywordNode, KeywordNode} from '../../src/nodes/KeywordNode';
+
+const theme: EditorThemeClasses = {
+  text: {
+    bold: 'theme-bold',
+    underline: 'theme-underline',
+  },
+};
+
+describe('KeywordNode', () => {
+  initializeUnitTest(
+    testEnv => {
+      function $appendKeyword(format: 'bold' | 'underline'): void {
+        $getRoot()
+          .clear()
+          .append(
+            $createParagraphNode().append(
+              $createTextNode('hey '),
+              $createKeywordNode('congrats').setFormat(format),
+            ),
+          );
+      }
+
+      function getKeywordDOM(): HTMLElement {
+        const dom = testEnv.container.querySelector('.keyword');
+        expect(dom).not.toBe(null);
+        return dom as HTMLElement;
+      }
+
+      it('keeps the theme class of the text format it was created with', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => $appendKeyword('underline'), {
+          discrete: true,
+        });
+
+        const dom = getKeywordDOM();
+        expect(Array.from(dom.classList).sort()).toEqual([
+          'keyword',
+          'theme-underline',
+        ]);
+      });
+
+      it('keeps the theme class across a re-render of the keyword', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => $appendKeyword('bold'), {discrete: true});
+        // Re-create the node so that createDOM() runs again, which is what a
+        // paste, an undo/redo across the node, or a reload does.
+        await editor.update(() => $appendKeyword('bold'), {discrete: true});
+
+        const dom = getKeywordDOM();
+        expect(Array.from(dom.classList).sort()).toEqual([
+          'keyword',
+          'theme-bold',
+        ]);
+      });
+    },
+    {namespace: 'test', nodes: [KeywordNode], theme},
+  );
+});

--- a/packages/lexical-playground/src/nodes/KeywordNode.ts
+++ b/packages/lexical-playground/src/nodes/KeywordNode.ts
@@ -9,6 +9,7 @@
 import {registerLexicalTextEntity} from '@lexical/text';
 import {
   $applyNodeReplacement,
+  addClassNamesToElement,
   defineExtension,
   type EditorConfig,
   type LexicalNode,
@@ -27,7 +28,11 @@ export class KeywordNode extends TextNode {
   createDOM(config: EditorConfig): HTMLElement {
     const dom = super.createDOM(config);
     dom.style.cursor = 'default';
-    dom.className = 'keyword';
+    // Add to the class names TextNode.createDOM already applied for the text
+    // formats rather than replacing them: registerLexicalTextEntity carries
+    // the format of the node it replaces over to the KeywordNode, so a
+    // keyword typed under an active format has one to render.
+    addClassNamesToElement(dom, 'keyword');
     return dom;
   }
 


### PR DESCRIPTION

## Description

`KeywordNode.createDOM` replaces the class name that `TextNode.createDOM` just set instead of adding to it:

```ts
createDOM(config: EditorConfig): HTMLElement {
  const dom = super.createDOM(config);
  dom.style.cursor = 'default';
  dom.className = 'keyword';   // <- discards everything super applied
  return dom;
}
```

`TextNode.createDOM` renders the node's text formats through `$createTextInnerDOM`, which applies `config.theme.text.*` to the element. Every format the playground theme implements as a class — underline, strikethrough, highlight, subscript, superscript, code, uppercase/lowercase/capitalize — is written onto that element and then thrown away by the assignment.

The formats really are there to render: `registerLexicalTextEntity`, which is what promotes a `TextNode` into a `KeywordNode`, explicitly carries the format over.

```ts
replacementNode.setFormat(nodeToReplace.getFormat());
```

So turning on underline and typing `congrats` gives a node whose state, toolbar and `exportDOM` all say underlined, rendered without an underline. It is not permanently broken, which is what makes it confusing: `TextNode.updateDOM` re-runs `setTextThemeClassNames` on a *format change*, so toggling the format off and back on paints it correctly, and it stays correct until something re-runs `createDOM` — pasting the keyword elsewhere, an undo/redo across it, reloading a saved document, or receiving it over collab — at which point the styling disappears again. The same document renders differently depending on how it was arrived at.

Fixed by using `addClassNamesToElement`, which is what the sibling `SpecialTextNode` in the same directory already does for the same reason. The outer `.keyword` class is unchanged, so the CSS still matches; formats are simply no longer dropped.

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/KeywordNode.test.ts` renders a formatted keyword with a theme and reads the class list off the rendered element.

### Before

```
 ❯ packages/lexical-playground/__tests__/unit/KeywordNode.test.ts (2 tests | 2 failed)
   × keeps the theme class of the text format it was created with
     AssertionError: expected [ 'keyword' ] to deeply equal [ 'keyword', 'theme-underline' ]

     - Expected
     + Received

       Array [
         "keyword",
     -   "theme-underline",
       ]

   × keeps the theme class across a re-render of the keyword
     AssertionError: expected [ 'keyword' ] to deeply equal [ 'keyword', 'theme-bold' ]

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-playground
 Test Files  18 passed (18)
      Tests  273 passed (273)
```
