### PR TITLE
[lexical-list] Bug Fix: changing a list's type keeps the list's own state

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/InsertListKeepsListState.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/InsertListKeepsListState.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createListItemNode,
+  $createListNode,
+  $insertList,
+  $isListNode,
+  ListExtension,
+  type ListNode,
+} from '@lexical/list';
+import {$createTextNode, $getRoot, defineExtension} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [ListExtension],
+      name: 'insert-list-state-host',
+    }),
+  );
+}
+
+function $rootList(): ListNode {
+  const node = $getRoot().getFirstChild();
+  assert($isListNode(node), 'expected a ListNode at the root');
+  return node;
+}
+
+describe('$insertList keeps the replaced list state', () => {
+  test('converting a populated list keeps its direction, format and start', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const list = $createListNode('number', 4)
+          .setDirection('rtl')
+          .setFormat('center')
+          .setStyle('color: red;');
+        list.append(
+          $createListItemNode().append($createTextNode('a')),
+          $createListItemNode().append($createTextNode('b')),
+        );
+        $getRoot().clear().append(list);
+        list.getFirstChild()!.selectEnd();
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => $insertList('bullet'), {discrete: true});
+
+    editor.read(() => {
+      const list = $rootList();
+      expect(list.getListType()).toBe('bullet');
+      expect(list.getDirection()).toBe('rtl');
+      expect(list.getFormatType()).toBe('center');
+      expect(list.getStyle()).toBe('color: red;');
+      expect(list.getStart()).toBe(4);
+      expect(list.getChildren().map(item => item.getTextContent())).toEqual([
+        'a',
+        'b',
+      ]);
+    });
+  });
+
+  test('converting from an empty list item keeps the list state', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const list = $createListNode('bullet')
+          .setDirection('rtl')
+          .setFormat('right');
+        list.append($createListItemNode());
+        $getRoot().clear().append(list);
+        list.getFirstChild()!.selectEnd();
+      },
+      {discrete: true},
+    );
+
+    editor.update(() => $insertList('number'), {discrete: true});
+
+    editor.read(() => {
+      const list = $rootList();
+      expect(list.getListType()).toBe('number');
+      expect(list.getDirection()).toBe('rtl');
+      expect(list.getFormatType()).toBe('right');
+    });
+  });
+});

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -59,6 +59,21 @@ function $isSelectingEmptyListItem(
 }
 
 /**
+ * Build the ListNode that replaces `list` when its type is changed. The
+ * replacement stands in for the same list, so it is a copy — carrying the
+ * direction, format, style, indent and start the original was given — rather
+ * than a default-constructed ListNode. Every other place a ListNode is
+ * replaced by an equivalent one ({@link $handleIndent},
+ * {@link $handleOutdent}, {@link ListItemNode.replace}, …) uses `$copyNode`
+ * for the same reason.
+ */
+function $newListFrom(list: ElementNode, listType: ListType): ListNode {
+  return $isListNode(list)
+    ? $copyNode(list).setListType(listType)
+    : $createListNode(listType);
+}
+
+/**
  * Inserts a new ListNode. If the selection's anchor node is an empty ListItemNode and is a child of
  * the root/shadow root, it will replace the ListItemNode with a ListNode and the old ListItemNode.
  * Otherwise it will replace its parent with a new ListNode and re-insert the ListItemNode and any previous children.
@@ -87,9 +102,8 @@ export function $insertList(listType: ListType): void {
           nodes = paragraph.select().getNodes();
         }
       } else if ($isSelectingEmptyListItem(anchorNode, nodes)) {
-        const list = $createListNode(listType);
-
         if ($isRootOrShadowRoot(anchorNodeParent)) {
+          const list = $createListNode(listType);
           anchorNode.replace(list);
           const listItem = $createListItemNode();
           if ($isElementNode(anchorNode)) {
@@ -104,6 +118,7 @@ export function $insertList(listType: ListType): void {
           // owns the slot, so converting it is a no-op rather than a
           // replace (which would throw).
           if ($getSlotHost(parent) === null) {
+            const list = $newListFrom(parent, listType);
             append(list, parent.getChildren());
             parent.replace(list);
           }
@@ -145,7 +160,7 @@ export function $insertList(listType: ListType): void {
           // assignment is managed by the node or extension that owns the
           // slot.
           if (!handled.has(parentKey) && $getSlotHost(parent) === null) {
-            const newListNode = $createListNode(listType);
+            const newListNode = $newListFrom(parent, listType);
             append(newListNode, parent.getChildren());
             parent.replace(newListNode);
             handled.add(parentKey);


### PR DESCRIPTION
## Description

`$insertList` converts an existing list to another type by building a
replacement and moving the items across:

```ts
const newListNode = $createListNode(listType);
append(newListNode, parent.getChildren());
parent.replace(newListNode);
```

`$createListNode` is default-constructed, so the replacement drops everything
the old list carried: its `direction` (which the importers read off the
`<ol>`/`<ul>`'s `dir`), its `format` and `style`, its `indent`, and its
`start`. Toggling an RTL list from bullets to numbers silently re-renders it
left-to-right; toggling a centred list loses the alignment; toggling
`<ol start="4">` restarts it at 1.

The replacement stands in for the same list, and everywhere else in the
package that swaps a `ListNode` for an equivalent one — `$handleIndent`,
`$handleOutdent`, `$handleListInsertParagraph`, `ListItemNode.replace`,
`ListItemNode.insertAfter`, `ListItemNode.collapseAtStart` — builds it with
`$copyNode` for exactly that reason. `$insertList` is the odd one out.

This adds a small `$newListFrom` helper that copies the list being replaced
and sets the new type, and uses it at both sites in `$insertList` that replace
a `ListNode` (the populated-list path and the empty-list-item path).
`$createListOrMerge` is unchanged: there the node being converted is a
paragraph or heading, not a list, so there is nothing to copy from.

## Test plan

`npx vitest run packages/lexical-list/src/__tests__/unit/InsertListKeepsListState.test.ts`

(The natural test file, `formatList.test.ts`, is already being edited by an
open PR, so the repro lives in its own file.)

### Before

```
 ❯ |unit| packages/lexical-list/src/__tests__/unit/InsertListKeepsListState.test.ts (2 tests | 2 failed) 14ms
     × converting a populated list keeps its direction, format and start 11ms
     × converting from an empty list item keeps the list state 2ms

 FAIL  ... > converting a populated list keeps its direction, format and start
AssertionError: expected null to be 'rtl' // Object.is equality

- Expected:
"rtl"

+ Received:
null

 FAIL  ... > converting from an empty list item keeps the list state
AssertionError: expected null to be 'rtl' // Object.is equality

- Expected:
"rtl"

+ Received:
null
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Also green:

- `npx vitest run packages/lexical-list packages/lexical-markdown packages/lexical-mdast packages/lexical-react` — 49 files, 902 tests
- `E2E_BROWSER=chromium npx playwright test --project=chromium List.spec.mjs` — 36 passed

Only chromium was exercised locally for the e2e run.

