### PR TITLE
[lexical] Bug Fix: a parsed EditorState carries the _slotsUsed flag

### DIFF
--- a/packages/lexical/src/LexicalSlot.ts
+++ b/packages/lexical/src/LexicalSlot.ts
@@ -20,7 +20,11 @@ import type {ElementNode} from './nodes/LexicalElementNode';
 import invariant from '@lexical/internal/invariant';
 
 import {$getEditor, $getNodeByKey, $isDecoratorNode, $isElementNode} from '.';
-import {$removeFromParent, iterStaticNodeConfigChain} from './LexicalUtils';
+import {
+  $markSlotsUsed,
+  $removeFromParent,
+  iterStaticNodeConfigChain,
+} from './LexicalUtils';
 
 const __DEV__ = process.env.NODE_ENV !== 'production';
 
@@ -482,16 +486,8 @@ export function $setSlot<T extends LexicalNode & SlotHostNode>(
   writableNode.__slotHost = writableSelf.__key;
   slots.set(name, writableNode.__key);
   $canonicalizeSlotOrder(writableSelf);
-  $setSlotsUsed();
+  $markSlotsUsed();
   return writableSelf;
-}
-
-function $setSlotsUsed() {
-  const editor = $getEditor();
-  editor._slotsUsed = true;
-  if (editor._pendingEditorState) {
-    editor._pendingEditorState._slotsUsed = true;
-  }
 }
 
 /**

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -486,6 +486,24 @@ function internalMarkParentElementsAsDirty(
 }
 
 /**
+ * @internal
+ *
+ * Latch the "this document uses slots" flag. The editor keeps it for its
+ * lifetime, and the EditorState currently being built carries it so that a
+ * state handed to another editor via `setEditorState` brings the flag with it.
+ *
+ * The state marked here is the *active* one. Inside `editor.update()` that is
+ * `editor._pendingEditorState`, but `parseEditorState` builds a detached
+ * EditorState and leaves `_pendingEditorState` untouched, so keying off
+ * pending would miss the parsed state entirely (and could stamp the flag onto
+ * an unrelated pending state).
+ */
+export function $markSlotsUsed(): void {
+  getActiveEditor()._slotsUsed = true;
+  getActiveEditorState()._slotsUsed = true;
+}
+
+/**
  * Removes a node from its parent, updating all necessary pointers and links.
  * @internal
  *

--- a/packages/lexical/src/__tests__/unit/SlotParseEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/SlotParseEditorState.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalEditorWithDispose} from '@lexical/extension';
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {describe, expect, test} from 'vitest';
+
+import {
+  $create,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $setSlot,
+  defineExtension,
+  ElementNode,
+} from '../..';
+
+// A shadow-root block used as a slot value, mirroring the shape a slot host
+// holds in production.
+class SlotContainerNode extends ElementNode {
+  $config() {
+    return this.config('slot_container_parse', {extends: ElementNode});
+  }
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+  updateDOM(): boolean {
+    return false;
+  }
+  isShadowRoot(): boolean {
+    return true;
+  }
+}
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: null,
+      name: '[slot-parse-editor-state]',
+      nodes: [SlotContainerNode],
+    }),
+  );
+}
+
+function seedSlotDocument(editor: LexicalEditorWithDispose) {
+  editor.update(
+    () => {
+      const host = $createParagraphNode();
+      const container = $create(SlotContainerNode).append(
+        $createParagraphNode().append($createTextNode('Title')),
+      );
+      $setSlot(host, 'title', container);
+      $getRoot().clear().append(host);
+    },
+    {discrete: true},
+  );
+}
+
+describe('_slotsUsed survives parseEditorState', () => {
+  test('a state built by update() carries the flag', () => {
+    using editor = buildEditor();
+    seedSlotDocument(editor);
+
+    expect(editor._slotsUsed).toBe(true);
+    expect(editor.getEditorState()._slotsUsed).toBe(true);
+  });
+
+  test('a parsed state carries the flag', () => {
+    using source = buildEditor();
+    seedSlotDocument(source);
+    const json = JSON.stringify(source.getEditorState().toJSON());
+
+    using target = buildEditor();
+    const parsed = target.parseEditorState(json);
+
+    // Guard the premise: the slot really did survive serialization.
+    parsed.read(() => {
+      const host = $getRoot().getFirstChildOrThrow();
+      expect(host.getTextContent()).toContain('Title');
+    });
+
+    expect(parsed._slotsUsed).toBe(true);
+  });
+
+  test('setEditorState latches the flag on an editor that did not parse it', () => {
+    using source = buildEditor();
+    seedSlotDocument(source);
+    const json = JSON.stringify(source.getEditorState().toJSON());
+
+    // Parsing is done by one editor and the state handed to another, e.g. a
+    // headless parse on the server or a shared document cache. The parsing
+    // editor sets its own `_slotsUsed` as a side effect of $setSlot, so only
+    // the receiving editor exposes whether the flag travelled with the state.
+    using parser = buildEditor();
+    const parsed = parser.parseEditorState(json);
+
+    using target = buildEditor();
+    expect(target._slotsUsed).toBe(false);
+    target.setEditorState(parsed);
+
+    expect(target._slotsUsed).toBe(true);
+  });
+
+  test('parsing a slotless document leaves the flag alone', () => {
+    using source = buildEditor();
+    source.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('plain')));
+      },
+      {discrete: true},
+    );
+    const json = JSON.stringify(source.getEditorState().toJSON());
+
+    using target = buildEditor();
+    const parsed = target.parseEditorState(json);
+
+    expect(parsed._slotsUsed).toBe(false);
+    target.setEditorState(parsed);
+    expect(target._slotsUsed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

`$setSlot` latches "this document uses slots" so the slot-gated paths know to
run. It marks the pending editor state:

```js
function $setSlotsUsed() {
  const editor = $getEditor();
  editor._slotsUsed = true;
  if (editor._pendingEditorState) {
    editor._pendingEditorState._slotsUsed = true;
  }
}
```

Inside `editor.update()` that is correct, because `activeEditorState ===
editor._pendingEditorState`. But `$setSlot` also runs during
`parseEditorState` (`$parseSerializedNodeImpl`), and that function builds a
*detached* `EditorState` and assigns it to `activeEditorState` while leaving
`editor._pendingEditorState` untouched:

```js
const editorState = createEmptyEditorState();
...
activeEditorState = editorState;   // _pendingEditorState is never touched
```

So a parsed state never receives the flag, and whatever unrelated state happens
to be pending may receive it instead.

`EditorState._slotsUsed` documents itself as "True if this EditorState or the
LexicalEditor that created it has ever used slots", and
`LexicalEditor.setEditorState` is the only way an editor learns that an
incoming state uses slots:

```js
this._slotsUsed = this._slotsUsed || editorState._slotsUsed;
```

An editor that receives a parsed slot document therefore keeps
`_slotsUsed === false` and silently skips every gated path —
`$clampRangeSelectionToSlotFrame` (so a RangeSelection may straddle a slot
boundary), the slot-island re-render in `setEditable`, and the slot walks in
`LexicalSelection`, `LexicalUtils` and `LexicalMutations`. `cloneEditorState`
and `EditorState.clone` both propagate the wrong `false` onward.

This marks the *active* editor state, which is the one actually being built in
both cases. The existing test `setEditorState latches _slotsUsed when the state
contains slots` covers the `update()` path, where the two are the same object;
the parse path was the gap.

The helper moves to `LexicalUtils` because `LexicalSlot` cannot import
`LexicalUpdates` directly — that edge forms a module-initialization cycle
(`LexicalSlot -> LexicalUpdates -> LexicalSelection -> LexicalTabNode ->
LexicalTextNode -> LexicalNode` still undefined), which is the same reason this
file already avoids a runtime `LexicalNode` import. `LexicalUtils` already
imports `getActiveEditorState` and is already imported by `LexicalSlot`.

## Test plan

New unit test `packages/lexical/src/__tests__/unit/SlotParseEditorState.test.ts`.
The third case has one editor parse and a *different* editor receive the state:
the parsing editor sets its own `_slotsUsed` as a side effect of `$setSlot`, so
only a receiving editor shows whether the flag travelled with the state. The
`update()` case and a slotless document are controls and pass before and after.

### Before

```
$ npx vitest run packages/lexical/src/__tests__/unit/SlotParseEditorState.test.ts

     × a parsed state carries the flag 4ms
     × setEditorState latches the flag on an editor that did not parse it 1ms

AssertionError: expected false to be true // Object.is equality

      Tests  2 failed | 2 passed (4)
```

### After

```
$ npx vitest run packages/lexical/src/__tests__/unit/SlotParseEditorState.test.ts

      Tests  4 passed (4)

$ npx vitest run packages/lexical/src/__tests__

 Test Files  58 passed (58)
      Tests  943 passed | 1 skipped (944)
```
