### PR TITLE
[lexical-yjs] Bug Fix: refresh a remote cursor when its peer changes name or colour

### DIFF
--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -912,6 +912,17 @@ export function syncCursorPositions(
       if (cursor === undefined) {
         cursor = createCursor(name, color);
         cursors.set(clientID, cursor);
+      } else if (cursor.name !== name || cursor.color !== color) {
+        // Awareness is mutable: a peer can rename itself or change colour at
+        // any time (the React plugin republishes local state whenever its
+        // `username` / `cursorColor` props change). The name and colour are
+        // baked into the caret DOM and the ::highlight() rule when the
+        // selection is built, so drop the stale selection here and let the
+        // code below rebuild it from the new values.
+        destroyCursor(binding, cursor);
+        cursor.name = name;
+        cursor.color = color;
+        cursor.selection = null;
       }
 
       if (focusing) {

--- a/packages/lexical-yjs/src/__tests__/unit/SyncCursorsAwarenessRefresh.test.ts
+++ b/packages/lexical-yjs/src/__tests__/unit/SyncCursorsAwarenessRefresh.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  buildEditorFromExtensions,
+  type LexicalEditorWithDispose,
+} from '@lexical/extension';
+import {
+  createBinding,
+  type Provider,
+  syncCursorPositions,
+  type UserState,
+} from '@lexical/yjs';
+import {defineExtension} from 'lexical';
+import {afterEach, assert, describe, expect, test} from 'vitest';
+import {Doc} from 'yjs';
+
+const REMOTE_CLIENT_ID = 4242;
+
+function userState(name: string, color: string): UserState {
+  return {
+    anchorPos: null,
+    awarenessData: {},
+    color,
+    focusPos: null,
+    focusing: false,
+    name,
+  };
+}
+
+describe('syncCursorPositions awareness refresh', () => {
+  const editors: LexicalEditorWithDispose[] = [];
+  afterEach(() => {
+    for (const editor of editors) {
+      editor.dispose();
+    }
+    editors.length = 0;
+  });
+
+  function buildBinding() {
+    const editor = buildEditorFromExtensions(
+      defineExtension({
+        $initialEditorState: null,
+        name: '[cursor-awareness]',
+      }),
+    );
+    editors.push(editor);
+    const doc = new Doc();
+    const docMap = new Map<string, Doc>([['cursor-awareness', doc]]);
+    const binding = createBinding(
+      editor,
+      null as unknown as Provider,
+      'cursor-awareness',
+      doc,
+      docMap,
+    );
+    return {binding, editor};
+  }
+
+  function sync(
+    binding: ReturnType<typeof createBinding>,
+    state: UserState,
+  ): void {
+    syncCursorPositions(binding, null as unknown as Provider, {
+      getAwarenessStates: () =>
+        new Map<number, UserState>([[REMOTE_CLIENT_ID, state]]),
+    });
+  }
+
+  test('a peer that renames itself updates its cursor name', () => {
+    const {binding} = buildBinding();
+
+    sync(binding, userState('Bob', '#ff0000'));
+    const cursor = binding.cursors.get(REMOTE_CLIENT_ID);
+    assert(cursor !== undefined);
+    expect(cursor.name).toBe('Bob');
+
+    sync(binding, userState('Robert', '#ff0000'));
+    expect(binding.cursors.get(REMOTE_CLIENT_ID)?.name).toBe('Robert');
+  });
+
+  test('a peer that changes colour updates its cursor colour', () => {
+    const {binding} = buildBinding();
+
+    sync(binding, userState('Bob', '#ff0000'));
+    expect(binding.cursors.get(REMOTE_CLIENT_ID)?.color).toBe('#ff0000');
+
+    sync(binding, userState('Bob', '#0000ff'));
+    expect(binding.cursors.get(REMOTE_CLIENT_ID)?.color).toBe('#0000ff');
+  });
+
+  test('an unchanged peer keeps the same cursor object', () => {
+    const {binding} = buildBinding();
+
+    sync(binding, userState('Bob', '#ff0000'));
+    const first = binding.cursors.get(REMOTE_CLIENT_ID);
+    sync(binding, userState('Bob', '#ff0000'));
+    expect(binding.cursors.get(REMOTE_CLIENT_ID)).toBe(first);
+  });
+});


### PR DESCRIPTION
## Description

`syncCursorPositions` is the awareness-change handler: it runs on every
awareness update and reconciles `binding.cursors` against the current states.
It reads three fields from each peer's state, but only ever applies `name` and
`color` on the pass that first creates the cursor:

```js
const {name, color, focusing} = awareness;
...
let cursor = cursors.get(clientID);

if (cursor === undefined) {
  cursor = createCursor(name, color);
  cursors.set(clientID, cursor);
}
```

Every later pass updates only `anchor` / `focus`. `cursor.name` and
`cursor.color` are baked into the DOM once, when `createCursorSelection` builds
the caret (`name.textContent = cursor.name`, the caret and label background
from `cursor.color`) and registers the `::highlight()` rule via
`addCursorHighlightRule`. So a peer that renames itself or changes colour keeps
its old label and colour on every other client until it disconnects, which is
the only thing that removes the cursor.

This is reachable through the supported API rather than a hypothetical:
`LexicalCollaborationPlugin` takes `username` and `cursorColor` props, and
`useYjsCollaboration`'s effect lists `name` and `color` in its dependencies and
re-publishes local awareness through `initLocalState` when they change (
`useYjsFocusTracking` does the same via `setLocalStateFocus`). The local peer
therefore does broadcast the change; remote peers just ignore it. A common
case is a session that starts anonymous and picks up a real display name after
sign-in.

When the name or colour actually changes, this destroys the stale selection
(which releases its caret DOM and its `::highlight()` rule) and clears
`cursor.selection`, so the existing code below rebuilds it from the new values
on the same pass. A peer whose name and colour are unchanged keeps its cursor
object untouched, so there is no rebuild churn on ordinary cursor movement.

## Test plan

New unit test `packages/lexical-yjs/src/__tests__/unit/SyncCursorsAwarenessRefresh.test.ts`,
driving `syncCursorPositions` through its `getAwarenessStates` option. The
third case asserts an unchanged peer keeps the *same* cursor object, pinning
that the rebuild only happens when the awareness fields really change.

### Before

```
$ npx vitest run packages/lexical-yjs/src/__tests__/unit/SyncCursorsAwarenessRefresh.test.ts

     × a peer that renames itself updates its cursor name 9ms
     × a peer that changes colour updates its cursor colour 1ms

AssertionError: expected 'Bob' to be 'Robert' // Object.is equality
AssertionError: expected '#ff0000' to be '#0000ff' // Object.is equality

      Tests  2 failed | 1 passed (3)
```

### After

```
$ npx vitest run packages/lexical-yjs

 Test Files  6 passed (6)
      Tests  81 passed (81)

$ npx vitest run packages/lexical-react

 Test Files  31 passed (31)
      Tests  182 passed (182)
```

The DOM rebuild itself is not exercised by the unit test — jsdom has no layout,
so `updateCursor` returns before touching the caret. It was not verified in a
real browser.
