### PR TITLE
[lexical-list] Bug Fix: splicing a block into a list keeps its text formatting

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -8,7 +8,6 @@
 
 import {
   $applyNodeReplacement,
-  $createTextNode,
   $getDocument,
   $isElementNode,
   $setDirectionFromDOM,
@@ -204,11 +203,18 @@ export class ListNode extends ElementNode {
         if (listItemNodesToInsert === nodesToInsert) {
           listItemNodesToInsert = [...nodesToInsert];
         }
-        listItemNodesToInsert[i] = this.createListItemNode().append(
-          $isElementNode(node) && !($isListNode(node) || node.isInline())
-            ? $createTextNode(node.getTextContent())
-            : node,
-        );
+        const listItem = this.createListItemNode();
+        if ($isElementNode(node) && !($isListNode(node) || node.isInline())) {
+          // A block can't stay a block inside a list item, so it is unwrapped
+          // into its own children — the same conversion $createListOrMerge and
+          // ListItemNode.append already perform. Stringifying it with
+          // getTextContent() instead would drop every text format and style and
+          // replace inline nodes (links, mentions, …) with plain text.
+          listItem.append(...node.getChildren());
+        } else {
+          listItem.append(node);
+        }
+        listItemNodesToInsert[i] = listItem;
       }
     }
     return super.splice(start, deleteCount, listItemNodesToInsert);

--- a/packages/lexical-list/src/__tests__/unit/ListSpliceKeepsFormatting.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListSpliceKeepsFormatting.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createLinkNode, $isLinkNode, LinkExtension} from '@lexical/link';
+import {
+  $createListItemNode,
+  $createListNode,
+  $isListItemNode,
+  $isListNode,
+  ListExtension,
+} from '@lexical/list';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isTextNode,
+  defineExtension,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [ListExtension, LinkExtension],
+      name: 'list-splice-host',
+    }),
+  );
+}
+
+function $splicedItemChildren() {
+  const list = $getRoot().getFirstChild();
+  assert($isListNode(list), 'expected a ListNode at the root');
+  const item = list.getChildAtIndex(1);
+  assert($isListItemNode(item), 'expected a ListItemNode');
+  return item.getChildren();
+}
+
+describe('ListNode.splice converting a block into a list item', () => {
+  test('keeps the text formats of the block it unwraps', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const list = $createListNode('bullet').append(
+          $createListItemNode().append($createTextNode('A')),
+          $createListItemNode().append($createTextNode('C')),
+        );
+        $getRoot().clear().append(list);
+
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode('bold').toggleFormat('bold'),
+          $createTextNode('styled').setStyle('color: red;'),
+        );
+        list.splice(1, 0, [paragraph]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const children = $splicedItemChildren();
+      expect(children.map(n => n.getTextContent())).toEqual(['bold', 'styled']);
+      assert($isTextNode(children[0]), 'expected a TextNode');
+      assert($isTextNode(children[1]), 'expected a TextNode');
+      expect(children[0].hasFormat('bold')).toBe(true);
+      expect(children[1].getStyle()).toBe('color: red;');
+    });
+  });
+
+  test('keeps an inline node of the block it unwraps', () => {
+    using editor = buildEditor();
+
+    editor.update(
+      () => {
+        const list = $createListNode('bullet').append(
+          $createListItemNode().append($createTextNode('A')),
+          $createListItemNode().append($createTextNode('C')),
+        );
+        $getRoot().clear().append(list);
+
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createLinkNode('https://lexical.dev/').append(
+            $createTextNode('link'),
+          ),
+        );
+        list.splice(1, 0, [paragraph]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const children = $splicedItemChildren();
+      expect(children).toHaveLength(1);
+      assert($isLinkNode(children[0]), 'expected the LinkNode to survive');
+      expect(children[0].getURL()).toBe('https://lexical.dev/');
+      expect(children[0].getTextContent()).toBe('link');
+    });
+  });
+});


### PR DESCRIPTION
## Description

`ListNode.splice` wraps any non-`ListItemNode` it is given in a list item. For
a block-level node it does not put the block inside the item — a list item is
an inline-level container, so that would be invalid — it replaces it with its
plain text:

```ts
listItemNodesToInsert[i] = this.createListItemNode().append(
  $isElementNode(node) && !($isListNode(node) || node.isInline())
    ? $createTextNode(node.getTextContent())
    : node,
);
```

`getTextContent()` returns a string, so every text format and style on the
block's children is discarded and inline nodes are flattened: a paragraph
holding **bold** text and a link becomes one unformatted TextNode with the
link gone.

The package already performs this exact conversion in two other places, and
both keep the children. `$createListOrMerge` does
`append(listItem, node.getChildren())`, and `ListItemNode.append` unwraps a
block it can merge with by re-appending `node.getChildren()`. `ListNode.splice`
is the only one that stringifies.

This unwraps the block into its own children instead. Non-block and inline
nodes take the same path as before, and a `ListNode` child is still left alone.

## Test plan

`npx vitest run packages/lexical-list/src/__tests__/unit/ListSpliceKeepsFormatting.test.ts`

(The natural test file, `LexicalListNode.test.ts`, is already being edited by
an open PR, so the repro lives in its own file.)

### Before

```
 ❯ |unit| packages/lexical-list/src/__tests__/unit/ListSpliceKeepsFormatting.test.ts (2 tests | 2 failed) 14ms
     × keeps the text formats of the block it unwraps 12ms
     × keeps an inline node of the block it unwraps 2ms

 FAIL  ... > keeps the text formats of the block it unwraps
AssertionError: expected [ 'boldstyled' ] to deeply equal [ 'bold', 'styled' ]

- Expected
+ Received

  [
-   "bold",
-   "styled",
+   "boldstyled",
  ]
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Also green:

- `npx vitest run packages/lexical-list packages/lexical-markdown packages/lexical-mdast packages/lexical-react packages/lexical-clipboard` — 52 files, 925 tests
- `E2E_BROWSER=chromium npx playwright test --project=chromium List.spec.mjs` — 36 passed

Only chromium was exercised locally for the e2e run.

