### PR TITLE
[lexical-link] Bug Fix: TOGGLE_LINK_COMMAND applies validateUrl to the object payload too

### DIFF
--- a/packages/lexical-link/src/LexicalLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalLinkExtension.ts
@@ -89,6 +89,11 @@ export function registerLink(
           // configured value, since an explicit `undefined` still shadows a
           // spread key.
           const {url, ...payloadAttributes} = payload;
+          // Same gate as the string payload above: validateUrl is documented
+          // as rejecting URLs for this command, not for one of its two shapes.
+          if (validateUrl !== undefined && !validateUrl(url)) {
+            return false;
+          }
           $toggleLink(url, {...attributes, ...payloadAttributes});
           return true;
         }

--- a/packages/lexical-link/src/__tests__/unit/LinkExtensionValidateUrl.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkExtensionValidateUrl.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {$isLinkNode, LinkExtension, TOGGLE_LINK_COMMAND} from '@lexical/link';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  $isTextNode,
+  configExtension,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+const ALLOWED = 'https://lexical.dev/';
+// Rejected by the configured policy below (https-only), which is the shape
+// most validateUrl implementations take: an allowlist, not a scheme blocklist.
+const REJECTED = 'http://not-allowed.example.com/';
+
+function makeExtension(validateUrl?: (url: string) => boolean) {
+  return defineExtension({
+    $initialEditorState: () => {
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode('Hello'));
+      $getRoot().append(paragraph);
+    },
+    dependencies: [
+      configExtension(
+        LinkExtension,
+        validateUrl === undefined ? {} : {validateUrl},
+      ),
+      RichTextExtension,
+    ],
+    name: '[root-validate-url]',
+  });
+}
+
+function $selectHello(): void {
+  const textNode = $getRoot().getLastDescendant();
+  assert($isTextNode(textNode), 'Expected a TextNode');
+  textNode.select(0, textNode.getTextContentSize());
+}
+
+function $hasLink(): boolean {
+  const paragraph = $getRoot().getFirstChild();
+  assert($isParagraphNode(paragraph), 'Expected a ParagraphNode');
+  return $isLinkNode(paragraph.getFirstChild());
+}
+
+/**
+ * Dispatch the given payload over a selection of "Hello" and report whether
+ * the command claimed it and whether a LinkNode was actually produced.
+ */
+function toggleLink(
+  payload: string | {url: string},
+  validateUrl?: (url: string) => boolean,
+): {handled: boolean; linked: boolean} {
+  using editor = buildEditorFromExtensions(makeExtension(validateUrl));
+  let handled = false;
+  editor.update(
+    () => {
+      $selectHello();
+      handled = editor.dispatchCommand(TOGGLE_LINK_COMMAND, payload);
+    },
+    {discrete: true},
+  );
+  return {handled, linked: editor.read($hasLink)};
+}
+
+const isHttps = (url: string) => url.startsWith('https://');
+
+describe('LinkExtension validateUrl', () => {
+  it('rejects a URL the validator refuses, for an object payload', () => {
+    expect(toggleLink({url: REJECTED}, isHttps)).toEqual({
+      handled: false,
+      linked: false,
+    });
+  });
+
+  it('rejects a URL the validator refuses, for a string payload', () => {
+    expect(toggleLink(REJECTED, isHttps)).toEqual({
+      handled: false,
+      linked: false,
+    });
+  });
+
+  it('accepts a URL the validator allows, for an object payload', () => {
+    expect(toggleLink({url: ALLOWED}, isHttps)).toEqual({
+      handled: true,
+      linked: true,
+    });
+  });
+
+  it('accepts any URL when no validator is configured', () => {
+    expect(toggleLink({url: REJECTED})).toEqual({handled: true, linked: true});
+    expect(toggleLink(REJECTED)).toEqual({handled: true, linked: true});
+  });
+});


### PR DESCRIPTION

## Description

`TOGGLE_LINK_COMMAND` accepts either a URL string or an object carrying the URL plus link attributes. The handler validates one of them:

```ts
} else if (typeof payload === 'string') {
  if (validateUrl === undefined || validateUrl(payload)) {
    $toggleLink(payload, attributes);
    return true;
  }
  return false;                                     // string: gated
} else {
  const {url, ...payloadAttributes} = payload;
  $toggleLink(url, {...attributes, ...payloadAttributes});
  return true;                                      // object: validateUrl never called
}
```

`$toggleLink` does no validation of its own — it only reshuffles `url`/`attributes` and edits the selection — so nothing downstream compensates.

The contract is stated in `LinkConfig` in this same file, and it is written against the command, not against one of its shapes:

> In the implementation of {@link TOGGLE_LINK_COMMAND} it will reject URLs that return false when specified. The default of `undefined` will always accept URLs.

The object payload is the shape you are pushed toward as soon as you need to set `target`, `rel` or `title` at the same time as the URL — which is the common case for a link dialog. An app that configures `validateUrl` to enforce its own policy (an allowlist of internal hosts, a scheme allowlist, a length or shape rule) has that policy silently applied to `dispatchCommand(TOGGLE_LINK_COMMAND, url)` and silently skipped for `dispatchCommand(TOGGLE_LINK_COMMAND, {url, target: '_blank'})`. The same rejected URL is accepted or refused depending only on which shape the caller used.

To be precise about severity: this is a policy bypass, not by itself an XSS. `LinkNode.updateLinkDOM` runs `sanitizeUrl` when it writes `href`, so a dangerous scheme still renders as `about:blank` regardless. What escapes is the application's own rule — typically an allowlist rather than a scheme blocklist. The node is created, and `exportJSON` persists the raw URL the app said it did not want.

The fix applies the same gate in the object branch. Nothing in the repo dispatches an object payload except the `PASTE_COMMAND` handler a few lines below, which already calls `validateUrl(clipboardText)` before dispatching, so it re-validates the same string and passes unchanged.

## Test plan

New unit test `packages/lexical-link/src/__tests__/unit/LinkExtensionValidateUrl.test.ts` (a separate file from `LinkExtension.test.ts`). Three of the four cases are controls that pass before and after — in particular the string-payload case, which pins the asymmetry: the same URL, the same config, only the payload shape differs.

### Before

```
 ❯ packages/lexical-link/src/__tests__/unit/LinkExtensionValidateUrl.test.ts (4 tests | 1 failed)
   × rejects a URL the validator refuses, for an object payload
     AssertionError: expected { handled: true, linked: true } to deeply equal { handled: false, linked: false }
   ✓ rejects a URL the validator refuses, for a string payload
   ✓ accepts a URL the validator allows, for an object payload
   ✓ accepts any URL when no validator is configured

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```

### After

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Package suite is unchanged, including the paste-to-link tests that route through the object payload:

```
$ npx vitest run packages/lexical-link
 Test Files  7 passed (7)
      Tests  162 passed (162)
```
