### PR TITLE
[lexical-history] Bug Fix: CLEAR_EDITOR_COMMAND reports that undo is no longer available

### DIFF
--- a/packages/lexical-history/src/__tests__/unit/ClearEditorCanCommands.test.ts
+++ b/packages/lexical-history/src/__tests__/unit/ClearEditorCanCommands.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {HistoryExtension} from '@lexical/history';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  CAN_REDO_COMMAND,
+  CAN_UNDO_COMMAND,
+  CLEAR_EDITOR_COMMAND,
+  CLEAR_HISTORY_COMMAND,
+  COMMAND_PRIORITY_LOW,
+  defineExtension,
+  type LexicalCommand,
+  type LexicalEditor,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: null,
+      dependencies: [HistoryExtension],
+      name: '[clear-editor-can-commands]',
+    }),
+  );
+}
+
+/** Records the latest payload seen for each CAN_* command. */
+function trackCanCommands(editor: LexicalEditor) {
+  const seen = {canRedo: false, canUndo: false};
+  const listen = (
+    command: LexicalCommand<boolean>,
+    key: 'canUndo' | 'canRedo',
+  ) =>
+    editor.registerCommand(
+      command,
+      payload => {
+        seen[key] = payload;
+        return false;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+  listen(CAN_UNDO_COMMAND, 'canUndo');
+  listen(CAN_REDO_COMMAND, 'canRedo');
+  return seen;
+}
+
+function seedUndoableEdit(editor: LexicalEditor) {
+  editor.update(
+    () => {
+      $getRoot()
+        .clear()
+        .append($createParagraphNode().append($createTextNode('one')));
+    },
+    {discrete: true},
+  );
+  editor.update(
+    () => {
+      $getRoot()
+        .clear()
+        .append($createParagraphNode().append($createTextNode('two')));
+    },
+    {discrete: true},
+  );
+  editor.read(() => {});
+}
+
+describe('clearing the editor resets undo availability', () => {
+  test('CLEAR_EDITOR_COMMAND reports that undo is no longer available', () => {
+    using editor = buildEditor();
+    const seen = trackCanCommands(editor);
+
+    seedUndoableEdit(editor);
+    expect(seen.canUndo).toBe(true);
+
+    editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
+    editor.read(() => {});
+
+    expect(seen.canUndo).toBe(false);
+    expect(seen.canRedo).toBe(false);
+  });
+
+  test('CLEAR_HISTORY_COMMAND does the same', () => {
+    using editor = buildEditor();
+    const seen = trackCanCommands(editor);
+
+    seedUndoableEdit(editor);
+    expect(seen.canUndo).toBe(true);
+
+    editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+    editor.read(() => {});
+
+    expect(seen.canUndo).toBe(false);
+    expect(seen.canRedo).toBe(false);
+  });
+});

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -589,6 +589,16 @@ export function registerHistory(
       CLEAR_EDITOR_COMMAND,
       () => {
         clearHistory(historyState, onHistoryStateChange);
+        // Same observable result as CLEAR_HISTORY_COMMAND below: the stacks
+        // are empty, so undo and redo are unavailable and listeners have to
+        // be told. Nothing else re-dispatches these — `current` is null now,
+        // so the next applyChange pushes nothing — and the buttons would
+        // stay enabled on a no-op until a second edit.
+        // Still returns false: unlike CLEAR_HISTORY_COMMAND this command is
+        // not fully handled here, and the listener that clears the editor
+        // content must still run.
+        editor.dispatchCommand(CAN_REDO_COMMAND, false);
+        editor.dispatchCommand(CAN_UNDO_COMMAND, false);
         return false;
       },
       COMMAND_PRIORITY_EDITOR,


### PR DESCRIPTION
## Description

`registerHistory` registers two adjacent handlers that do the same thing —
`clearHistory` empties `undoStack`, `redoStack` and sets `current` to null —
but only one of them tells anyone:

```js
editor.registerCommand(CLEAR_EDITOR_COMMAND, () => {
  clearHistory(historyState, onHistoryStateChange);
  return false;                                    // no CAN_* dispatch
}, COMMAND_PRIORITY_EDITOR),
editor.registerCommand(CLEAR_HISTORY_COMMAND, () => {
  clearHistory(historyState, onHistoryStateChange);
  editor.dispatchCommand(CAN_REDO_COMMAND, false);
  editor.dispatchCommand(CAN_UNDO_COMMAND, false);
  return true;
}, COMMAND_PRIORITY_EDITOR),
```

`CAN_UNDO_COMMAND` / `CAN_REDO_COMMAND` are how the editor tells UI whether
undo is available, and nothing re-dispatches them after the clear: `current` is
now null, so the next `applyChange` takes the `current === null` path and
pushes nothing. The stale `true` therefore survives until a *second* edit.

The result is that after `CLEAR_EDITOR_COMMAND` the undo and redo buttons stay
enabled and do nothing when pressed. The playground reaches this directly —
`ActionsPlugin/index.tsx:427` dispatches `CLEAR_EDITOR_COMMAND` for its
"Clear" action.

The same state is also published through the extension's signals, and those
are already correct — `syncFromHistoryState` derives them from the stacks:

```js
canUndo.value = historyState != null && historyState.undoStack.length > 0;
canRedo.value = historyState != null && historyState.redoStack.length > 0;
```

So after one `CLEAR_EDITOR_COMMAND` the signal API and the command API report
opposite answers about the same fact.

This dispatches both commands from the `CLEAR_EDITOR_COMMAND` handler, matching
`CLEAR_HISTORY_COMMAND`. The handler still returns `false`: unlike
`CLEAR_HISTORY_COMMAND` this command is not fully handled here and must keep
propagating to the listener that clears the editor's content.

## Test plan

New unit test `packages/lexical-history/src/__tests__/unit/ClearEditorCanCommands.test.ts`
(a new file so it does not collide with other in-flight edits to
`LexicalHistory.test.tsx`). The `CLEAR_HISTORY_COMMAND` case is included as a
control — it passes before and after, which is what pins the divergence to the
one handler.

### Before

```
$ npx vitest run packages/lexical-history/src/__tests__/unit/ClearEditorCanCommands.test.ts

     × CLEAR_EDITOR_COMMAND reports that undo is no longer available 9ms

AssertionError: expected true to be false // Object.is equality

      Tests  1 failed | 1 passed (2)
```

### After

```
$ npx vitest run packages/lexical-history

 Test Files  2 passed (2)
      Tests  27 passed (27)
```
