### PR TITLE
[lexical-table] Bug Fix: align every cell a table selection covers, not just the naive rect

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -887,19 +887,14 @@ export function applyTableHandlers(
           anchorNode,
           focusNode,
         );
-        const maxRow = Math.max(
-          anchorCell.startRow + anchorCell.cell.__rowSpan - 1,
-          focusCell.startRow + focusCell.cell.__rowSpan - 1,
-        );
-        const maxColumn = Math.max(
-          anchorCell.startColumn + anchorCell.cell.__colSpan - 1,
-          focusCell.startColumn + focusCell.cell.__colSpan - 1,
-        );
-        const minRow = Math.min(anchorCell.startRow, focusCell.startRow);
-        const minColumn = Math.min(
-          anchorCell.startColumn,
-          focusCell.startColumn,
-        );
+        // The same rect TableSelection.getNodes() walks. A naive min/max over
+        // the two cells' own spans is not enough: a merged cell that straddles
+        // the boundary pulls the rect outwards, and $computeTableCellRectBoundary
+        // iterates until it stops growing. Using the smaller rect here left the
+        // cells that only the expansion brings in selected and highlighted but
+        // unformatted.
+        const {minColumn, maxColumn, minRow, maxRow} =
+          $computeTableCellRectBoundary(tableMap, anchorCell, focusCell);
 
         if (
           minRow === 0 &&

--- a/packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts
@@ -22,11 +22,12 @@ import {
   $setSelection,
   defineExtension,
   FORMAT_ELEMENT_COMMAND,
+  type InitialEditorStateType,
 } from 'lexical';
 import {$assertNodeType} from 'lexical/src/__tests__/utils';
 import {assert, describe, expect, test} from 'vitest';
 
-function buildTestEditor($initialEditorState = undefined) {
+function buildTestEditor($initialEditorState?: InitialEditorStateType) {
   return buildEditorFromExtensions(
     defineExtension({
       $initialEditorState,

--- a/packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts
@@ -23,55 +23,43 @@ import {
   defineExtension,
   FORMAT_ELEMENT_COMMAND,
 } from 'lexical';
-import {afterEach, assert, beforeEach, describe, expect, test} from 'vitest';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, test} from 'vitest';
 
-let container: HTMLDivElement;
-let editor: ReturnType<typeof buildEditorFromExtensions>;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-  editor = buildEditorFromExtensions(
+function buildTestEditor($initialEditorState = undefined) {
+  return buildEditorFromExtensions(
     defineExtension({
+      $initialEditorState,
+      afterRegistration(editor, config, state) {
+        // The FORMAT_ELEMENT_COMMAND handler is registered by the table selection
+        // observer, which needs the editor to have a root element.
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        editor.setRootElement(container);
+        return () => document.body.removeChild(container);
+      },
       dependencies: [TableExtension],
       name: 'format-element-rect-host',
     }),
   );
-  // The FORMAT_ELEMENT_COMMAND handler is registered by the table selection
-  // observer, which needs the editor to have a root element.
-  editor.setRootElement(container);
-});
-
-afterEach(() => {
-  editor.dispose();
-  document.body.removeChild(container);
-});
-
-function $table() {
-  const table = $getRoot().getFirstChild();
-  assert($isTableNode(table), 'expected a TableNode at the root');
-  return table;
 }
 
 describe('FORMAT_ELEMENT_COMMAND over a table selection', () => {
   test('formats every cell the selection contains, including one pulled in by a merge', () => {
-    editor.update(
-      () => {
-        const table = $createTableNodeWithDimensions(3, 3, false);
-        $getRoot().clear().append(table);
-        const [map] = $computeTableMapSkipCellCheck(table, null, null);
-        // Merge grid columns 0 and 1 of row 1. The merged cell straddles the
-        // left edge of the rect the next selection describes, so the rect has
-        // to grow to column 0 to contain it.
-        const merged = $mergeCells([map[1][0].cell, map[1][1].cell]);
-        assert(merged !== null, 'expected the cells to merge');
-      },
-      {discrete: true},
-    );
+    using editor = buildTestEditor(() => {
+      const table = $createTableNodeWithDimensions(3, 3, false);
+      $getRoot().append(table);
+      const [map] = $computeTableMapSkipCellCheck(table, null, null);
+      // Merge grid columns 0 and 1 of row 1. The merged cell straddles the
+      // left edge of the rect the next selection describes, so the rect has
+      // to grow to column 0 to contain it.
+      const merged = $mergeCells([map[1][0].cell, map[1][1].cell]);
+      assert(merged !== null, 'expected the cells to merge');
+    });
 
     editor.update(
       () => {
-        const table = $table();
+        const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
         const [map] = $computeTableMapSkipCellCheck(table, null, null);
         // Anchor at (row 0, column 1), focus at (row 1, column 2).
         $setSelection(
@@ -81,14 +69,9 @@ describe('FORMAT_ELEMENT_COMMAND over a table selection', () => {
       {discrete: true},
     );
 
-    editor.update(
-      () => {
-        editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
-      },
-      {discrete: true},
-    );
+    editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
 
-    editor.read('latest', () => {
+    editor.read('force-commit', () => {
       const selection = $getSelection();
       assert(selection !== null, 'expected a selection');
       const selectedCells = selection.getNodes().filter($isTableCellNode);

--- a/packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $computeTableMapSkipCellCheck,
+  $createTableNodeWithDimensions,
+  $createTableSelectionFrom,
+  $isTableCellNode,
+  $isTableNode,
+  $mergeCells,
+  TableExtension,
+} from '@lexical/table';
+import {
+  $getRoot,
+  $getSelection,
+  $setSelection,
+  defineExtension,
+  FORMAT_ELEMENT_COMMAND,
+} from 'lexical';
+import {afterEach, assert, beforeEach, describe, expect, test} from 'vitest';
+
+let container: HTMLDivElement;
+let editor: ReturnType<typeof buildEditorFromExtensions>;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  editor = buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [TableExtension],
+      name: 'format-element-rect-host',
+    }),
+  );
+  // The FORMAT_ELEMENT_COMMAND handler is registered by the table selection
+  // observer, which needs the editor to have a root element.
+  editor.setRootElement(container);
+});
+
+afterEach(() => {
+  editor.dispose();
+  document.body.removeChild(container);
+});
+
+function $table() {
+  const table = $getRoot().getFirstChild();
+  assert($isTableNode(table), 'expected a TableNode at the root');
+  return table;
+}
+
+describe('FORMAT_ELEMENT_COMMAND over a table selection', () => {
+  test('formats every cell the selection contains, including one pulled in by a merge', () => {
+    editor.update(
+      () => {
+        const table = $createTableNodeWithDimensions(3, 3, false);
+        $getRoot().clear().append(table);
+        const [map] = $computeTableMapSkipCellCheck(table, null, null);
+        // Merge grid columns 0 and 1 of row 1. The merged cell straddles the
+        // left edge of the rect the next selection describes, so the rect has
+        // to grow to column 0 to contain it.
+        const merged = $mergeCells([map[1][0].cell, map[1][1].cell]);
+        assert(merged !== null, 'expected the cells to merge');
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const table = $table();
+        const [map] = $computeTableMapSkipCellCheck(table, null, null);
+        // Anchor at (row 0, column 1), focus at (row 1, column 2).
+        $setSelection(
+          $createTableSelectionFrom(table, map[0][1].cell, map[1][2].cell),
+        );
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
+      },
+      {discrete: true},
+    );
+
+    editor.read('latest', () => {
+      const selection = $getSelection();
+      assert(selection !== null, 'expected a selection');
+      const selectedCells = selection.getNodes().filter($isTableCellNode);
+      expect(selectedCells.length).toBeGreaterThan(0);
+      expect(selectedCells.map(cell => cell.getFormatType())).toEqual(
+        selectedCells.map(() => 'center'),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

A `TableSelection` is two cells, and the set of cells it covers is the smallest
rect containing both — but that rect has to be *grown* whenever a merged cell
straddles its edge, otherwise the rect would cut a cell in half.
`$computeTableCellRectBoundary` does that expansion, iterating until the rect
stops growing, and `TableSelection.getNodes()` uses it to decide what is
selected. `$adjustFocusInDirection` and `$extractRectCorners` use it too.

The `FORMAT_ELEMENT_COMMAND` handler is the one place that reimplements the
rect, and it reimplements only the first half of it:

```ts
const maxRow = Math.max(
  anchorCell.startRow + anchorCell.cell.__rowSpan - 1,
  focusCell.startRow + focusCell.cell.__rowSpan - 1,
);
...
const minColumn = Math.min(anchorCell.startColumn, focusCell.startColumn);
```

That is the un-expanded rect, so whenever a merged cell pulls the boundary
outwards the handler formats a strict subset of what the selection contains.
The extra cells are selected and highlighted, but pressing an alignment button
leaves them untouched.

This uses `$computeTableCellRectBoundary` so the handler walks the same rect
the selection reports. The "whole table selected" shortcut just above now also
tests the expanded rect, which is the rect that actually covers the table.

## Test plan

`npx vitest run packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts`

The test merges grid columns 0–1 of row 1 in a 3x3 table, selects
(row 0, column 1) → (row 1, column 2), centres it, and asserts every cell
`selection.getNodes()` reports came out centred.

(The natural test file, `LexicalTableSelectionHelpers.test.ts`, is already
being edited by an open PR, so the repro lives in its own file.)

### Before

```
 FAIL  ... > formats every cell the selection contains, including one pulled in by a merge
AssertionError: expected [ '', 'center', 'center', …(2) ] to deeply equal [ 'center', 'center', 'center', …(2) ]

- Expected
+ Received

  [
-   "center",
+   "",
    "center",
    "center",
    "center",
    "center",
  ]
```

### After

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Also green:

- `npx vitest run packages/lexical-table` — 13 files, 158 tests
- `E2E_BROWSER=chromium npx playwright test --project=chromium Tables.spec.mjs` — 88 passed, 1 skipped

Only chromium was exercised locally for the e2e run.

