### PR TITLE
[lexical-react] Bug Fix: the character limit counts the text that is already in the editor

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/LexicalCharacterLimitPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalCharacterLimitPlugin.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {OverflowNode} from '@lexical/overflow';
+import {CharacterLimitPlugin} from '@lexical/react/LexicalCharacterLimitPlugin';
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {EditorRefPlugin} from '@lexical/react/LexicalEditorRefPlugin';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type LexicalEditor,
+} from 'lexical';
+import * as React from 'react';
+import {act, createRef} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+const MAX_LENGTH = 5;
+
+describe('CharacterLimitPlugin', () => {
+  let container: HTMLDivElement;
+  let reactRoot: Root;
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      reactRoot.unmount();
+    });
+    container.remove();
+  });
+
+  /**
+   * Mount an editor that already holds `text`, then mount the plugin on top of
+   * it -- which is what toggling the character-limit setting on does.
+   */
+  async function mountWithText(
+    text: string,
+    charset: 'UTF-8' | 'UTF-16' = 'UTF-16',
+  ): Promise<void> {
+    const editorRef =
+      createRef<LexicalEditor>() as React.RefObject<LexicalEditor>;
+    await act(async () => {
+      reactRoot.render(
+        <LexicalComposer
+          initialConfig={{
+            editorState: () => {
+              $getRoot()
+                .clear()
+                .append($createParagraphNode().append($createTextNode(text)));
+            },
+            namespace: 'character-limit',
+            nodes: [OverflowNode],
+            onError: (error: Error) => {
+              throw error;
+            },
+          }}>
+          <EditorRefPlugin editorRef={editorRef} />
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            ErrorBoundary={({children}) => <>{children}</>}
+          />
+          <CharacterLimitPlugin charset={charset} maxLength={MAX_LENGTH} />
+        </LexicalComposer>,
+      );
+    });
+    editor = editorRef.current;
+  }
+
+  function remainingCharacters(): string {
+    const span = container.querySelector('.characters-limit');
+    expect(span).not.toBe(null);
+    return (span as HTMLElement).textContent ?? '';
+  }
+
+  function overflowNodeCount(): number {
+    return editor.read(
+      () =>
+        $getRoot()
+          .getAllTextNodes()
+          .filter(node => node.getParent() instanceof OverflowNode).length,
+    );
+  }
+
+  it('counts the text that is already in the editor when it mounts', async () => {
+    await mountWithText('hello world');
+
+    // 5 - 11
+    expect(remainingCharacters()).toBe('-6');
+    expect(overflowNodeCount()).toBeGreaterThan(0);
+  });
+
+  it('reports a full budget for an editor that is under the limit', async () => {
+    await mountWithText('hi');
+
+    expect(remainingCharacters()).toBe('3');
+    expect(overflowNodeCount()).toBe(0);
+  });
+
+  it('counts in the charset it was given', async () => {
+    // Three 3-byte characters: 3 UTF-16 code units, 9 UTF-8 bytes.
+    await mountWithText('一二三', 'UTF-8');
+
+    expect(remainingCharacters()).toBe('-4');
+  });
+});

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -61,7 +61,38 @@ export function useCharacterLimit(
 
   useEffect(() => {
     let text = editor.read('latest', $rootTextContent);
-    let lastComputedTextLength = 0;
+    let lastComputedTextLength: null | number = null;
+
+    function $updateCharacterLimit(): void {
+      const textLength = strlen(text);
+      const textLengthAboveThreshold =
+        textLength > maxCharacters ||
+        (lastComputedTextLength !== null &&
+          lastComputedTextLength > maxCharacters);
+      const diff = maxCharacters - textLength;
+
+      remainingCharacters(diff);
+
+      if (lastComputedTextLength === null || textLengthAboveThreshold) {
+        const offset = findOffset(text, maxCharacters, strlen);
+        editor.update(
+          () => {
+            $wrapOverflowedNodes(offset);
+          },
+          {
+            tag: HISTORY_MERGE_TAG,
+          },
+        );
+      }
+
+      lastComputedTextLength = textLength;
+    }
+
+    // Derive the count from the content that is already there before
+    // subscribing. registerUpdateListener does not fire on registration, so
+    // otherwise both the reported count and the OverflowNode wrapping stay at
+    // their initial values until the next edit.
+    $updateCharacterLimit();
 
     return mergeRegister(
       editor.registerTextContentListener((currentText: string) => {
@@ -76,28 +107,7 @@ export function useCharacterLimit(
           return;
         }
 
-        const textLength = strlen(text);
-        const textLengthAboveThreshold =
-          textLength > maxCharacters ||
-          (lastComputedTextLength !== null &&
-            lastComputedTextLength > maxCharacters);
-        const diff = maxCharacters - textLength;
-
-        remainingCharacters(diff);
-
-        if (lastComputedTextLength === null || textLengthAboveThreshold) {
-          const offset = findOffset(text, maxCharacters, strlen);
-          editor.update(
-            () => {
-              $wrapOverflowedNodes(offset);
-            },
-            {
-              tag: HISTORY_MERGE_TAG,
-            },
-          );
-        }
-
-        lastComputedTextLength = textLength;
+        $updateCharacterLimit();
       }),
       editor.registerCommand(
         DELETE_CHARACTER_COMMAND,


### PR DESCRIPTION

## Description

`useCharacterLimit` derives the remaining-character count only from inside an update listener, and `registerUpdateListener` does not fire on registration:

```ts
useEffect(() => {
  let text = editor.read('latest', $rootTextContent);
  let lastComputedTextLength = 0;

  return mergeRegister(
    editor.registerTextContentListener((currentText: string) => { text = currentText; }),
    editor.registerUpdateListener(({dirtyLeaves, dirtyElements}) => {
      ...
      remainingCharacters(diff);          // <- the only place the count is produced
```

`text` is read from the editor, then never used until something else changes. The consumer seeds its state from a constant, not from the editor:

```tsx
// LexicalCharacterLimitPlugin.tsx
const [remainingCharacters, setRemainingCharacters] = useState(maxLength);
```

So a `CharacterLimitPlugin` mounted over an editor that already has content reports `maxLength` no matter what is in it, and `$wrapOverflowedNodes` never runs, so overflowing text is not wrapped in `OverflowNode`s and not styled. It stays that way until the next edit.

That is the normal way this plugin is reached. The playground renders it behind a setting —

```tsx
{isCharLimit && <CharacterLimitPlugin charset="UTF-16" maxLength={5} />}
```

— so turning "Char Limit" on after typing shows the full budget over text that is already far past it, with no overflow highlight. Type one more character and the number jumps straight to the true value. The same applies to any editor loaded from saved content, and to switching `charset`: `strlen` changes identity, the effect re-subscribes, and the displayed number stays in the old charset's units.

The effect's own code shows the initial pass was intended: `lastComputedTextLength` is tested against `null` in two places,

```ts
(lastComputedTextLength !== null && lastComputedTextLength > maxCharacters);
...
if (lastComputedTextLength === null || textLengthAboveThreshold) {
```

but it is initialized to `0`, so neither branch can ever be taken and the "first pass, always reconcile the overflow wrapping" case is dead. That matters beyond the counter: a document deserialized with `OverflowNode`s under a larger limit never gets them unwrapped.

This restores `null` as the initial value, lifts the listener body into `$updateCharacterLimit()`, and calls it once before subscribing — the shape `useCanShowPlaceholder` in this same directory already uses:

```ts
useLayoutEffect(() => {
  function resetCanShowPlaceholder() { ... }
  resetCanShowPlaceholder();
  return mergeRegister(...);
}, [editor]);
```

The listener behaviour is otherwise untouched; `git diff -w` is 33 insertions / 23 deletions, most of it the extraction. No API change.

## Test plan

New unit test `packages/lexical-react/src/__tests__/unit/LexicalCharacterLimitPlugin.test.tsx` mounts the plugin over an editor that already holds text, which is what toggling the setting on does.

### Before

```
 ❯ packages/lexical-react/src/__tests__/unit/LexicalCharacterLimitPlugin.test.tsx (3 tests | 3 failed)
   × counts the text that is already in the editor when it mounts
     AssertionError: expected '5' to be '-6' // Object.is equality
   × reports a full budget for an editor that is under the limit
     AssertionError: expected '5' to be '3' // Object.is equality
   × counts in the charset it was given
     AssertionError: expected '5' to be '-4' // Object.is equality

 Test Files  1 failed (1)
      Tests  3 failed (3)
```

(The counter reads `5` — the seeded `maxLength` — regardless of the content.)

### After

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Package suite is unchanged, including the existing `useLexicalCharacterLimit` helper tests:

```
$ npx vitest run packages/lexical-react
 Test Files  32 passed (32)
      Tests  185 passed (185)
```
