### PR TITLE
[lexical-react] Bug Fix: the draggable block handle follows setEditable

### DIFF
--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -7,6 +7,7 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {eventFiles} from '@lexical/rich-text';
 import {calculateZoomLevel} from '@lexical/utils';
 import {
@@ -621,12 +622,16 @@ export function DraggableBlockPlugin_EXPERIMENTAL({
   onElementChanged?: (element: HTMLElement | null) => void;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
+  // Subscribed rather than read off the editor, so that setEditable() actually
+  // re-renders the handle. useLexicalEditable also handles StrictMode and
+  // concurrent rendering correctly.
+  const isEditable = useLexicalEditable();
   return useDraggableBlockMenu(
     editor,
     anchorElem,
     menuRef,
     targetLineRef,
-    editor._editable,
+    isEditable,
     menuComponent,
     targetLineComponent,
     isOnMenu,

--- a/packages/lexical-react/src/__tests__/unit/LexicalDraggableBlockPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalDraggableBlockPlugin.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {DraggableBlockPlugin_EXPERIMENTAL} from '@lexical/react/LexicalDraggableBlockPlugin';
+import {EditorRefPlugin} from '@lexical/react/LexicalEditorRefPlugin';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {type LexicalEditor} from 'lexical';
+import * as React from 'react';
+import {act, createRef} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+const MENU_CLASS = 'draggable-block-menu';
+
+describe('DraggableBlockPlugin_EXPERIMENTAL', () => {
+  let container: HTMLDivElement;
+  let anchorElem: HTMLDivElement;
+  let reactRoot: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    anchorElem = document.createElement('div');
+    container.appendChild(anchorElem);
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      reactRoot.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
+  function Test({editorRef}: {editorRef: React.RefObject<LexicalEditor>}) {
+    const menuRef = React.useRef<HTMLDivElement | null>(null);
+    const targetLineRef = React.useRef<HTMLDivElement | null>(null);
+    return (
+      <LexicalComposer
+        initialConfig={{
+          namespace: 'draggable-block',
+          onError: (error: Error) => {
+            throw error;
+          },
+        }}>
+        <EditorRefPlugin editorRef={editorRef} />
+        <RichTextPlugin
+          contentEditable={<ContentEditable />}
+          ErrorBoundary={({children}) => <>{children}</>}
+        />
+        <DraggableBlockPlugin_EXPERIMENTAL
+          anchorElem={anchorElem}
+          menuRef={menuRef}
+          targetLineRef={targetLineRef}
+          menuComponent={<div ref={menuRef} className={MENU_CLASS} />}
+          targetLineComponent={<div ref={targetLineRef} />}
+          isOnMenu={element => element.closest(`.${MENU_CLASS}`) !== null}
+        />
+      </LexicalComposer>
+    );
+  }
+
+  function hasDragHandle(): boolean {
+    return anchorElem.querySelector(`.${MENU_CLASS}`) !== null;
+  }
+
+  it('follows setEditable', async () => {
+    const editorRef =
+      createRef<LexicalEditor>() as React.RefObject<LexicalEditor>;
+    await act(async () => {
+      reactRoot.render(<Test editorRef={editorRef} />);
+    });
+
+    expect(hasDragHandle()).toBe(true);
+
+    await act(async () => {
+      editorRef.current.setEditable(false);
+    });
+    expect(hasDragHandle()).toBe(false);
+
+    await act(async () => {
+      editorRef.current.setEditable(true);
+    });
+    expect(hasDragHandle()).toBe(true);
+  });
+
+  it('renders no drag handle for an editor that mounts read-only', async () => {
+    const editorRef =
+      createRef<LexicalEditor>() as React.RefObject<LexicalEditor>;
+
+    function ReadOnlyTest() {
+      const menuRef = React.useRef<HTMLDivElement | null>(null);
+      const targetLineRef = React.useRef<HTMLDivElement | null>(null);
+      return (
+        <LexicalComposer
+          initialConfig={{
+            editable: false,
+            namespace: 'draggable-block',
+            onError: (error: Error) => {
+              throw error;
+            },
+          }}>
+          <EditorRefPlugin editorRef={editorRef} />
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            ErrorBoundary={({children}) => <>{children}</>}
+          />
+          <DraggableBlockPlugin_EXPERIMENTAL
+            anchorElem={anchorElem}
+            menuRef={menuRef}
+            targetLineRef={targetLineRef}
+            menuComponent={<div ref={menuRef} className={MENU_CLASS} />}
+            targetLineComponent={<div ref={targetLineRef} />}
+            isOnMenu={element => element.closest(`.${MENU_CLASS}`) !== null}
+          />
+        </LexicalComposer>
+      );
+    }
+
+    await act(async () => {
+      reactRoot.render(<ReadOnlyTest />);
+    });
+    expect(hasDragHandle()).toBe(false);
+
+    await act(async () => {
+      editorRef.current.setEditable(true);
+    });
+    expect(hasDragHandle()).toBe(true);
+  });
+});


### PR DESCRIPTION

## Description

`DraggableBlockPlugin_EXPERIMENTAL` takes the editability it renders on straight off the editor's private field, during render, with no subscription:

```tsx
const [editor] = useLexicalComposerContext();
return useDraggableBlockMenu(
  editor,
  anchorElem,
  menuRef,
  targetLineRef,
  editor._editable,   // <- plain field read
  ...
```

`editor.setEditable(...)` notifies editable listeners; it does not schedule a React render for a component that merely read the field. So the value the plugin renders on is whatever it happened to be at the last render:

- Switching an editor to read-only leaves the drag handle rendered — `{isEditable && menuComponent}` is still true — and fully functional. Dragging still runs `$onDrop`, which calls `targetNode.insertAfter(...)` / `insertBefore(...)`, so a read-only document can be reordered by dragging.
- The reverse also breaks: an editor mounted with `editable: false` and later made editable never grows a handle.
- The Firefox blur guard inside the hook is gated on the same stale value, so it registers against the wrong state.

It is intermittent, which is the usual signature: any unrelated re-render of the plugin's parent silently corrects it until the next toggle.

`@lexical/react` already ships the hook for this, and its doc comment is explicit:

> Get the current value for `LexicalEditor.isEditable` using `useLexicalSubscription`. You should prefer this over manually observing the value with `LexicalEditor.registerEditableListener`, which is a bit tricky to do correctly, particularly when using React StrictMode (the default for development) or concurrency.

Every other editability consumer in the package uses it — `LexicalRichTextPlugin`, `ContentEditableElement`, `LexicalContentEditable` — and `editor._editable` is the only `_editable` reference in `packages/lexical-react/src`. This swaps it for `useLexicalEditable()`. The hook's signature is unchanged (it already takes `isEditable` as a parameter), so this is internal to the exported component; no API or serialization change.

This is reachable in the shipped playground, which renders `DraggableBlockPlugin` unconditionally and has a read-only toggle calling `editor.setEditable(!editor.isEditable())`.

## Test plan

New unit test `packages/lexical-react/src/__tests__/unit/LexicalDraggableBlockPlugin.test.tsx` renders the plugin and toggles editability in both directions.

### Before

```
 ❯ packages/lexical-react/src/__tests__/unit/LexicalDraggableBlockPlugin.test.tsx (2 tests | 2 failed)
   × follows setEditable
     AssertionError: expected true to be false // Object.is equality
   × renders no drag handle for an editor that mounts read-only
     AssertionError: expected false to be true // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-react
 Test Files  32 passed (32)
      Tests  184 passed (184)
```
