### PR TITLE
[lexical-markdown] Bug Fix: don't import a code fence's info string as code

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -658,9 +658,19 @@ export const CODE: MultilineElementTransformer = {
         const endMatch = line.match(multilineEndRegex);
         const linesInBetween = lines.slice(startLineIndex + 1, i);
 
-        const afterFullMatch = currentLine.slice(startMatch[0].length);
-        if (afterFullMatch.length > 0) {
-          linesInBetween.unshift(afterFullMatch);
+        // Everything after the opening fence is the info string, and only its
+        // first word is the language. When a language was captured, whatever
+        // follows it on that line is metadata (```js title="x", ```ts {1,3})
+        // and must not be prepended to the block's content.
+        // https://spec.commonmark.org/0.31.2/#fenced-code-blocks
+        //
+        // With no language captured the fence carries no info string, so the
+        // remainder is kept as content (``` code) as before.
+        if (!startMatch[2]) {
+          const afterFullMatch = currentLine.slice(startMatch[0].length);
+          if (afterFullMatch.length > 0) {
+            linesInBetween.unshift(afterFullMatch);
+          }
         }
 
         CODE.replace(

--- a/packages/lexical-markdown/src/__tests__/unit/CodeBlockInfoString.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/CodeBlockInfoString.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$isCodeNode, CodeNode} from '@lexical/code-core';
+import {createHeadlessEditor} from '@lexical/headless';
+import {LinkNode} from '@lexical/link';
+import {ListItemNode, ListNode} from '@lexical/list';
+import {$convertFromMarkdownString, TRANSFORMERS} from '@lexical/markdown';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {$getRoot} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+function importCodeBlock(markdown: string): {
+  language: string | null | undefined;
+  text: string | null;
+} {
+  const editor = createHeadlessEditor({
+    nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, CodeNode, LinkNode],
+    onError: error => {
+      throw error;
+    },
+  });
+  let result: {language: string | null | undefined; text: string | null} = {
+    language: undefined,
+    text: null,
+  };
+  editor.update(
+    () => {
+      $convertFromMarkdownString(markdown, TRANSFORMERS);
+      const first = $getRoot().getFirstChild();
+      result = $isCodeNode(first)
+        ? {language: first.getLanguage(), text: first.getTextContent()}
+        : {language: undefined, text: null};
+    },
+    {discrete: true},
+  );
+  return result;
+}
+
+describe('fenced code block info string', () => {
+  it('does not put a title attribute into the code content', () => {
+    expect(importCodeBlock('```js title="x"\ncode\n```')).toEqual({
+      language: 'js',
+      text: 'code',
+    });
+  });
+
+  it('does not put a line-highlight range into the code content', () => {
+    expect(importCodeBlock('```ts {1,3}\ncode\n```')).toEqual({
+      language: 'ts',
+      text: 'code',
+    });
+  });
+
+  it('does not put a bare info-string word into the code content', () => {
+    expect(importCodeBlock('```js showLineNumbers\na\nb\n```')).toEqual({
+      language: 'js',
+      text: 'a\nb',
+    });
+  });
+
+  it('keeps content that follows a fence with no language', () => {
+    expect(importCodeBlock('``` code\nmore\n```')).toEqual({
+      language: undefined,
+      text: 'code\nmore',
+    });
+  });
+
+  it('leaves a plain language fence unchanged', () => {
+    expect(importCodeBlock('```javascript\nCode\n```')).toEqual({
+      language: 'javascript',
+      text: 'Code',
+    });
+  });
+
+  it('leaves an unterminated fence unchanged', () => {
+    expect(importCodeBlock('```javascript Incomplete tag')).toEqual({
+      language: 'javascript',
+      text: 'Incomplete tag',
+    });
+  });
+});


### PR DESCRIPTION
## Description

CommonMark defines everything after an opening code fence as the *info string*,
whose first word is conventionally the language, and states that the info
string is not part of the code block's content.
https://spec.commonmark.org/0.31.2/#fenced-code-blocks

`CODE_START_REGEX` captures only the leading word as the language
(`([\w-]+)?`). `handleImportAfterStartMatch` then takes whatever is left on the
fence line and prepends it to the block's content:

```js
const afterFullMatch = currentLine.slice(startMatch[0].length);
if (afterFullMatch.length > 0) {
  linesInBetween.unshift(afterFullMatch);
}
```

So the very common attribute forms produce a code block whose *first line of
code* is the metadata:

| markdown | imported code |
| --- | --- |
| ` ```js title="x" ` / `code` / ` ``` ` | `title="x"\ncode` |
| ` ```ts {1,3} ` / `code` / ` ``` ` | `{1,3}\ncode` |
| ` ```js showLineNumbers ` / `a` / `b` / ` ``` ` | `showLineNumbers\na\nb` |

The user's code is corrupted with a line they never wrote, and it survives
export, so the round trip entrenches it.

This skips the remainder only when a language was actually captured — that is
exactly the case where the text is a trailing info string. Two existing
behaviours are deliberately untouched:

- A fence with **no** language (` ``` code `) keeps its remainder as content;
  nothing there looks like an info string to this parser.
- An **unterminated** fence keeps its lenient reading (the
  `'```javascript Incomplete tag'` cases in `LexicalMarkdown.test.ts`), so this
  only applies where a closing fence makes the block unambiguous.

`CodeNode` stores a single `language`, and the serialization format is fixed,
so there is nowhere to retain the rest of the info string; dropping unsupported
metadata matches what the importer already does for anything else it cannot
model.

## Test plan

New unit test `packages/lexical-markdown/src/__tests__/unit/CodeBlockInfoString.test.ts`.
The last three cases are controls for the behaviours listed above — they pass
before and after.

### Before

```
$ npx vitest run packages/lexical-markdown/src/__tests__/unit/CodeBlockInfoString.test.ts

     × does not put a title attribute into the code content 18ms
     × does not put a line-highlight range into the code content 2ms
     × does not put a bare info-string word into the code content 1ms

AssertionError: expected { language: 'js', …(1) } to deeply equal { language: 'js', text: 'code' }

      Tests  3 failed | 3 passed (6)
```

### After

```
$ npx vitest run packages/lexical-markdown/src/__tests__/unit/CodeBlockInfoString.test.ts

      Tests  6 passed (6)

$ npx vitest run packages/lexical-markdown packages/lexical-code-core

 Test Files  7 passed (7)
      Tests  467 passed (467)
```
