### PR TITLE
[lexical-table] Bug Fix: keep the pasted cell's verticalAlign when a table is inserted into a grid

### DIFF
--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -1591,6 +1591,10 @@ export function $insertTableIntoGrid(
       if (backgroundColor !== null && backgroundColor !== undefined) {
         cell.setBackgroundColor(backgroundColor);
       }
+      const verticalAlign = templateCell.getVerticalAlign();
+      if (verticalAlign !== undefined) {
+        cell.setVerticalAlign(verticalAlign);
+      }
       const originalChildren = cell.getChildren();
       templateCell.getChildren().forEach(child => {
         if ($isTextNode(child)) {

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -516,6 +516,52 @@ describe('TableExtension', () => {
         ]);
       });
     });
+
+    test('pasting a table carries the cell backgroundColor and verticalAlign', () => {
+      editor.update(
+        () => {
+          const root = $getRoot().clear();
+          const table = $createTableNode();
+          const row = $createTableRowNode();
+          const cell = $createTableCellNode();
+          cell.append($createParagraphNode().append($createTextNode('old')));
+          row.append(cell);
+          table.append(row);
+          root.append(table);
+          cell.selectStart();
+        },
+        {discrete: true},
+      );
+
+      editor.update(
+        () => {
+          const template = $createTableNode();
+          const row = $createTableRowNode();
+          const cell = $createTableCellNode()
+            .setBackgroundColor('rgb(255, 0, 0)')
+            .setVerticalAlign('middle');
+          cell.append($createParagraphNode().append($createTextNode('new')));
+          row.append(cell);
+          template.append(row);
+          const selection = $getSelection();
+          assert(selection !== null, 'Expected a selection');
+          $insertGeneratedNodes(editor, [template], selection);
+        },
+        {discrete: true},
+      );
+
+      editor.read('latest', () => {
+        const table = $getRoot().getFirstChild();
+        assert($isTableNode(table), 'Expected table node');
+        const row = table.getFirstChild();
+        assert($isTableRowNode(row), 'Expected row node');
+        const cell = row.getFirstChild();
+        assert($isTableCellNode(cell), 'Expected cell node');
+        expect(cell.getTextContent()).toBe('new');
+        expect(cell.getBackgroundColor()).toBe('rgb(255, 0, 0)');
+        expect(cell.getVerticalAlign()).toBe('middle');
+      });
+    });
   });
 
   describe('colWidths', () => {


### PR DESCRIPTION
## Description

`$insertTableIntoGrid` fills the destination table's cells from a template
table, and copies the template cell's presentation state onto the destination
cell:

```ts
const backgroundColor = templateCell.getBackgroundColor();
if (backgroundColor !== null && backgroundColor !== undefined) {
  cell.setBackgroundColor(backgroundColor);
}
```

`verticalAlign` is the other per-cell presentation property on
`TableCellNode` — it sits beside `backgroundColor` in
`SerializedTableCellNode`, in `afterCloneFrom`, in `updateDOM`, and in the
table action menu, which sets both through the same code path. It was added
after this copy loop (#7077) and the loop was never updated, so copying a
table with vertically aligned cells and pasting it over an existing table
keeps the background colours and silently drops the alignment.

This copies `verticalAlign` alongside `backgroundColor`. `setVerticalAlign`
already normalises anything falsy to `undefined`, and the guard keeps a
template cell with no alignment from clearing the destination's, matching the
`backgroundColor` line above it.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts`

The new case pastes a one-cell table whose cell has both a background colour
and `verticalAlign: middle` over an existing table, and asserts both survive —
the `backgroundColor` assertion passes on both sides of the change, which is
what pins the asymmetry.

### Before

```
 FAIL  |unit| packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts > TableExtension > $insertGeneratedNodes > pasting a table carries the cell backgroundColor and verticalAlign
AssertionError: expected undefined to be 'middle' // Object.is equality

- Expected:
"middle"

+ Received:
undefined

 Test Files  1 failed (1)
      Tests  1 failed | 23 passed (24)
```

### After

```
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

`npx vitest run packages/lexical-table` is green (11 files, 158 tests).

