### PR TITLE
[lexical-text][lexical-mark][lexical-link][lexical-playground] Bug Fix: inline node transforms keep the node and its DOM in step

### DIFF
--- a/packages/lexical-link/src/LexicalAutoLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalAutoLinkExtension.ts
@@ -475,16 +475,24 @@ function handleLinkEdit(
   }
 
   if (match.attributes) {
-    const rel = linkNode.getRel();
-    if (rel !== match.attributes.rel) {
+    // `ChangeHandler` is documented as receiving the new url and the previous
+    // url, so an attribute refresh is not something it can describe: passing a
+    // rel or target through it reports that value as the link's url. These
+    // assignments keep the node in sync with the matcher without reporting a
+    // url change that did not happen.
+    if (linkNode.getRel() !== match.attributes.rel) {
       linkNode.setRel(match.attributes.rel || null);
-      onChange(match.attributes.rel || null, rel);
     }
 
-    const target = linkNode.getTarget();
-    if (target !== match.attributes.target) {
+    if (linkNode.getTarget() !== match.attributes.target) {
       linkNode.setTarget(match.attributes.target || null);
-      onChange(match.attributes.target || null, target);
+    }
+
+    // `title` is the third member of LinkAttributes and the creation path
+    // ($createAutoLinkNode(match.url, match.attributes)) already applies it,
+    // so the edit path has to refresh it too or it goes stale.
+    if (linkNode.getTitle() !== match.attributes.title) {
+      linkNode.setTitle(match.attributes.title || null);
     }
   }
 }

--- a/packages/lexical-link/src/LexicalLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalLinkExtension.ts
@@ -89,6 +89,11 @@ export function registerLink(
           // configured value, since an explicit `undefined` still shadows a
           // spread key.
           const {url, ...payloadAttributes} = payload;
+          // Same gate as the string payload above: validateUrl is documented
+          // as rejecting URLs for this command, not for one of its two shapes.
+          if (validateUrl !== undefined && !validateUrl(url)) {
+            return false;
+          }
           $toggleLink(url, {...attributes, ...payloadAttributes});
           return true;
         }

--- a/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkExtension.test.ts
@@ -10,7 +10,9 @@ import {buildEditorFromExtensions} from '@lexical/extension';
 import {
   $isAutoLinkNode,
   AutoLinkExtension,
+  type AutoLinkNode,
   createLinkMatcherWithRegExp,
+  type LinkMatcher,
 } from '@lexical/link';
 import {
   $create,
@@ -279,6 +281,124 @@ describe('LexicalAutoLinkExtension tests', () => {
       const nextSibling = autoLinkNode.getNextSibling();
       assert($isTextNode(nextSibling), 'next sibling must be a TextNode');
       expect(nextSibling.getTextContent()).toBe(' ');
+    });
+  });
+
+  describe('handleLinkEdit keeps the matcher attributes in sync', () => {
+    // Every attribute in LinkAttributes is derived from the matched url, so
+    // re-running the matcher on edited text must refresh all of them.
+    const ATTRIBUTE_MATCHER: LinkMatcher = text => {
+      const match = /https?:\/\/[a-z]+\.com/.exec(text);
+      if (match === null) {
+        return null;
+      }
+      const host = match[0].replace('https://', '');
+      return {
+        attributes: {
+          rel: `rel-${host}`,
+          target: `target-${host}`,
+          title: `title-${host}`,
+        },
+        index: match.index,
+        length: match[0].length,
+        text: match[0],
+        url: match[0],
+      };
+    };
+
+    function buildEditor() {
+      return buildEditorFromExtensions({
+        $initialEditorState() {
+          $getRoot().append(
+            $createParagraphNode().append($createTextNode('https://a.com')),
+          );
+        },
+        dependencies: [
+          TestLexicalAutoLinkExtension,
+          configExtension(AutoLinkExtension, {
+            matchers: [ATTRIBUTE_MATCHER],
+          }),
+        ],
+        name: '[test attributes]',
+      });
+    }
+
+    function $getAutoLink(): AutoLinkNode {
+      const paragraph = $getRoot().getFirstChild();
+      assert($isParagraphNode(paragraph), 'expected a ParagraphNode');
+      const autoLink = paragraph.getFirstChild();
+      assert($isAutoLinkNode(autoLink), 'expected an AutoLinkNode');
+      return autoLink;
+    }
+
+    function retypeAsB(editor: ReturnType<typeof buildEditor>) {
+      editor.update(
+        () => {
+          const textNode = $getAutoLink().getFirstChild();
+          assert($isTextNode(textNode), 'expected a TextNode');
+          textNode.setTextContent('https://b.com');
+        },
+        {discrete: true},
+      );
+    }
+
+    test('the creation path applies every attribute', () => {
+      using editor = buildEditor();
+      editor.read(() => {
+        const autoLink = $getAutoLink();
+        expect(autoLink.getURL()).toBe('https://a.com');
+        expect(autoLink.getRel()).toBe('rel-a.com');
+        expect(autoLink.getTarget()).toBe('target-a.com');
+        expect(autoLink.getTitle()).toBe('title-a.com');
+      });
+    });
+
+    test('editing the link text refreshes rel and target', () => {
+      using editor = buildEditor();
+      retypeAsB(editor);
+      editor.read(() => {
+        const autoLink = $getAutoLink();
+        expect(autoLink.getURL()).toBe('https://b.com');
+        expect(autoLink.getRel()).toBe('rel-b.com');
+        expect(autoLink.getTarget()).toBe('target-b.com');
+      });
+    });
+
+    test('editing the link text refreshes the title', () => {
+      using editor = buildEditor();
+      retypeAsB(editor);
+      editor.read(() => {
+        expect($getAutoLink().getTitle()).toBe('title-b.com');
+      });
+    });
+
+    test('an attribute refresh is not reported as a url change', () => {
+      const changes: [string | null, string | null][] = [];
+      using editor = buildEditorFromExtensions({
+        $initialEditorState() {
+          $getRoot().append(
+            $createParagraphNode().append($createTextNode('https://a.com')),
+          );
+        },
+        dependencies: [
+          TestLexicalAutoLinkExtension,
+          configExtension(AutoLinkExtension, {
+            changeHandlers: [
+              (url, prevUrl) => {
+                changes.push([url, prevUrl]);
+              },
+            ],
+            matchers: [ATTRIBUTE_MATCHER],
+          }),
+        ],
+        name: '[test change handler]',
+      });
+      changes.length = 0;
+      retypeAsB(editor);
+
+      // ChangeHandler is documented as (url, prevUrl). Every reported pair must
+      // be a url, never a rel/target/title carried over from the same edit.
+      expect(changes).toEqual([['https://b.com', 'https://a.com']]);
     });
   });
 });

