### PR TITLE
[lexical-react] Bug Fix: the node context menu leaves the native menu alone when it has nothing to show

### DIFF
--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -221,6 +221,26 @@ const NodeContextMenuPlugin = forwardRef<
 
   useEffect(() => {
     function onContextMenu(e: MouseEvent) {
+      let visibleItems: ContextMenuType[] = [];
+      if (items) {
+        editor.read(() => {
+          const node =
+            $getNearestNodeFromDOMNode(e.target as Element) ?? $getRoot();
+          if (node) {
+            visibleItems = items!.filter(option =>
+              option.$showOn ? option.$showOn(node) : true,
+            );
+          }
+        });
+      }
+
+      // Every item is hidden for this node, so there is no menu to show. Let
+      // the browser's own context menu open rather than suppressing it and
+      // mounting a scroll-locking overlay around nothing.
+      if (visibleItems.length === 0) {
+        return;
+      }
+
       e.preventDefault();
 
       refs.setPositionReference({
@@ -237,19 +257,6 @@ const NodeContextMenuPlugin = forwardRef<
           };
         },
       });
-
-      let visibleItems: ContextMenuType[] = [];
-      if (items) {
-        editor.read(() => {
-          const node =
-            $getNearestNodeFromDOMNode(e.target as Element) ?? $getRoot();
-          if (node) {
-            visibleItems = items!.filter(option =>
-              option.$showOn ? option.$showOn(node) : true,
-            );
-          }
-        });
-      }
 
       const renderableItems = visibleItems.map((option, index) => {
         if (option.type === 'separator') {

--- a/packages/lexical-react/src/__tests__/unit/LexicalNodeContextMenuPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalNodeContextMenuPlugin.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {
+  NodeContextMenuOption,
+  NodeContextMenuPlugin,
+} from '@lexical/react/LexicalNodeContextMenuPlugin';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import * as React from 'react';
+import {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const MENU_CLASS = 'node-context-menu';
+
+describe('NodeContextMenuPlugin', () => {
+  let container: HTMLDivElement;
+  let reactRoot: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      reactRoot.unmount();
+    });
+    container.remove();
+  });
+
+  async function renderPlugin(showOn: boolean): Promise<void> {
+    const items = [
+      new NodeContextMenuOption('Do a thing', {
+        $onSelect: vi.fn(),
+        $showOn: () => showOn,
+      }),
+    ];
+    await act(async () => {
+      reactRoot.render(
+        <LexicalComposer
+          initialConfig={{
+            namespace: 'context-menu',
+            onError: (error: Error) => {
+              throw error;
+            },
+          }}>
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            ErrorBoundary={({children}) => <>{children}</>}
+          />
+          <NodeContextMenuPlugin className={MENU_CLASS} items={items} />
+        </LexicalComposer>,
+      );
+    });
+  }
+
+  async function rightClick(): Promise<MouseEvent> {
+    const rootElement = container.querySelector(
+      '[contenteditable="true"]',
+    ) as HTMLElement;
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      rootElement.dispatchEvent(event);
+    });
+    return event;
+  }
+
+  function isMenuOpen(): boolean {
+    return document.querySelector(`.${MENU_CLASS}`) !== null;
+  }
+
+  it('leaves the native context menu alone when no item is shown', async () => {
+    await renderPlugin(false);
+
+    const event = await rightClick();
+    expect(event.defaultPrevented).toBe(false);
+    expect(isMenuOpen()).toBe(false);
+  });
+
+  it('opens and replaces the native context menu when an item is shown', async () => {
+    await renderPlugin(true);
+
+    const event = await rightClick();
+    expect(event.defaultPrevented).toBe(true);
+    expect(isMenuOpen()).toBe(true);
+  });
+});


### PR DESCRIPTION

## Description

`NodeContextMenuPlugin` suppresses the browser's context menu and opens its own before it knows whether it has anything to put in it:

```tsx
function onContextMenu(e: MouseEvent) {
  e.preventDefault();          // <- unconditional
  refs.setPositionReference({ ... });

  let visibleItems: ContextMenuType[] = [];
  if (items) {
    editor.read(() => {
      const node = $getNearestNodeFromDOMNode(e.target as Element) ?? $getRoot();
      if (node) {
        visibleItems = items!.filter(option =>
          option.$showOn ? option.$showOn(node) : true,
        );
      }
    });
  }
  ...
  setIsOpen(true);             // <- unconditional
}
```

`$showOn` is documented as the per-node predicate that decides "whether the item is shown for the right-clicked node", so it is expected that a given node hides some items — and a node that hides *all* of them is the natural consequence of that, not a misuse. When it happens the user gets the worst of both: no native menu, because `preventDefault` already ran; no visible menu, because the rendered `<div>` has no children; and the page cannot be scrolled, because the plugin still mounts

```tsx
<FloatingOverlay lockScroll={true}>
```

around it. The only way out is to click somewhere to dismiss an overlay that shows nothing. Right-clicking to reach Copy, Paste, or Inspect on such a node is simply not possible.

This computes `visibleItems` first and returns early when it is empty, before `preventDefault` and before `setIsOpen(true)`. Everything else is unchanged; the item-building code just moves below the filter it always depended on. No API or serialization change.

## Test plan

New unit test `packages/lexical-react/src/__tests__/unit/LexicalNodeContextMenuPlugin.test.tsx`. The second case is the control — the menu must still replace the native one when it does have an item — and passes before and after.

### Before

```
 ❯ packages/lexical-react/src/__tests__/unit/LexicalNodeContextMenuPlugin.test.tsx (2 tests | 1 failed)
   × leaves the native context menu alone when no item is shown
     AssertionError: expected true to be false // Object.is equality
   ✓ opens and replaces the native context menu when an item is shown

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-react
 Test Files  32 passed (32)
      Tests  184 passed (184)
```
