### PR TITLE
[lexical-playground] Bug Fix: a mention keeps the text format applied to it

### DIFF
--- a/packages/lexical-playground/__tests__/unit/MentionNodeTheme.test.ts
+++ b/packages/lexical-playground/__tests__/unit/MentionNodeTheme.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $isTextNode,
+  defineExtension,
+  type LexicalEditor,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+import {$createMentionNode, MentionNode} from '../../src/nodes/MentionNode';
+
+const MentionThemeTestExtension = /* @__PURE__ */ defineExtension({
+  $initialEditorState: null,
+  dependencies: [RichTextExtension],
+  name: '[test-mention-theme]',
+  nodes: [MentionNode],
+  // Only underline gets a class: bold changes the HTML tag instead, which is
+  // what forces the element to be rebuilt through createDOM.
+  theme: {text: {underline: 'theme-underline'}},
+});
+
+function makeEditor(): [LexicalEditor & Disposable, HTMLElement] {
+  const editor = buildEditorFromExtensions(MentionThemeTestExtension);
+  const rootElement = document.createElement('div');
+  editor.setRootElement(rootElement);
+  return [editor, rootElement];
+}
+
+function mentionClasses(rootElement: HTMLElement): string[] {
+  const dom = rootElement.querySelector<HTMLElement>('[data-lexical-text]');
+  assert(dom !== null, 'mention DOM');
+  return Array.from(dom.classList).sort();
+}
+
+describe('MentionNode theme classes', () => {
+  it('keeps the theme class of the format it was created with', () => {
+    const [editor, rootElement] = makeEditor();
+    using _ = editor;
+    editor.update(
+      () => {
+        const mention = $createMentionNode('Luke').setFormat('underline');
+        $getRoot().clear().append($createParagraphNode().append(mention));
+      },
+      {discrete: true},
+    );
+
+    expect(mentionClasses(rootElement)).toEqual(['mention', 'theme-underline']);
+  });
+
+  it('keeps the theme class when a format change rebuilds the element', () => {
+    const [editor, rootElement] = makeEditor();
+    using _ = editor;
+    editor.update(
+      () => {
+        const mention = $createMentionNode('Luke');
+        $getRoot().clear().append($createParagraphNode().append(mention));
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const mention = $getRoot().getLastDescendant();
+        assert($isTextNode(mention), 'mention node');
+        mention.setFormat('underline');
+      },
+      {discrete: true},
+    );
+    expect(mentionClasses(rootElement)).toEqual(['mention', 'theme-underline']);
+
+    // Bold changes the tag, so TextNode.updateDOM returns true and the
+    // reconciler rebuilds the element through createDOM.
+    editor.update(
+      () => {
+        const mention = $getRoot().getLastDescendant();
+        assert($isTextNode(mention), 'mention node');
+        mention.toggleFormat('bold');
+      },
+      {discrete: true},
+    );
+
+    expect(
+      editor.read(() => {
+        const mention = $getRoot().getLastDescendant();
+        assert($isTextNode(mention), 'mention node');
+        return mention.hasFormat('underline');
+      }),
+    ).toBe(true);
+    expect(mentionClasses(rootElement)).toEqual(['mention', 'theme-underline']);
+  });
+});

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {addClassNamesToElement} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $getDocument,
@@ -57,7 +58,10 @@ export class MentionNode extends TextNode {
   createDOM(config: EditorConfig): HTMLElement {
     const dom = super.createDOM(config);
     dom.style.backgroundColor = mentionBackgroundColor;
-    dom.className = 'mention';
+    // Add to the class names TextNode.createDOM applied for the text formats
+    // rather than replacing them, otherwise a formatted mention renders
+    // unstyled every time the element is rebuilt.
+    addClassNamesToElement(dom, 'mention');
     dom.spellcheck = false;
 
     return dom;


### PR DESCRIPTION

## Description

`MentionNode.createDOM` replaces the class name that `TextNode.createDOM` just set instead of adding to it:

```ts
createDOM(config: EditorConfig): HTMLElement {
  const dom = super.createDOM(config);
  dom.style.backgroundColor = mentionBackgroundColor;
  dom.className = 'mention';   // <- discards everything super applied
  dom.spellcheck = false;
  return dom;
}
```

`super.createDOM` renders the node's text formats through `$createTextInnerDOM`, which applies `config.theme.text.*` to that element. Every class-based format — underline, strikethrough, highlight, subscript, superscript, code, uppercase/lowercase/capitalize — is written onto it and then thrown away by the assignment.

`MentionNode` does not override `updateDOM`, so `TextNode.updateDOM` keeps writing those classes back. The two halves disagree, which is what makes this look intermittent rather than simply broken. Rendered on `upstream/main`:

```html
<!-- created -->            <span class="mention" ...>Luke</span>
<!-- underline applied -->  <span class="mention theme-underline" ...>Luke</span>
<!-- then bold applied -->  <strong class="mention" ...>Luke</strong>
```

Underlining a mention works, because `updateDOM` handles it in place. Then press Ctrl+B: bold changes the HTML tag, so `TextNode.updateDOM` returns `true` before touching the DOM, the reconciler rebuilds the element through `createDOM`, and the underline class is gone — while the node state, the toolbar and `exportDOM` all still say underlined. The formatting also disappears on any other rebuild: pasting a formatted mention, undo/redo across it, reloading a saved document, or receiving it over collab.

Fixed with `addClassNamesToElement`, which is what the sibling `SpecialTextNode` in the same directory already does, and what `KeywordNode` needed for the same reason. The `.mention` class is unchanged, so the CSS still matches; formats are simply no longer dropped.

The hardcoded `dom.style.backgroundColor` on the line above has a related problem — it overrides a background colour set from the toolbar, which `super.createDOM` applied from `this.__style` — but fixing that means moving the colour into CSS, so I have left it out of this change.

This file has two other open PRs of mine (#8969 on `exportDOM`, #8999 on `$createMentionNode`); all three touch different methods and do not overlap.

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/MentionNodeTheme.test.ts`. The theme gives a class only to underline, so that toggling bold isolates the tag-change rebuild.

### Before

```
 ❯ packages/lexical-playground/__tests__/unit/MentionNodeTheme.test.ts (2 tests | 2 failed)
   × keeps the theme class of the format it was created with
     AssertionError: expected [ 'mention' ] to deeply equal [ 'mention', 'theme-underline' ]
   × keeps the theme class when a format change rebuilds the element
     AssertionError: expected [ 'mention' ] to deeply equal [ 'mention', 'theme-underline' ]

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-playground
 Test Files  19 passed (19)
      Tests  276 passed (276)
```