--- a/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkExtension.test.ts
@@ -24,8 +24,10 @@ import {
   configExtension,
   defineExtension,
   ElementNode,
+  type LexicalEditor,
   type LexicalNode,
 } from 'lexical';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
 import {assert, describe, expect, test} from 'vitest';
 
 class ExcludedParentNode extends ElementNode {
@@ -324,18 +326,20 @@ describe('LexicalAutoLinkExtension tests', () => {
     }
 
     function $getAutoLink(): AutoLinkNode {
-      const paragraph = $getRoot().getFirstChild();
-      assert($isParagraphNode(paragraph), 'expected a ParagraphNode');
-      const autoLink = paragraph.getFirstChild();
-      assert($isAutoLinkNode(autoLink), 'expected an AutoLinkNode');
-      return autoLink;
+      const paragraph = $assertNodeType(
+        $getRoot().getFirstChild(),
+        $isParagraphNode,
+      );
+      return $assertNodeType(paragraph.getFirstChild(), $isAutoLinkNode);
     }
 
-    function retypeAsB(editor: ReturnType<typeof buildEditor>) {
+    function retypeAsB(editor: LexicalEditor) {
       editor.update(
         () => {
-          const textNode = $getAutoLink().getFirstChild();
-          assert($isTextNode(textNode), 'expected a TextNode');
+          const textNode = $assertNodeType(
+            $getAutoLink().getFirstChild(),
+            $isTextNode,
+          );
           textNode.setTextContent('https://b.com');
         },
         {discrete: true},

--- a/packages/lexical-link/src/__tests__/unit/LinkExtensionValidateUrl.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkExtensionValidateUrl.test.ts
@@ -16,7 +16,8 @@ import {
   $isTextNode,
   configExtension,
 } from 'lexical';
-import {assert, describe, expect, it} from 'vitest';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
 
 const ALLOWED = 'https://lexical.dev/';
 // Rejected by the configured policy below (https-only), which is the shape
@@ -42,14 +43,15 @@ function makeExtension(validateUrl?: (url: string) => boolean) {
 }
 
 function $selectHello(): void {
-  const textNode = $getRoot().getLastDescendant();
-  assert($isTextNode(textNode), 'Expected a TextNode');
+  const textNode = $assertNodeType($getRoot().getLastDescendant(), $isTextNode);
   textNode.select(0, textNode.getTextContentSize());
 }
 
 function $hasLink(): boolean {
-  const paragraph = $getRoot().getFirstChild();
-  assert($isParagraphNode(paragraph), 'Expected a ParagraphNode');
+  const paragraph = $assertNodeType(
+    $getRoot().getFirstChild(),
+    $isParagraphNode,
+  );
   return $isLinkNode(paragraph.getFirstChild());
 }
 

--- a/packages/lexical-link/src/__tests__/unit/LinkExtensionValidateUrl.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkExtensionValidateUrl.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {$isLinkNode, LinkExtension, TOGGLE_LINK_COMMAND} from '@lexical/link';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  $isTextNode,
+  configExtension,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+const ALLOWED = 'https://lexical.dev/';
+// Rejected by the configured policy below (https-only), which is the shape
+// most validateUrl implementations take: an allowlist, not a scheme blocklist.
+const REJECTED = 'http://not-allowed.example.com/';
+
+function makeExtension(validateUrl?: (url: string) => boolean) {
+  return defineExtension({
+    $initialEditorState: () => {
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode('Hello'));
+      $getRoot().append(paragraph);
+    },
+    dependencies: [
+      configExtension(
+        LinkExtension,
+        validateUrl === undefined ? {} : {validateUrl},
+      ),
+      RichTextExtension,
+    ],
+    name: '[root-validate-url]',
+  });
+}
+
+function $selectHello(): void {
+  const textNode = $getRoot().getLastDescendant();
+  assert($isTextNode(textNode), 'Expected a TextNode');
+  textNode.select(0, textNode.getTextContentSize());
+}
+
+function $hasLink(): boolean {
+  const paragraph = $getRoot().getFirstChild();
+  assert($isParagraphNode(paragraph), 'Expected a ParagraphNode');
+  return $isLinkNode(paragraph.getFirstChild());
+}
+
+/**
+ * Dispatch the given payload over a selection of "Hello" and report whether
+ * the command claimed it and whether a LinkNode was actually produced.
+ */
+function toggleLink(
+  payload: string | {url: string},
+  validateUrl?: (url: string) => boolean,
+): {handled: boolean; linked: boolean} {
+  using editor = buildEditorFromExtensions(makeExtension(validateUrl));
+  let handled = false;
+  editor.update(
+    () => {
+      $selectHello();
+      handled = editor.dispatchCommand(TOGGLE_LINK_COMMAND, payload);
+    },
+    {discrete: true},
+  );
+  return {handled, linked: editor.read($hasLink)};
+}
+
+const isHttps = (url: string) => url.startsWith('https://');
+
+describe('LinkExtension validateUrl', () => {
+  it('rejects a URL the validator refuses, for an object payload', () => {
+    expect(toggleLink({url: REJECTED}, isHttps)).toEqual({
+      handled: false,
+      linked: false,
+    });
+  });
+
+  it('rejects a URL the validator refuses, for a string payload', () => {
+    expect(toggleLink(REJECTED, isHttps)).toEqual({
+      handled: false,
+      linked: false,
+    });
+  });
+
+  it('accepts a URL the validator allows, for an object payload', () => {
+    expect(toggleLink({url: ALLOWED}, isHttps)).toEqual({
+      handled: true,
+      linked: true,
+    });
+  });
+
+  it('accepts any URL when no validator is configured', () => {
+    expect(toggleLink({url: REJECTED})).toEqual({handled: true, linked: true});
+    expect(toggleLink(REJECTED)).toEqual({handled: true, linked: true});
+  });
+});

--- a/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
+++ b/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
@@ -6,12 +6,17 @@
  *
  */
 import {$generateNodesFromDOM} from '@lexical/html';
-import {$isMarkNode, $wrapSelectionInMarkNode} from '@lexical/mark';
+import {
+  $createMarkNode,
+  $isMarkNode,
+  $wrapSelectionInMarkNode,
+} from '@lexical/mark';
 import {$insertNodeIntoLeaf} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
+  $getNodeByKey,
   $getRoot,
   $isElementNode,
   $isParagraphNode,
@@ -293,4 +298,54 @@ describe('LexicalMarkNode tests', () => {
       });
     });
   });
