### PR TITLE
[lexical-playground] Bug Fix: an emoji renders the text format applied to it

### DIFF
--- a/packages/lexical-playground/__tests__/unit/EmojiNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/EmojiNode.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isTextNode,
+  type EditorThemeClasses,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, it} from 'vitest';
+
+import {$createEmojiNode, EmojiNode} from '../../src/nodes/EmojiNode';
+
+const theme: EditorThemeClasses = {
+  text: {
+    bold: 'theme-bold',
+    underline: 'theme-underline',
+  },
+};
+
+describe('EmojiNode', () => {
+  initializeUnitTest(
+    testEnv => {
+      function $appendEmoji(): EmojiNode {
+        const emoji = $createEmojiNode('emoji happysmile', '🙂');
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('hi '), emoji));
+        return emoji;
+      }
+
+      function $getEmoji(): EmojiNode {
+        const emoji = $getRoot().getLastDescendant();
+        assert($isTextNode(emoji) && emoji instanceof EmojiNode, 'EmojiNode');
+        return emoji;
+      }
+
+      function getEmojiDOM(): HTMLElement {
+        const dom = testEnv.container.querySelector('.emoji');
+        expect(dom).not.toBe(null);
+        return dom as HTMLElement;
+      }
+
+      it('renders a tag-changing format applied after the emoji exists', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => void $appendEmoji(), {discrete: true});
+        expect(getEmojiDOM().querySelector('strong')).toBe(null);
+
+        // Formatting a selection that covers the emoji formats the whole
+        // token node, so the emoji really does become bold in the state.
+        await editor.update(() => void $getEmoji().setFormat('bold'), {
+          discrete: true,
+        });
+
+        expect(editor.read(() => $getEmoji().hasFormat('bold'))).toBe(true);
+        expect(getEmojiDOM().querySelector('strong')).not.toBe(null);
+      });
+
+      it('keeps the theme class of a class-only format on the inner element', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => void $appendEmoji().setFormat('underline'), {
+          discrete: true,
+        });
+
+        const inner = getEmojiDOM().firstElementChild as HTMLElement;
+        expect(Array.from(inner.classList).sort()).toEqual([
+          'emoji-inner',
+          'theme-underline',
+        ]);
+      });
+    },
+    {namespace: 'test', nodes: [EmojiNode], theme},
+  );
+});

--- a/packages/lexical-playground/src/nodes/EmojiNode.tsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.tsx
@@ -9,6 +9,7 @@
 import {
   $applyNodeReplacement,
   $getDocument,
+  addClassNamesToElement,
   type EditorConfig,
   type LexicalNode,
   type NodeKey,
@@ -44,7 +45,9 @@ export class EmojiNode extends TextNode {
     const dom = $getDocument().createElement('span');
     const inner = super.createDOM(config);
     dom.className = this.__className;
-    inner.className = 'emoji-inner';
+    // Add to the class names TextNode.createDOM applied for the text formats
+    // rather than replacing them, otherwise a formatted emoji renders unstyled.
+    addClassNamesToElement(inner, 'emoji-inner');
     dom.appendChild(inner);
     return dom;
   }
@@ -54,8 +57,11 @@ export class EmojiNode extends TextNode {
     if (inner === null) {
       return true;
     }
-    super.updateDOM(prevNode, inner as HTMLElement, config);
-    return false;
+    // TextNode.updateDOM returns true when the format change needs a different
+    // tag, in which case it has not touched the DOM at all and the element has
+    // to be recreated. Returning false regardless would promise the reconciler
+    // that the difference was already applied.
+    return super.updateDOM(prevNode, inner as HTMLElement, config);
   }
 
   static importJSON(serializedNode: SerializedEmojiNode): EmojiNode {


### PR DESCRIPTION

## Description

`EmojiNode` renders a wrapper span around the element `TextNode.createDOM` builds, and drops the format work that element carries in two places.

**`updateDOM` discards `super`'s return value.**

```ts
updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
  const inner = dom.firstChild;
  if (inner === null) {
    return true;
  }
  super.updateDOM(prevNode, inner as HTMLElement, config);
  return false;   // <- super may have returned true
}
```

`TextNode.updateDOM` returns `true` when the new format needs a different tag, and it does so *before touching the DOM*:

```ts
if (prevTag !== nextTag) {
  return true;
}
```

`true` means "I could not apply this, recreate the element". `EmojiNode` throws that away and returns `false`, which promises the reconciler that every difference is already in the DOM — so nothing is recreated. Selecting a range that contains an emoji and pressing Ctrl+B formats the emoji (`$updateTextFormat` formats token nodes wholesale, and an `EmojiNode` is a token), the surrounding text goes bold, and the emoji does not. The editor state and `exportJSON`/`exportDOM` all say bold: what you see is not what you copy. Same for italic, code, highlight, subscript and superscript — every format that changes the tag. Underline and strikethrough happen to work, because they are applied as classes on the same tag.

The `if (inner === null) return true` line above shows the intent was already understood here; the `super` result is simply dropped.

**`createDOM` replaces the inner element's class name.**

```ts
const inner = super.createDOM(config);
inner.className = 'emoji-inner';   // <- discards theme.text classes
```

`TextNode.createDOM` applies `config.theme.text.*` to that element for the class-based formats. Assigning `className` throws them away, so an underlined or highlighted emoji comes back unstyled every time `createDOM` runs again — pasting it elsewhere, undo/redo across it, reloading a saved document, or receiving it over collab.

Both are fixed without changing the emoji's own markup: `updateDOM` now returns what `TextNode.updateDOM` returned, and `createDOM` uses `addClassNamesToElement` (as the sibling `SpecialTextNode` already does) so `.emoji-inner` is added to the theme classes rather than replacing them. The CSS selectors `.emoji` and `.emoji-inner` still match.

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/EmojiNode.test.ts`, one case per defect.

### Before

```
 ❯ packages/lexical-playground/__tests__/unit/EmojiNode.test.ts (2 tests | 2 failed)
   × renders a tag-changing format applied after the emoji exists
     AssertionError: expected null not to be null // Object.is equality
   × keeps the theme class of a class-only format on the inner element
     AssertionError: expected [ 'emoji-inner' ] to deeply equal [ 'emoji-inner', 'theme-underline' ]

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-playground
 Test Files  18 passed (18)
      Tests  273 passed (273)
```
