### PR TITLE
[lexical-table] Bug Fix: move the selection out of the table before deleting its last rows

### DIFF
--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -640,7 +640,11 @@ export function $deleteTableRowAtSelection(): void {
   const {startRow: focusStartRow} = focusCellMap;
   const focusEndRow = focusStartRow + focusCell.__rowSpan - 1;
   if (gridMap.length === focusEndRow - anchorStartRow + 1) {
-    // Empty grid
+    // Empty grid. Move the selection out of the table before removing it,
+    // otherwise a TableSelection is left pointing at cells that no longer
+    // exist — $deleteTableColumnAtSelection and TableObserver.$clearText both
+    // call selectPrevious() here for the same reason.
+    grid.selectPrevious();
     grid.remove();
     return;
   }

--- a/packages/lexical-table/src/__tests__/unit/DeleteAllRowsSelection.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/DeleteAllRowsSelection.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $computeTableMapSkipCellCheck,
+  $createTableNodeWithDimensions,
+  $createTableSelectionFrom,
+  $deleteTableColumnAtSelection,
+  $deleteTableRowAtSelection,
+  $isTableNode,
+  $isTableSelection,
+  TableExtension,
+} from '@lexical/table';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $setSelection,
+  defineExtension,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+function deleteWholeTable(kind: 'row' | 'column'): {
+  selectionType: string;
+  staleTableSelection: boolean;
+  rootChildren: number;
+} {
+  using editor = buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [TableExtension],
+      name: `delete-all-${kind}-host`,
+    }),
+  );
+
+  editor.update(
+    () => {
+      const root = $getRoot().clear();
+      root.append($createParagraphNode().append($createTextNode('before')));
+      root.append($createTableNodeWithDimensions(2, 2, false));
+      const table = root.getChildAtIndex(1);
+      assert($isTableNode(table), 'expected a TableNode');
+      const [map] = $computeTableMapSkipCellCheck(table, null, null);
+      // Every cell selected, so deleting rows/columns empties the table.
+      $setSelection(
+        $createTableSelectionFrom(table, map[0][0].cell, map[1][1].cell),
+      );
+    },
+    {discrete: true},
+  );
+
+  editor.update(
+    () => {
+      if (kind === 'row') {
+        $deleteTableRowAtSelection();
+      } else {
+        $deleteTableColumnAtSelection();
+      }
+    },
+    {discrete: true},
+  );
+
+  return editor.read(() => {
+    const selection = $getSelection();
+    return {
+      rootChildren: $getRoot().getChildrenSize(),
+      
+      
+      selectionType: $isRangeSelection(selection)
+        ? 'range'
+        : $isTableSelection(selection)
+          ? 'table'
+          : String(selection),
+      // A TableSelection left behind by the removed table reports isValid()
+// false, because the cells it points at are gone.
+staleTableSelection: $isTableSelection(selection) && !selection.isValid(),
+    };
+  });
+}
+
+describe('deleting every row of a table', () => {
+  test('leaves the selection outside the removed table', () => {
+    expect(deleteWholeTable('row')).toEqual({
+      rootChildren: 1,
+      selectionType: 'range',
+      staleTableSelection: false,
+    });
+  });
+
+  test('matches what deleting every column already does', () => {
+    expect(deleteWholeTable('column')).toEqual({
+      rootChildren: 1,
+      selectionType: 'range',
+      staleTableSelection: false,
+    });
+  });
+});


### PR DESCRIPTION
## Description

When the selected rows cover the whole table, `$deleteTableRowAtSelection`
removes the table outright:

```ts
if (gridMap.length === focusEndRow - anchorStartRow + 1) {
  // Empty grid
  grid.remove();
  return;
}
```

It never moves the selection first, so the `TableSelection` that triggered the
delete survives and keeps pointing at cells that no longer exist —
`TableSelection.isValid()` returns false for it, and the editor is left with a
selection anchored to detached nodes instead of a caret where the table was.

Both siblings that remove a whole table already handle this.
`$deleteTableColumnAtSelection`, in the same file, does `grid.selectPrevious()`
immediately before `grid.remove()` in its identical "empty grid" branch, and so
does `TableObserver.$clearText` when the entire table is selected. The row path
is the only one that does not.

This adds the same `grid.selectPrevious()` call. Deletes that leave the table
standing are untouched — they already end with `$moveSelectionToCell`.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/DeleteAllRowsSelection.test.ts`

Both cases select every cell of a 2x2 table and then delete all rows / all
columns. The column case passes on both sides of the change, which is what pins
the asymmetry.

### Before

```
 ❯ |unit| packages/lexical-table/src/__tests__/unit/DeleteAllRowsSelection.test.ts (2 tests | 1 failed) 14ms
     × leaves the selection outside the removed table 12ms

 FAIL  ... > deleting every row of a table > leaves the selection outside the removed table
AssertionError: expected { rootChildren: 1, …(2) } to deeply equal { rootChildren: 1, …(2) }

- Expected
+ Received

  {
    "rootChildren": 1,
-   "selectionType": "range",
-   "staleTableSelection": false,
+   "selectionType": "table",
+   "staleTableSelection": true,
  }
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Also green:

- `npx vitest run packages/lexical-table` — 12 files, 159 tests
- `E2E_BROWSER=chromium npx playwright test --project=chromium Tables.spec.mjs` — 88 passed, 1 skipped

Only chromium was exercised locally for the e2e run.