+});
+
+describe('MarkNode overlap theme class', () => {
+  initializeUnitTest(
+    testEnv => {
+      function markElement(ids: string[], nextIds?: string[]): HTMLElement {
+        const {editor} = testEnv;
+        let key = '';
+        editor.update(
+          () => {
+            const markNode = $createMarkNode(ids);
+            markNode.append($createTextNode('marked'));
+            key = markNode.getKey();
+            $getRoot().clear().append($createParagraphNode().append(markNode));
+          },
+          {discrete: true},
+        );
+        if (nextIds) {
+          editor.update(
+            () => {
+              const markNode = $getNodeByKey(key);
+              assert($isMarkNode(markNode), 'Expected a MarkNode');
+              markNode.setIDs(nextIds);
+            },
+            {discrete: true},
+          );
+        }
+        const element = editor.getElementByKey(key);
+        assert(element !== null, 'Expected a rendered MarkNode');
+        return element;
+      }
+
+      test('createDOM adds the overlap class for more than one id', () => {
+        expect(markElement(['a', 'b', 'c']).className).toContain('mk-overlap');
+      });
+
+      test('updateDOM adds the overlap class when going from 1 to 3 ids', () => {
+        expect(markElement(['a'], ['a', 'b', 'c']).className).toContain(
+          'mk-overlap',
+        );
+      });
+
+      test('updateDOM removes the overlap class when going from 2 to 0 ids', () => {
+        expect(markElement(['a', 'b'], []).className).not.toContain(
+          'mk-overlap',
+        );
+      });
+    },
+    {namespace: 'test', theme: {mark: 'mk', markOverlap: 'mk-overlap'}},
+  );
 });

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -82,12 +82,15 @@ export class MarkNode extends ElementNode {
     const nextIDsCount = nextIDs.length;
     const overlapTheme = config.theme.markOverlap;
 
-    if (prevIDsCount !== nextIDsCount) {
-      if (prevIDsCount === 1) {
-        if (nextIDsCount === 2) {
-          addClassNamesToElement(element, overlapTheme);
-        }
-      } else if (nextIDsCount === 1) {
+    // Mirror createDOM's rule (`ids.length > 1` carries the overlap class)
+    // rather than enumerating transitions: only 1 -> 2 and N -> 1 used to be
+    // handled, so e.g. 1 -> 3 never gained the class and 2 -> 0 never lost it.
+    const hadOverlap = prevIDsCount > 1;
+    const hasOverlap = nextIDsCount > 1;
+    if (hadOverlap !== hasOverlap) {
+      if (hasOverlap) {
+        addClassNamesToElement(element, overlapTheme);
+      } else {
         removeClassNamesFromElement(element, overlapTheme);
       }
     }

--- a/packages/lexical-playground/__tests__/unit/EquationNodeHTML.test.ts
+++ b/packages/lexical-playground/__tests__/unit/EquationNodeHTML.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $generateHtmlFromNodes,
+  $generateNodesFromDOMViaExtension,
+} from '@lexical/html';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $insertNodes,
+  $isElementNode,
+  defineExtension,
+  type LexicalNode,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+import {
+  $createEquationNode,
+  $isEquationNode,
+} from '../../src/nodes/EquationNode';
+import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
+import {EquationsExtension} from '../../src/plugins/EquationsExtension';
+
+const EquationHTMLTestExtension = /* @__PURE__ */ defineExtension({
+  $initialEditorState: null,
+  dependencies: [PlaygroundImportExtension, EquationsExtension],
+  name: '[test-equation-html]',
+});
+
+function $findFirst(
+  predicate: (node: LexicalNode) => boolean,
+): LexicalNode | null {
+  const stack: LexicalNode[] = [...$getRoot().getChildren()];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if (predicate(node)) {
+      return node;
+    }
+    if ($isElementNode(node)) {
+      stack.push(...node.getChildren());
+    }
+  }
+  return null;
+}
+
+function exportEquationHtml(equation: string, inline: boolean): string {
+  using editor = buildEditorFromExtensions(EquationHTMLTestExtension);
+  editor.update(
+    () => {
+      $getRoot().clear();
+      const paragraph = $createParagraphNode();
+      $getRoot().append(paragraph);
+      paragraph.selectStart();
+      $insertNodes([$createEquationNode(equation, inline)]);
+    },
+    {discrete: true},
+  );
+  return editor.read(() => $generateHtmlFromNodes(editor, null));
+}
+
+function importEquationHtml(htmlString: string): null | string {
+  using editor = buildEditorFromExtensions(EquationHTMLTestExtension);
+  editor.update(
+    () => {
+      $getRoot().clear().select();
+      const dom = new DOMParser().parseFromString(htmlString, 'text/html');
+      $insertNodes($generateNodesFromDOMViaExtension(dom));
+    },
+    {discrete: true},
+  );
+  return editor.read(() => {
+    const node = $findFirst($isEquationNode);
+    assert($isEquationNode(node), 'expected an EquationNode');
+    return node.getEquation();
+  });
+}
+
+describe('EquationNode HTML round trip', () => {
+  it('exports an equation with non Latin-1 characters without throwing', () => {
+    // A free-form LaTeX equation routinely carries code points above U+00FF,
+    // which is exactly the range btoa() rejects.
+    expect(() => exportEquationHtml('\\text{\u03b1}', true)).not.toThrow();
+  });
+
+  it('round trips an equation with non Latin-1 characters', () => {
+    const equation = '\\text{\u03b1} + \\text{\u9762\u7a4d}';
+    expect(importEquationHtml(exportEquationHtml(equation, false))).toBe(
+      equation,
+    );
+  });
+
+  it('round trips an equation outside the basic multilingual plane', () => {
+    const equation = '\\text{\ud83d\ude42}';
+    expect(importEquationHtml(exportEquationHtml(equation, true))).toBe(
+      equation,
+    );
+  });
+
+  it('still decodes an equation exported before the encoding change', () => {
+    // Pure ASCII encodes byte for byte, so HTML written by older builds
+    // decodes unchanged.
+    const legacy = `<span data-lexical-equation="${btoa(
+      'x^2 + y^2',
+    )}" data-lexical-inline="true"></span>`;
+    expect(importEquationHtml(legacy)).toBe('x^2 + y^2');
+  });
+});

--- a/packages/lexical-playground/__tests__/unit/EquationNodeHTML.test.ts
+++ b/packages/lexical-playground/__tests__/unit/EquationNodeHTML.test.ts
@@ -15,40 +15,24 @@ import {
   $createParagraphNode,
   $getRoot,
   $insertNodes,
-  $isElementNode,
+  $nodesOfType,
   defineExtension,
-  type LexicalNode,
 } from 'lexical';
 import {assert, describe, expect, it} from 'vitest';
 
 import {
   $createEquationNode,
   $isEquationNode,
+  EquationNode,
 } from '../../src/nodes/EquationNode';
 import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
 import {EquationsExtension} from '../../src/plugins/EquationsExtension';
 
-const EquationHTMLTestExtension = /* @__PURE__ */ defineExtension({
+const EquationHTMLTestExtension = defineExtension({
   $initialEditorState: null,
   dependencies: [PlaygroundImportExtension, EquationsExtension],
   name: '[test-equation-html]',
 });
-
-function $findFirst(
-  predicate: (node: LexicalNode) => boolean,
-): LexicalNode | null {
-  const stack: LexicalNode[] = [...$getRoot().getChildren()];
-  while (stack.length > 0) {
-    const node = stack.shift()!;
-    if (predicate(node)) {
-      return node;
-    }
-    if ($isElementNode(node)) {
-      stack.push(...node.getChildren());
-    }
-  }
-  return null;
-}
 
 function exportEquationHtml(equation: string, inline: boolean): string {
   using editor = buildEditorFromExtensions(EquationHTMLTestExtension);
@@ -76,29 +60,16 @@ function importEquationHtml(htmlString: string): null | string {
     {discrete: true},
   );
   return editor.read(() => {
-    const node = $findFirst($isEquationNode);
+    const node = $nodesOfType(EquationNode)[0];
     assert($isEquationNode(node), 'expected an EquationNode');
     return node.getEquation();
   });
 }
 
 describe('EquationNode HTML round trip', () => {
-  it('exports an equation with non Latin-1 characters without throwing', () => {
-    // A free-form LaTeX equation routinely carries code points above U+00FF,
-    // which is exactly the range btoa() rejects.
-    expect(() => exportEquationHtml('\\text{\u03b1}', true)).not.toThrow();
-  });
-
   it('round trips an equation with non Latin-1 characters', () => {
-    const equation = '\\text{\u03b1} + \\text{\u9762\u7a4d}';
+    const equation = '\u03b1 + \u03b2 = \u03b3';
     expect(importEquationHtml(exportEquationHtml(equation, false))).toBe(
-      equation,
-    );
-  });
-
-  it('round trips an equation outside the basic multilingual plane', () => {
-    const equation = '\\text{\ud83d\ude42}';
-    expect(importEquationHtml(exportEquationHtml(equation, true))).toBe(
       equation,
     );
   });

--- a/packages/lexical-playground/__tests__/unit/MentionHTML.test.ts
+++ b/packages/lexical-playground/__tests__/unit/MentionHTML.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $generateHtmlFromNodes,
+  $generateNodesFromDOMViaExtension,
+} from '@lexical/html';
+import {$patchStyleText} from '@lexical/selection';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $insertNodes,
+  $isElementNode,
+  $selectAll,
+  $setSelection,
+  defineExtension,
+  type LexicalNode,
+} from 'lexical';
+import {expectHtmlToBeEqual, html} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, it} from 'vitest';
+
+import {$createMentionNode, $isMentionNode} from '../../src/nodes/MentionNode';
+import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
+import {MentionsExtension} from '../../src/plugins/MentionsExtension';
+
+const MentionTestExtension = defineExtension({
+  $initialEditorState: null,
+  dependencies: [PlaygroundImportExtension, MentionsExtension],
+  name: '[test]',
+});
+
+function $findFirst(
+  predicate: (node: LexicalNode) => boolean,
+): LexicalNode | null {
+  const stack: LexicalNode[] = [...$getRoot().getChildren()];
+  while (stack.length > 0) {
+    const node = stack.shift()!;
+    if (predicate(node)) {
+      return node;
+    }
+    if ($isElementNode(node)) {
+      stack.push(...node.getChildren());
+    }
+  }
+  return null;
+}
+
+/**
+ * Insert a mention, then apply `$patchStyleText` / `formatText` to the whole
+ * document the way the playground toolbar's font-size dropdown and format
+ * buttons do, and return the HTML the editor exports.
+ */
+function exportMentionHtml(
+  patch: Record<string, string> | null,
+  formats: readonly ('bold' | 'italic' | 'underline' | 'strikethrough')[],
+): string {
+  using editor = buildEditorFromExtensions(MentionTestExtension);
+  editor.update(
+    () => {
+      const paragraph = $createParagraphNode();
+      $getRoot().clear().append(paragraph);
+      paragraph.selectStart();
+      $insertNodes([$createMentionNode('Luke Skywalker')]);
+      const selection = $selectAll();
+      if (patch !== null) {
+        $patchStyleText(selection, patch);
+      }
+      for (const format of formats) {
+        selection.formatText(format);
+      }
+      $setSelection(null);
+    },
+    {discrete: true},
+  );
+  return editor.read(() => $generateHtmlFromNodes(editor, null));
+}
+
+describe('MentionNode HTML export', () => {
+  // Control: this passes with and without the exportDOM fix, and guards the
+  // markup the `span[data-lexical-mention]` import rule matches on.
+  it('exports a plain mention as a data-lexical-mention span', () => {
+    expectHtmlToBeEqual(
+      exportMentionHtml(null, []),
+      html`
+        <p><span data-lexical-mention="true">Luke Skywalker</span></p>
+      `,
+    );
+  });
+
+  it('exports the font-size applied to a mention (#6453)', () => {
+    expectHtmlToBeEqual(
+      exportMentionHtml({'font-size': '20px'}, []),
+      html`
+        <p>
+          <span style="font-size: 20px;" data-lexical-mention="true">
+            Luke Skywalker
+          </span>
+        </p>
+      `,
+    );
+  });
+
+  it('exports the text formats applied to a mention (#6453)', () => {
+    expectHtmlToBeEqual(
+      exportMentionHtml(null, ['bold', 'italic', 'underline']),
+      html`
+        <p>
+          <u>
+            <i>
+              <b><span data-lexical-mention="true">Luke Skywalker</span></b>
+            </i>
+          </u>
+        </p>
+      `,
+    );
+  });
+
+  // Control: passes with and without the exportDOM fix. It pins down that the
+  // format wrappers added around the mention span do not stop the
+  // `span[data-lexical-mention]` import rule from recognizing it again.
+  it('still imports a formatted mention back as a MentionNode', () => {
+    using editor = buildEditorFromExtensions(MentionTestExtension);
+    const htmlString = exportMentionHtml({'font-size': '20px'}, ['bold']);
+    editor.update(
+      () => {
+        $getRoot().clear().select();
+        const dom = new DOMParser().parseFromString(htmlString, 'text/html');
+        $insertNodes($generateNodesFromDOMViaExtension(dom));
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const node = $findFirst($isMentionNode);
+      assert($isMentionNode(node), 'expected a MentionNode');
+      expect(node.getTextContent()).toBe('Luke Skywalker');
+    });
+  });
+});

--- a/packages/lexical-playground/__tests__/unit/MentionHTML.test.ts
+++ b/packages/lexical-playground/__tests__/unit/MentionHTML.test.ts
@@ -16,16 +16,23 @@ import {
   $createParagraphNode,
   $getRoot,
   $insertNodes,
-  $isElementNode,
+  $nodesOfType,
   $selectAll,
   $setSelection,
   defineExtension,
-  type LexicalNode,
 } from 'lexical';
-import {expectHtmlToBeEqual, html} from 'lexical/src/__tests__/utils';
-import {assert, describe, expect, it} from 'vitest';
+import {
+  $assertNodeType,
+  expectHtmlToBeEqual,
+  html,
+} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
 
-import {$createMentionNode, $isMentionNode} from '../../src/nodes/MentionNode';
+import {
+  $createMentionNode,
+  $isMentionNode,
+  MentionNode,
+} from '../../src/nodes/MentionNode';
 import {PlaygroundImportExtension} from '../../src/nodes/PlaygroundImportExtension';
 import {MentionsExtension} from '../../src/plugins/MentionsExtension';
 
@@ -34,22 +41,6 @@ const MentionTestExtension = defineExtension({
   dependencies: [PlaygroundImportExtension, MentionsExtension],
   name: '[test]',
 });
-
-function $findFirst(
-  predicate: (node: LexicalNode) => boolean,
-): LexicalNode | null {
-  const stack: LexicalNode[] = [...$getRoot().getChildren()];
-  while (stack.length > 0) {
-    const node = stack.shift()!;
-    if (predicate(node)) {
-      return node;
-    }
-    if ($isElementNode(node)) {
-      stack.push(...node.getChildren());
-    }
-  }
-  return null;
-}
 
 /**
  * Insert a mention, then apply `$patchStyleText` / `formatText` to the whole
@@ -136,8 +127,10 @@ describe('MentionNode HTML export', () => {
       {discrete: true},
     );
     editor.read(() => {
-      const node = $findFirst($isMentionNode);
-      assert($isMentionNode(node), 'expected a MentionNode');
+      const node = $assertNodeType(
+        $nodesOfType(MentionNode)[0],
+        $isMentionNode,
+      );
       expect(node.getTextContent()).toBe('Luke Skywalker');
     });
   });

--- a/packages/lexical-playground/__tests__/unit/RubyNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/RubyNode.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $getRoot,
+  defineExtension,
+  type LexicalEditor,
+  type TextFormatType,
+} from 'lexical';
+import {assert, describe, expect, it} from 'vitest';
+
+import {
+  $createRubyNode,
+  $isRubyNode,
+  RubyNode,
+} from '../../src/plugins/RubyExtension/RubyNode';
+
+const RubyTestExtension = /* @__PURE__ */ defineExtension({
+  $initialEditorState: null,
+  dependencies: [RichTextExtension],
+  name: '[test-ruby]',
+  nodes: [RubyNode],
+  theme: {ruby: 'theme-ruby', text: {underline: 'theme-underline'}},
+});
+
+type RubyDOM = {inner: HTMLElement; wrapper: HTMLElement};
+
+function makeEditor(): [LexicalEditor & Disposable, HTMLElement] {
+  const editor = buildEditorFromExtensions(RubyTestExtension);
+  const rootElement = document.createElement('div');
+  editor.setRootElement(rootElement);
+  return [editor, rootElement];
+}
+
+function getRubyDOM(rootElement: HTMLElement): RubyDOM {
+  const wrapper = rootElement.querySelector<HTMLElement>('[role="group"]');
+  assert(wrapper !== null, 'ruby wrapper');
+  const inner = wrapper.firstElementChild as HTMLElement | null;
+  assert(inner !== null, 'ruby inner');
+  return {inner, wrapper};
+}
+
+function describeRuby({inner, wrapper}: RubyDOM) {
+  return {
+    innerClass: Array.from(inner.classList).sort().join(' '),
+    innerStyle: inner.getAttribute('style') || '',
+    wrapperClass: Array.from(wrapper.classList).sort().join(' '),
+    wrapperStyle: wrapper.getAttribute('style') || '',
+  };
+}
+
+/** Build a ruby node in its final state, so only createDOM runs. */
+function renderFresh(style: string, format: null | TextFormatType) {
+  const [editor, rootElement] = makeEditor();
+  using _ = editor;
+  editor.update(
+    () => {
+      const ruby = $createRubyNode('kanji', 'kana').setStyle(style);
+      if (format) {
+        ruby.setFormat(format);
+      }
+      $getRoot().clear().append($createParagraphNode().append(ruby));
+    },
+    {discrete: true},
+  );
+  return describeRuby(getRubyDOM(rootElement));
+}
+
+/** Build a plain ruby node and then mutate it, so updateDOM runs. */
+function renderThenUpdate(style: string, format: null | TextFormatType) {
+  const [editor, rootElement] = makeEditor();
+  using _ = editor;
+  editor.update(
+    () => {
+      const ruby = $createRubyNode('kanji', 'kana').setStyle('color: red');
+      $getRoot().clear().append($createParagraphNode().append(ruby));
+    },
+    {discrete: true},
+  );
+  editor.update(
+    () => {
+      const ruby = $getRoot().getLastDescendant();
+      assert($isRubyNode(ruby), 'RubyNode');
+      ruby.setStyle(style);
+      if (format) {
+        ruby.setFormat(format);
+      }
+    },
+    {discrete: true},
+  );
+  return describeRuby(getRubyDOM(rootElement));
+}
+
+describe('RubyNode.updateDOM', () => {
+  it('applies a style change to the element createDOM styled', () => {
+    // updateDOM returning false promises the DOM already matches what
+    // createDOM would have produced for this node.
+    expect(renderThenUpdate('color: blue', null)).toEqual(
+      renderFresh('color: blue', null),
+    );
+  });
+
+  it('applies a class-only text format to the element createDOM classed', () => {
+    expect(renderThenUpdate('color: red', 'underline')).toEqual(
+      renderFresh('color: red', 'underline'),
+    );
+  });
+
+  it('leaves the annotation and the accessible name on the wrapper', () => {
+    const [editor, rootElement] = makeEditor();
+    using _ = editor;
+    editor.update(
+      () => {
+        const ruby = $createRubyNode('kanji', 'kana');
+        $getRoot().clear().append($createParagraphNode().append(ruby));
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        const ruby = $getRoot().getLastDescendant();
+        assert($isRubyNode(ruby), 'RubyNode');
+        ruby.setAnnotation('kana2');
+      },
+      {discrete: true},
+    );
+    const {inner, wrapper} = getRubyDOM(rootElement);
+    expect(inner.dataset.rubyAnnotation).toBe('kana2');
+    expect(wrapper.getAttribute('aria-label')).toBe('kanji (kana2)');
+  });
+});

--- a/packages/lexical-playground/__tests__/unit/RubyNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/RubyNode.test.ts
@@ -28,6 +28,7 @@ const RubyTestExtension = /* @__PURE__ */ defineExtension({
   $initialEditorState: null,
   afterRegistration: editor => {
     editor.setRootElement(document.createElement('div'));
+    return () => editor.setRootElement(null);
   },
   dependencies: [RichTextExtension],
   name: '[test-ruby]',

--- a/packages/lexical-playground/__tests__/unit/RubyNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/RubyNode.test.ts
@@ -12,6 +12,7 @@ import {
   $createParagraphNode,
   $getRoot,
   defineExtension,
+  isHTMLElement,
   type LexicalEditor,
   type TextFormatType,
 } from 'lexical';
@@ -25,6 +26,9 @@ import {
 
 const RubyTestExtension = /* @__PURE__ */ defineExtension({
   $initialEditorState: null,
+  afterRegistration: editor => {
+    editor.setRootElement(document.createElement('div'));
+  },
   dependencies: [RichTextExtension],
   name: '[test-ruby]',
   nodes: [RubyNode],
@@ -33,14 +37,13 @@ const RubyTestExtension = /* @__PURE__ */ defineExtension({
 
 type RubyDOM = {inner: HTMLElement; wrapper: HTMLElement};
 
-function makeEditor(): [LexicalEditor & Disposable, HTMLElement] {
-  const editor = buildEditorFromExtensions(RubyTestExtension);
-  const rootElement = document.createElement('div');
-  editor.setRootElement(rootElement);
-  return [editor, rootElement];
+function makeEditor() {
+  return buildEditorFromExtensions(RubyTestExtension);
 }
 
-function getRubyDOM(rootElement: HTMLElement): RubyDOM {
+function getRubyDOM(editor: LexicalEditor): RubyDOM {
+  const rootElement = editor.getRootElement();
+  assert(isHTMLElement(rootElement), 'editor must have a root element');
   const wrapper = rootElement.querySelector<HTMLElement>('[role="group"]');
   assert(wrapper !== null, 'ruby wrapper');
   const inner = wrapper.firstElementChild as HTMLElement | null;
@@ -59,8 +62,7 @@ function describeRuby({inner, wrapper}: RubyDOM) {
 
 /** Build a ruby node in its final state, so only createDOM runs. */
 function renderFresh(style: string, format: null | TextFormatType) {
-  const [editor, rootElement] = makeEditor();
-  using _ = editor;
+  using editor = makeEditor();
   editor.update(
     () => {
       const ruby = $createRubyNode('kanji', 'kana').setStyle(style);
@@ -71,13 +73,12 @@ function renderFresh(style: string, format: null | TextFormatType) {
     },
     {discrete: true},
   );
-  return describeRuby(getRubyDOM(rootElement));
+  return describeRuby(getRubyDOM(editor));
 }
 
 /** Build a plain ruby node and then mutate it, so updateDOM runs. */
 function renderThenUpdate(style: string, format: null | TextFormatType) {
-  const [editor, rootElement] = makeEditor();
-  using _ = editor;
+  using editor = makeEditor();
   editor.update(
     () => {
       const ruby = $createRubyNode('kanji', 'kana').setStyle('color: red');
@@ -96,7 +97,7 @@ function renderThenUpdate(style: string, format: null | TextFormatType) {
     },
     {discrete: true},
   );
-  return describeRuby(getRubyDOM(rootElement));
+  return describeRuby(getRubyDOM(editor));
 }
 
 describe('RubyNode.updateDOM', () => {
@@ -115,8 +116,7 @@ describe('RubyNode.updateDOM', () => {
   });
 
   it('leaves the annotation and the accessible name on the wrapper', () => {
-    const [editor, rootElement] = makeEditor();
-    using _ = editor;
+    using editor = makeEditor();
     editor.update(
       () => {
         const ruby = $createRubyNode('kanji', 'kana');
@@ -132,7 +132,7 @@ describe('RubyNode.updateDOM', () => {
       },
       {discrete: true},
     );
-    const {inner, wrapper} = getRubyDOM(rootElement);
+    const {inner, wrapper} = getRubyDOM(editor);
     expect(inner.dataset.rubyAnnotation).toBe('kana2');
     expect(wrapper.getAttribute('aria-label')).toBe('kanji (kana2)');
   });

--- a/packages/lexical-playground/__tests__/unit/SpecialTextNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/SpecialTextNode.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createParagraphNode, $getRoot, $isTextNode} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, it} from 'vitest';
+
+import {
+  $createSpecialTextNode,
+  SpecialTextNode,
+} from '../../src/nodes/SpecialTextNode';
+
+describe('SpecialTextNode', () => {
+  initializeUnitTest(
+    testEnv => {
+      function $appendSpecialText(text: string): void {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createSpecialTextNode(text)));
+      }
+
+      function $getSpecialText(): SpecialTextNode {
+        const node = $getRoot().getLastDescendant();
+        assert(
+          $isTextNode(node) && node instanceof SpecialTextNode,
+          'SpecialTextNode',
+        );
+        return node;
+      }
+
+      function getRenderedText(): string {
+        const dom = testEnv.container.querySelector('.PlaygroundSpecialText');
+        expect(dom).not.toBe(null);
+        return (dom as HTMLElement).textContent ?? '';
+      }
+
+      it('re-renders the text when it changes', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => $appendSpecialText('foo'), {discrete: true});
+        expect(getRenderedText()).toBe('foo');
+
+        await editor.update(
+          () => void $getSpecialText().setTextContent('bar'),
+          {
+            discrete: true,
+          },
+        );
+        expect(getRenderedText()).toBe('bar');
+      });
+
+      it('renders the text verbatim when it is bracketed', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => $appendSpecialText('[foo]'), {
+          discrete: true,
+        });
+        expect(getRenderedText()).toBe('[foo]');
+
+        await editor.update(
+          () => void $getSpecialText().setTextContent('[bar]'),
+          {discrete: true},
+        );
+        expect(getRenderedText()).toBe('[bar]');
+      });
+    },
+    {
+      namespace: 'test',
+      nodes: [SpecialTextNode],
+      theme: {specialText: 'PlaygroundSpecialText'},
+    },
+  );
+});

--- a/packages/lexical-playground/__tests__/unit/SpecialTextNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/SpecialTextNode.test.ts
@@ -6,8 +6,14 @@
  *
  */
 
-import {$createParagraphNode, $getRoot, $isTextNode} from 'lexical';
-import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $isTextNode,
+  isHTMLElement,
+  type LexicalEditor,
+} from 'lexical';
 import {assert, describe, expect, it} from 'vitest';
 
 import {
@@ -15,62 +21,66 @@ import {
   SpecialTextNode,
 } from '../../src/nodes/SpecialTextNode';
 
+function buildEditor() {
+  return buildEditorFromExtensions({
+    afterRegistration: editor => {
+      editor.setRootElement(document.createElement('div'));
+      return () => editor.setRootElement(null);
+    },
+    name: 'test',
+    nodes: [SpecialTextNode],
+    theme: {specialText: 'PlaygroundSpecialText'},
+  });
+}
+
 describe('SpecialTextNode', () => {
-  initializeUnitTest(
-    testEnv => {
-      function $appendSpecialText(text: string): void {
-        $getRoot()
-          .clear()
-          .append($createParagraphNode().append($createSpecialTextNode(text)));
-      }
+  function $appendSpecialText(text: string): void {
+    $getRoot()
+      .clear()
+      .append($createParagraphNode().append($createSpecialTextNode(text)));
+  }
 
-      function $getSpecialText(): SpecialTextNode {
-        const node = $getRoot().getLastDescendant();
-        assert(
-          $isTextNode(node) && node instanceof SpecialTextNode,
-          'SpecialTextNode',
-        );
-        return node;
-      }
+  function $getSpecialText(): SpecialTextNode {
+    const node = $getRoot().getLastDescendant();
+    assert(
+      $isTextNode(node) && node instanceof SpecialTextNode,
+      'SpecialTextNode',
+    );
+    return node;
+  }
 
-      function getRenderedText(): string {
-        const dom = testEnv.container.querySelector('.PlaygroundSpecialText');
-        expect(dom).not.toBe(null);
-        return (dom as HTMLElement).textContent ?? '';
-      }
+  function getRenderedText(editor: LexicalEditor): string {
+    const rootElement = editor.getRootElement();
+    assert(isHTMLElement(rootElement), 'editor must have a rootElement');
+    const dom = rootElement.querySelector('.PlaygroundSpecialText');
+    assert(
+      isHTMLElement(dom),
+      'rootElement must have a .PlaygroundSpecialText descendant',
+    );
+    return dom.textContent;
+  }
 
-      it('re-renders the text when it changes', async () => {
-        const {editor} = testEnv;
-        await editor.update(() => $appendSpecialText('foo'), {discrete: true});
-        expect(getRenderedText()).toBe('foo');
+  it('re-renders the text when it changes', () => {
+    using editor = buildEditor();
+    editor.update(() => $appendSpecialText('foo'), {discrete: true});
+    expect(getRenderedText(editor)).toBe('foo');
 
-        await editor.update(
-          () => void $getSpecialText().setTextContent('bar'),
-          {
-            discrete: true,
-          },
-        );
-        expect(getRenderedText()).toBe('bar');
-      });
+    editor.update(() => void $getSpecialText().setTextContent('bar'), {
+      discrete: true,
+    });
+    expect(getRenderedText(editor)).toBe('bar');
+  });
 
-      it('renders the text verbatim when it is bracketed', async () => {
-        const {editor} = testEnv;
-        await editor.update(() => $appendSpecialText('[foo]'), {
-          discrete: true,
-        });
-        expect(getRenderedText()).toBe('[foo]');
+  it('renders the text verbatim when it is bracketed', () => {
+    using editor = buildEditor();
+    editor.update(() => $appendSpecialText('[foo]'), {
+      discrete: true,
+    });
+    expect(getRenderedText(editor)).toBe('[foo]');
 
-        await editor.update(
-          () => void $getSpecialText().setTextContent('[bar]'),
-          {discrete: true},
-        );
-        expect(getRenderedText()).toBe('[bar]');
-      });
-    },
-    {
-      namespace: 'test',
-      nodes: [SpecialTextNode],
-      theme: {specialText: 'PlaygroundSpecialText'},
-    },
-  );
+    editor.update(() => void $getSpecialText().setTextContent('[bar]'), {
+      discrete: true,
+    });
+    expect(getRenderedText(editor)).toBe('[bar]');
+  });
 });

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -32,6 +32,31 @@ export type SerializedEquationNode = Spread<
   SerializedLexicalNode
 >;
 
+/**
+ * btoa/atob only handle Latin-1, so go through the UTF-8 bytes -- the same way
+ * docSerialization does. An equation is free-form LaTeX and routinely holds
+ * code points above U+00FF (`\text{α}`, CJK, an emoji), which btoa throws on.
+ * Pure ASCII encodes byte for byte, so previously exported HTML still decodes.
+ */
+export function encodeEquation(equation: string): string {
+  const bytes = new TextEncoder().encode(equation);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/** Inverse of {@link encodeEquation}. */
+export function decodeEquation(encoded: string): string {
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
 export class EquationNode extends DecoratorNode<JSX.Element> {
   __equation: string;
   __inline: boolean;
@@ -83,7 +108,7 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
       this.__inline ? 'span' : 'div',
     );
     // Encode the equation as base64 to avoid issues with special characters
-    const equation = btoa(this.__equation);
+    const equation = encodeEquation(this.__equation);
     element.setAttribute('data-lexical-equation', equation);
     element.setAttribute('data-lexical-inline', `${this.__inline}`);
     katex.render(this.__equation, element, {

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -15,8 +15,18 @@ import {
   type NodeKey,
   type SerializedTextNode,
   type Spread,
+  type TextFormatType,
   TextNode,
 } from 'lexical';
+
+// The element TextNode.exportDOM wraps its output with, one per text format,
+// innermost first.
+const FORMAT_WRAPPER_TAGS: readonly (readonly [TextFormatType, string])[] = [
+  ['bold', 'b'],
+  ['italic', 'i'],
+  ['strikethrough', 's'],
+  ['underline', 'u'],
+];
 
 export type SerializedMentionNode = Spread<
   {
@@ -64,13 +74,30 @@ export class MentionNode extends TextNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = $getDocument().createElement('span');
+    const document = $getDocument();
+    const element = document.createElement('span');
     element.setAttribute('data-lexical-mention', 'true');
     if (this.__text !== this.__mention) {
       element.setAttribute('data-lexical-mention-name', this.__mention);
     }
     element.textContent = this.__text;
-    return {element};
+    // Carry the inline style (e.g. a font-size applied from the toolbar) and
+    // the text formats onto the exported markup the way TextNode.exportDOM
+    // does, otherwise they are silently dropped from the HTML. The mention
+    // itself stays a <span> so the `span[data-lexical-mention]` import rule
+    // keeps matching it.
+    if (this.__style !== '') {
+      element.style.cssText = this.__style;
+    }
+    let wrapped: HTMLElement = element;
+    for (const [format, tag] of FORMAT_WRAPPER_TAGS) {
+      if (this.hasFormat(format)) {
+        const wrapper = document.createElement(tag);
+        wrapper.appendChild(wrapped);
+        wrapped = wrapper;
+      }
+    }
+    return {element: wrapped};
   }
 
   isTextEntity(): true {

--- a/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
+++ b/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
@@ -29,9 +29,12 @@ export class SpecialTextNode extends TextNode {
   }
 
   updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
-    if (prevNode.__text.startsWith('[') && prevNode.__text.endsWith(']')) {
-      const strippedText = this.__text.substring(1, this.__text.length - 1); // Strip brackets again
-      dom.textContent = strippedText; // Update the text content
+    if (prevNode.__text !== this.__text) {
+      // Write the text the same way createDOM does. Returning false promises
+      // the reconciler that every difference is already in the DOM, so the
+      // text has to be re-synced here or the element keeps the text it was
+      // created with.
+      dom.textContent = this.getTextContent();
     }
 
     addClassNamesToElement(dom, config.theme.specialText);

--- a/packages/lexical-playground/src/plugins/EquationsExtension/index.tsx
+++ b/packages/lexical-playground/src/plugins/EquationsExtension/index.tsx
@@ -26,7 +26,11 @@ import {
 } from 'lexical';
 import {type JSX, useCallback} from 'react';
 
-import {$createEquationNode, EquationNode} from '../../nodes/EquationNode';
+import {
+  $createEquationNode,
+  decodeEquation,
+  EquationNode,
+} from '../../nodes/EquationNode';
 import KatexEquationAlterer from '../../ui/KatexEquationAlterer';
 
 type CommandPayload = {
@@ -42,7 +46,7 @@ function $convertEquationElement(el: HTMLElement) {
   if (!encoded) {
     return null;
   }
-  const equation = atob(encoded);
+  const equation = decodeEquation(encoded);
   if (!equation) {
     return null;
   }

--- a/packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts
+++ b/packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts
@@ -21,6 +21,7 @@ import {
   type DOMExportOutput,
   type DOMSlot,
   type EditorConfig,
+  isHTMLElement,
   type LexicalNode,
   type NodeStateVersion,
   type StateConfigValue,
@@ -59,8 +60,8 @@ export class RubyNode extends TextNode {
   }
 
   getDOMSlot(dom: HTMLElement): DOMSlot<HTMLElement> {
-    const inner = dom.firstElementChild as HTMLElement | null;
-    if (inner) {
+    const inner = dom.firstElementChild;
+    if (isHTMLElement(inner)) {
       return super.getDOMSlot(dom).withElement(inner);
     }
     return super.getDOMSlot(dom);
@@ -70,8 +71,8 @@ export class RubyNode extends TextNode {
     // `dom` is the wrapper, but createDOM applies the text format classes and
     // the node style to the inner element, so super has to be handed the same
     // element or the two disagree about where those live.
-    const inner = dom.firstElementChild as HTMLElement | null;
-    if (inner === null) {
+    const inner = dom.firstElementChild;
+    if (!isHTMLElement(inner)) {
       return true;
     }
     const updated = super.updateDOM(prevNode, inner, config);

--- a/packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts
+++ b/packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts
@@ -67,13 +67,17 @@ export class RubyNode extends TextNode {
   }
 
   updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
-    const updated = super.updateDOM(prevNode, dom, config);
+    // `dom` is the wrapper, but createDOM applies the text format classes and
+    // the node style to the inner element, so super has to be handed the same
+    // element or the two disagree about where those live.
+    const inner = dom.firstElementChild as HTMLElement | null;
+    if (inner === null) {
+      return true;
+    }
+    const updated = super.updateDOM(prevNode, inner, config);
     const annotationChange = $getStateChange(this, prevNode, annotationState);
     if (annotationChange || prevNode.__text !== this.__text) {
-      const inner = dom.firstElementChild as HTMLElement;
-      if (inner) {
-        inner.dataset.rubyAnnotation = this.getAnnotation();
-      }
+      inner.dataset.rubyAnnotation = this.getAnnotation();
       dom.setAttribute(
         'aria-label',
         `${this.__text} (${this.getAnnotation()})`,

--- a/packages/lexical-text/src/__tests__/unit/Issue5466Repro.test.ts
+++ b/packages/lexical-text/src/__tests__/unit/Issue5466Repro.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $applyNodeReplacement,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type ElementNode,
+  TextNode,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+import {type EntityMatch, registerLexicalTextEntity} from '../..';
+
+class TestEntityNode extends TextNode {
+  $config() {
+    return this.config('test-entity-5466', {extends: TextNode});
+  }
+
+  isTextEntity(): true {
+    return true;
+  }
+}
+
+function $createTestEntityNode(text: string): TestEntityNode {
+  return $applyNodeReplacement(new TestEntityNode(text));
+}
+
+// Matches `${…}` placeholders, as in the report.
+function getMatch(text: string): null | EntityMatch {
+  const match = /\$\{[^}]*\}/.exec(text);
+  return match === null
+    ? null
+    : {end: match.index + match[0].length, start: match.index};
+}
+
+/**
+ * Renders the paragraph children as `E:"…"` for entity nodes and `T:"…"` for
+ * plain text nodes.
+ */
+function $describeParagraph(): string {
+  return ($getRoot().getFirstChild() as ElementNode)
+    .getChildren<TextNode>()
+    .map(
+      node =>
+        `${node instanceof TestEntityNode ? 'E' : 'T'}:${JSON.stringify(
+          node.getTextContent(),
+        )}`,
+    )
+    .join(' ');
+}
+
+describe('registerLexicalTextEntity (#5466)', () => {
+  initializeUnitTest(
+    testEnv => {
+      // The second text node is bold so that it is not normalized into the first
+      // one. That leaves the match at the end of a text node that still has a
+      // TextNode sibling, which is the shape produced by $insertNodes.
+      const cases: [string, string, string, string][] = [
+        [
+          'x ${A}',
+          ' tail',
+          'T:"x " E:"${A}" T:" tail"',
+          'replaces a match that ends the node and does not start at offset 0',
+        ],
+        [
+          'x ${A} y ${B}',
+          ' tail',
+          'T:"x " E:"${A}" T:" y " E:"${B}" T:" tail"',
+          'replaces the last of several matches in the same node',
+        ],
+        [
+          '${A} ${B} ${C}',
+          ' tail',
+          'E:"${A}" T:" " E:"${B}" T:" " E:"${C}" T:" tail"',
+          'replaces every match when the first one starts at offset 0',
+        ],
+        [
+          'x ${A} y',
+          ' tail',
+          'T:"x " E:"${A}" T:" y" T:" tail"',
+          'replaces a match that does not end the node (control)',
+        ],
+        [
+          'x ${A',
+          'B} tail',
+          'T:"x ${A" T:"B} tail"',
+          'leaves a match that only completes inside the sibling (control)',
+        ],
+      ];
+
+      for (const [first, second, expected, description] of cases) {
+        test(description, async () => {
+          const {editor} = testEnv;
+          registerLexicalTextEntity(
+            editor,
+            getMatch,
+            TestEntityNode,
+            textNode => $createTestEntityNode(textNode.getTextContent()),
+          );
+
+          await editor.update(() => {
+            const paragraph = $createParagraphNode();
+            paragraph.append(
+              $createTextNode(first),
+              $createTextNode(second).toggleFormat('bold'),
+            );
+            $getRoot().clear().append(paragraph);
+          });
+
+          editor.getEditorState().read(() => {
+            expect($describeParagraph()).toBe(expected);
+          });
+        });
+      }
+    },
+    {namespace: 'test', nodes: [TestEntityNode], theme: {}},
+  );
+});

--- a/packages/lexical-text/src/__tests__/unit/Issue5466Repro.test.ts
+++ b/packages/lexical-text/src/__tests__/unit/Issue5466Repro.test.ts
@@ -6,18 +6,17 @@
  *
  */
 
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {type EntityMatch, registerLexicalTextEntity} from '@lexical/text';
 import {
   $applyNodeReplacement,
   $createParagraphNode,
   $createTextNode,
   $getRoot,
-  type ElementNode,
+  mergeRegister,
   TextNode,
 } from 'lexical';
-import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 import {describe, expect, test} from 'vitest';
-
-import {type EntityMatch, registerLexicalTextEntity} from '../..';
 
 class TestEntityNode extends TextNode {
   $config() {
@@ -45,9 +44,9 @@ function getMatch(text: string): null | EntityMatch {
  * Renders the paragraph children as `E:"…"` for entity nodes and `T:"…"` for
  * plain text nodes.
  */
-function $describeParagraph(): string {
-  return ($getRoot().getFirstChild() as ElementNode)
-    .getChildren<TextNode>()
+function $describeTextNodes(): string {
+  return $getRoot()
+    .getAllTextNodes()
     .map(
       node =>
         `${node instanceof TestEntityNode ? 'E' : 'T'}:${JSON.stringify(
@@ -58,69 +57,70 @@ function $describeParagraph(): string {
 }
 
 describe('registerLexicalTextEntity (#5466)', () => {
-  initializeUnitTest(
-    testEnv => {
-      // The second text node is bold so that it is not normalized into the first
-      // one. That leaves the match at the end of a text node that still has a
-      // TextNode sibling, which is the shape produced by $insertNodes.
-      const cases: [string, string, string, string][] = [
-        [
-          'x ${A}',
-          ' tail',
-          'T:"x " E:"${A}" T:" tail"',
-          'replaces a match that ends the node and does not start at offset 0',
-        ],
-        [
-          'x ${A} y ${B}',
-          ' tail',
-          'T:"x " E:"${A}" T:" y " E:"${B}" T:" tail"',
-          'replaces the last of several matches in the same node',
-        ],
-        [
-          '${A} ${B} ${C}',
-          ' tail',
-          'E:"${A}" T:" " E:"${B}" T:" " E:"${C}" T:" tail"',
-          'replaces every match when the first one starts at offset 0',
-        ],
-        [
-          'x ${A} y',
-          ' tail',
-          'T:"x " E:"${A}" T:" y" T:" tail"',
-          'replaces a match that does not end the node (control)',
-        ],
-        [
-          'x ${A',
-          'B} tail',
-          'T:"x ${A" T:"B} tail"',
-          'leaves a match that only completes inside the sibling (control)',
-        ],
-      ];
+  // The second text node is bold so that it is not normalized into the first
+  // one. That leaves the match at the end of a text node that still has a
+  // TextNode sibling, which is the shape produced by $insertNodes.
+  const cases: [string, string, string, string][] = [
+    [
+      'x ${A}',
+      ' tail',
+      'T:"x " E:"${A}" T:" tail"',
+      'replaces a match that ends the node and does not start at offset 0',
+    ],
+    [
+      'x ${A} y ${B}',
+      ' tail',
+      'T:"x " E:"${A}" T:" y " E:"${B}" T:" tail"',
+      'replaces the last of several matches in the same node',
+    ],
+    [
+      '${A} ${B} ${C}',
+      ' tail',
+      'E:"${A}" T:" " E:"${B}" T:" " E:"${C}" T:" tail"',
+      'replaces every match when the first one starts at offset 0',
+    ],
+    [
+      'x ${A} y',
+      ' tail',
+      'T:"x " E:"${A}" T:" y" T:" tail"',
+      'replaces a match that does not end the node (control)',
+    ],
+    [
+      'x ${A',
+      'B} tail',
+      'T:"x ${A" T:"B} tail"',
+      'leaves a match that only completes inside the sibling (control)',
+    ],
+  ];
 
-      for (const [first, second, expected, description] of cases) {
-        test(description, async () => {
-          const {editor} = testEnv;
-          registerLexicalTextEntity(
-            editor,
-            getMatch,
-            TestEntityNode,
-            textNode => $createTestEntityNode(textNode.getTextContent()),
-          );
+  for (const [first, second, expected, description] of cases) {
+    test(description, async () => {
+      using editor = buildEditorFromExtensions({
+        name: 'test',
+        nodes: [TestEntityNode],
+        register: editor_ =>
+          mergeRegister(
+            ...registerLexicalTextEntity(
+              editor_,
+              getMatch,
+              TestEntityNode,
+              textNode => $createTestEntityNode(textNode.getTextContent()),
+            ),
+          ),
+      });
 
-          await editor.update(() => {
-            const paragraph = $createParagraphNode();
-            paragraph.append(
-              $createTextNode(first),
-              $createTextNode(second).toggleFormat('bold'),
-            );
-            $getRoot().clear().append(paragraph);
-          });
+      editor.update(() => {
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode(first),
+          $createTextNode(second).toggleFormat('bold'),
+        );
+        $getRoot().clear().append(paragraph);
+      });
 
-          editor.getEditorState().read(() => {
-            expect($describeParagraph()).toBe(expected);
-          });
-        });
-      }
-    },
-    {namespace: 'test', nodes: [TestEntityNode], theme: {}},
-  );
+      editor.read(() => {
+        expect($describeTextNodes()).toBe(expected);
+      });
+    });
+  }
 });

--- a/packages/lexical-text/src/__tests__/unit/canShowPlaceholder.test.ts
+++ b/packages/lexical-text/src/__tests__/unit/canShowPlaceholder.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$canShowPlaceholder} from '@lexical/text';
+import {
+  $create,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  DecoratorNode,
+  defineExtension,
+  type TextModeType,
+} from 'lexical';
+import {$assertNodeType} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+// An inline decorator that contributes no text, e.g. an inline image or
+// equation chip. Its emptiness keeps the root's text content empty while the
+// document plainly is not empty.
+class InlineDecoratorNode extends DecoratorNode<null> {
+  $config() {
+    return this.config('inline_decorator_placeholder', {
+      extends: DecoratorNode,
+    });
+  }
+  isInline(): boolean {
+    return true;
+  }
+  createDOM(): HTMLElement {
+    return document.createElement('span');
+  }
+  updateDOM(): boolean {
+    return false;
+  }
+  decorate(): null {
+    return null;
+  }
+}
+
+function $createInlineDecoratorNode(): InlineDecoratorNode {
+  return $create(InlineDecoratorNode);
+}
+
+function buildEditor() {
+  return buildEditorFromExtensions(
+    defineExtension({
+      $initialEditorState: null,
+      name: '[can-show-placeholder]',
+      nodes: [InlineDecoratorNode],
+    }),
+  );
+}
+
+// A simple empty TextNode is removed during reconciliation, which would move
+// the decorator to index 0. `token` and `segmented` nodes are not simple text,
+// so they survive and keep a TextNode at index 0 — the shape that exercises
+// the scan of the remaining children.
+const NON_SIMPLE_MODES: TextModeType[] = ['token', 'segmented'];
+
+describe('$canShowPlaceholder', () => {
+  for (const mode of NON_SIMPLE_MODES) {
+    test(`is false when a decorator follows an empty ${mode} text node`, () => {
+      using editor = buildEditor();
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          paragraph.append(
+            $createTextNode('').setMode(mode),
+            $createInlineDecoratorNode(),
+          );
+          $getRoot().clear().append(paragraph);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const paragraph = $assertNodeType(
+          $getRoot().getFirstChild(),
+          $isParagraphNode,
+        );
+        // Guard the premise: the text node must have survived, otherwise the
+        // decorator would sit at index 0 and the scan would be trivial.
+        expect(paragraph.getChildrenSize()).toBe(2);
+        expect($getRoot().getTextContent()).toBe('');
+        expect($canShowPlaceholder(false)).toBe(false);
+      });
+    });
+  }
+
+  test('is false when the decorator is several positions along', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode('').setMode('token'),
+          $createTextNode('').setMode('token'),
+          $createInlineDecoratorNode(),
+        );
+        $getRoot().clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $canShowPlaceholder(false))).toBe(false);
+  });
+
+  test('is still false when the decorator is first', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createInlineDecoratorNode(),
+          $createTextNode('').setMode('token'),
+        );
+        $getRoot().clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $canShowPlaceholder(false))).toBe(false);
+  });
+
+  test('is still true for an empty paragraph', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        $getRoot().clear().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $canShowPlaceholder(false))).toBe(true);
+  });
+
+  test('is still true for a paragraph of empty text nodes', () => {
+    using editor = buildEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode('').setMode('token'),
+          $createTextNode('').setMode('token'),
+        );
+        $getRoot().clear().append(paragraph);
+      },
+      {discrete: true},
+    );
+
+    expect(editor.read(() => $canShowPlaceholder(false))).toBe(true);
+  });
+});

--- a/packages/lexical-text/src/__tests__/unit/registerLexicalTextEntity.test.ts
+++ b/packages/lexical-text/src/__tests__/unit/registerLexicalTextEntity.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $applyNodeReplacement,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type LexicalNode,
+  TextNode,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+import {type EntityMatch, registerLexicalTextEntity} from '../..';
+
+class TestEntityNode extends TextNode {
+  $config() {
+    return this.config('test-entity', {extends: TextNode});
+  }
+
+  isTextEntity(): true {
+    return true;
+  }
+}
+
+function $createTestEntityNode(text: string): TestEntityNode {
+  return $applyNodeReplacement(new TestEntityNode(text));
+}
+
+function $isTestEntityNode(node: LexicalNode | null): node is TestEntityNode {
+  return node instanceof TestEntityNode;
+}
+
+function getMatch(text: string): null | EntityMatch {
+  const match = /#\w+/.exec(text);
+  return match === null
+    ? null
+    : {end: match.index + match[0].length, start: match.index};
+}
+
+describe('registerLexicalTextEntity', () => {
+  initializeUnitTest(
+    testEnv => {
+      test('preserves style and detail when reverting an entity to simple text', async () => {
+        const {editor} = testEnv;
+        registerLexicalTextEntity(editor, getMatch, TestEntityNode, textNode =>
+          $createTestEntityNode(textNode.getTextContent()),
+        );
+
+        await editor.update(() => {
+          const paragraph = $createParagraphNode();
+          paragraph.append($createTextNode('#lexical'));
+          $getRoot().clear().append(paragraph);
+        });
+
+        await editor.update(() => {
+          const node = $getRoot().getFirstDescendant();
+          expect($isTestEntityNode(node)).toBe(true);
+          (node as TestEntityNode)
+            .setFormat('bold')
+            .setStyle('color: red')
+            .setDetail('directionless');
+        });
+
+        // Break the match so the entity reverts to a plain TextNode.
+        await editor.update(() => {
+          const node = $getRoot().getFirstDescendant() as TextNode;
+          node.setTextContent('lexical');
+        });
+
+        editor.getEditorState().read(() => {
+          const node = $getRoot().getFirstDescendant() as TextNode;
+          expect($isTestEntityNode(node)).toBe(false);
+          expect(node.getTextContent()).toBe('lexical');
+          expect(node.hasFormat('bold')).toBe(true);
+          expect(node.getStyle()).toBe('color: red');
+          expect(node.isDirectionless()).toBe(true);
+        });
+      });
+    },
+    {namespace: 'test', nodes: [TestEntityNode], theme: {}},
+  );
+});

--- a/packages/lexical-text/src/canShowPlaceholder.ts
+++ b/packages/lexical-text/src/canShowPlaceholder.ts
@@ -54,7 +54,7 @@ export function $canShowPlaceholder(isComposing: boolean): boolean {
       const topBlockChildrenLength = topBlockChildren.length;
 
       for (let s = 0; s < topBlockChildrenLength; s++) {
-        const child = topBlockChildren[i];
+        const child = topBlockChildren[s];
 
         if (!$isTextNode(child)) {
           return false;

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -48,8 +48,10 @@ export function registerLexicalTextEntity<T extends TextNode>(
   };
 
   const $replaceWithSimpleText = (node: TextNode): void => {
-    const textNode = $createTextNode(node.getTextContent());
-    textNode.setFormat(node.getFormat());
+    const textNode = $createTextNode(node.getTextContent())
+      .setFormat(node.getFormat())
+      .setStyle(node.getStyle())
+      .setDetail(node.getDetail());
     node.replace(textNode);
   };
 
@@ -104,17 +106,23 @@ export function registerLexicalTextEntity<T extends TextNode>(
     let prevMatchLengthToSkip = 0;
 
     while (true) {
-      match = getMatch(text);
-      let nextText = match === null ? '' : text.slice(match.end);
+      const remainingText = text;
+      match = getMatch(remainingText);
+      const nextText = match === null ? '' : remainingText.slice(match.end);
       text = nextText;
 
       if (nextText === '') {
         const nextSibling = currentNode.getNextSibling();
 
         if ($isTextNode(nextSibling)) {
-          nextText =
-            currentNode.getTextContent() + nextSibling.getTextContent();
-          const nextMatch = getMatch(nextText);
+          // The match ends where this node ends, so the next sibling's text may
+          // extend, shorten or invalidate it. Re-run getMatch over the text that
+          // is still to be processed plus the sibling's text and bail out unless
+          // the same match is found at the same offset. Matches that were
+          // already replaced (or skipped) are excluded from `remainingText`, so
+          // the comparison is against `match.start` rather than 0.
+          const combinedText = remainingText + nextSibling.getTextContent();
+          const nextMatch = getMatch(combinedText);
 
           if (nextMatch === null) {
             if (isTargetNode(nextSibling)) {
@@ -124,7 +132,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
             }
 
             return;
-          } else if (nextMatch.start !== 0) {
+          } else if (match === null || nextMatch.start !== match.start) {
             return;
           }
         }


### PR DESCRIPTION
## Description

Ten fixes for one defect class: an inline or custom node and the DOM/HTML it
renders drift apart because the code that rewrites the node only re-applies
*some* of what built it. A text-entity transform rebuilds a `TextNode` and drops
properties the original carried, or misses a match that ends the node; an
`updateDOM` returns `false` — promising the reconciler every difference is
already in the DOM — while writing to a different element than `createDOM` did,
or to none at all; a class or attribute is refreshed on only some of the
transitions that should refresh it; an export path loses formats or throws on
non-Latin-1 text. Same shape as #9049 (nodes overwriting what `super.createDOM`
applied), so they are consolidated into one review.

- `$replaceWithSimpleText` in `packages/lexical-text/src/registerLexicalTextEntity.ts`
  carried only `format` onto the replacement node, so an entity reverting to
  plain text silently lost its `style` and `detail`.
- `$textNodeTransform` in the same file re-ran `getMatch` over the *whole*
  combined text of the node and its sibling and then required
  `nextMatch.start === 0`. Matches already replaced or skipped are part of that
  text, so a match that ends the node without starting it — typically the last
  of several in one node — was never replaced. It now compares against the text
  still to be processed and against the current match's own `start` (#5466).
- `MarkNode.updateDOM` (`packages/lexical-mark/src/MarkNode.ts`) enumerated
  id-count transitions instead of re-applying the `ids.length > 1` rule
  `createDOM` states, so `1 -> 3` never gained `theme.markOverlap` and `2 -> 0`
  never lost it. It now derives the overlap state from the same rule.
- `handleLinkEdit` (`packages/lexical-link/src/LexicalAutoLinkExtension.ts`)
  refreshed `rel` and `target` from the new match but never `title`, the third
  member of `LinkAttributes` that the creation path already applies. It also
  reported those attribute refreshes through `onChange`, which is documented as
  receiving `(url, prevUrl)`; attribute refreshes no longer fire it, while
  creation, removal and real url changes still do.
- `TOGGLE_LINK_COMMAND`'s object-payload branch in
  `packages/lexical-link/src/LexicalLinkExtension.ts` never called
  `validateUrl`, so a configured policy applied to
  `dispatchCommand(TOGGLE_LINK_COMMAND, url)` and was skipped for
  `dispatchCommand(TOGGLE_LINK_COMMAND, {url, target})`. The same gate now
  covers both shapes.
- `MentionNode.exportDOM`
  (`packages/lexical-playground/src/nodes/MentionNode.ts`) built a bare
  `<span data-lexical-mention>` from `this.__text`, dropping the node's inline
  style and text formats from the exported HTML. It now carries the style and
  wraps the span in the same `<b>/<i>/<s>/<u>` elements `TextNode.exportDOM`
  uses; the mention stays a `<span>` so the `span[data-lexical-mention]` import
  rule still matches (#6453).
- `SpecialTextNode.updateDOM`
  (`packages/lexical-playground/src/nodes/SpecialTextNode.tsx`) returned `false`
  but only wrote `dom.textContent` behind a `prevNode.__text.startsWith('[')`
  guard that cannot hold — the node is built from the regex capture group, with
  the brackets already stripped — so the chip kept the text it was created with
  forever. It now writes the text the way `createDOM` does, when it changed.
- `EquationNode.exportDOM`
  (`packages/lexical-playground/src/nodes/EquationNode.tsx`) base64-encoded
  free-form LaTeX with `btoa`, which throws `InvalidCharacterError` on any code
  point above U+00FF, so copying or exporting `\text{α}` failed outright; the
  importer's `atob` had the mirror-image limit. Both sides now go through the
  UTF-8 bytes with shared `encodeEquation`/`decodeEquation` helpers, the same
  approach `utils/docSerialization.ts` already uses. Pure ASCII encodes byte for
  byte, so previously exported HTML still decodes.
- `RubyNode.updateDOM`
  (`packages/lexical-playground/src/plugins/RubyExtension/RubyNode.ts`) handed
  `super.updateDOM` the wrapper element, while `createDOM` puts the text theme
  classes and the node's inline style on the *inner* element. The two disagreed
  about which element carries the formatting, so restyling a ruby annotation did
  nothing (the inner element's own `color` still won) and underline/strikethrough
  landed on a wrapper whose only child is an inline-block. It now resolves the
  inner element and passes it to super, and returns `true` when the inner is
  missing so the reconciler rebuilds instead.
- `$canShowPlaceholder` (`packages/lexical-text/src/canShowPlaceholder.ts`)
  indexed its innermost loop with the *outer* loop's `i` instead of `s`. `i` is
  always `0` there, so the scan tested `topBlockChildren[0]` N times and never
  looked past index 0 — the one thing it exists to do. A paragraph of
  `[TextNode(""), <inline DecoratorNode>]` reported that the placeholder may be
  shown, rendering it on top of real content.

## Test plan

Seven new unit test files and three extended ones, covering every fix:
`registerLexicalTextEntity.test.ts`, `Issue5466Repro.test.ts` and
`canShowPlaceholder.test.ts` in `packages/lexical-text`;
`LexicalMarkNode.test.ts` in `packages/lexical-mark`;
`LexicalAutoLinkExtension.test.ts` and `LinkExtensionValidateUrl.test.ts` in
`packages/lexical-link`; and `MentionHTML.test.ts`, `SpecialTextNode.test.ts`,
`EquationNodeHTML.test.ts` and `RubyNode.test.ts` in
`packages/lexical-playground`. Several cases are deliberate controls that pass
before and after — the `createDOM` reference the `updateDOM` cases are held to,
the legacy ASCII equation that must still decode, and the string-payload
`validateUrl` case that pins the asymmetry with the object payload.

### Before

Source fixes reverted, new tests kept:

```
$ npx vitest run --project unit packages/lexical-text packages/lexical-mark packages/lexical-link packages/lexical-playground

     × replaces a match that ends the node and does not start at offset 0 265ms
     × replaces the last of several matches in the same node 23ms
     × replaces every match when the first one starts at offset 0 53ms
     × exports the font-size applied to a mention (#6453) 258ms
     × exports the text formats applied to a mention (#6453) 90ms
     × updateDOM adds the overlap class when going from 1 to 3 ids 27ms
     × updateDOM removes the overlap class when going from 2 to 0 ids 22ms
     × preserves style and detail when reverting an entity to simple text 191ms
     × re-renders the text when it changes 98ms
     × renders the text verbatim when it is bracketed 5ms
     × applies a style change to the element createDOM styled 71ms
     × applies a class-only text format to the element createDOM classed 4ms
     × exports an equation with non Latin-1 characters without throwing 53ms
     × round trips an equation with non Latin-1 characters 4ms
     × round trips an equation outside the basic multilingual plane 1ms
     × rejects a URL the validator refuses, for an object payload 64ms
     × is false when a decorator follows an empty token text node 29ms
     × is false when a decorator follows an empty segmented text node 4ms
     × is false when the decorator is several positions along 1ms
       × editing the link text refreshes the title 28ms
       × an attribute refresh is not reported as a url change 3ms

 Test Files  10 failed | 27 passed (37)
      Tests  21 failed | 895 passed (916)
```

### After

```
$ npx vitest run --project unit packages/lexical-text packages/lexical-mark packages/lexical-link packages/lexical-playground

 Test Files  37 passed (37)
      Tests  916 passed (916)

$ npx tsc --noEmit -p .
(clean)
```

Supersedes #8919, #8969, #8982, #8987, #8998, #9014, #9019, #9032, #9036, #9046,
consolidated per the review feedback on #9027 and #9035.

