### PR TITLE
[lexical] Bug Fix: restore managed line break in wrapped slot hosts

### DIFF
--- a/packages/lexical/src/LexicalDOMSlot.ts
+++ b/packages/lexical/src/LexicalDOMSlot.ts
@@ -431,11 +431,19 @@ export class ElementDOMSlot<
     lineBreakType: null | 'empty' | 'line-break' | 'decorator',
   ): void {
     const element: HTMLElement & LexicalPrivateDOM = this.element;
-    element.__lexicalLastChildKind = lineBreakType;
-    if (lineBreakType === null) {
+    const nextLineBreakType =
+      lineBreakType === 'empty' &&
+      Array.from(element.children).some(isSlotContainerDOM)
+        ? null
+        : lineBreakType;
+    if (element.__lexicalLastChildKind === nextLineBreakType) {
+      return;
+    }
+    element.__lexicalLastChildKind = nextLineBreakType;
+    if (nextLineBreakType === null) {
       this.removeManagedLineBreak();
     } else {
-      const webkitHack = lineBreakType === 'decorator' && IS_WEBKIT_BROWSER;
+      const webkitHack = nextLineBreakType === 'decorator' && IS_WEBKIT_BROWSER;
       this.insertManagedLineBreak(webkitHack);
     }
   }

--- a/packages/lexical/src/LexicalDOMSlot.ts
+++ b/packages/lexical/src/LexicalDOMSlot.ts
@@ -431,9 +431,13 @@ export class ElementDOMSlot<
     lineBreakType: null | 'empty' | 'line-break' | 'decorator',
   ): void {
     const element: HTMLElement & LexicalPrivateDOM = this.element;
+    // Slot containers are a contiguous prefix of the managed range, so only
+    // its first node needs to be inspected. This also excludes containers
+    // outside an `after` boundary.
+    const firstNode =
+      this.after === null ? element.firstChild : this.after.nextSibling;
     const nextLineBreakType =
-      lineBreakType === 'empty' &&
-      Array.from(element.children).some(isSlotContainerDOM)
+      lineBreakType === 'empty' && isSlotContainerDOM(firstNode)
         ? null
         : lineBreakType;
     if (element.__lexicalLastChildKind === nextLineBreakType) {

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -898,7 +898,6 @@ type LastChildState = 'line-break' | 'decorator' | 'empty';
 function $isLastChildLineBreakOrDecorator(
   element: null | ElementNode,
   nodeMap: NodeMap,
-  slotsOccupyDOMSlot: boolean,
 ): null | LastChildState {
   if (element) {
     const lastKey = element.__last;
@@ -912,28 +911,9 @@ function $isLastChildLineBreakOrDecorator(
             : null;
       }
     }
-    // A host whose named slots occupy the same DOMSlot as its linked-list
-    // children is not empty. Adding a line break there would create a stray
-    // caret target after the slot containers. A custom getDOMSlot can redirect
-    // linked-list children elsewhere, though; that separate empty child area
-    // still needs its own caret target.
-    return slotsOccupyDOMSlot ? null : 'empty';
+    return 'empty';
   }
   return null;
-}
-
-function $slotsOccupyDOMSlot(
-  element: ElementNode,
-  slotElement: HTMLElement,
-): boolean {
-  for (const slotKey of $readSlots(element).values()) {
-    const slotDOM = activeEditor._keyToDOMMap.get(slotKey);
-    const slotContainer = slotDOM === undefined ? null : slotDOM.parentElement;
-    if (slotContainer != null && slotElement.contains(slotContainer)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function $isBlockDecoratorChild(
@@ -977,21 +957,14 @@ function $reconcileElementTerminatingLineBreak(
   nextElement: ElementNode,
   dom: HTMLElement & LexicalPrivateDOM,
 ): void {
-  // Read previous render's last-child kind from the slot element's cache
-  // so the prev-state DecoratorNode reference's isInline() (which routes
-  // through getLatest() and would throw once the key is detached from the
-  // active node map) is never called.
   const slot = $getDOMSlot(nextElement, dom, activeEditor);
-  const slotElement: HTMLElement & LexicalPrivateDOM = slot.element;
-  const prevLineBreak = slotElement.__lexicalLastChildKind ?? null;
   const nextLineBreak = $isLastChildLineBreakOrDecorator(
     nextElement,
     activeNextNodeMap,
-    $slotsOccupyDOMSlot(nextElement, slotElement),
   );
-  if (prevLineBreak !== nextLineBreak) {
-    slot.setManagedLineBreak(nextLineBreak);
-  }
+  // ElementDOMSlot normalizes the empty state against the actual content
+  // range, including named-slot containers, and caches the result.
+  slot.setManagedLineBreak(nextLineBreak);
 }
 
 function reconcileTextFormat(element: ElementNode): void {

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -898,6 +898,7 @@ type LastChildState = 'line-break' | 'decorator' | 'empty';
 function $isLastChildLineBreakOrDecorator(
   element: null | ElementNode,
   nodeMap: NodeMap,
+  slotsOccupyDOMSlot: boolean,
 ): null | LastChildState {
   if (element) {
     const lastKey = element.__last;
@@ -911,14 +912,28 @@ function $isLastChildLineBreakOrDecorator(
             : null;
       }
     }
-    // A host with slots but no linked-list children is not empty (the slots
-    // carry its content). The 'empty' line break exists to give a truly empty
-    // block a caret target; on a slots-only host that <br> would instead be a
-    // stray caret target in the host's own child area, after the slot
-    // containers — text typed there leaks out of the slot. Skip it.
-    return $readSlots(element).size > 0 ? null : 'empty';
+    // A host whose named slots occupy the same DOMSlot as its linked-list
+    // children is not empty. Adding a line break there would create a stray
+    // caret target after the slot containers. A custom getDOMSlot can redirect
+    // linked-list children elsewhere, though; that separate empty child area
+    // still needs its own caret target.
+    return slotsOccupyDOMSlot ? null : 'empty';
   }
   return null;
+}
+
+function $slotsOccupyDOMSlot(
+  element: ElementNode,
+  slotElement: HTMLElement,
+): boolean {
+  for (const slotKey of $readSlots(element).values()) {
+    const slotDOM = activeEditor._keyToDOMMap.get(slotKey);
+    const slotContainer = slotDOM === undefined ? null : slotDOM.parentElement;
+    if (slotContainer != null && slotElement.contains(slotContainer)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function $isBlockDecoratorChild(
@@ -972,6 +987,7 @@ function $reconcileElementTerminatingLineBreak(
   const nextLineBreak = $isLastChildLineBreakOrDecorator(
     nextElement,
     activeNextNodeMap,
+    $slotsOccupyDOMSlot(nextElement, slotElement),
   );
   if (prevLineBreak !== nextLineBreak) {
     slot.setManagedLineBreak(nextLineBreak);

--- a/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalDOMSlot.test.tsx
@@ -125,6 +125,19 @@ describe('ElementDOMSlot class', () => {
     expect(updated).toBe(original);
   });
 
+  test('setManagedLineBreak ignores slot containers before the managed range', () => {
+    const el = makeElement();
+    const slotContainer = document.createElement('div');
+    slotContainer.setAttribute('data-lexical-slot', 'title');
+    const after = document.createElement('span');
+    el.append(slotContainer, after);
+    const slot = new ElementDOMSlot(el, null, after);
+
+    inEditor(() => slot.setManagedLineBreak('empty'));
+
+    expect(slot.getManagedLineBreak()).not.toBe(null);
+  });
+
   test('insertChild appends when before is null', () => {
     const el = makeElement();
     const slot = new ElementDOMSlot(el);

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -1452,6 +1452,29 @@ describe('named-slots: core foundation', () => {
     // A truly empty host (no slots, no children) still gets the br — the
     // gate is scoped to slots-only hosts.
     expect(directBr(editor.getElementByKey(emptyHostKey)!)).not.toBe(undefined);
+
+    editor.update(
+      () => {
+        $removeSlot(
+          $assertNodeType($getNodeByKey(slotHostKey), $isElementNode),
+          'title',
+        );
+      },
+      {discrete: true},
+    );
+    expect(directBr(editor.getElementByKey(slotHostKey)!)).not.toBe(undefined);
+
+    editor.update(
+      () => {
+        $setSlot(
+          $assertNodeType($getNodeByKey(slotHostKey), $isElementNode),
+          'title',
+          $slotContainer('New title'),
+        );
+      },
+      {discrete: true},
+    );
+    expect(directBr(editor.getElementByKey(slotHostKey)!)).toBeUndefined();
   });
 
   test('descendant navigation stays children-only (slots stay out of selection)', () => {

--- a/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSlot.test.ts
@@ -143,6 +143,30 @@ class ReservedDeclaredHostNode extends ElementNode {
   }
 }
 
+class WrappedSlotHostNode extends ElementNode {
+  $config() {
+    return this.config('wrapped_slot_host', {
+      extends: ElementNode,
+      slots: ['title'],
+    });
+  }
+  createDOM() {
+    const host = document.createElement('div');
+    const content = document.createElement('span');
+    content.dataset.content = 'true';
+    host.appendChild(content);
+    return host;
+  }
+  updateDOM() {
+    return false;
+  }
+  getDOMSlot(dom: HTMLElement) {
+    return super
+      .getDOMSlot(dom)
+      .withElement(dom.querySelector<HTMLElement>('[data-content]') ?? dom);
+  }
+}
+
 const mountedRoots: HTMLElement[] = [];
 afterEach(() => {
   while (mountedRoots.length > 0) {
@@ -170,6 +194,7 @@ function createSlotEditor(): LexicalEditorWithDispose {
         ReorderedHostNode,
         DupDeclaredHostNode,
         ReservedDeclaredHostNode,
+        WrappedSlotHostNode,
       ],
     }),
   );
@@ -182,6 +207,35 @@ function createSlotEditor(): LexicalEditorWithDispose {
 }
 
 describe('named-slots: core foundation', () => {
+  test('an empty wrapped child area gets a managed line break', () => {
+    using editor = createSlotEditor();
+    let hostKey = '';
+
+    editor.update(
+      () => {
+        const host = $create(WrappedSlotHostNode).append(
+          $createTextNode('Body'),
+        );
+        $getRoot().append(host);
+        $setSlot(host, 'title', $slotContainer('Title'));
+        hostKey = host.getKey();
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        $assertNodeType($getNodeByKey(hostKey), $isElementNode).clear();
+      },
+      {discrete: true},
+    );
+
+    const hostDom = editor.getElementByKey(hostKey)!;
+    const content = hostDom.querySelector('[data-content]')!;
+    expect(
+      content.querySelector('[data-lexical-managed-linebreak="true"]'),
+    ).not.toBe(null);
+  });
+
   test('a slotted node is reachable, parentless, and attached', () => {
     using editor = createSlotEditor();
     let hostKey = '';


### PR DESCRIPTION
## Description

An element with named slots can redirect its linked-list children to a separate DOM element through `getDOMSlot().withElement(...)`. When that child area becomes empty, it still needs a managed line break even though the host has content in a named slot.

`ElementDOMSlot` now owns this decision. Named-slot containers form a contiguous prefix of its managed range, so it only checks the first node after the `after` boundary, or the element's first child when there is no boundary. A wrapped child area therefore receives the line break, while the default slot keeps the existing slots-only behavior. The reconciler delegates the decision on each relevant render, so adding or removing a slot updates the managed line break without leaving stale cached state.

Closes #9063

## Test plan

### Before

The wrapped-host regression fails because the redirected content element has no managed line break. The boundary regression also fails because a slot container before the managed range incorrectly suppresses the line break.

### After

The wrapped content element receives the managed line break. Removing the named slot from a childless default host restores its line break, and adding the slot again removes it. Slot containers before an `after` boundary do not affect the managed range.

- Core unit suite: 56 files, 1,269 tests passed.
- Browser suite: 51 files, 365 tests passed and 4 skipped across Chromium, Firefox, and WebKit.
- TypeScript, ESLint, Prettier, `git diff --check`, and the pre-commit hook passed.
