### PR TITLE
[lexical-table] Bug Fix: clearing table cells keeps each cell's paragraph state

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -8,6 +8,7 @@
 
 import invariant from '@lexical/internal/invariant';
 import {
+  $copyNode,
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
@@ -606,7 +607,15 @@ export class TableObserver {
 
     selectedNodes.forEach(cellNode => {
       if ($isElementNode(cellNode)) {
-        const paragraphNode = $createParagraphNode();
+        // Clearing a cell empties its content; it does not reset how that
+        // content is laid out. A fresh ParagraphNode would start with no
+        // format, style, direction or indent, so the cell's paragraph is
+        // copied instead when there is one — $copyNode carries that state and
+        // returns it childless.
+        const firstChild = cellNode.getFirstChild();
+        const paragraphNode = $isParagraphNode(firstChild)
+          ? $copyNode(firstChild)
+          : $createParagraphNode();
         const textNode = $createTextNode();
         paragraphNode.append(textNode);
         cellNode.append(paragraphNode);

--- a/packages/lexical-table/src/__tests__/unit/ClearTextKeepsParagraphState.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/ClearTextKeepsParagraphState.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $computeTableMapSkipCellCheck,
+  $createTableNodeWithDimensions,
+  $createTableSelectionFrom,
+  $isTableCellNode,
+  $isTableNode,
+  $isTableRowNode,
+  TableExtension,
+} from '@lexical/table';
+import {
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  $setSelection,
+  defineExtension,
+  KEY_BACKSPACE_COMMAND,
+} from 'lexical';
+import {afterEach, assert, beforeEach, describe, expect, test} from 'vitest';
+
+let container: HTMLDivElement;
+let editor: ReturnType<typeof buildEditorFromExtensions>;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  editor = buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [TableExtension],
+      name: 'clear-text-host',
+    }),
+  );
+  // The table selection observer only registers its key handlers once the
+  // editor has a root element in the document.
+  editor.setRootElement(container);
+});
+
+afterEach(() => {
+  editor.dispose();
+  document.body.removeChild(container);
+});
+
+function $firstRowParagraphState() {
+  const table = $getRoot().getFirstChild();
+  assert($isTableNode(table), 'expected a TableNode at the root');
+  const firstRow = table.getChildren().filter($isTableRowNode)[0];
+  return firstRow
+    .getChildren()
+    .filter($isTableCellNode)
+    .map(cell => {
+      const paragraph = cell.getFirstChild();
+      assert($isParagraphNode(paragraph), 'expected a ParagraphNode in a cell');
+      return {
+        direction: paragraph.getDirection(),
+        format: paragraph.getFormatType(),
+        style: paragraph.getStyle(),
+        text: cell.getTextContent(),
+      };
+    });
+}
+
+describe('clearing a table selection', () => {
+  test('keeps the paragraph format, style and direction of each cell', () => {
+    editor.update(
+      () => {
+        const table = $createTableNodeWithDimensions(2, 2, false);
+        $getRoot().clear().append(table);
+        const [map] = $computeTableMapSkipCellCheck(table, null, null);
+        for (const {cell} of map[0]) {
+          const paragraph = cell.getFirstChild();
+          assert($isParagraphNode(paragraph), 'expected a ParagraphNode');
+          paragraph
+            .setFormat('center')
+            .setDirection('rtl')
+            .setStyle('line-height: 2;');
+          paragraph.append($createTextNode('text'));
+        }
+        $setSelection(
+          $createTableSelectionFrom(table, map[0][0].cell, map[0][1].cell),
+        );
+      },
+      {discrete: true},
+    );
+
+    // Backspace over a multi-cell selection routes to TableObserver.$clearText.
+    // The selection covers only the first row, so the table itself survives.
+    editor.update(
+      () => {
+        editor.dispatchCommand(
+          KEY_BACKSPACE_COMMAND,
+          new KeyboardEvent('keydown', {key: 'Backspace'}),
+        );
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      expect($firstRowParagraphState()).toEqual([
+        {
+          direction: 'rtl',
+          format: 'center',
+          style: 'line-height: 2;',
+          text: '',
+        },
+        {
+          direction: 'rtl',
+          format: 'center',
+          style: 'line-height: 2;',
+          text: '',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

`TableObserver.$clearText` empties every selected cell by building a brand new
paragraph and deleting whatever was there:

```ts
const paragraphNode = $createParagraphNode();
const textNode = $createTextNode();
paragraphNode.append(textNode);
cellNode.append(paragraphNode);
cellNode.getChildren().forEach(child => {
  if (child !== paragraphNode) {
    child.remove();
  }
});
```

A fresh `ParagraphNode` starts with no format, style, direction, indent or
carried text format/style, so pressing Backspace/Delete over a multi-cell
selection also resets how those cells are laid out — centred cells come back
left-aligned, RTL cells come back LTR. The cell itself is not recreated, so
`backgroundColor`, `headerState`, spans, `width` and `verticalAlign` do
survive; the loss is confined to the block state of the content.

Clearing a cell should empty it, not restyle it. `RangeSelection.removeText()`
leaves the paragraph and its format in place for the same gesture outside a
table, and this class already treats the cell's first paragraph as the carrier
of that state — `$formatCells` two methods up reads
`cellNodes[0].getFirstChild()` and its `getFormatFlags(...)` for exactly that
reason.

This copies the cell's existing paragraph instead of constructing one, when
there is one. `$copyNode` carries the element state and returns a childless
copy, so the cell still ends up with a single empty paragraph. A cell whose
first child is not a paragraph falls back to the previous behavior.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/ClearTextKeepsParagraphState.test.ts`

The test presses Backspace over a `TableSelection` covering the first row of a
2x2 table. The `text: ""` assertions pass on both sides of the change — the
cells are emptied either way — which is what isolates the state loss.

### Before

```
 FAIL  ... > clearing a table selection > keeps the paragraph format, style and direction of each cell
AssertionError: expected [ { direction: null, …(3) }, …(1) ] to deeply equal [ { direction: 'rtl', …(3) }, …(1) ]

- Expected
+ Received

  [
    {
-     "direction": "rtl",
-     "format": "center",
-     "style": "line-height: 2;",
+     "direction": null,
+     "format": "",
+     "style": "",
      "text": "",
    },
    ...
```

### After

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

`npx vitest run packages/lexical-table` is green (13 files, 158 tests).

