### PR TITLE
[lexical-list] Bug Fix: removing a list keeps each item's own element state

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/RemoveListKeepsItemState.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/RemoveListKeepsItemState.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createListItemNode,
+  $createListNode,
+  $insertList,
+  $removeList,
+  ListExtension,
+} from '@lexical/list';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  $selectAll,
+  defineExtension,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [ListExtension],
+      name: 'remove-list-state-host',
+    }),
+  );
+}
+
+function $paragraphState() {
+  return $getRoot()
+    .getChildren()
+    .filter($isParagraphNode)
+    .map(p => ({
+      direction: p.getDirection(),
+      format: p.getFormatType(),
+      indent: p.getIndent(),
+      style: p.getStyle(),
+      text: p.getTextContent(),
+    }));
+}
+
+describe('$removeList keeps the list item state', () => {
+  test('the paragraphs keep the items format, indent, direction and style', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const list = $createListNode('bullet');
+        const outer = $createListItemNode()
+          .setFormat('center')
+          .setDirection('rtl')
+          .setStyle('color: red;');
+        outer.append($createTextNode('a'));
+        list.append(outer);
+        // A nested item renders one level in; getIndent() derives that from the
+        // nesting, so the paragraph has to carry it to look the same.
+        const wrapper = $createListItemNode();
+        const nested = $createListNode('bullet');
+        nested.append($createListItemNode().append($createTextNode('b')));
+        wrapper.append(nested);
+        list.append(wrapper);
+        $getRoot().clear().append(list);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        $selectAll();
+        $removeList();
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($paragraphState()).toEqual([
+        {
+          direction: 'rtl',
+          format: 'center',
+          indent: 0,
+          style: 'color: red;',
+          text: 'a',
+        },
+        {direction: null, format: '', indent: 1, style: '', text: 'b'},
+      ]);
+    });
+  });
+
+  test('a formatted paragraph round-trips through a list', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        // $createListOrMerge copies the block's format and indent onto the list
+        // item it creates, so removing the list again has to give them back.
+        const paragraph = $createParagraphNode()
+          .setFormat('right')
+          .setIndent(2);
+        paragraph.append($createTextNode('x'));
+        $getRoot().clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        $selectAll();
+        $insertList('bullet');
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        $selectAll();
+        $removeList();
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      expect($paragraphState()).toEqual([
+        {direction: null, format: 'right', indent: 2, style: '', text: 'x'},
+      ]);
+    });
+  });
+});

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -305,6 +305,17 @@ export function $removeList(): void {
           .setTextStyle(selection.style)
           .setTextFormat(selection.format);
 
+        // The paragraph stands in for the list item, so it keeps the item's own
+        // element state. $createListOrMerge does the mirror image of this on the
+        // way in — it copies the block's format and indent onto the list item it
+        // creates — and the importers and ListItemNode.exportDOM round-trip the
+        // direction and style, so dropping them here loses state the user set.
+        paragraph
+          .setFormat(listItemNode.getFormatType())
+          .setIndent(listItemNode.getIndent())
+          .setDirection(listItemNode.getDirection())
+          .setStyle(listItemNode.getStyle());
+
         append(paragraph, listItemNode.getChildren());
 
         insertionPoint.insertAfter(paragraph);


### PR DESCRIPTION
## Description

`$createListOrMerge` copies a block's element state onto the list item it
creates when a list is inserted:

```ts
listItem.setFormat(node.getFormatType());
listItem.setIndent(node.getIndent());
```

`$removeList` is the inverse operation and does not do the reverse. It builds
each replacement paragraph from the *selection's* text style and format only,
so the item's own `format` (alignment), `indent`, `direction` and `style` are
dropped. Turning a centred, indented paragraph into a list and back loses the
centring and the indent; a nested item comes back flush left instead of one
level in; an RTL item comes back LTR even though both importers read `dir` off
the `<li>` and `ListItemNode.exportDOM` writes it.

This carries those four onto the paragraph that stands in for the item.
`indent` in particular is derived from the nesting for an attached list item,
so it is the only thing that can reproduce a nested item's rendering once the
list is gone.

## Test plan

`npx vitest run packages/lexical-list/src/__tests__/unit/RemoveListKeepsItemState.test.ts`

(The natural test file, `formatList.test.ts`, is already being edited by an
open PR, so the repro lives in its own file.)

### Before

```
 ❯ |unit| packages/lexical-list/src/__tests__/unit/RemoveListKeepsItemState.test.ts (2 tests | 2 failed) 17ms
     × the paragraphs keep the items format, indent, direction and style 14ms
     × a formatted paragraph round-trips through a list 2ms

 FAIL  ... > the paragraphs keep the items format, indent, direction and style
AssertionError: expected [ { direction: null, …(4) }, …(1) ] to deeply equal [ { direction: 'rtl', …(4) }, …(1) ]

- Expected
+ Received

  [
    {
-     "direction": "rtl",
-     "format": "center",
+     "direction": null,
+     "format": "",
      "indent": 0,
-     "style": "color: red;",
+     "style": "",
      "text": "a",
    },
    {
      "direction": null,
      "format": "",
-     "indent": 1,
+     "indent": 0,
      "style": "",
      "text": "b",
    },
  ]
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Also green:

- `npx vitest run packages/lexical-list packages/lexical-markdown packages/lexical-mdast packages/lexical-react` — 49 files, 902 tests
- `E2E_BROWSER=chromium npx playwright test --project=chromium List.spec.mjs` — 36 passed

Only chromium was exercised locally for the e2e run.

