### PR TITLE
[lexical-table] Bug Fix: unmerged cells keep the merged cell's backgroundColor and verticalAlign

### DIFF
--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -987,13 +987,19 @@ export function $unmergeCellNode(cellNode: TableCellNode): void {
     return rowStyle;
   });
 
+  // The cells the merged cell splits into are the same region of the table it
+  // was, so they keep its per-cell presentation. Only the header state is
+  // recomputed (above), because that describes the row/column rather than the
+  // cell.
+  const $createSplitCell = (headerState: TableCellHeaderState) =>
+    $createTableCellNode(headerState)
+      .setBackgroundColor(cell.getBackgroundColor())
+      .setVerticalAlign(cell.getVerticalAlign())
+      .append($createParagraphNode());
+
   if (colSpan > 1) {
     for (let i = 1; i < colSpan; i++) {
-      cell.insertAfter(
-        $createTableCellNode(colStyles[i] | rowStyles[0]).append(
-          $createParagraphNode(),
-        ),
-      );
+      cell.insertAfter($createSplitCell(colStyles[i] | rowStyles[0]));
     }
     cell.setColSpan(1);
   }
@@ -1023,17 +1029,13 @@ export function $unmergeCellNode(cellNode: TableCellNode): void {
         for (let j = colSpan - 1; j >= 0; j--) {
           $insertFirst(
             currentRowNode,
-            $createTableCellNode(colStyles[j] | rowStyles[i]).append(
-              $createParagraphNode(),
-            ),
+            $createSplitCell(colStyles[j] | rowStyles[i]),
           );
         }
       } else {
         for (let j = colSpan - 1; j >= 0; j--) {
           insertAfterCell.insertAfter(
-            $createTableCellNode(colStyles[j] | rowStyles[i]).append(
-              $createParagraphNode(),
-            ),
+            $createSplitCell(colStyles[j] | rowStyles[i]),
           );
         }
       }

--- a/packages/lexical-table/src/__tests__/unit/UnmergeCellStyles.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/UnmergeCellStyles.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createTableNodeWithDimensions,
+  $isTableCellNode,
+  $isTableNode,
+  $isTableRowNode,
+  $mergeCells,
+  $unmergeCellNode,
+  type TableCellNode,
+  TableExtension,
+} from '@lexical/table';
+import {$getRoot, defineExtension} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [TableExtension],
+      name: 'unmerge-styles-host',
+    }),
+  );
+}
+
+function $cells(): TableCellNode[][] {
+  const table = $getRoot().getFirstChild();
+  assert($isTableNode(table), 'expected a TableNode at the root');
+  return table
+    .getChildren()
+    .filter($isTableRowNode)
+    .map(row => row.getChildren().filter($isTableCellNode));
+}
+
+describe('$unmergeCellNode keeps the cell presentation', () => {
+  test('the cells a merged cell splits into keep its backgroundColor and verticalAlign', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createTableNodeWithDimensions(2, 2, false));
+        const rows = $cells();
+        const merged = $mergeCells([
+          rows[0][0],
+          rows[0][1],
+          rows[1][0],
+          rows[1][1],
+        ]);
+        assert(merged !== null, 'expected the cells to merge');
+        merged.setBackgroundColor('rgb(255, 0, 0)').setVerticalAlign('middle');
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const merged = $cells()[0][0];
+        expect(merged.getColSpan()).toBe(2);
+        expect(merged.getRowSpan()).toBe(2);
+        $unmergeCellNode(merged);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const rows = $cells();
+      expect(rows.map(row => row.length)).toEqual([2, 2]);
+      for (const row of rows) {
+        for (const cell of row) {
+          expect(cell.getColSpan()).toBe(1);
+          expect(cell.getRowSpan()).toBe(1);
+          expect(cell.getBackgroundColor()).toBe('rgb(255, 0, 0)');
+          expect(cell.getVerticalAlign()).toBe('middle');
+        }
+      }
+    });
+  });
+
+  test('an unstyled merged cell still splits into unstyled cells', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createTableNodeWithDimensions(1, 2, false));
+        const rows = $cells();
+        const merged = $mergeCells([rows[0][0], rows[0][1]]);
+        assert(merged !== null, 'expected the cells to merge');
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        $unmergeCellNode($cells()[0][0]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      for (const cell of $cells()[0]) {
+        expect(cell.getBackgroundColor()).toBe(null);
+        expect(cell.getVerticalAlign()).toBe(undefined);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Description

`$unmergeCellNode` splits a merged cell back into one cell per grid position.
It is careful about the header state — `colStyles`/`rowStyles` intersect the
original state with what the surrounding rows and columns already had — but the
cells it creates get nothing else:

```ts
$createTableCellNode(colStyles[i] | rowStyles[0]).append($createParagraphNode())
```

`backgroundColor` and `verticalAlign` are the cell's own presentation, not a
description of its row or column, and the region the merged cell covered does
not change when it is split. Today the top-left cell keeps them and the rest of
the region silently reverts to the default, so a filled merged cell unmerges
into one filled cell and a run of blank ones.

Everywhere else in the package these two travel together and travel with the
cell: `afterCloneFrom` copies both, `updateDOM` compares both, `exportJSON`
serialises both, `$insertTableIntoGrid` copies both from the pasted template,
and the action menu sets both across a selection through the same code path.
Merge keeps them too — `$mergeCells` preserves the surviving cell — so this is
the one direction that drops them.

This gives every split-off cell the original's `backgroundColor` and
`verticalAlign`. A cell with neither set still splits into cells with neither,
which the second test pins.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/UnmergeCellStyles.test.ts`

(The natural test file, `LexicalTableUtils.test.ts`, is already being edited by
an open PR, so the repro lives in its own file.)

### Before

```
 ❯ |unit| packages/lexical-table/src/__tests__/unit/UnmergeCellStyles.test.ts (2 tests | 1 failed) 15ms
     × the cells a merged cell splits into keep its backgroundColor and verticalAlign 13ms

 FAIL  ... > the cells a merged cell splits into keep its backgroundColor and verticalAlign
AssertionError: expected null to be 'rgb(255, 0, 0)' // Object.is equality

- Expected:
"rgb(255, 0, 0)"

+ Received:
null
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Also green:

- `npx vitest run packages/lexical-table` — 12 files, 159 tests
- `E2E_BROWSER=chromium npx playwright test --project=chromium Tables.spec.mjs` — 88 passed, 1 skipped
- `E2E_BROWSER=chromium npx playwright test --project=chromium 4876-unmerge-cell.spec.mjs 4872-full-row-span-cell-merge.spec.mjs` — 2 passed

Only chromium was exercised locally for the e2e runs.

