### PR TITLE
[lexical-rich-text] Bug Fix: Enter at the end of a quote keeps the block alignment and style

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/QuoteInsertNewAfter.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/QuoteInsertNewAfter.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createQuoteNode, RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  defineExtension,
+  type ElementNode,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+const QuoteTestExtension = /* @__PURE__ */ defineExtension({
+  $initialEditorState: null,
+  dependencies: [RichTextExtension],
+  name: '[test-quote-insert-new-after]',
+});
+
+type BlockSnapshot = {
+  format: string;
+  style: string;
+  textFormat: number;
+  type: string;
+};
+
+/**
+ * Put the caret at the end of a centred, styled block and press Enter, then
+ * describe the continuation block that Enter produced.
+ */
+function pressEnterAtEndOf(
+  $createBlock: () => ElementNode,
+  boldPending: boolean,
+): BlockSnapshot {
+  using editor = buildEditorFromExtensions(QuoteTestExtension);
+  editor.setRootElement(document.createElement('div'));
+
+  editor.update(
+    () => {
+      const block = $createBlock();
+      block.setFormat('center');
+      block.setStyle('color: red');
+      block.append($createTextNode('hello'));
+      $getRoot().clear().append(block);
+      block.selectEnd();
+    },
+    {discrete: true},
+  );
+
+  if (boldPending) {
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'RangeSelection');
+        selection.formatText('bold');
+      },
+      {discrete: true},
+    );
+  }
+
+  editor.update(
+    () => {
+      const selection = $getSelection();
+      assert($isRangeSelection(selection), 'RangeSelection');
+      selection.insertParagraph();
+    },
+    {discrete: true},
+  );
+
+  return editor.read(() => {
+    const children = $getRoot().getChildren();
+    const last = children[children.length - 1];
+    assert(children.length === 2, 'expected the block plus its continuation');
+    return {
+      format: last.getFormatType(),
+      style: (last as ElementNode).getStyle(),
+      textFormat: (last as ElementNode).getTextFormat(),
+      type: last.getType(),
+    };
+  });
+}
+
+describe('QuoteNode.insertNewAfter', () => {
+  it('keeps the block alignment and style, as ParagraphNode does', () => {
+    // The reference behaviour, from core ParagraphNode.insertNewAfter.
+    const fromParagraph = pressEnterAtEndOf($createParagraphNode, false);
+    expect(fromParagraph).toMatchObject({
+      format: 'center',
+      style: 'color: red',
+      type: 'paragraph',
+    });
+
+    const fromQuote = pressEnterAtEndOf($createQuoteNode, false);
+    expect(fromQuote).toMatchObject({
+      format: 'center',
+      style: 'color: red',
+      type: 'paragraph',
+    });
+  });
+
+  it('seeds the continuation block with the pending text format', () => {
+    const fromParagraph = pressEnterAtEndOf($createParagraphNode, true);
+    const fromQuote = pressEnterAtEndOf($createQuoteNode, true);
+
+    expect(fromParagraph.textFormat).not.toBe(0);
+    expect(fromQuote.textFormat).toBe(fromParagraph.textFormat);
+  });
+});

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -254,10 +254,21 @@ export class QuoteNode extends ElementNode {
 
   // Mutation
 
-  insertNewAfter(_: RangeSelection, restoreSelection?: boolean): ParagraphNode {
+  insertNewAfter(
+    rangeSelection: RangeSelection,
+    restoreSelection?: boolean,
+  ): ParagraphNode {
     const newBlock = $createParagraphNode();
+    // Carry the block properties and the caret's pending text format over to
+    // the continuation block, the same way ParagraphNode.insertNewAfter does.
+    if (rangeSelection) {
+      newBlock.setTextFormat(rangeSelection.format);
+      newBlock.setTextStyle(rangeSelection.style);
+    }
     const direction = this.getDirection();
     newBlock.setDirection(direction);
+    newBlock.setFormat(this.getFormatType());
+    newBlock.setStyle(this.getStyle());
     this.insertAfter(newBlock, restoreSelection);
     return newBlock;
   }


### PR DESCRIPTION

## Description

`QuoteNode.insertNewAfter` builds the continuation block by hand and copies exactly one property across:

```ts
insertNewAfter(_: RangeSelection, restoreSelection?: boolean): ParagraphNode {
  const newBlock = $createParagraphNode();
  const direction = this.getDirection();
  newBlock.setDirection(direction);
  this.insertAfter(newBlock, restoreSelection);
  return newBlock;
}
```

The `RangeSelection` argument is named `_` and ignored. Core `ParagraphNode.insertNewAfter` — the same operation, one block type over — carries five:

```ts
insertNewAfter(rangeSelection: RangeSelection, restoreSelection: boolean): ParagraphNode {
  const newElement = $createParagraphNode();
  newElement.setTextFormat(rangeSelection.format);
  newElement.setTextStyle(rangeSelection.style);
  const direction = this.getDirection();
  newElement.setDirection(direction);
  newElement.setFormat(this.getFormatType());
  newElement.setStyle(this.getStyle());
  this.insertAfter(newElement, restoreSelection);
  return newElement;
}
```

So the identical keystroke behaves differently depending on which block you are in. Centre-align a paragraph and press Enter at the end: the next paragraph is centred. Centre-align a blockquote and press Enter at the end: the next paragraph is left-aligned. Same for the block's `style`, and for the caret's pending text format — toggle bold with nothing selected and press Enter, and the new block is not seeded with it.

Measured on `upstream/main`, same content and same keystroke:

```
PARAGRAPH: children=paragraph,paragraph lastFormat="center" lastStyle="color: red"
QUOTE:     children=quote,paragraph     lastFormat=""       lastStyle=""
```

`HeadingNode.insertNewAfter` in this same file already treats the argument as load-bearing and forwards the block format and style when a heading is split, so `QuoteNode` is the outlier.

This makes `QuoteNode` match `ParagraphNode`. The `rangeSelection` argument is guarded because `insertNewAfter` is also reachable with no selection. No API or serialization change.

## Test plan

New unit test `packages/lexical-rich-text/src/__tests__/unit/QuoteInsertNewAfter.test.ts`. Each case runs the *same* helper against a paragraph and against a quote and requires them to agree, so the assertion is pinned to core's behaviour rather than to a hardcoded expectation.

### Before

```
 ❯ packages/lexical-rich-text/src/__tests__/unit/QuoteInsertNewAfter.test.ts (2 tests | 2 failed)
   × keeps the block alignment and style, as ParagraphNode does
     AssertionError: expected { format: '', style: '', …(2) } to match object { format: 'center', …(2) }
   × seeds the continuation block with the pending text format
     AssertionError: expected +0 to be 1 // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite, plus the packages that build on quotes, are unchanged:

```
$ npx vitest run packages/lexical-rich-text
 Test Files  15 passed (15)
      Tests  129 passed (129)

$ npx vitest run packages/lexical-markdown packages/lexical-html packages/lexical-playground
 Test Files  30 passed (30)
      Tests  792 passed (792)
```
