### PR TITLE
[lexical-playground] Bug Fix: exporting an equation with non Latin-1 characters no longer throws

### DIFF
--- a/packages/lexical-playground/__tests__/unit/EquationNodeHTML.test.ts
+++ b/packages/lexical-playground/__tests__/unit/EquationNodeHTML.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $generateHtmlFromNodes,
+  $generateNodesFromDOMViaExtension,
+} from '@lexical/html';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $insertNodes,
+  $isElementNode,
+  defineExtension,
+  type LexicalNode,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+import {
+  $createEquationNode,
+  $isEquationNode,
+} from '../../src/nodes/EquationNode';
+import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
+import {EquationsExtension} from '../../src/plugins/EquationsExtension';
+
+const EquationHTMLTestExtension = /* @__PURE__ */ defineExtension({
+  $initialEditorState: null,
+  dependencies: [PlaygroundImportExtension, EquationsExtension],
+  name: '[test-equation-html]',
+});
+
+function $findFirst(
+  predicate: (node: LexicalNode) => boolean,
+): LexicalNode | null {
+  const stack: LexicalNode[] = [...$getRoot().getChildren()];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if (predicate(node)) {
+      return node;
+    }
+    if ($isElementNode(node)) {
+      stack.push(...node.getChildren());
+    }
+  }
+  return null;
+}
+
+function exportEquationHtml(equation: string, inline: boolean): string {
+  using editor = buildEditorFromExtensions(EquationHTMLTestExtension);
+  editor.update(
+    () => {
+      $getRoot().clear();
+      const paragraph = $createParagraphNode();
+      $getRoot().append(paragraph);
+      paragraph.selectStart();
+      $insertNodes([$createEquationNode(equation, inline)]);
+    },
+    {discrete: true},
+  );
+  return editor.read(() => $generateHtmlFromNodes(editor, null));
+}
+
+function importEquationHtml(htmlString: string): null | string {
+  using editor = buildEditorFromExtensions(EquationHTMLTestExtension);
+  editor.update(
+    () => {
+      $getRoot().clear().select();
+      const dom = new DOMParser().parseFromString(htmlString, 'text/html');
+      $insertNodes($generateNodesFromDOMViaExtension(dom));
+    },
+    {discrete: true},
+  );
+  return editor.read(() => {
+    const node = $findFirst($isEquationNode);
+    assert($isEquationNode(node), 'expected an EquationNode');
+    return node.getEquation();
+  });
+}
+
+describe('EquationNode HTML round trip', () => {
+  it('exports an equation with non Latin-1 characters without throwing', () => {
+    // A free-form LaTeX equation routinely carries code points above U+00FF,
+    // which is exactly the range btoa() rejects.
+    expect(() => exportEquationHtml('\\text{\u03b1}', true)).not.toThrow();
+  });
+
+  it('round trips an equation with non Latin-1 characters', () => {
+    const equation = '\\text{\u03b1} + \\text{\u9762\u7a4d}';
+    expect(importEquationHtml(exportEquationHtml(equation, false))).toBe(
+      equation,
+    );
+  });
+
+  it('round trips an equation outside the basic multilingual plane', () => {
+    const equation = '\\text{\ud83d\ude42}';
+    expect(importEquationHtml(exportEquationHtml(equation, true))).toBe(
+      equation,
+    );
+  });
+
+  it('still decodes an equation exported before the encoding change', () => {
+    // Pure ASCII encodes byte for byte, so HTML written by older builds
+    // decodes unchanged.
+    const legacy = `<span data-lexical-equation="${btoa(
+      'x^2 + y^2',
+    )}" data-lexical-inline="true"></span>`;
+    expect(importEquationHtml(legacy)).toBe('x^2 + y^2');
+  });
+});

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -32,6 +32,31 @@ export type SerializedEquationNode = Spread<
   SerializedLexicalNode
 >;
 
