### PR TITLE
[lexical-playground] Bug Fix: the floating format toolbar follows setEditable

### DIFF
--- a/packages/lexical-playground/__tests__/unit/FloatingTextFormatToolbar.test.tsx
+++ b/packages/lexical-playground/__tests__/unit/FloatingTextFormatToolbar.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {RovingTabIndexExtension} from '@lexical/a11y';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $selectAll,
+  defineExtension,
+  type LexicalEditor,
+} from 'lexical';
+import * as React from 'react';
+import {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import FloatingTextFormatToolbarPlugin from '../../src/plugins/FloatingTextFormatToolbarPlugin';
+
+const ToolbarTestExtension = /* @__PURE__ */ defineExtension({
+  $initialEditorState: () => {
+    $getRoot()
+      .clear()
+      .append($createParagraphNode().append($createTextNode('hello')));
+  },
+  dependencies: [RichTextExtension, RovingTabIndexExtension],
+  name: '[test-floating-toolbar]',
+});
+
+describe('FloatingTextFormatToolbarPlugin', () => {
+  let container: HTMLDivElement;
+  let anchorElem: HTMLDivElement;
+  let reactRoot: Root;
+  let editor: LexicalEditor;
+
+  function Capture() {
+    const [contextEditor] = useLexicalComposerContext();
+    editor = contextEditor;
+    return null;
+  }
+
+  beforeEach(async () => {
+    container = document.createElement('div');
+    anchorElem = document.createElement('div');
+    document.body.append(container, anchorElem);
+    reactRoot = createRoot(container);
+
+    await act(async () => {
+      reactRoot.render(
+        <LexicalExtensionComposer extension={ToolbarTestExtension}>
+          <Capture />
+          <FloatingTextFormatToolbarPlugin
+            anchorElem={anchorElem}
+            setIsLinkEditMode={vi.fn()}
+          />
+        </LexicalExtensionComposer>,
+      );
+    });
+
+    // The popup only opens for a non-collapsed selection whose DOM anchor is
+    // inside the root element, so set both.
+    await act(async () => {
+      editor.update(() => void $selectAll(), {discrete: true});
+      const textDOM = editor.getRootElement()!.querySelector('p')!.firstChild!
+        .firstChild!;
+      document
+        .getSelection()!
+        .setBaseAndExtent(textDOM, 0, textDOM, 'hello'.length);
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      reactRoot.unmount();
+    });
+    container.remove();
+    anchorElem.remove();
+  });
+
+  function formatButtonCount(): number {
+    return anchorElem.querySelectorAll(
+      '.floating-text-format-popup button[aria-label^="Format text"]',
+    ).length;
+  }
+
+  it('hides its format buttons when the editor becomes read-only', async () => {
+    expect(anchorElem.querySelector('.floating-text-format-popup')).not.toBe(
+      null,
+    );
+    expect(formatButtonCount()).toBeGreaterThan(0);
+
+    await act(async () => {
+      editor.setEditable(false);
+    });
+    expect(formatButtonCount()).toBe(0);
+
+    await act(async () => {
+      editor.setEditable(true);
+    });
+    expect(formatButtonCount()).toBeGreaterThan(0);
+  });
+});

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -12,6 +12,7 @@ import {useMergeRefs} from '@floating-ui/react';
 import {$isCodeNode} from '@lexical/code';
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalRovingTabIndexRef} from '@lexical/react/useLexicalRovingTabIndexRef';
 import {
   $getSelection,
@@ -82,6 +83,9 @@ function TextFormatFloatingToolbar({
 }): JSX.Element {
   const popupCharStylesEditorRef = useRef<HTMLDivElement | null>(null);
   const rovingRef = useLexicalRovingTabIndexRef();
+  // Subscribed rather than read off the editor, so that setEditable() actually
+  // re-renders the toolbar.
+  const isEditable = useLexicalEditable();
   const mergedRef = useMergeRefs([popupCharStylesEditorRef, rovingRef, ref]);
 
   const insertLink = useCallback(() => {
@@ -224,7 +228,7 @@ function TextFormatFloatingToolbar({
       className="floating-text-format-popup"
       role="toolbar"
       aria-label="Floating text format toolbar">
-      {editor.isEditable() && (
+      {isEditable && (
         <>
           <button
             type="button"


### PR DESCRIPTION

## Description

`TextFormatFloatingToolbar` gates its entire button row on editability, read straight off the editor during render with no subscription:

```tsx
return (
  <div ref={mergedRef} className="floating-text-format-popup" role="toolbar" ...>
    {editor.isEditable() && (
      <>
        <button onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold')} ...
```

The gate says plainly what is intended: no format buttons when the editor is not editable. But `editor.setEditable(...)` notifies editable listeners — it does not re-render a component that merely called `isEditable()`. Nothing else in this component re-renders on that event either: `updatePopup` is driven by `registerUpdateListener` and `selectionchange`, and toggling editability fires neither.

So with the toolbar open — which is its normal state, since it appears whenever there is a non-collapsed text selection — switching the editor to read-only leaves every format button rendered and fully live. They are not inert: the handlers call `editor.dispatchCommand(FORMAT_TEXT_COMMAND, ...)`, which applies formatting regardless of editability. A document the user has just set to read-only can still be bolded, italicised, subscripted, linked and commented from the floating toolbar. The playground ships the toggle that gets you there (`ActionsPlugin` calls `editor.setEditable(!editor.isEditable())`), and the toolbar survives it because the selection survives it.

It is also intermittent in the confusing direction: any unrelated re-render — a selection change, a keystroke — silently corrects the toolbar, so the buttons come and go depending on what else happened.

`@lexical/react` ships the hook for exactly this, and its doc comment says to prefer it over hand-rolling `registerEditableListener`. The playground already uses it in `TableCellResizer`, `TableActionMenuPlugin`, `TableHoverActionsV2Plugin`, `ImageComponent`, `EquationComponent` and `ExcalidrawComponent`; this component is the one that reads the value directly. Swapping in `useLexicalEditable()` is the whole change.

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/FloatingTextFormatToolbar.test.tsx` opens the toolbar on a real selection and toggles editability in both directions.

### Before

```
 ❯ packages/lexical-playground/__tests__/unit/FloatingTextFormatToolbar.test.tsx (1 test | 1 failed)
   × hides its format buttons when the editor becomes read-only
     AssertionError: expected 7 to be +0 // Object.is equality

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

(Seven format buttons are still mounted and clickable after `setEditable(false)`.)

### After

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-playground
 Test Files  19 passed (19)
      Tests  275 passed (275)
```
