### PR TITLE
[lexical] Bug fix: apply nodes replacement for importJSON

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -3405,6 +3405,7 @@ export function getStaticNodeConfig(
           String(klass.length),
         );
       }
+      // TODO: replace $applyNodeReplacement with $create once `withKlass` is required.
       klass.importJSON =
         (ownNodeConfig && ownNodeConfig.$importJSON) ||
         (serializedNode =>

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -3407,7 +3407,8 @@ export function getStaticNodeConfig(
       }
       klass.importJSON =
         (ownNodeConfig && ownNodeConfig.$importJSON) ||
-        (serializedNode => new klass().updateFromJSON(serializedNode));
+        (serializedNode =>
+          $applyNodeReplacement(new klass()).updateFromJSON(serializedNode));
     }
     if (!hasOwnStaticMethod(klass, 'importDOM') && ownNodeConfig) {
       const {importDOM} = ownNodeConfig;

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -3943,6 +3943,62 @@ describe('LexicalEditor tests', () => {
       expect(onError).not.toHaveBeenCalled();
       removeTransform();
     });
+
+    it('applies the replacement when deserializing a base node type via parseEditorState (#8640 regression)', async () => {
+      class CustomParagraphNode extends ParagraphNode {
+        $config() {
+          return this.config('custom-paragraph', {extends: ParagraphNode});
+        }
+      }
+      const onError = vi.fn();
+
+      const newEditor = createTestEditor({
+        nodes: [
+          CustomParagraphNode,
+          {
+            replace: ParagraphNode,
+            with: () => new CustomParagraphNode(),
+            withKlass: CustomParagraphNode,
+          },
+        ],
+        onError: onError,
+      });
+
+      // Serialized state whose paragraph uses the default type ("paragraph"), as
+      // an older persisted document (or one produced without the replacement)
+      // would contain.
+      const json = {
+        root: {
+          children: [
+            {
+              children: [],
+              direction: null,
+              format: '',
+              indent: 0,
+              type: 'paragraph',
+              version: 1,
+            },
+          ],
+          direction: null,
+          format: '',
+          indent: 0,
+          type: 'root',
+          version: 1,
+        },
+      };
+
+      newEditor.setEditorState(
+        newEditor.parseEditorState(JSON.stringify(json)),
+      );
+
+      newEditor.read(() => {
+        const paragraph = $getRoot().getFirstChild();
+        expect(paragraph instanceof CustomParagraphNode).toBe(true);
+        expect(paragraph!.getType()).toBe('custom-paragraph');
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+    });
   });
 
   it('recovers from reconciler failure and trigger proper prev editor state', async () => {

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -3972,18 +3972,54 @@ describe('LexicalEditor tests', () => {
           children: [
             {
               children: [],
-              direction: null,
-              format: '',
-              indent: 0,
               type: 'paragraph',
-              version: 1,
             },
           ],
-          direction: null,
-          format: '',
-          indent: 0,
           type: 'root',
-          version: 1,
+        },
+      };
+
+      newEditor.setEditorState(
+        newEditor.parseEditorState(JSON.stringify(json)),
+      );
+
+      newEditor.read(() => {
+        const paragraph = $getRoot().getFirstChild();
+        expect(paragraph instanceof CustomParagraphNode).toBe(true);
+        expect(paragraph!.getType()).toBe('custom-paragraph');
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('applies the replacement on import for `with` without `withKlass`', async () => {
+      class CustomParagraphNode extends ParagraphNode {
+        $config() {
+          return this.config('custom-paragraph', {extends: ParagraphNode});
+        }
+      }
+      const onError = vi.fn();
+
+      const newEditor = createTestEditor({
+        nodes: [
+          CustomParagraphNode,
+          {
+            replace: ParagraphNode,
+            with: () => new CustomParagraphNode(),
+          },
+        ],
+        onError: onError,
+      });
+
+      const json = {
+        root: {
+          children: [
+            {
+              children: [],
+              type: 'paragraph',
+            },
+          ],
+          type: 'root',
         },
       };
 


### PR DESCRIPTION
Bug Fix: apply node replacement when deserializing a base node type via parseEditorState

## Description

Registering a node replacement (`{replace: ParagraphNode, with, withKlass}`) no longer took effect when deserializing through `parseEditorState` / `setEditorState`.

The synthesized importJSON default now wraps construction in `$applyNodeReplacement`, restoring the old behavior.

## Test plan

Added unit test to cover it.