### PR TITLE
[lexical-react] Bug Fix: deselecting a node no longer discards the user's range selection

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/useLexicalNodeSelection.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalNodeSelection.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {EditorRefPlugin} from '@lexical/react/LexicalEditorRefPlugin';
+import {
+  $createHorizontalRuleNode,
+  HorizontalRuleNode,
+} from '@lexical/react/LexicalHorizontalRuleNode';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getNodeByKey,
+  $getRoot,
+  $getSelection,
+  $isNodeSelection,
+  $isRangeSelection,
+  $selectAll,
+  type LexicalEditor,
+  type NodeKey,
+} from 'lexical';
+import * as React from 'react';
+import {act, createRef} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+describe('useLexicalNodeSelection', () => {
+  let container: HTMLDivElement;
+  let reactRoot: Root;
+  let editor: LexicalEditor;
+  let editorRef: React.RefObject<LexicalEditor>;
+  let setSelected: (selected: boolean) => void;
+  let ruleKey: NodeKey;
+
+  function Probe({nodeKey}: {nodeKey: NodeKey}) {
+    [, setSelected] = useLexicalNodeSelection(nodeKey);
+    return null;
+  }
+
+  function Seed({onSeeded}: {onSeeded: (key: NodeKey) => void}) {
+    const [contextEditor] = useLexicalComposerContext();
+    React.useEffect(() => {
+      let key = '';
+      contextEditor.update(
+        () => {
+          const rule = $createHorizontalRuleNode();
+          $getRoot()
+            .clear()
+            .append(
+              $createParagraphNode().append($createTextNode('hello')),
+              rule,
+            );
+          key = rule.getKey();
+        },
+        {discrete: true},
+      );
+      onSeeded(key);
+    }, [contextEditor, onSeeded]);
+    return null;
+  }
+
+  function Harness() {
+    const [key, setKey] = React.useState<NodeKey | null>(null);
+    const onSeeded = React.useCallback((seeded: NodeKey) => {
+      ruleKey = seeded;
+      setKey(seeded);
+    }, []);
+    return (
+      <LexicalComposer
+        initialConfig={{
+          namespace: 'node-selection',
+          nodes: [HorizontalRuleNode],
+          onError: (error: Error) => {
+            throw error;
+          },
+        }}>
+        <EditorRefPlugin editorRef={editorRef} />
+        <RichTextPlugin
+          contentEditable={<ContentEditable />}
+          ErrorBoundary={({children}) => <>{children}</>}
+        />
+        <Seed onSeeded={onSeeded} />
+        {key !== null && <Probe nodeKey={key} />}
+      </LexicalComposer>
+    );
+  }
+
+  beforeEach(async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+    editorRef = createRef<LexicalEditor>() as React.RefObject<LexicalEditor>;
+
+    await act(async () => {
+      reactRoot.render(<Harness />);
+    });
+    editor = editorRef.current;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      reactRoot.unmount();
+    });
+    container.remove();
+  });
+
+  it('keeps a range selection when asked to deselect', async () => {
+    editor.update(() => void $selectAll(), {discrete: true});
+    expect(editor.read(() => $isRangeSelection($getSelection()))).toBe(true);
+
+    // LexicalNode.isSelected() is true for a RangeSelection that covers the
+    // node, so the `setSelected(!isSelected)` toggle that this package's own
+    // HorizontalRuleComponent and BlockWithAlignableContents use arrives here
+    // with `false` while a range selection is active.
+    await act(async () => {
+      setSelected(false);
+    });
+
+    expect(editor.read(() => $isRangeSelection($getSelection()))).toBe(true);
+  });
+
+  it('still creates a node selection when asked to select', async () => {
+    editor.update(() => void $selectAll(), {discrete: true});
+
+    await act(async () => {
+      setSelected(true);
+    });
+
+    expect(
+      editor.read(() => {
+        const selection = $getSelection();
+        return $isNodeSelection(selection) && selection.has(ruleKey);
+      }),
+    ).toBe(true);
+  });
+
+  it('still removes the node from an existing node selection', async () => {
+    await act(async () => {
+      setSelected(true);
+    });
+    expect(
+      editor.read(() => {
+        const selection = $getSelection();
+        return $isNodeSelection(selection) && selection.has(ruleKey);
+      }),
+    ).toBe(true);
+
+    await act(async () => {
+      setSelected(false);
+    });
+    expect(editor.read(() => $getNodeByKey(ruleKey)!.isSelected())).toBe(false);
+  });
+});

--- a/packages/lexical-react/src/useLexicalNodeSelection.ts
+++ b/packages/lexical-react/src/useLexicalNodeSelection.ts
@@ -84,6 +84,13 @@ export function useLexicalNodeSelection(
         let selection = $getSelection();
 
         if (!$isNodeSelection(selection)) {
+          if (!selected) {
+            // There is no NodeSelection to remove the node from. Creating one
+            // would replace whatever selection the user has -- a RangeSelection
+            // covering this node, typically, since isSelected() is true for
+            // those too -- with an empty NodeSelection, discarding their caret.
+            return;
+          }
           selection = $createNodeSelection();
           $setSelection(selection);
         }


### PR DESCRIPTION

## Description

`useLexicalNodeSelection`'s `setSelected` creates a `NodeSelection` before it looks at what it was asked to do:

```ts
editor.update(() => {
  let selection = $getSelection();

  if (!$isNodeSelection(selection)) {
    selection = $createNodeSelection();
    $setSelection(selection);
  }

  if ($isNodeSelection(selection)) {
    if (selected) {
      selection.add(key);
    } else {
      selection.delete(key);
    }
  }
});
```

Called with `false` when the current selection is not a `NodeSelection`, it installs a brand new, **empty** `NodeSelection` and then deletes a key that was never in it. The net effect is that the user's selection is thrown away and replaced with one that contains nothing — the caret disappears, and the range they had is gone.

This is on the normal path, not an edge case, because `LexicalNode.isSelected()` is true for a `RangeSelection` that covers the node:

```ts
isSelected(selection?: null | BaseSelection): boolean {
  const targetSelection = selection || $getSelection();
  ...
  const isSelected = targetSelection.getNodes()...
```

and the hook's own `isSelected` is computed from it. So the `setSelected(!isSelected)` toggle that this package ships in `LexicalHorizontalRuleNode` and `LexicalBlockWithAlignableContents` —

```tsx
setSelected(!isSelected);
```

— evaluates to `setSelected(false)` whenever a range selection happens to cover the node. Select a paragraph and the horizontal rule after it (Ctrl+A, or a drag across both), then click the rule: instead of selecting it, the selection is wiped. The playground's image, poll, equation, page-break and Excalidraw components all use the same toggle.

The fix is to make the request a no-op when there is nothing to deselect: if the current selection is not a `NodeSelection`, there is no `NodeSelection` to remove the node from, so leave the selection alone. Adding a node still creates one exactly as before.

## Test plan

New unit test `packages/lexical-react/src/__tests__/unit/useLexicalNodeSelection.test.tsx`, driving the hook through a real `HorizontalRuleNode` — the shipped caller of this toggle. The two "still ..." cases are controls and pass before and after, so the change is not over-narrowed.

### Before

```
 ❯ packages/lexical-react/src/__tests__/unit/useLexicalNodeSelection.test.tsx (3 tests | 1 failed)
   × keeps a range selection when asked to deselect
     AssertionError: expected false to be true // Object.is equality
   ✓ still creates a node selection when asked to select
   ✓ still removes the node from an existing node selection

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

### After

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-react
 Test Files  32 passed (32)
      Tests  185 passed (185)
```
