### PR TITLE
[lexical-playground] Bug Fix: RubyNode.updateDOM updates the element createDOM rendered

### DIFF
--- a/packages/lexical-playground/__tests__/unit/RubyNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/RubyNode.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $getRoot,
+  defineExtension,
+  type LexicalEditor,
+  type TextFormatType,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+import {
+  $createRubyNode,
+  $isRubyNode,
+  RubyNode,
+} from '../../src/plugins/RubyExtension/RubyNode';
+
+const RubyTestExtension = /* @__PURE__ */ defineExtension({
+  $initialEditorState: null,
+  dependencies: [RichTextExtension],
+  name: '[test-ruby]',
+  nodes: [RubyNode],
+  theme: {ruby: 'theme-ruby', text: {underline: 'theme-underline'}},
+});
+
+type RubyDOM = {inner: HTMLElement; wrapper: HTMLElement};
+
+function makeEditor(): [LexicalEditor & Disposable, HTMLElement] {
+  const editor = buildEditorFromExtensions(RubyTestExtension);
+  const rootElement = document.createElement('div');
+  editor.setRootElement(rootElement);
+  return [editor, rootElement];
+}
+
+function getRubyDOM(rootElement: HTMLElement): RubyDOM {
+  const wrapper = rootElement.querySelector<HTMLElement>('[role="group"]');
+  assert(wrapper !== null, 'ruby wrapper');
+  const inner = wrapper.firstElementChild as HTMLElement | null;
+  assert(inner !== null, 'ruby inner');
+  return {inner, wrapper};
+}
+
+function describeRuby({inner, wrapper}: RubyDOM) {
+  return {
+    innerClass: Array.from(inner.classList).sort().join(' '),
+    innerStyle: inner.getAttribute('style') || '',
+    wrapperClass: Array.from(wrapper.classList).sort().join(' '),
+    wrapperStyle: wrapper.getAttribute('style') || '',
+  };
+}
+
+/** Build a ruby node in its final state, so only createDOM runs. */
+function renderFresh(style: string, format: null | TextFormatType) {
+  const [editor, rootElement] = makeEditor();
+  using _ = editor;
+  editor.update(
+    () => {
+      const ruby = $createRubyNode('kanji', 'kana').setStyle(style);
+      if (format) {
+        ruby.setFormat(format);
+      }
+      $getRoot().clear().append($createParagraphNode().append(ruby));
+    },
+    {discrete: true},
+  );
+  return describeRuby(getRubyDOM(rootElement));
+}
+
+/** Build a plain ruby node and then mutate it, so updateDOM runs. */
+function renderThenUpdate(style: string, format: null | TextFormatType) {
+  const [editor, rootElement] = makeEditor();
+  using _ = editor;
+  editor.update(
+    () => {
+      const ruby = $createRubyNode('kanji', 'kana').setStyle('color: red');
+      $getRoot().clear().append($createParagraphNode().append(ruby));
+    },
+    {discrete: true},
+  );
+  editor.update(
+    () => {
+      const ruby = $getRoot().getLastDescendant();
+      assert($isRubyNode(ruby), 'RubyNode');
+      ruby.setStyle(style);
+      if (format) {
+        ruby.setFormat(format);
+      }
+    },
+    {discrete: true},
+  );
+  return describeRuby(getRubyDOM(rootElement));
+}
+
+describe('RubyNode.updateDOM', () => {
+  it('applies a style change to the element createDOM styled', () => {
+    // updateDOM returning false promises the DOM already matches what
+    // createDOM would have produced for this node.
+    expect(renderThenUpdate('color: blue', null)).toEqual(
+      renderFresh('color: blue', null),
+    );
+  });
+
+  it('applies a class-only text format to the element createDOM classed', () => {
+    expect(renderThenUpdate('color: red', 'underline')).toEqual(
+      renderFresh('color: red', 'underline'),
+    );
+  });
+
+  it('leaves the annotation and the accessible name on the wrapper', () => {
+    const [editor, rootElement] = makeEditor();
+    using _ = editor;
+    editor.update(
+      () => {
+        const ruby = $createRubyNode('kanji', 'kana');
+        $getRoot().clear().append($createParagraphNode().append(ruby));
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const ruby = $getRoot().getLastDescendant();
+        assert($isRubyNode(ruby), 'RubyNode');
+        ruby.setAnnotation('kana2');
+      },
+      {discrete: true},
+    );
+    const {inner, wrapper} = getRubyDOM(rootElement);
+    expect(inner.dataset.rubyAnnotation).toBe('kana2');
+    expect(wrapper.getAttribute('aria-label')).toBe('kanji (kana2)');
+  });
+});

--- a/packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts
+++ b/packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts
@@ -67,13 +67,17 @@ export class RubyNode extends TextNode {
   }
 
   updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
