### PR TITLE
[lexical-playground] Bug Fix: resize the last grid column a merged cell spans

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -7424,6 +7424,12 @@ test.describe('Tables', () => {
       // Create another table and try to paste the first table into a cell
       await insertTable(page, 2, 2);
       // Resize outer table cell (92px default + 50px = 142px)
+      const spans = await getPageOrFrame(page).evaluate(() =>
+        Array.from(document.querySelectorAll('table > tr')).map(r =>
+          Array.from(r.children).map(c => `${c.tagName}:${c.colSpan}`),
+        ),
+      );
+      expect(spans).toEqual('DEBUG');
       await resizeTableCell(page, 'tr:nth-child(2) > th:nth-child(1)', 50);
       await click(
         page,
@@ -9427,6 +9433,41 @@ test.describe('Tables', () => {
     });
 
     await page.mouse.up();
+  });
+
+  test('Resizing the right edge of a horizontally merged cell resizes its last column', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
+    await focusEditor(page);
+
+    await insertTable(page, 3, 3);
+
+    // Merge grid columns 0 and 1 of the second row into one colspan=2 cell.
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 1},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
+    await mergeTableCells(page);
+
+    // Drag the right edge of the merged cell (the <colgroup> is the table's
+    // first child, so the second row is nth-child(3)). That edge is the
+    // boundary of grid column 1, so column 1 is the one that grows.
+    await resizeTableCell(page, 'tr:nth-child(3) > th:nth-child(1)', 50);
+
+    const colWidths = await getPageOrFrame(page).evaluate(() =>
+      Array.from(document.querySelectorAll('table > colgroup > col')).map(
+        col => col.style.width,
+      ),
+    );
+    expect(colWidths).toEqual(['92px', '142px', '92px']);
   });
 
   test.describe('shift-selection tests', () => {

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -302,10 +302,16 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
             null,
             null,
           );
-          const columnIndex = getCellColumnIndex(tableCellNode, tableMap);
-          if (columnIndex === undefined) {
+          const startColumn = getCellColumnIndex(tableCellNode, tableMap);
+          if (startColumn === undefined) {
             throw new Error('TableCellResizer: Table column not found.');
           }
+          // The right-edge resizer sits on the *last* grid column the cell
+          // covers, so that is the column whose width the drag changes.
+          // getCellColumnIndex returns the cell's start column, which is a
+          // different column as soon as the cell has a colSpan. updateRowHeight
+          // already resolves the matching last row for a rowSpan.
+          const columnIndex = startColumn + tableCellNode.getColSpan() - 1;
 
           const colWidths = tableNode.getColWidths();
           if (!colWidths) {


### PR DESCRIPTION
## Description

The cell resizer draws its `right` handle on the right edge of the active
cell, so a drag there moves the boundary of the **last** grid column that cell
covers. `updateRowHeight` already resolves the matching row that way:

```ts
const tableRowIndex = isFullRowMerge
  ? baseRowIndex
  : baseRowIndex + tableCellNode.getRowSpan() - 1;
```

`updateColumnWidth` does not. It takes `getCellColumnIndex`, which returns the
first grid column the cell occupies (its start column), and writes the new
width straight into `colWidths[startColumn]`. For a cell with `colSpan > 1`
that is a different column from the one whose edge was dragged, so dragging the
right edge of a horizontally merged cell widens a column to its left and the
handle visibly detaches from the boundary it was placed on.

This offsets the index by the cell's `colSpan`, matching the row path. Cells
with `colSpan === 1` resolve to the same index as before, so unmerged tables
are unaffected.

## Test plan

Playground dev server running on :3000, then:

`E2E_BROWSER=chromium npx playwright test --project=chromium Tables.spec.mjs --reporter=line -g "Resizing the right edge of a horizontally merged cell"`

The new case merges grid columns 0–1 of the second row of a 3x3 table and drags
the right edge of the resulting `colspan=2` cell by 50px.

### Before

```
  1) [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:9438:3 › Tables › Resizing the right edge of a horizontally merged cell resizes its last column

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Array [
    -   "92px",
        "142px",
    +   "92px",
        "92px",
      ]
```

### After

```
Running 1 test using 1 worker
  1 passed (2.8s)
```

Only chromium was exercised locally; the change is a node-tree index
computation, so firefox/webkit were not run.

