### PR TITLE
[lexical-html] Bug Fix: apply the slot frame redirect to a NodeSelection when exporting HTML

### DIFF
--- a/packages/lexical-html/src/__tests__/unit/SlotNodeSelectionExport.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/SlotNodeSelectionExport.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$generateHtmlFromNodes} from '@lexical/html';
+import {
+  $create,
+  $createNodeSelection,
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getNodeByKey,
+  $getRoot,
+  $getSelection,
+  $setSelection,
+  $setSlot,
+  defineExtension,
+  ElementNode,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+// A plain shadow-root ElementNode used as a slot value, mirroring the shape a
+// slot host holds in production (shadow-root container with block content).
+class PlainShadowRootNode extends ElementNode {
+  $config() {
+    return this.config('plain_shadow_root_html', {extends: ElementNode});
+  }
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+  updateDOM(): boolean {
+    return false;
+  }
+  isShadowRoot(): boolean {
+    return true;
+  }
+}
+
+function $createPlainShadowRootNode(): PlainShadowRootNode {
+  return $create(PlainShadowRootNode);
+}
+
+const TARGET_TEXT = 'SlotNodeTarget';
+
+function buildEditorWithSlottedParagraph() {
+  const editor = buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: null,
+      name: '[slot-node-selection-html]',
+      nodes: [PlainShadowRootNode],
+    }),
+  );
+  const keys = {paragraph: '', text: ''};
+  editor.update(
+    () => {
+      const host = $createParagraphNode();
+      const slot = $createPlainShadowRootNode();
+      const text = $createTextNode(TARGET_TEXT);
+      const innerParagraph = $createParagraphNode().append(text);
+      slot.append(innerParagraph);
+      $setSlot(host, 'media', slot);
+      $getRoot().append(host);
+      keys.paragraph = innerParagraph.getKey();
+      keys.text = text.getKey();
+    },
+    {discrete: true},
+  );
+  return {editor, keys};
+}
+
+describe('$generateHtmlFromNodes slot frame redirect', () => {
+  test('a NodeSelection inside a slot exports the node, not empty HTML', () => {
+    const {editor, keys} = buildEditorWithSlottedParagraph();
+    using disposableEditor = editor;
+
+    disposableEditor.update(
+      () => {
+        const innerParagraph = $getNodeByKey(keys.paragraph);
+        assert(innerParagraph !== null);
+        const nodeSelection = $createNodeSelection();
+        nodeSelection.add(innerParagraph.getKey());
+        $setSelection(nodeSelection);
+      },
+      {discrete: true},
+    );
+
+    disposableEditor.read(() => {
+      expect(
+        $generateHtmlFromNodes(disposableEditor, $getSelection()),
+      ).toContain(TARGET_TEXT);
+    });
+  });
+
+  test('a RangeSelection inside a slot still exports the node', () => {
+    const {editor, keys} = buildEditorWithSlottedParagraph();
+    using disposableEditor = editor;
+
+    disposableEditor.update(
+      () => {
+        const rangeSelection = $createRangeSelection();
+        rangeSelection.anchor.set(keys.text, 0, 'text');
+        rangeSelection.focus.set(keys.text, TARGET_TEXT.length, 'text');
+        $setSelection(rangeSelection);
+      },
+      {discrete: true},
+    );
+
+    disposableEditor.read(() => {
+      expect(
+        $generateHtmlFromNodes(disposableEditor, $getSelection()),
+      ).toContain(TARGET_TEXT);
+    });
+  });
+});

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -192,13 +192,23 @@ export function $generateDOMFromNodes<T extends HTMLElement | DocumentFragment>(
     const root = $getRoot();
     const domConfig = $getSessionDOMRenderConfig(editor);
 
-    // A RangeSelection wholly inside a slot subtree never includes its host
+    // A selection wholly inside a slot subtree never includes its host
     // (slots are shadow-root isolated), so a root-children walk would miss
     // the selected nodes entirely and export an empty payload. Walk the
     // selection's slot frame instead; outside slots this is the root.
-    const slotFrame = $isRangeSelection(selection)
-      ? $getSlotFrame(selection.anchor.getNode())
-      : null;
+    //
+    // NodeSelection participates here too — a click that selects a decorator
+    // nested in a slot needs the same frame redirect, otherwise this export
+    // silently produces empty HTML while the JSON channel is correct. This
+    // mirrors $generateJSONFromSelectedNodes in @lexical/clipboard, which
+    // anchors on the first selected node for the same reason.
+    const slotFrameAnchor = $isRangeSelection(selection)
+      ? selection.anchor.getNode()
+      : $isNodeSelection(selection)
+        ? (selection.getNodes()[0] ?? null)
+        : null;
+    const slotFrame =
+      slotFrameAnchor !== null ? $getSlotFrame(slotFrameAnchor) : null;
     const parentElementAppend = container.append.bind(container);
     for (const topLevelNode of ($isElementNode(slotFrame)
       ? slotFrame


### PR DESCRIPTION
## Description

Slots are shadow-root isolated, so a selection wholly inside a slot subtree
never includes its host. A walk over the root's children therefore misses the
selected nodes and exports nothing. `$generateDOMFromNodes` handles that by
redirecting the walk through the selection's slot frame — but only for a
`RangeSelection`:

```js
const slotFrame = $isRangeSelection(selection)
  ? $getSlotFrame(selection.anchor.getNode())
  : null;
```

Its sibling `$generateJSONFromSelectedNodes` in `@lexical/clipboard` handles
both selection types, and says why in a comment that applies verbatim here:

> NodeSelection participates here too — a click that selects a decorator
> nested in a slot needs the same frame redirect, otherwise its export
> pipeline silently produces an empty clipboard.

The fix for #8712 (`2f2bc97c1`) only updated `@lexical/clipboard`;
`$generateDOMFromNodes` was never brought along. `$isNodeSelection` is already
imported in this file, so the omission is not a missing import.

The result is a split between the two clipboard channels: selecting a node
nested in a slot and copying puts a correct `application/x-lexical-editor`
payload on the clipboard and an **empty** `text/html` one, so pasting into any
other application yields nothing. The existing regression test for #8712
(`SlotClipboardExport.test.ts`) only asserts the JSON channel, which is why the
gap was not caught — the RangeSelection test beside it deliberately asserts
"on both channels".

This mirrors the clipboard implementation exactly, including anchoring on the
first selected node for a `NodeSelection`.

## Test plan

New unit test `packages/lexical-html/src/__tests__/unit/SlotNodeSelectionExport.test.ts`.
The RangeSelection case is included as a control: it passes before and after,
which is what pins the asymmetry to the selection type.

### Before

```
$ npx vitest run packages/lexical-html/src/__tests__/unit/SlotNodeSelectionExport.test.ts

     × a NodeSelection inside a slot exports the node, not empty HTML 10ms

AssertionError: expected '' to contain 'SlotNodeTarget'

      Tests  1 failed | 1 passed (2)
```

### After

```
$ npx vitest run packages/lexical-html/src/__tests__/unit/SlotNodeSelectionExport.test.ts

 Test Files  1 passed (1)
      Tests  2 passed (2)

$ npx vitest run packages/lexical-html packages/lexical-clipboard

 Test Files  14 passed (14)
      Tests  114 passed (114)
```
