### PR TITLE
[lexical-list] Bug Fix: keep the numbering when a block is inserted between list items

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -47,7 +47,7 @@ import {
 
 import {$createListNode, $isListNode, type ListNode, type ListType} from './';
 import {$handleIndent, $handleOutdent, mergeLists} from './formatList';
-import {$isNestedListNode} from './utils';
+import {$getNewListStart, $isNestedListNode} from './utils';
 
 export type SerializedListItemNode = Spread<
   {
@@ -354,6 +354,17 @@ export class ListItemNode extends ElementNode {
 
     if (siblings.length !== 0) {
       const newListNode = $copyNode(listNode);
+      // $copyNode carries the original list's start, which would restart the
+      // numbering at the split. The items moving into the new list keep the
+      // numbers they were already rendered with, so the new list has to start
+      // from the first of them (see issue #7032).
+      const firstSibling = siblings[0];
+      if (
+        newListNode.getListType() === 'number' &&
+        $isListItemNode(firstSibling)
+      ) {
+        newListNode.setStart($getNewListStart(listNode, firstSibling));
+      }
 
       siblings.forEach(sibling => newListNode.append(sibling));
 

--- a/packages/lexical-list/src/__tests__/unit/Issue7032Repro.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/Issue7032Repro.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createListItemNode,
+  $createListNode,
+  $isListItemNode,
+  $isListNode,
+  ListExtension,
+  type ListNode,
+} from '@lexical/list';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  defineExtension,
+  type LexicalNode,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [ListExtension],
+      name: 'issue-7032-host',
+    }),
+  );
+}
+
+function $listAt(index: number): ListNode {
+  const node: LexicalNode | null = $getRoot().getChildAtIndex(index);
+  assert($isListNode(node), `expected a ListNode at root index ${index}`);
+  return node;
+}
+
+function $itemValues(list: ListNode): number[] {
+  return list
+    .getChildren()
+    .filter($isListItemNode)
+    .map(item => item.getValue());
+}
+
+describe('Issue #7032: splitting a numbered list restarts its numbering', () => {
+  test('inserting a block between list items continues the numbering', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const list = $createListNode('number');
+        for (const text of ['a', 'b', 'c']) {
+          list.append($createListItemNode().append($createTextNode(text)));
+        }
+        $getRoot().clear().append(list);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const first = $listAt(0).getFirstChild();
+        assert($isListItemNode(first), 'expected a ListItemNode');
+        // Inserting a non-list node between two items splits the list around
+        // it — the page-break case from issue #7032.
+        first.insertAfter(
+          $createParagraphNode().append($createTextNode('break')),
+        );
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect(
+        $getRoot()
+          .getChildren()
+          .map(n => n.getType()),
+      ).toEqual(['list', 'paragraph', 'list']);
+      expect($itemValues($listAt(0))).toEqual([1]);
+      const tail = $listAt(2);
+      expect(tail.getStart()).toBe(2);
+      expect($itemValues(tail)).toEqual([2, 3]);
+    });
+  });
+
+  test('a list that does not start at 1 continues from the split point', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const list = $createListNode('number', 5);
+        for (const text of ['a', 'b', 'c']) {
+          list.append($createListItemNode().append($createTextNode(text)));
+        }
+        $getRoot().clear().append(list);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const items = $listAt(0).getChildren();
+        const second = items[1];
+        assert($isListItemNode(second), 'expected a ListItemNode');
+        second.insertAfter(
+          $createParagraphNode().append($createTextNode('break')),
+        );
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($itemValues($listAt(0))).toEqual([5, 6]);
+      expect($listAt(2).getStart()).toBe(7);
+      expect($itemValues($listAt(2))).toEqual([7]);
+    });
+  });
+
+  test('a bullet list keeps its start when it is split', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const list = $createListNode('bullet');
+        for (const text of ['a', 'b']) {
+          list.append($createListItemNode().append($createTextNode(text)));
+        }
+        $getRoot().clear().append(list);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const first = $listAt(0).getFirstChild();
+        assert($isListItemNode(first), 'expected a ListItemNode');
+        first.insertAfter(
+          $createParagraphNode().append($createTextNode('break')),
+        );
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($listAt(2).getStart()).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description

`ListItemNode.insertAfter` splits its list when the node being inserted is not
a `ListItemNode` — that is how a page break, horizontal rule, image, or any
other block ends up between two items. The trailing items are moved into
`$copyNode(listNode)`, which carries the *original* list's `start`, so the
`ListNode` `$transform` renumbers them from that start and the list visibly
restarts at 1 after the inserted block.

`$getNewListStart` already exists for exactly this: it is the helper
`$handleListInsertParagraph` uses to continue the numbering across a split, and
it returns the number the split point was rendered with (the item's value, not
its index, so nested-list wrapper items do not skew it).

This applies it to the `insertAfter` split, using the first item that moves
into the new list. It is scoped to `listType === 'number'`, the only list type
where `start` is meaningful, so bullet and check lists keep the `start` they
copy today.

Refs #7032

## Test plan

`npx vitest run packages/lexical-list/src/__tests__/unit/Issue7032Repro.test.ts`

(The natural test file, `LexicalListItemNode.test.ts`, is already being edited
by an open PR, so the repro lives in its own file.)

### Before

```
 ❯ |unit| packages/lexical-list/src/__tests__/unit/Issue7032Repro.test.ts (3 tests | 2 failed) 14ms
     × inserting a block between list items continues the numbering 11ms
     × a list that does not start at 1 continues from the split point 1ms

 FAIL  ... > inserting a block between list items continues the numbering
AssertionError: expected 1 to be 2 // Object.is equality

- Expected
+ Received

- 2
+ 1

 FAIL  ... > a list that does not start at 1 continues from the split point
AssertionError: expected 5 to be 7 // Object.is equality

- Expected
+ Received

- 7
+ 5
```

### After

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Also green:

- `npx vitest run packages/lexical-list` — 11 files, 128 tests
- `npx vitest run packages/lexical-markdown packages/lexical-mdast packages/lexical-react packages/lexical-clipboard` — 41 files, 798 tests
- `E2E_BROWSER=chromium npx playwright test --project=chromium List.spec.mjs` — 36 passed
- `E2E_BROWSER=chromium npx playwright test --project=chromium HorizontalRule.spec.mjs` — 15 passed
  (this is the suite that exercises inserting a rule inside a list)

Only chromium was exercised locally for the e2e runs.

