### PR TITLE
[lexical-react] Bug Fix: TreeView re-renders when the editor prop changes

### DIFF
--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -16,6 +16,8 @@ import {type EditorState, type LexicalEditor, mergeRegister} from 'lexical';
 import * as React from 'react';
 import {type JSX, useEffect, useState} from 'react';
 
+import useLayoutEffect from './shared/useLayoutEffect';
+
 /**
  * TreeView is a React component that provides a visual representation of
  * the Lexical editor's state and enables debugging features like time travel
@@ -65,7 +67,14 @@ export function TreeView({
 
   const commandsLog = useLexicalCommandsLog(editor);
 
-  useEffect(() => {
+  // useLayoutEffect, like useCanShowPlaceholder and ContentEditableElement, so
+  // the state can be re-derived before subscribing without the cascading
+  // render that setState inside a useEffect body causes.
+  useLayoutEffect(() => {
+    // The state was seeded on the first render only, so re-read it here: when
+    // the editor prop changes, neither listener has fired yet for the new
+    // editor and the view would keep rendering the previous editor's state.
+    setEditorCurrentState(editor.getEditorState());
     // Registers listeners to update the tree view when the editor state changes
     return mergeRegister(
       editor.registerUpdateListener(({editorState}) => {

--- a/packages/lexical-react/src/__tests__/unit/LexicalTreeView.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalTreeView.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {TreeView} from '@lexical/react/LexicalTreeView';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+  type LexicalEditor,
+} from 'lexical';
+import * as React from 'react';
+import {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+function makeEditor(text: string): LexicalEditor {
+  const editor = createEditor({
+    namespace: 'tree-view',
+    onError: error => {
+      throw error;
+    },
+  });
+  editor.setRootElement(document.createElement('div'));
+  editor.update(
+    () => {
+      $getRoot()
+        .clear()
+        .append($createParagraphNode().append($createTextNode(text)));
+    },
+    {discrete: true},
+  );
+  return editor;
+}
+
+describe('TreeView', () => {
+  let container: HTMLDivElement;
+  let reactRoot: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      reactRoot.unmount();
+    });
+    container.remove();
+  });
+
+  /** The rendered tree is produced asynchronously, so let it settle. */
+  async function renderTreeFor(editor: LexicalEditor): Promise<string> {
+    await act(async () => {
+      reactRoot.render(<TreeView editor={editor} />);
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBe(null);
+    return (pre as HTMLPreElement).textContent ?? '';
+  }
+
+  it('renders the tree of the editor it was given', async () => {
+    expect(await renderTreeFor(makeEditor('AAAAA'))).toContain('"AAAAA"');
+  });
+
+  it('re-renders when the editor prop changes', async () => {
+    expect(await renderTreeFor(makeEditor('AAAAA'))).toContain('"AAAAA"');
+
+    const tree = await renderTreeFor(makeEditor('BBBBB'));
+    expect(tree).toContain('"BBBBB"');
+    expect(tree).not.toContain('"AAAAA"');
+  });
+});


### PR DESCRIPTION

## Description

`TreeView` seeds the editor state it renders on the first render, then only ever updates it from listeners:

```tsx
const [editorCurrentState, setEditorCurrentState] = useState<EditorState>(
  editor.getEditorState(),
);

useEffect(() => {
  // Registers listeners to update the tree view when the editor state changes
  return mergeRegister(
    editor.registerUpdateListener(({editorState}) => { setEditorCurrentState(editorState); }),
    editor.registerEditableListener(() => { setEditorCurrentState(editor.getEditorState()); }),
  );
}, [editor]);
```

`editor` is a required prop of this public component (`@lexical/react/LexicalTreeView`) and it is in the effect's dependency array, so it is expected to change. But `useState`'s initial value is only used on mount: when a new editor arrives the effect re-subscribes while `editorCurrentState` still holds the *previous* editor's state, and neither listener has fired yet for the new one.

That value is not merely displayed — it is the gate on regenerating the pane. `TreeView` in `@lexical/devtools-core` only rebuilds when the identity changes:

```tsx
const shouldUpdate =
  lastEditorStateRef.current !== editorState ||
  lastCommandsLogRef.current !== commandsLog;
```

so the view keeps rendering the old editor's node tree until the *new* editor happens to produce an update or an editability change. Point a devtools pane at a different editor — the root editor and a nested one (an image caption, a sticky note, a table cell), which is what `LexicalNestedComposer` creates — and you are reading the wrong tree, with no indication that it is stale. For an idle or read-only editor it never resolves.

Rendered on `upstream/main`, switching the prop from an editor containing `AAAAA` to one containing `BBBBB`:

```
 root
  └ (1) paragraph
    └ (2) text "AAAAA"
```

The sibling hooks in this package all re-derive before subscribing — `useCanShowPlaceholder` calls `resetCanShowPlaceholder()` at the top of its layout effect, `ContentEditableElement` and `LexicalContentEditable` call `setEditable(editor.isEditable())`, and `LexicalNestedComposer` calls `editableListener(parentEditor.isEditable())`. This adds the same line, and moves the registration to the package's shared `useLayoutEffect` so it matches them: `react-hooks/set-state-in-effect` rejects a synchronous `setState` in a `useEffect` body, which is why every one of those siblings is a layout effect too. No API change.

## Test plan

New unit test `packages/lexical-react/src/__tests__/unit/LexicalTreeView.test.tsx`. The first case is a control covering a single editor and passes before and after; the second swaps the prop.

### Before

```
 ❯ packages/lexical-react/src/__tests__/unit/LexicalTreeView.test.tsx (2 tests | 1 failed)
   ✓ renders the tree of the editor it was given
   × re-renders when the editor prop changes
     AssertionError: expected ' root\n  └ (3) paragraph \n    └ (4) …' to contain '"BBBBB"'

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

### After

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-react
 Test Files  32 passed (32)
      Tests  184 passed (184)
```
