### PR TITLE
[lexical-playground] Bug Fix: importing an unparseable data-lexical-datetime no longer breaks serialization

### DIFF
--- a/packages/lexical-playground/__tests__/unit/DateTimeImport.test.ts
+++ b/packages/lexical-playground/__tests__/unit/DateTimeImport.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$generateNodesFromDOMViaExtension} from '@lexical/html';
+import {$dfs} from '@lexical/utils';
+import {
+  $getRoot,
+  $insertNodes,
+  defineExtension,
+  type LexicalEditor,
+} from 'lexical';
+import {describe, expect, it} from 'vitest';
+
+import {$isDateTimeNode} from '../../src/nodes/DateTimeNode/DateTimeNode';
+import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
+import {DateTimeExtension} from '../../src/plugins/DateTimeExtension';
+
+const DateTimeImportTestExtension = /* @__PURE__ */ defineExtension({
+  $initialEditorState: null,
+  dependencies: [PlaygroundImportExtension, DateTimeExtension],
+  name: '[test-datetime-import]',
+});
+
+type ImportResult = {
+  hasDateTimeNode: boolean;
+  serializes: boolean;
+  text: string;
+};
+
+function importHtml(html: string): ImportResult {
+  using editor: LexicalEditor & Disposable = buildEditorFromExtensions(
+    DateTimeImportTestExtension,
+  );
+  editor.update(
+    () => {
+      $getRoot().clear().select();
+      const dom = new DOMParser().parseFromString(html, 'text/html');
+      $insertNodes($generateNodesFromDOMViaExtension(dom));
+    },
+    {discrete: true},
+  );
+
+  let serializes = true;
+  try {
+    editor.getEditorState().toJSON();
+  } catch {
+    serializes = false;
+  }
+
+  return editor.read(() => ({
+    hasDateTimeNode: $dfs().some(({node}) => $isDateTimeNode(node)),
+    serializes,
+    text: $getRoot().getTextContent(),
+  }));
+}
+
+describe('DateTime HTML import', () => {
+  it('keeps the element content when the date cannot be parsed', () => {
+    const result = importHtml(
+      '<p><span data-lexical-datetime="not a date">some text</span></p>',
+    );
+
+    expect(result.hasDateTimeNode).toBe(false);
+    expect(result.text).toBe('some text');
+    expect(result.serializes).toBe(true);
+  });
+
+  it('still imports a parseable date', () => {
+    const result = importHtml(
+      '<p><span data-lexical-datetime="2026-05-29T00:00:00.000Z">May 29</span></p>',
+    );
+
+    expect(result.hasDateTimeNode).toBe(true);
+    expect(result.serializes).toBe(true);
+  });
+
+  it('matches how the Google Docs rule already handles an unparseable date', () => {
+    const result = importHtml(
+      '<p><span data-rich-links=\'{"type":"date","dat_df":{"dfie_dt":"nope"}}\'>gd text</span></p>',
+    );
+
+    expect(result.hasDateTimeNode).toBe(false);
+    expect(result.text).toBe('gd text');
+    expect(result.serializes).toBe(true);
+  });
+});

--- a/packages/lexical-playground/__tests__/unit/DateTimeImport.test.ts
+++ b/packages/lexical-playground/__tests__/unit/DateTimeImport.test.ts
@@ -8,35 +8,26 @@
 
 import {buildEditorFromExtensions} from '@lexical/extension';
 import {$generateNodesFromDOMViaExtension} from '@lexical/html';
-import {$dfs} from '@lexical/utils';
-import {
-  $getRoot,
-  $insertNodes,
-  defineExtension,
-  type LexicalEditor,
-} from 'lexical';
+import {$getRoot, $insertNodes, $nodesOfType, defineExtension} from 'lexical';
 import {describe, expect, it} from 'vitest';
 
-import {$isDateTimeNode} from '../../src/nodes/DateTimeNode/DateTimeNode';
+import {DateTimeNode} from '../../src/nodes/DateTimeNode/DateTimeNode';
 import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
 import {DateTimeExtension} from '../../src/plugins/DateTimeExtension';
 
