### PR TITLE
[lexical-table] Bug Fix: padding cells inherit the header row state

### DIFF
--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -46,6 +46,7 @@ import {
 import {
   $createTableCellNode,
   $isTableCellNode,
+  TableCellHeaderStates,
   TableCellNode,
 } from './LexicalTableCellNode';
 import {
@@ -152,9 +153,16 @@ function $tableTransform(node: TableNode) {
     if (rowLength === maxRowLength) {
       continue;
     }
+    // Padding cells are appended to the end of the row, so they are never in
+    // a header column — but they are in a header row whenever the row they
+    // extend is one. Inherit only that bit from the row's last cell, the same
+    // reference $insertTableColumnAtNode uses when it appends a column.
+    const lastCell = rowNode.getLastChild();
+    const headerState = $isTableCellNode(lastCell)
+      ? lastCell.getHeaderStyles() & TableCellHeaderStates.ROW
+      : TableCellHeaderStates.NO_STATUS;
     for (let j = rowLength; j < maxRowLength; ++j) {
-      // TODO: inherit header state from another header or body
-      const newCell = $createTableCellNode();
+      const newCell = $createTableCellNode(headerState);
       newCell.append($createParagraphNode());
       rowNode.append(newCell);
     }

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -23,6 +23,7 @@ import {
   $isTableSelection,
   $mergeCells,
   INSERT_TABLE_COMMAND,
+  TableCellHeaderStates,
   type TableCellNode,
   TableExtension,
   type TableNode,
@@ -513,6 +514,93 @@ describe('TableExtension', () => {
         expect(texts).toEqual([
           ['A', 'B'],
           ['D', 'E'],
+        ]);
+      });
+    });
+  });
+
+  describe('$tableTransform padding', () => {
+    test('a short header row is padded with header cells', () => {
+      editor.update(
+        () => {
+          const root = $getRoot().clear();
+          const table = $createTableNode();
+          // First row is a header row but is one cell short.
+          const headerRow = $createTableRowNode();
+          headerRow.append(
+            $createTableCellNode(TableCellHeaderStates.ROW).append(
+              $createParagraphNode().append($createTextNode('h')),
+            ),
+          );
+          table.append(headerRow);
+          const bodyRow = $createTableRowNode();
+          for (const text of ['a', 'b']) {
+            bodyRow.append(
+              $createTableCellNode().append(
+                $createParagraphNode().append($createTextNode(text)),
+              ),
+            );
+          }
+          table.append(bodyRow);
+          root.append(table);
+        },
+        {discrete: true},
+      );
+
+      editor.read('latest', () => {
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
+        const rows = table.getChildren().filter($isTableRowNode);
+        const tags = rows.map(row =>
+          row
+            .getChildren()
+            .filter($isTableCellNode)
+            .map(cell => cell.getTag()),
+        );
+        expect(tags).toEqual([
+          ['th', 'th'],
+          ['td', 'td'],
+        ]);
+      });
+    });
+
+    test('a short body row is padded with body cells', () => {
+      editor.update(
+        () => {
+          const root = $getRoot().clear();
+          const table = $createTableNode();
+          const headerRow = $createTableRowNode();
+          for (const text of ['h1', 'h2']) {
+            headerRow.append(
+              $createTableCellNode(TableCellHeaderStates.ROW).append(
+                $createParagraphNode().append($createTextNode(text)),
+              ),
+            );
+          }
+          table.append(headerRow);
+          const bodyRow = $createTableRowNode();
+          bodyRow.append(
+            $createTableCellNode().append(
+              $createParagraphNode().append($createTextNode('a')),
+            ),
+          );
+          table.append(bodyRow);
+          root.append(table);
+        },
+        {discrete: true},
+      );
+
+      editor.read('latest', () => {
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
+        const rows = table.getChildren().filter($isTableRowNode);
+        const tags = rows.map(row =>
+          row
+            .getChildren()
+            .filter($isTableCellNode)
+            .map(cell => cell.getTag()),
+        );
+        expect(tags).toEqual([
+          ['th', 'th'],
+          ['td', 'td'],
         ]);
       });
     });


### PR DESCRIPTION
## Description

`$tableTransform` normalises a table by padding every short row out to the
table's width. The padding cells were created with no header state:

```ts
for (let j = rowLength; j < maxRowLength; ++j) {
  // TODO: inherit header state from another header or body
  const newCell = $createTableCellNode();
```

so a header row that is short — a very common shape for imported or
programmatically built tables — is repaired into a mix of `<th>` and `<td>`,
and the header row stops being one for the columns that were padded.

Every other place the package grows a table already inherits here.
`$insertTableColumnAtNode`, which is the equivalent operation done
deliberately, takes the header state of the row's reference cell masked to
`TableCellHeaderStates.ROW`, so the appended column stays a header in the
header row and stays a body cell everywhere else.

This does the same for the padding cells, reading the bit off the row's last
existing cell. Padding is always appended at the end of the row, so the new
cells are never in the header *column* and only the `ROW` bit is inherited —
a short body row is still padded with `<td>`, which the second test pins.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts`

### Before

```
 ❯ |unit| packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts (25 tests | 1 failed) 113ms
       × a short header row is padded with header cells 7ms

 FAIL  ... > $tableTransform padding > a short header row is padded with header cells
AssertionError: expected [ [ 'th', 'td' ], [ 'td', 'td' ] ] to deeply equal [ [ 'th', 'th' ], [ 'td', 'td' ] ]

- Expected
+ Received

@@ -1,9 +1,9 @@
  [
    [
      "th",
-     "th",
+     "td",
    ],
    [
      "td",
      "td",
    ],
```

### After

```
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

Also green:

- `npx vitest run packages/lexical-table` — 11 files, 159 tests
- `E2E_BROWSER=chromium npx playwright test --project=chromium Tables.spec.mjs` — 88 passed, 1 skipped

Only chromium was exercised locally for the e2e run.

