### PR TITLE
[lexical-table] Bug Fix: export the table's dir when scrollable tables are active

### DIFF
--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -575,6 +575,20 @@ export class TableNode extends ElementNode {
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const superExport = super.exportDOM(editor);
     const {element} = superExport;
+    const exportedElement =
+      !isHTMLTableElement(element) && isHTMLElement(element)
+        ? element.querySelector('table')
+        : element;
+    // ElementNode.exportDOM writes `dir` onto whatever createDOM returned,
+    // which is the scroll wrapper when scrollable tables are active. That
+    // wrapper is not part of the export, so the direction has to be re-applied
+    // to the <table> itself — that is where $convertTableElement reads it back.
+    if (isHTMLTableElement(exportedElement) && exportedElement !== element) {
+      const direction = this.getDirection();
+      if (direction) {
+        exportedElement.dir = direction;
+      }
+    }
     return {
       after: tableElement => {
         if (superExport.after) {
@@ -647,10 +661,7 @@ export class TableNode extends ElementNode {
         }
         return tableElement;
       },
-      element:
-        !isHTMLTableElement(element) && isHTMLElement(element)
-          ? element.querySelector('table')
-          : element,
+      element: exportedElement,
     };
   }
 

--- a/packages/lexical-table/src/__tests__/unit/TableExportDirection.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/TableExportDirection.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions, configExtension} from '@lexical/extension';
+import {$generateHtmlFromNodes} from '@lexical/html';
+import {
+  $createTableNodeWithDimensions,
+  $isTableNode,
+  TableExtension,
+} from '@lexical/table';
+import {$getRoot, defineExtension} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+function buildEditor(hasHorizontalScroll: boolean) {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [configExtension(TableExtension, {hasHorizontalScroll})],
+      name: 'table-export-dir-host',
+      theme: {tableScrollableWrapper: 'scroll-wrapper'},
+    }),
+  );
+}
+
+function exportRtlTable(hasHorizontalScroll: boolean): string {
+  using editor = buildEditor(hasHorizontalScroll);
+  editor.update(
+    () => {
+      $getRoot()
+        .clear()
+        .append(
+          $createTableNodeWithDimensions(1, 1, false).setDirection('rtl'),
+        );
+    },
+    {discrete: true},
+  );
+  return editor.read(() => {
+    const table = $getRoot().getFirstChild();
+    assert($isTableNode(table), 'expected a TableNode at the root');
+    expect(table.getDirection()).toBe('rtl');
+    return $generateHtmlFromNodes(editor);
+  });
+}
+
+describe('TableNode.exportDOM direction', () => {
+  test('exports dir with scrollable tables active', () => {
+    expect(exportRtlTable(true)).toContain('<table dir="rtl">');
+  });
+
+  test('exports dir without scrollable tables', () => {
+    expect(exportRtlTable(false)).toContain('<table dir="rtl">');
+  });
+});


### PR DESCRIPTION
## Description

`$convertTableElement` reads `dir` back off the `<table>` on import. On the way
out it is written by `ElementNode.exportDOM`, which sets it on whatever
`createDOM` returned — and when scrollable tables are active `TableNode.createDOM`
returns the scroll **wrapper** `<div>`, not the `<table>`.

`TableNode.exportDOM` then narrows the export down to `element.querySelector('table')`
and throws the wrapper away, taking the `dir` with it. So the direction survives
only when `hasHorizontalScroll` is off; with the default config (and in the
playground) copying an RTL table produces `<table>` with no direction, and
re-importing that HTML no longer produces the node it came from.

This resolves the exported element once and re-applies the node's direction to
it when the wrapper was dropped. A table with no explicit direction, and the
non-wrapped case where `ElementNode.exportDOM` already wrote `dir` onto the
`<table>` itself, are both unaffected.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/TableExportDirection.test.ts`

The two cases are the same table exported with `hasHorizontalScroll` on and off;
the second passes on both sides of the change, which is what pins the wrapper as
the cause.

### Before

```
 ❯ |unit| packages/lexical-table/src/__tests__/unit/TableExportDirection.test.ts (2 tests | 1 failed) 33ms
     × exports dir with scrollable tables active 29ms

 FAIL  ... > TableNode.exportDOM direction > exports dir with scrollable tables active
AssertionError: expected '<table><tbody><tr><td style="border: …' to contain '<table dir="rtl">'

Expected: "<table dir="rtl">"
Received: "<table><tbody><tr><td style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;"><p><br></p></td></tr></tbody></table>"
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Also green:

- `npx vitest run packages/lexical-table` — 12 files, 159 tests
- `npx vitest run packages/lexical-clipboard packages/lexical-html packages/lexical-markdown` — 15 files, 541 tests