+/**
+ * btoa/atob only handle Latin-1, so go through the UTF-8 bytes -- the same way
+ * docSerialization does. An equation is free-form LaTeX and routinely holds
+ * code points above U+00FF (`\text{α}`, CJK, an emoji), which btoa throws on.
+ * Pure ASCII encodes byte for byte, so previously exported HTML still decodes.
+ */
+export function encodeEquation(equation: string): string {
+  const bytes = new TextEncoder().encode(equation);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/** Inverse of {@link encodeEquation}. */
+export function decodeEquation(encoded: string): string {
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
 export class EquationNode extends DecoratorNode<JSX.Element> {
   __equation: string;
   __inline: boolean;
@@ -83,7 +108,7 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
       this.__inline ? 'span' : 'div',
     );
     // Encode the equation as base64 to avoid issues with special characters
-    const equation = btoa(this.__equation);
+    const equation = encodeEquation(this.__equation);
     element.setAttribute('data-lexical-equation', equation);
     element.setAttribute('data-lexical-inline', `${this.__inline}`);
     katex.render(this.__equation, element, {

--- a/packages/lexical-playground/src/plugins/EquationsExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/EquationsExtension/index.tsx
@@ -26,7 +26,11 @@ import {
 } from 'lexical';
 import {type JSX, useCallback} from 'react';
 
-import {$createEquationNode, EquationNode} from '../../nodes/EquationNode';
+import {
+  $createEquationNode,
+  decodeEquation,
+  EquationNode,
+} from '../../nodes/EquationNode';
 import KatexEquationAlterer from '../../ui/KatexEquationAlterer';
 
 type CommandPayload = {
@@ -42,7 +46,7 @@ function $convertEquationElement(el: HTMLElement) {
   if (!encoded) {
     return null;
   }
-  const equation = atob(encoded);
+  const equation = decodeEquation(encoded);
   if (!equation) {
     return null;
   }


### PR DESCRIPTION

## Description

`EquationNode.exportDOM` base64-encodes the LaTeX with `btoa`:

```ts
// Encode the equation as base64 to avoid issues with special characters
const equation = btoa(this.__equation);
element.setAttribute('data-lexical-equation', equation);
```

`btoa` only accepts Latin-1: it throws `InvalidCharacterError` on any code point above U+00FF. An equation is free-form LaTeX typed into a textarea, so those are ordinary content — `\text{α}`, CJK inside `\text{}`, an emoji. Insert one and then copy it, or use Export HTML, and `$generateHtmlFromNodes` → `exportDOM` throws and the whole copy/export fails. The comment one line above says the encoding is there "to avoid issues with special characters", which is precisely the input it breaks on.

The importer is the mirror image and has the same limit:

```ts
const equation = atob(encoded);
```

Even if `btoa` had not thrown, decoding through Latin-1 would mangle multi-byte content.

Both sides now go through the UTF-8 bytes, which is the same approach `utils/docSerialization.ts` already uses in this package for the shareable-document hash (`new TextEncoder().encode(...)` → `String.fromCharCode` → `btoa`, and the inverse). The helpers live next to the node and are shared with the import rule so the two cannot drift apart again.

Backwards compatible: for pure ASCII the UTF-8 bytes are identical to the Latin-1 bytes, so anything an older build exported decodes unchanged. Nothing else could have been exported, because `btoa` threw. `exportJSON` is untouched — it has always carried the raw string — so this is an HTML-only change with no serialization change.

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/EquationNodeHTML.test.ts`, using the same export/re-import harness as the existing `PlaygroundNodeImporters` round-trip tests. The last case pins the backwards compatibility claim and passes before and after.

### Before

```
 ❯ packages/lexical-playground/__tests__/unit/EquationNodeHTML.test.ts (4 tests | 3 failed)
   × exports an equation with non Latin-1 characters without throwing
     AssertionError: expected [Function] to not throw an error but 'InvalidCharacterError: Invalid charac…' was thrown
   × round trips an equation with non Latin-1 characters
     InvalidCharacterError: Invalid character
   × round trips an equation outside the basic multilingual plane
     InvalidCharacterError: Invalid character
   ✓ still decodes an equation exported before the encoding change

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

### After

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-playground
 Test Files  18 passed (18)
      Tests  275 passed (275)
```