-    const updated = super.updateDOM(prevNode, dom, config);
+    // `dom` is the wrapper, but createDOM applies the text format classes and
+    // the node style to the inner element, so super has to be handed the same
+    // element or the two disagree about where those live.
+    const inner = dom.firstElementChild as HTMLElement | null;
+    if (inner === null) {
+      return true;
+    }
+    const updated = super.updateDOM(prevNode, inner, config);
     const annotationChange = $getStateChange(this, prevNode, annotationState);
     if (annotationChange || prevNode.__text !== this.__text) {
-      const inner = dom.firstElementChild as HTMLElement;
-      if (inner) {
-        inner.dataset.rubyAnnotation = this.getAnnotation();
-      }
+      inner.dataset.rubyAnnotation = this.getAnnotation();
       dom.setAttribute(
         'aria-label',
         `${this.__text} (${this.getAnnotation()})`,


### PR DESCRIPTION

## Description

`RubyNode` wraps the element `TextNode.createDOM` builds, and `createDOM` is careful to keep everything super produced on the **inner** element:

```ts
createDOM(config: EditorConfig): HTMLElement {
  const inner = super.createDOM(config);          // theme.text.* classes + this.__style land here
  inner.dataset.rubyAnnotation = this.getAnnotation();
  addClassNamesToElement(inner, config.theme.ruby || 'PlaygroundEditorTheme__ruby');
  const wrapper = $getDocument().createElement('span');
  ...
  wrapper.appendChild(inner);
  return wrapper;                                  // the keyed element is the wrapper
}
```

`updateDOM` then hands super the **wrapper**:

```ts
updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
  const updated = super.updateDOM(prevNode, dom, config);   // dom === wrapper
```

The text itself survives, because the `getDOMSlot` override redirects `$setTextContent` to `dom.firstElementChild`. The other two things `TextNode.updateDOM` does bypass the slot and write to the element they were handed:

- `setTextThemeClassNames(..., innerDOM, textClassNames)`
- `setDOMStyleFromCSS(dom.style, nextStyle, prevStyle)`

So the two methods disagree about which element carries the formatting, and `updateDOM` returns `false` — promising the reconciler the DOM is already correct.

Rendered on `upstream/main`, a ruby node with `color: red` restyled to `color: blue` and underlined:

```html
<!-- after createDOM -->
<span role="group" aria-label="kanji (kana)">
  <span style="color: red;" data-ruby-annotation="kana" class="theme-ruby">kanji</span>
</span>

<!-- after updateDOM -->
<span role="group" aria-label="kanji (kana)" class="theme-underline" style="color: blue;">
  <span style="color: red;" data-ruby-annotation="kana" class="theme-ruby">kanji</span>
</span>
```

The inner element's own inline `color: red` still wins over the wrapper's `color: blue`, so **changing the colour of a ruby annotation does nothing** — the toolbar swatch moves and the text stays red. Underline and strikethrough land on the wrapper, whose only child is `.PlaygroundEditorTheme__ruby` with `display: inline-block`; text decoration does not propagate into an atomic inline box, so they are not painted either. Removing a format that was carried in from the original text (`$toggleRuby` copies `format` and `style` from the source node) strips the class from the wrapper while the inner keeps it, so the formatting can never be turned off.

Bold, italic, code, highlight, subscript and superscript are unaffected — those change the HTML tag, so `TextNode.updateDOM` returns `true` before touching the DOM and the node is rebuilt through `createDOM`. Only the formats applied in place are broken, which is why this looks arbitrary in use.

The fix resolves the inner element and passes it to super, exactly as `createDOM` and `getDOMSlot` already do. The wrapper keeps the `role`/`aria-label` it owns. When the inner is missing, `updateDOM` returns `true` so the reconciler rebuilds rather than silently promising a DOM it could not update.

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/RubyNode.test.ts`. The first two cases assert the invariant `updateDOM` returning `false` actually promises: the DOM after mutating a node must equal the DOM of a freshly created node in the same state. That pins the assertion to `createDOM` rather than to a hardcoded expectation. The third case is a control covering the annotation and accessible name the wrapper legitimately owns, and passes before and after.

### Before

```
 ❯ packages/lexical-playground/__tests__/unit/RubyNode.test.ts (3 tests | 2 failed)
   × applies a style change to the element createDOM styled
       "innerClass": "theme-ruby",
     -   "innerStyle": "color: blue;",
     +   "innerStyle": "color: red;",
         "wrapperClass": "",
     -   "wrapperStyle": "",
     +   "wrapperStyle": "color: blue;",
   × applies a class-only text format to the element createDOM classed
     -   "innerClass": "theme-ruby theme-underline",
     +   "innerClass": "theme-ruby",
         "innerStyle": "color: red;",
     -   "wrapperClass": "",
     +   "wrapperClass": "theme-underline",
   ✓ leaves the annotation and the accessible name on the wrapper

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

### After

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-playground
 Test Files  19 passed (19)
      Tests  277 passed (277)
```
