### PR TITLE
[lexical-react][lexical-playground] Bug Fix: restore focus after dragging decorator blocks

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
@@ -6,13 +6,19 @@
  *
  */
 
+import {expect} from '@playwright/test';
+
 import {
   assertHTML,
   dragDraggableMenuTo,
+  dragMouse,
   focusEditor,
   initialize,
+  insertYouTubeEmbed,
   mouseMoveToSelector,
+  selectorBoundingBox,
   test,
+  YOUTUBE_SAMPLE_URL,
 } from '../utils/index.mjs';
 
 test.describe('DraggableBlock', () => {
@@ -186,5 +192,47 @@ test.describe('DraggableBlock', () => {
       </p>
     `,
     );
+  });
+
+  test('Restores focus after dragging a selected decorator block', async ({
+    page,
+    isPlainText,
+    browserName,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    test.skip(isPlainText);
+    test.skip(browserName === 'firefox');
+
+    await focusEditor(page);
+    await page.keyboard.type('Before');
+    await insertYouTubeEmbed(page, YOUTUBE_SAMPLE_URL);
+    await page.keyboard.type('After');
+
+    const decorator = page.locator('.PlaygroundEditorTheme__embedBlock');
+    const decoratorElement = page.locator('div[data-lexical-decorator="true"]');
+    const decoratorBox = await decoratorElement.boundingBox();
+    if (decoratorBox === null) {
+      throw new Error('Decorator block is not visible');
+    }
+    const pointerX = decoratorBox.x + 10;
+    const pointerY = decoratorBox.y + decoratorBox.height / 2;
+    await decorator.evaluate(element => element.click());
+    await expect(decorator).toHaveClass(
+      /PlaygroundEditorTheme__embedBlockFocus/,
+    );
+    await decoratorElement.dispatchEvent('mousemove', {
+      clientX: pointerX,
+      clientY: pointerY,
+    });
+    await page.locator('.draggable-block-menu').waitFor();
+    await dragMouse(
+      page,
+      await selectorBoundingBox(page, '.draggable-block-menu'),
+      await selectorBoundingBox(page, 'p:has-text("After")'),
+      {positionEnd: 'end', positionStart: 'middle', slow: true},
+    );
+
+    await expect(page.locator('.ContentEditable__root')).toBeFocused();
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
@@ -202,7 +202,6 @@ test.describe('DraggableBlock', () => {
   }) => {
     test.skip(isCollab);
     test.skip(isPlainText);
-    test.skip(browserName === 'firefox');
 
     await focusEditor(page);
     await page.keyboard.type('Before');

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -574,11 +574,15 @@ function useDraggableBlockMenu(
     isDraggingBlockRef.current = false;
     hideTargetLine(targetLineRef.current);
 
-    // Firefox-specific fix: Use editor.focus() to properly restore both focus and
-    // selection after drag ends. This ensures cursor visibility immediately.
-    if (IS_FIREFOX) {
-      // editor.focus() handles both focus restoration and selection update properly
-      editor.focus();
+    const rootElement = editor.getRootElement();
+    if (rootElement !== null && getActiveElement(rootElement) !== rootElement) {
+      rootElement.focus({preventScroll: true});
+      editor.update(() => {
+        const selection = $getSelection();
+        if (selection !== null && !selection.dirty) {
+          selection.dirty = true;
+        }
+      });
     }
   }
   return createPortal(

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -72,6 +72,19 @@ function getTopLevelNodeKeys(editor: LexicalEditor): string[] {
   return editor.read('latest', () => $getRoot().getChildrenKeys());
 }
 
+function restoreEditorFocus(
+  editor: LexicalEditor,
+  rootElement: HTMLElement,
+): void {
+  rootElement.focus({preventScroll: true});
+  editor.update(() => {
+    const selection = $getSelection();
+    if (selection !== null && !selection.dirty) {
+      selection.dirty = true;
+    }
+  });
+}
+
 function getCollapsedMargins(elem: HTMLElement): {
   marginTop: number;
   marginBottom: number;
@@ -477,14 +490,7 @@ function useDraggableBlockMenu(
             // Blur is caused by clicking on drag handle - restore focus immediately
             // to prevent cursor from disappearing. This must be synchronous to work.
             if (rootElement) {
-              rootElement.focus({preventScroll: true});
-              // Force selection update to ensure cursor is visible
-              editor.update(() => {
-                const selection = $getSelection();
-                if (selection !== null && !selection.dirty) {
-                  selection.dirty = true;
-                }
-              });
+              restoreEditorFocus(editor, rootElement);
             }
             // Prevent the event from propagating to LexicalEvents handler
             event.stopImmediatePropagation();
@@ -512,13 +518,7 @@ function useDraggableBlockMenu(
             isOnMenu(activeElement)
           ) {
             // Focus is on menu - restore to root and prevent blur command
-            rootElement.focus({preventScroll: true});
-            editor.update(() => {
-              const selection = $getSelection();
-              if (selection !== null && !selection.dirty) {
-                selection.dirty = true;
-              }
-            });
+            restoreEditorFocus(editor, rootElement);
             return true; // Prevent command from propagating
           }
           return false;
@@ -558,14 +558,7 @@ function useDraggableBlockMenu(
       ) {
         // Restore focus synchronously - don't use requestAnimationFrame as blur already happened
         // and we need immediate focus restoration to maintain cursor visibility
-        rootElement.focus({preventScroll: true});
-        // Force selection update to ensure cursor is visible
-        editor.update(() => {
-          const selection = $getSelection();
-          if (selection !== null && !selection.dirty) {
-            selection.dirty = true;
-          }
-        });
+        restoreEditorFocus(editor, rootElement);
       }
     }
   }
@@ -576,13 +569,7 @@ function useDraggableBlockMenu(
 
     const rootElement = editor.getRootElement();
     if (rootElement !== null && getActiveElement(rootElement) !== rootElement) {
-      rootElement.focus({preventScroll: true});
-      editor.update(() => {
-        const selection = $getSelection();
-        if (selection !== null && !selection.dirty) {
-          selection.dirty = true;
-        }
-      });
+      restoreEditorFocus(editor, rootElement);
     }
   }
   return createPortal(


### PR DESCRIPTION
## Description

Dragging a selected decorator block can leave focus outside the editor. The selected node still appears active, but keyboard input no longer reaches the contenteditable root.

Firefox can blur the editor before `dragstart`, so the plugin restores focus from its Firefox-specific blur and drag handlers. Chromium and WebKit can instead lose focus when the drag ends. This change uses one `restoreEditorFocus` helper for both paths and applies the same recovery from `dragend`.

Closes #9048

## Test plan

### Before

The new E2E regression failed in Chromium and WebKit because the contenteditable root remained unfocused after dragging a selected YouTube decorator block. The test skipped Firefox.

### After

The focused regression passes in Chromium, Firefox, and WebKit:

```
3 passed (6.8s)
```

The complete DraggableBlock file passes all five Chromium tests. In the cross-browser run, the new regression also passed in Firefox and WebKit. Two older WebKit drag-placement cases still fail locally without touching the new focus assertion.

Prettier and ESLint pass for both changed files.