### PR TITLE
[lexical-playground] Bug Fix: a special text chip re-renders when its text changes

### DIFF
--- a/packages/lexical-playground/__tests__/unit/SpecialTextNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/SpecialTextNode.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createParagraphNode, $getRoot, $isTextNode} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, it} from 'vitest';
+
+import {
+  $createSpecialTextNode,
+  SpecialTextNode,
+} from '../../src/nodes/SpecialTextNode';
+
+describe('SpecialTextNode', () => {
+  initializeUnitTest(
+    testEnv => {
+      function $appendSpecialText(text: string): void {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createSpecialTextNode(text)));
+      }
+
+      function $getSpecialText(): SpecialTextNode {
+        const node = $getRoot().getLastDescendant();
+        assert(
+          $isTextNode(node) && node instanceof SpecialTextNode,
+          'SpecialTextNode',
+        );
+        return node;
+      }
+
+      function getRenderedText(): string {
+        const dom = testEnv.container.querySelector('.PlaygroundSpecialText');
+        expect(dom).not.toBe(null);
+        return (dom as HTMLElement).textContent ?? '';
+      }
+
+      it('re-renders the text when it changes', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => $appendSpecialText('foo'), {discrete: true});
+        expect(getRenderedText()).toBe('foo');
+
+        await editor.update(
+          () => void $getSpecialText().setTextContent('bar'),
+          {
+            discrete: true,
+          },
+        );
+        expect(getRenderedText()).toBe('bar');
+      });
+
+      it('renders the text verbatim when it is bracketed', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => $appendSpecialText('[foo]'), {
+          discrete: true,
+        });
+        expect(getRenderedText()).toBe('[foo]');
+
+        await editor.update(
+          () => void $getSpecialText().setTextContent('[bar]'),
+          {discrete: true},
+        );
+        expect(getRenderedText()).toBe('[bar]');
+      });
+    },
+    {
+      namespace: 'test',
+      nodes: [SpecialTextNode],
+      theme: {specialText: 'PlaygroundSpecialText'},
+    },
+  );
+});

--- a/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
+++ b/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
@@ -29,9 +29,12 @@ export class SpecialTextNode extends TextNode {
   }
 
   updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
-    if (prevNode.__text.startsWith('[') && prevNode.__text.endsWith(']')) {
-      const strippedText = this.__text.substring(1, this.__text.length - 1); // Strip brackets again
-      dom.textContent = strippedText; // Update the text content
+    if (prevNode.__text !== this.__text) {
+      // Write the text the same way createDOM does. Returning false promises
+      // the reconciler that every difference is already in the DOM, so the
+      // text has to be re-synced here or the element keeps the text it was
+      // created with.
+      dom.textContent = this.getTextContent();
     }
 
     addClassNamesToElement(dom, config.theme.specialText);


### PR DESCRIPTION

## Description

`SpecialTextNode` builds its element from the node's text and returns `false` from `updateDOM`, but never re-syncs that text:

```ts
createDOM(config: EditorConfig): HTMLElement {
  const dom = $getDocument().createElement('span');
  addClassNamesToElement(dom, config.theme.specialText);
  dom.textContent = this.getTextContent();
  return dom;
}

updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
  if (prevNode.__text.startsWith('[') && prevNode.__text.endsWith(']')) {
    const strippedText = this.__text.substring(1, this.__text.length - 1); // Strip brackets again
    dom.textContent = strippedText; // Update the text content
  }
  addClassNamesToElement(dom, config.theme.specialText);
  return false;
}
```

`false` means "I have already applied every difference between `prevNode` and `this`", so the reconciler leaves the element alone. The only write to `dom.textContent` is behind a guard that cannot hold: the node is created by `SpecialTextExtension` from the *capture group*, not the whole match —

```ts
const BRACKETED_TEXT_REGEX = /\[([^[\]]+)\]/;
...
const specialTextNode = $createSpecialTextNode(matchedText);   // match[1], brackets already gone
```

— and the group excludes brackets, so `prevNode.__text` never starts with `[`. The branch is dead and the element keeps whatever text it was created with, forever.

`SpecialTextNode` does not override `canInsertTextBefore`, so typing at the start of a chip merges the character into the node. Type `[foo]` to get a `foo` chip, put the caret at its start and type `x` (the node's text becomes `xfoo`), then undo: the editor state goes back to `foo`, the chip still reads `xfoo`, and the undo looks like it did nothing. Any programmatic `setTextContent`, and any collab edit, desync the same way.

The guard is also wrong on its own terms. In the one case it *can* fire — the user typing brackets back around a chip, which the transform skips because a `SpecialTextNode` is not `isSimpleText()` — it writes `this.__text` minus its first and last character, while `createDOM` writes the whole string. The two methods disagree about who strips brackets, and `createDOM` is the one that matches how the node is actually constructed.

Fixed by dropping the dead guard and writing the text the same way `createDOM` does, only when it changed. `$setTextContent`, the helper `TextNode.updateDOM` uses, is module-private, and assigning `textContent` is exactly what this node's own `createDOM` already does. Still returns `false`; no API or serialization change.

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/SpecialTextNode.test.ts`. The second case pins the bracket contradiction: a chip whose text is `[bar]` must render `[bar]`, which is what `createDOM` produces.

### Before

```
 ❯ packages/lexical-playground/__tests__/unit/SpecialTextNode.test.ts (2 tests | 2 failed)
   × re-renders the text when it changes
     AssertionError: expected 'foo' to be 'bar' // Object.is equality
   × renders the text verbatim when it is bracketed
     AssertionError: expected 'bar' to be '[bar]' // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-playground
 Test Files  18 passed (18)
      Tests  273 passed (273)
```