-const DateTimeImportTestExtension = /* @__PURE__ */ defineExtension({
+const DateTimeImportTestExtension = defineExtension({
   $initialEditorState: null,
   dependencies: [PlaygroundImportExtension, DateTimeExtension],
   name: '[test-datetime-import]',
 });
 
-type ImportResult = {
+interface ImportResult {
   hasDateTimeNode: boolean;
-  serializes: boolean;
   text: string;
-};
+}
 
 function importHtml(html: string): ImportResult {
-  using editor: LexicalEditor & Disposable = buildEditorFromExtensions(
-    DateTimeImportTestExtension,
-  );
+  using editor = buildEditorFromExtensions(DateTimeImportTestExtension);
   editor.update(
     () => {
       $getRoot().clear().select();
@@ -46,16 +37,10 @@ function importHtml(html: string): ImportResult {
     {discrete: true},
   );
 
-  let serializes = true;
-  try {
-    editor.getEditorState().toJSON();
-  } catch {
-    serializes = false;
-  }
+  expect(() => editor.getEditorState().toJSON()).not.toThrow();
 
   return editor.read(() => ({
-    hasDateTimeNode: $dfs().some(({node}) => $isDateTimeNode(node)),
-    serializes,
+    hasDateTimeNode: $nodesOfType(DateTimeNode).length > 0,
     text: $getRoot().getTextContent(),
   }));
 }
@@ -68,16 +53,17 @@ describe('DateTime HTML import', () => {
 
     expect(result.hasDateTimeNode).toBe(false);
     expect(result.text).toBe('some text');
-    expect(result.serializes).toBe(true);
   });
 
   it('still imports a parseable date', () => {
+    // Use a date in the local time zone and locale
+    const may29 = new Date(2026, 4, 29);
     const result = importHtml(
-      '<p><span data-lexical-datetime="2026-05-29T00:00:00.000Z">May 29</span></p>',
+      `<p><span data-lexical-datetime="${may29.toISOString()}">May 29</span></p>`,
     );
 
     expect(result.hasDateTimeNode).toBe(true);
-    expect(result.serializes).toBe(true);
+    expect(result.text).toBe(may29.toDateString());
   });
 
   it('matches how the Google Docs rule already handles an unparseable date', () => {
@@ -87,6 +73,5 @@ describe('DateTime HTML import', () => {
 
     expect(result.hasDateTimeNode).toBe(false);
     expect(result.text).toBe('gd text');
-    expect(result.serializes).toBe(true);
   });
 });

--- a/packages/lexical-playground/src/plugins/DateTimeExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/DateTimeExtension/index.tsx
@@ -40,9 +40,17 @@ export const INSERT_DATETIME_COMMAND: LexicalCommand<CommandPayload> =
   /* @__PURE__ */ createCommand('INSERT_DATETIME_COMMAND');
 
 const DateTimeRule = /* @__PURE__ */ defineImportRule({
-  $import: (ctx, el) => {
+  $import: (ctx, el, $next) => {
     const dateTimeValue = el.getAttribute('data-lexical-datetime')!;
-    const node = $createDateTimeNode(new Date(Date.parse(dateTimeValue)));
+    const parsedDate = Date.parse(dateTimeValue);
+    // An unparseable attribute would build a node around an Invalid Date,
+    // whose dateTime state cannot be serialized (toISOString throws). Fall
+    // through and keep the element's own content instead, the same way
+    // GoogleDocsDateRule below does.
+    if (isNaN(parsedDate)) {
+      return $next();
+    }
+    const node = $createDateTimeNode(new Date(parsedDate));
     const [firstChild] = ctx.$importChildren(el);
     if ($isTextNode(firstChild)) {
       node.setFormat(firstChild.getFormat());


### PR DESCRIPTION

## Description

`DateTimeRule` builds a node from the attribute without checking that it parsed:

```ts
const DateTimeRule = defineImportRule({
  $import: (ctx, el) => {
    const dateTimeValue = el.getAttribute('data-lexical-datetime')!;
    const node = $createDateTimeNode(new Date(Date.parse(dateTimeValue)));   // NaN -> Invalid Date
    const [firstChild] = ctx.$importChildren(el);
    ...
    return [node];
  },
  match: sel.tag('span').attr('data-lexical-datetime', true),
```

`GoogleDocsDateRule`, twenty lines below in the same file and matching the same kind of pasted markup, does exactly the check that is missing:

```ts
if (isNaN(parsedDate)) {
  return $next();
}
```

When `Date.parse` fails, the rule still claims the element and returns the node, so `$next()` is never reached and the element's own text is discarded. The node then holds an `Invalid Date`, and its state config unparses with `toISOString()`:

```ts
const dateTimeState = createState('dateTime', {
  parse: v => new Date(v as string),
  unparse: v => v.toISOString(),
});
```

`Date.prototype.toISOString` throws `RangeError: Invalid time value` on an Invalid Date, and `LexicalNodeState.toJSON` calls `unparse` for any value that differs from the default — which an `Invalid Date` object always does.

Measured on `upstream/main`, pasting `<span data-lexical-datetime="not a date">some text</span>`:

```
INVALID       text= "Invalid Date NaN:NaN"   toJSON THREW: RangeError Invalid time value
GDOCS-INVALID text= "gd text"                toJSON: OK
VALID         text= "Thu May 28 2026 17:00"  toJSON: OK
```

So one bad attribute in pasted HTML both replaces the visible text with `Invalid Date NaN:NaN` and makes the whole editor state unserializable: every later `editorState.toJSON()` throws, which is what the playground's autosave, the shareable-document URL, collab and the debug tree view all call. The document cannot be saved again until that node is deleted. The sibling rule shows the intended handling — fall through and keep the element as ordinary content.

This adds the same guard. `$next` was already part of the rule signature, it simply was not used here. No API or serialization change.

## Test plan

New unit test `packages/lexical-playground/__tests__/unit/DateTimeImport.test.ts`. Two of the three cases are controls that pass before and after: a parseable date must still import, and the Google Docs rule's existing behaviour is asserted alongside so the two rules are pinned to the same contract.

### Before

```
 ❯ packages/lexical-playground/__tests__/unit/DateTimeImport.test.ts (3 tests | 1 failed)
   × keeps the element content when the date cannot be parsed
     AssertionError: expected true to be false // Object.is equality
   ✓ still imports a parseable date
   ✓ matches how the Google Docs rule already handles an unparseable date

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

### After

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Package suite is unchanged:

```
$ npx vitest run packages/lexical-playground
 Test Files  19 passed (19)
      Tests  277 passed (277)
```
