### PR TITLE
[lexical-markdown] Bug Fix: an escaped backslash is not a hard line break

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -315,7 +315,15 @@ export function parseMarkdownHardLineBreak(
   line: string,
 ): [string, MarkdownHardLineBreak] | null {
   if (line.endsWith('\\')) {
-    return [line.slice(0, -1), '\\'];
+    // A trailing backslash is a hard line break only when it is not itself
+    // escaped. `foo\\` is an escaped backslash — a literal `\` followed by an
+    // ordinary (soft) line ending — so only an odd-length run counts.
+    // https://spec.commonmark.org/0.31.2/#backslash-escapes
+    let backslashes = 0;
+    for (let i = line.length - 1; i >= 0 && line[i] === '\\'; i--) {
+      backslashes++;
+    }
+    return backslashes % 2 === 1 ? [line.slice(0, -1), '\\'] : null;
   }
 
   const spaces = line.match(/^(.*?\S)( {2,})$/);

--- a/packages/lexical-markdown/src/__tests__/unit/EscapedBackslashHardLineBreak.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/EscapedBackslashHardLineBreak.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {CodeNode} from '@lexical/code-core';
+import {createHeadlessEditor} from '@lexical/headless';
+import {LinkNode} from '@lexical/link';
+import {ListItemNode, ListNode} from '@lexical/list';
+import {$convertFromMarkdownString, TRANSFORMERS} from '@lexical/markdown';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {$getRoot} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+import {
+  normalizeMarkdown,
+  parseMarkdownHardLineBreak,
+} from '../../MarkdownTransformers';
+
+// Single-quoted TS strings: '\\' is one literal backslash.
+const ONE = 'foo\\';
+const TWO = 'foo\\\\';
+const THREE = 'foo\\\\\\';
+
+function importText(markdown: string): string {
+  const editor = createHeadlessEditor({
+    nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, CodeNode, LinkNode],
+    onError: error => {
+      throw error;
+    },
+  });
+  let text = '';
+  editor.update(
+    () => {
+      $convertFromMarkdownString(
+        markdown,
+        TRANSFORMERS,
+        undefined,
+        false,
+        true,
+      );
+      text = $getRoot().getTextContent();
+    },
+    {discrete: true},
+  );
+  return text;
+}
+
+describe('escaped backslash at end of line', () => {
+  it('treats a lone trailing backslash as a hard line break', () => {
+    expect(parseMarkdownHardLineBreak(ONE)).toEqual(['foo', '\\']);
+  });
+
+  it('does not treat an escaped backslash as a hard line break', () => {
+    expect(parseMarkdownHardLineBreak(TWO)).toBe(null);
+  });
+
+  it('treats an odd run of backslashes as a hard line break', () => {
+    expect(parseMarkdownHardLineBreak(THREE)).toEqual(['foo\\\\', '\\']);
+  });
+
+  it('still recognises the two-space hard line break', () => {
+    expect(parseMarkdownHardLineBreak('foo  ')).toEqual(['foo', '  ']);
+  });
+
+  it('merges a line ending in an escaped backslash with the next line', () => {
+    expect(normalizeMarkdown(TWO + '\nbar', true)).toBe(TWO + ' bar');
+  });
+
+  it('keeps a real hard line break unmerged', () => {
+    expect(normalizeMarkdown(ONE + '\nbar', true)).toBe(ONE + '\nbar');
+  });
+
+  it('keeps the literal backslash in the imported text', () => {
+    // `foo\\` is an escaped backslash, so the paragraph text is `foo\ bar`.
+    expect(importText(TWO + '\nbar')).toBe('foo\\ bar');
+  });
+});


### PR DESCRIPTION
## Description

`parseMarkdownHardLineBreak` treats any line ending in a backslash as a hard
line break:

```js
if (line.endsWith('\\')) {
  return [line.slice(0, -1), '\\'];
}
```

CommonMark only gives a trailing backslash that meaning when the backslash is
not itself escaped. `foo\\` is a backslash escape — a literal `\` followed by
an ordinary (soft) line ending — so only an **odd**-length run of trailing
backslashes is a hard line break.
https://spec.commonmark.org/0.31.2/#backslash-escapes

Because the parser cannot tell `foo\` from `foo\\`, the final backslash is
consumed as a line-break marker and removed from the text. With
`shouldMergeAdjacentLines`, `normalizeMarkdown` also refuses to merge the two
lines, since it asks the same function whether the previous line ended in a
hard line break:

```
input:    foo\\
          bar

expected: one paragraph, text `foo\ bar`
actual:   two lines, text `foo` + hard break + `bar`  (the `\` is gone)
```

This counts the trailing backslash run and only reports a hard line break for
an odd length. The lone-backslash and two-space forms are unchanged.

Note this fixes the merging path, where `normalizeMarkdown` joins the lines
before any line-break node is built. Without `shouldMergeAdjacentLines` the
marker is extracted from a TextNode whose escapes have already been resolved
by `importTextTransformers`, so `foo\\` and `foo\` are genuinely
indistinguishable at that point; disambiguating those would mean moving
hard-line-break detection ahead of unescaping, which is a larger change and is
left alone here.

## Test plan

New unit test `packages/lexical-markdown/src/__tests__/unit/EscapedBackslashHardLineBreak.test.ts`,
covering the parser directly, `normalizeMarkdown`, and the imported text. The
lone-backslash and two-space cases are included as controls — they pass before
and after.

### Before

```
$ npx vitest run packages/lexical-markdown/src/__tests__/unit/EscapedBackslashHardLineBreak.test.ts

     × does not treat an escaped backslash as a hard line break 3ms
     × merges a line ending in an escaped backslash with the next line 2ms
     × keeps the literal backslash in the imported text 5ms

AssertionError: expected [ 'foo\', '\' ] to be null // Object.is equality
AssertionError: expected 'foo\\\nbar' to be 'foo\\ bar' // Object.is equality
AssertionError: expected 'foo\nbar' to be 'foo\ bar' // Object.is equality

      Tests  3 failed | 4 passed (7)
```

### After

```
$ npx vitest run packages/lexical-markdown/src/__tests__/unit/EscapedBackslashHardLineBreak.test.ts

      Tests  7 passed (7)

$ npx vitest run packages/lexical-markdown packages/lexical-code-core

 Test Files  8 passed (8)
      Tests  474 passed (474)
```
