### PR TITLE
[lexical-text] Bug Fix: $canShowPlaceholder scans every child of the top block

### DIFF
--- a/packages/lexical-text/src/__tests__/unit/canShowPlaceholder.test.ts
+++ b/packages/lexical-text/src/__tests__/unit/canShowPlaceholder.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$canShowPlaceholder} from '@lexical/text';
+import {
+  $create,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  DecoratorNode,
+  defineExtension,
+  type TextModeType,
+} from 'lexical';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+// An inline decorator that contributes no text, e.g. an inline image or
+// equation chip. Its emptiness keeps the root's text content empty while the
+// document plainly is not empty.
+class InlineDecoratorNode extends DecoratorNode<null> {
+  $config() {
+    return this.config('inline_decorator_placeholder', {
+      extends: DecoratorNode,
+    });
+  }
+  isInline(): boolean {
+    return true;
+  }
+  createDOM(): HTMLElement {
+    return document.createElement('span');
+  }
+  updateDOM(): boolean {
+    return false;
+  }
+  decorate(): null {
+    return null;
+  }
+}
+
+function $createInlineDecoratorNode(): InlineDecoratorNode {
+  return $create(InlineDecoratorNode);
+}
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: null,
+      name: '[can-show-placeholder]',
+      nodes: [InlineDecoratorNode],
+    }),
+  );
+}
+
+// A simple empty TextNode is removed during reconciliation, which would move
+// the decorator to index 0. `token` and `segmented` nodes are not simple text,
+// so they survive and keep a TextNode at index 0 — the shape that exercises
+// the scan of the remaining children.
+const NON_SIMPLE_MODES: TextModeType[] = ['token', 'segmented'];
+
+describe('$canShowPlaceholder', () => {
+  for (const mode of NON_SIMPLE_MODES) {
+    test(`is false when a decorator follows an empty ${mode} text node`, () => {
+      using editor = buildEditor();
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          paragraph.append(
+            $createTextNode('').setMode(mode),
+            $createInlineDecoratorNode(),
+          );
+          $getRoot().clear().append(paragraph);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const paragraph = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isParagraphNode,
+        );
+        // Guard the premise: the text node must have survived, otherwise the
+        // decorator would sit at index 0 and the scan would be trivial.
+        expect(paragraph.getChildrenSize()).toBe(2);
+        expect($getRoot().getTextContent()).toBe('');
+        expect($canShowPlaceholder(false)).toBe(false);
+      });
+    });
+  }
+
+  test('is false when the decorator is several positions along', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode('').setMode('token'),
+          $createTextNode('').setMode('token'),
+          $createInlineDecoratorNode(),
+        );
+        $getRoot().clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $canShowPlaceholder(false))).toBe(false);
+  });
+
+  test('is still false when the decorator is first', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createInlineDecoratorNode(),
+          $createTextNode('').setMode('token'),
+        );
+        $getRoot().clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $canShowPlaceholder(false))).toBe(false);
+  });
+
+  test('is still true for an empty paragraph', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        $getRoot().clear().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $canShowPlaceholder(false))).toBe(true);
+  });
+
+  test('is still true for a paragraph of empty text nodes', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode('').setMode('token'),
+          $createTextNode('').setMode('token'),
+        );
+        $getRoot().clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $canShowPlaceholder(false))).toBe(true);
+  });
+});

--- a/packages/lexical-text/src/canShowPlaceholder.ts
+++ b/packages/lexical-text/src/canShowPlaceholder.ts
@@ -54,7 +54,7 @@ export function $canShowPlaceholder(isComposing: boolean): boolean {
       const topBlockChildrenLength = topBlockChildren.length;
 
       for (let s = 0; s < topBlockChildrenLength; s++) {
-        const child = topBlockChildren[i];
+        const child = topBlockChildren[s];
 
         if (!$isTextNode(child)) {
           return false;


### PR DESCRIPTION
## Description

`$canShowPlaceholder` documents itself as "If anything is in the root the
placeholder should not be shown". Its innermost loop is meant to reject a top
block that holds any non-text child, but it indexes with the *outer* loop's
variable:

```js
for (let s = 0; s < topBlockChildrenLength; s++) {
  const child = topBlockChildren[i];   // `i`, not `s`
  if (!$isTextNode(child)) {
    return false;
  }
}
```

`s` is declared and incremented but never read, which is what gives the typo
away. `i` indexes the loop over the *root's* children, and the earlier
`if (childrenLength > 1) { return false; }` guard means it is always `0`. So
the loop tests `topBlockChildren[0]` N times and never looks at index 1 or
beyond — the one thing it exists to do.

A paragraph whose children are `[TextNode(""), <inline DecoratorNode>]`
therefore reports that the placeholder may be shown, and the placeholder
renders on top of real content. The root's text content is genuinely `""` (a
decorator contributes no text), so the `$isRootTextContentEmpty(isComposing,
false)` gate legitimately passes and the child scan is the only thing standing
between that document and a wrong placeholder.

Reaching it needs the TextNode at index 0 to survive reconciliation: a *simple*
empty TextNode is removed, which would shuffle the decorator to index 0 and
mask the bug. `token` and `segmented` nodes are not simple text and do survive,
which is the shape the test uses.

## Test plan

New unit test `packages/lexical-text/src/__tests__/unit/canShowPlaceholder.test.ts`.
It asserts the premise (the text node survived, root text content is `""`)
before asserting the result, so the test cannot silently stop exercising the
scan. The last three cases are controls — decorator first, empty paragraph, and
a paragraph of only empty text nodes — and pass before and after.

### Before

```
$ npx vitest run packages/lexical-text

     × is false when a decorator follows an empty token text node 32ms
     × is false when a decorator follows an empty segmented text node 4ms
     × is false when the decorator is several positions along 3ms

AssertionError: expected true to be false // Object.is equality

      Tests  3 failed | 3 passed (6)
```

### After

```
$ npx vitest run packages/lexical-text

 Test Files  1 passed (1)
      Tests  6 passed (6)
```
