### PR TITLE
[lexical-react] Bug Fix: useLexicalIsTextContentEmpty re-derives its value when its arguments change

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmptyResync.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmptyResync.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {useLexicalIsTextContentEmpty} from '@lexical/react/useLexicalIsTextContentEmpty';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+  type LexicalEditor,
+  ParagraphNode,
+} from 'lexical';
+import * as React from 'react';
+import {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+describe('useLexicalIsTextContentEmpty re-derives its value', () => {
+  let container: HTMLDivElement;
+  let reactRoot: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      reactRoot.unmount();
+    });
+    container.remove();
+  });
+
+  function makeEditor(text: string): LexicalEditor {
+    const editor = createEditor({
+      namespace: 'is-text-content-empty',
+      nodes: [ParagraphNode],
+      onError: error => {
+        throw error;
+      },
+    });
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        if (text !== '') {
+          paragraph.append($createTextNode(text));
+        }
+        $getRoot().clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+    return editor;
+  }
+
+  let current = false;
+
+  // Declared once, so that re-rendering with different props updates the same
+  // component instance rather than mounting a fresh one (which would re-run
+  // the useState initializer and hide the bug).
+  function Test({editor, trim}: {editor: LexicalEditor; trim: boolean}) {
+    current = useLexicalIsTextContentEmpty(editor, trim);
+    return null;
+  }
+
+  async function render(
+    editor: LexicalEditor,
+    trim: boolean,
+  ): Promise<boolean> {
+    await act(async () => {
+      reactRoot.render(<Test editor={editor} trim={trim} />);
+    });
+    return current;
+  }
+
+  it('follows a change of the trim argument', async () => {
+    // Whitespace-only content is empty when trimmed and not empty otherwise,
+    // so the answer depends entirely on `trim`.
+    const editor = makeEditor('   ');
+
+    expect(await render(editor, false)).toBe(false);
+    expect(await render(editor, true)).toBe(true);
+  });
+
+  it('follows a change of the editor', async () => {
+    const withText = makeEditor('hello');
+    const empty = makeEditor('');
+
+    expect(await render(withText, true)).toBe(false);
+    expect(await render(empty, true)).toBe(true);
+  });
+});

--- a/packages/lexical-react/src/useLexicalIsTextContentEmpty.ts
+++ b/packages/lexical-react/src/useLexicalIsTextContentEmpty.ts
@@ -24,7 +24,7 @@ export function useLexicalIsTextContentEmpty(
   editor: LexicalEditor,
   trim?: boolean,
 ): boolean {
-  const [isEmpty, setIsEmpty] = useState(
+  const [isEmpty, setIsEmpty] = useState(() =>
     editor.read(
       'latest',
       $isRootTextContentEmptyCurry(editor.isComposing(), trim),
@@ -32,6 +32,18 @@ export function useLexicalIsTextContentEmpty(
   );
 
   useLayoutEffect(() => {
+    function resetIsEmpty() {
+      setIsEmpty(
+        editor.read(
+          'latest',
+          $isRootTextContentEmptyCurry(editor.isComposing(), trim),
+        ),
+      );
+    }
+    // The state was seeded on the first render only, so re-derive it whenever
+    // the inputs the effect depends on change -- otherwise a new editor or a
+    // new trim keeps reporting the previous answer until the next update.
+    resetIsEmpty();
     return editor.registerUpdateListener(({editorState}) => {
       const isComposing = editor.isComposing();
       const currentIsEmpty = editorState.read(


### PR DESCRIPTION

## Description

`useLexicalIsTextContentEmpty` seeds its state on the first render and then only ever updates it from an update listener:

```ts
const [isEmpty, setIsEmpty] = useState(
  editor.read('latest', $isRootTextContentEmptyCurry(editor.isComposing(), trim)),
);

useLayoutEffect(() => {
  return editor.registerUpdateListener(({editorState}) => {
    ...
  });
}, [editor, trim]);
```

`editor` and `trim` are in the dependency array, so the effect knows they can change — but the state does not: `useState`'s initial value is only used on mount. Pass a different `editor`, or flip `trim`, and the hook keeps reporting the answer computed for the previous ones until that editor happens to fire an update. For an editor that is not being typed into, that is indefinitely.

Both are load-bearing. `trim` decides the answer outright for whitespace-only content — `$isRootTextContentEmpty` returns `text.trim() === ''` when trimming and `text === ''` otherwise — and `editor` changes whenever a component is re-pointed at another editor, which `LexicalNestedComposer` and multi-editor UIs do.

The sibling hook right next to it already does the resync, in the same layout effect, for the same reason:

```ts
// shared/useCanShowPlaceholder.ts
useLayoutEffect(() => {
  function resetCanShowPlaceholder() { ... }
  resetCanShowPlaceholder();
  return mergeRegister( ... );
}, [editor]);
```

`ContentEditableElement` and `LexicalContentEditable` follow the same pattern with `setEditable(editor.isEditable())` before `registerEditableListener`. This hook is the one that skips it.

This adds the same `resetIsEmpty()` call at the top of the effect. It also switches the `useState` argument to the lazy form: as written, `editor.read(...)` ran on *every* render and the result was thrown away after the first, which is the same shape `useCanShowPlaceholder` already avoids with `useState(() => ...)`. No API change.

## Test plan

New unit test `packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmptyResync.test.tsx`, one case per argument. The test re-renders the same component instance with new props, rather than mounting a new one, since a remount re-runs the initializer and would hide the bug.

### Before

```
 ❯ packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmptyResync.test.tsx (2 tests | 2 failed)
   × follows a change of the trim argument
     AssertionError: expected false to be true // Object.is equality
   × follows a change of the editor
     AssertionError: expected false to be true // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite is unchanged, including the existing `useLexicalIsTextContentEmpty` test:

```
$ npx vitest run packages/lexical-react
 Test Files  32 passed (32)
      Tests  184 passed (184)
```
