### PR TITLE
[lexical] Bug Fix: Ctrl+ArrowLeft/Right no longer jumps to line start/end

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1188,6 +1188,7 @@ export function isExactShortcutMatch(
 
 const CONTROL_OR_META = {ctrlKey: !IS_APPLE, metaKey: IS_APPLE};
 const CONTROL_OR_ALT = {altKey: IS_APPLE, ctrlKey: !IS_APPLE};
+const META_ONLY = {metaKey: true};
 
 export function isTab(event: KeyboardEventModifiers): boolean {
   return isExactShortcutMatch(event, 'Tab', {
@@ -1295,7 +1296,7 @@ export function isMoveBackward(event: KeyboardEventModifiers): boolean {
 
 export function isMoveToStart(event: KeyboardEventModifiers): boolean {
   return isExactShortcutMatch(event, 'ArrowLeft', {
-    ...CONTROL_OR_META,
+    ...META_ONLY,
     shiftKey: 'any',
   });
 }
@@ -1308,7 +1309,7 @@ export function isMoveForward(event: KeyboardEventModifiers): boolean {
 
 export function isMoveToEnd(event: KeyboardEventModifiers): boolean {
   return isExactShortcutMatch(event, 'ArrowRight', {
-    ...CONTROL_OR_META,
+    ...META_ONLY,
     shiftKey: 'any',
   });
 }

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -26,7 +26,6 @@ import {
   getParentElement,
   getRegisteredSubtypeMap,
   getTextDirection,
-  IS_APPLE,
   isExactShortcutMatch,
   isSelectionWithinEditor,
   LineBreakNode,
@@ -341,7 +340,7 @@ describe('LexicalUtils tests', () => {
     });
 
     test('isMoveToEnd() / isMoveToStart() accept Shift modifier', () => {
-      const modifier = IS_APPLE ? {metaKey: true} : {ctrlKey: true};
+      const modifier = {metaKey: true};
 
       const rightWithoutShift = new KeyboardEvent('keydown', {
         ...modifier,
@@ -378,6 +377,27 @@ describe('LexicalUtils tests', () => {
         key: 'ArrowRight',
       });
       expect(isMoveToEnd(rightWithAlt)).toBe(false);
+    });
+
+    test('isMoveToEnd() / isMoveToStart() reject plain Ctrl+Arrow (#8958)', () => {
+      const ctrlLeft = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        key: 'ArrowLeft',
+      });
+      const ctrlRight = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        key: 'ArrowRight',
+      });
+
+      expect(isMoveToStart(ctrlLeft)).toBe(false);
+      expect(isMoveToEnd(ctrlRight)).toBe(false);
+
+      const cmdCtrlLeft = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        key: 'ArrowLeft',
+        metaKey: true,
+      });
+      expect(isMoveToStart(cmdCtrlLeft)).toBe(false);
     });
 
     test('isTokenOrSegmented()', async () => {


### PR DESCRIPTION
## Description

`isMoveToStart()`/`isMoveToEnd()` treated Ctrl on Windows/Linux as equivalent to Cmd on Mac, the same way letter shortcuts like Bold treat them.

However, jumping to the start/end of a line with an arrow key is a macOS only gesture. Windows/Linux use the Home/End keys for this and reserve Ctrl+Arrow for word-by-word navigation.

As a result, plain Ctrl+ArrowLeft/Right on Windows/Linux was being hijacked into a jump to the start/end of the block instead of moving one word at a time.

This was most noticeable in blocks starting with an inline decorator, such as a Date chip, where Lexical already intercepts the key to work around a separate Chromium caret bug. That interception was firing unconditionally regardless of where the caret actually was in the block.

I dug deep and found that, This `ctrlKey`/`metaKey` mixup goes back to the original 2022 implementation (#2257) and was later carried into a shared, platform aware constant by #7443 without accounting for the differences in arrow key behavior between platforms. This likely went unnoticed until #8558 widened the handler from code blocks to general rich text.

This PR scopes `isMoveToStart()`/`isMoveToEnd()` to only match on `metaKey` (Cmd). This leaves Ctrl+Arrow on Windows/Linux alone so it can fall through to native word navigation, while Cmd+Arrow on macOS keeps its existing behavior unchanged.

Closes #8958

## Test plan

### Before

1. In the playground, insert a Date (or any inline decorator) at the start of a paragraph.
2. Type some text after it, for example, "the quick brown fox jumps".
3. Place the cursor in the middle/end of the text.
4. Press Ctrl+ArrowLeft on Windows/Linux.

The cursor jumps all the way to the start of the paragraph instead of moving back one word.

### After

Follow the same steps. Ctrl+ArrowLeft now moves the cursor back one word at a time, as expected.

Verified manually on Windows.

Cmd+ArrowLeft/Right on macOS is unaffected and still jumps to the block start/end past the decorator, as covered by the existing #8555/#8601/#8604 tests.

Added `packages/lexical/src/__tests__/unit/LexicalUtils.test.ts` with `isMoveToEnd() / isMoveToStart() reject plain Ctrl+Arrow (#8958)`. The test asserts that Ctrl+ArrowLeft/Right no longer match, while Cmd+ArrowLeft/Right still do.