### PR TITLE
[lexical-table] Bug Fix: toggleHeaderStyle stays inside TableCellHeaderStates

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -262,10 +262,15 @@ export class TableCellNode extends ElementNode {
   toggleHeaderStyle(headerStateToToggle: TableCellHeaderState): this {
     const self = this.getWritable();
 
+    // The test is bitwise ("does it already have all of these bits") so the
+    // mutation has to be too. `+=`/`-=` happen to agree for a single-bit
+    // argument, but for BOTH they overflow the enum: toggling BOTH on a cell
+    // that only has ROW produced __headerState 4, which is neither ROW, COLUMN,
+    // BOTH nor NO_STATUS.
     if ((self.__headerState & headerStateToToggle) === headerStateToToggle) {
-      self.__headerState -= headerStateToToggle;
+      self.__headerState &= ~headerStateToToggle;
     } else {
-      self.__headerState += headerStateToToggle;
+      self.__headerState |= headerStateToToggle;
     }
 
     return self;

--- a/packages/lexical-table/src/__tests__/unit/ToggleHeaderStyle.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/ToggleHeaderStyle.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createTableCellNode,
+  type TableCellHeaderState,
+  TableCellHeaderStates,
+  TableExtension,
+} from '@lexical/table';
+import {defineExtension} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+const {BOTH, COLUMN, NO_STATUS, ROW} = TableCellHeaderStates;
+
+function toggle(
+  from: TableCellHeaderState,
+  toToggle: TableCellHeaderState,
+): TableCellHeaderState {
+  using editor = buildEditorFromExtensions(
+    defineExtension({dependencies: [TableExtension], name: 'toggle-host'}),
+  );
+  let result: TableCellHeaderState = NO_STATUS;
+  editor.update(
+    () => {
+      const cell = $createTableCellNode(from);
+      result = cell.toggleHeaderStyle(toToggle).getHeaderStyles();
+    },
+    {discrete: true},
+  );
+  return result;
+}
+
+describe('TableCellNode.toggleHeaderStyle', () => {
+  test('stays inside the enum when toggling BOTH', () => {
+    // Toggling a state the cell does not already have in full adds it; a cell
+    // that has all of it loses it.
+    expect(toggle(ROW, BOTH)).toBe(BOTH);
+    expect(toggle(COLUMN, BOTH)).toBe(BOTH);
+    expect(toggle(NO_STATUS, BOTH)).toBe(BOTH);
+    expect(toggle(BOTH, BOTH)).toBe(NO_STATUS);
+  });
+
+  test('single-bit toggles are unchanged', () => {
+    expect(toggle(NO_STATUS, ROW)).toBe(ROW);
+    expect(toggle(ROW, ROW)).toBe(NO_STATUS);
+    expect(toggle(COLUMN, ROW)).toBe(BOTH);
+    expect(toggle(BOTH, ROW)).toBe(COLUMN);
+    expect(toggle(NO_STATUS, COLUMN)).toBe(COLUMN);
+    expect(toggle(COLUMN, COLUMN)).toBe(NO_STATUS);
+    expect(toggle(ROW, COLUMN)).toBe(BOTH);
+    expect(toggle(BOTH, COLUMN)).toBe(ROW);
+  });
+});

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -6,7 +6,10 @@
  *
  */
 
-export type {SerializedTableCellNode} from './LexicalTableCellNode';
+export type {
+  SerializedTableCellNode,
+  TableCellHeaderState,
+} from './LexicalTableCellNode';
 export {
   $createTableCellNode,
   $isTableCellNode,


### PR DESCRIPTION
## Description

`TableCellNode.toggleHeaderStyle` tests its argument bitwise and then mutates
arithmetically:

```ts
if ((self.__headerState & headerStateToToggle) === headerStateToToggle) {
  self.__headerState -= headerStateToToggle;
} else {
  self.__headerState += headerStateToToggle;
}
```

The two agree only while the argument is a single bit. The parameter is typed
`TableCellHeaderState`, which includes `BOTH` (`3`), and `BOTH` is a
first-class member of the enum everywhere else in the same class —
`setHeaderStyles(headerState, mask)` masks with it, `hasHeaderState(BOTH)`
tests it, `getHeaderState` in `LexicalTableUtils` compares against it.

Passing it here overflows: a cell with `ROW` (`1`) that is toggled with `BOTH`
(`3`) ends at `__headerState === 4`, which is not `NO_STATUS`, `ROW`, `COLUMN`
or `BOTH`. `hasHeaderState(ROW)` and `hasHeaderState(COLUMN)` both go false
while `hasHeader()` stays true, so the cell renders as a `<th>` that belongs to
neither a header row nor a header column, and `4` is what `exportJSON` writes
out.

This keeps the existing branch — "does it already have all of these bits" —
and makes the mutation bitwise to match: clear those bits, or set them.
Single-bit arguments resolve to exactly the same values as before, which the
second test pins.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/ToggleHeaderStyle.test.ts`

### Before

```
 ❯ |unit| packages/lexical-table/src/__tests__/unit/ToggleHeaderStyle.test.ts (2 tests | 1 failed) 12ms
     × stays inside the enum when toggling BOTH 9ms

 FAIL  ... > TableCellNode.toggleHeaderStyle > stays inside the enum when toggling BOTH
AssertionError: expected 4 to be 3 // Object.is equality

- Expected
+ Received

- 3
+ 4
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`npx vitest run packages/lexical-table` is green (12 files, 159 tests).

