### PR TITLE
[lexical-link] Feature: Tell screen reader users when typing turns text into a link

### DIFF
--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -163,3 +163,17 @@ declare export function registerLink(
   editor: LexicalEditor,
   stores: NamedSignalsOutput<LinkConfig>,
 ): () => void;
+
+export type AutoLinkAnnounceExtensionConfig = {
+  created: string,
+  createdMany: string,
+  destroyed: string,
+  destroyedMany: string,
+  disabled: boolean,
+};
+declare export var AutoLinkAnnounceExtension: LexicalExtension<
+  AutoLinkAnnounceExtensionConfig,
+  '@lexical/link/AutoLinkAnnounce',
+  NamedSignalsOutput<AutoLinkAnnounceExtensionConfig>,
+  void,
+>;

--- a/packages/lexical-link/package.json
+++ b/packages/lexical-link/package.json
@@ -12,6 +12,7 @@
   "main": "./dist/LexicalLink.js",
   "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
+    "@lexical/a11y": "workspace:*",
     "@lexical/extension": "workspace:*",
     "@lexical/html": "workspace:*",
     "@lexical/internal": "workspace:*",

--- a/packages/lexical-link/src/AutoLinkAnnounceExtension.ts
+++ b/packages/lexical-link/src/AutoLinkAnnounceExtension.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {AriaLiveRegionExtension} from '@lexical/a11y';
+import {effect, namedSignals} from '@lexical/extension';
+import {defineExtension, safeCast} from 'lexical';
+
+import {AutoLinkNode} from './LexicalLinkNode';
+
+export interface AutoLinkAnnounceExtensionConfig {
+  /** Announced when typing turns text into a link. */
+  created: string;
+  /**
+   * Announced when several links appear at once, as pasting a block of text
+   * can. `%s` is replaced with how many.
+   */
+  createdMany: string;
+  /** Announced when an automatic link stops being a link. */
+  destroyed: string;
+  /**
+   * Announced when several links go at once, as deleting a selection that
+   * spans them does. `%s` is replaced with how many.
+   */
+  destroyedMany: string;
+  /**
+   * When `true`, automatic links are not announced. Toggle at runtime via the
+   * output signal. Default `false`.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Announces automatic links through the {@link AriaLiveRegionExtension} sink.
+ *
+ * Typing a web address turns it into a link on its own, partway through typing
+ * it, with no keystroke to confirm and nothing inserted. A screen reader says
+ * nothing, so the user has no way to know a link now exists.
+ *
+ * A creation paired with a destruction in the same update is not announced.
+ * Every keystroke that extends an address rebuilds the link — the old node
+ * destroyed and a new one created at once — so announcing every creation would
+ * say "Link" at `www.example.c`, again at `o`, and again at `m`. Only a
+ * creation on its own is a link that was not there a moment ago.
+ */
+export const AutoLinkAnnounceExtension = /* @__PURE__ */ defineExtension({
+  build: (_editor, config) => namedSignals(config),
+  config: /* @__PURE__ */ safeCast<AutoLinkAnnounceExtensionConfig>({
+    created: 'Link',
+    createdMany: '%s links',
+    destroyed: 'Link removed',
+    destroyedMany: '%s links removed',
+    disabled: false,
+  }),
+  dependencies: [AriaLiveRegionExtension],
+  name: '@lexical/link/AutoLinkAnnounce',
+  register(editor, _config, state) {
+    const {created, createdMany, destroyed, destroyedMany, disabled} =
+      state.getOutput();
+    const {announce} = state.getDependency(AriaLiveRegionExtension).output;
+
+    // Gate on `disabled` from an effect so a disabled announcer registers no
+    // listener at all. Peek the message signals at announce time so editing
+    // them does not re-register.
+    return effect(() =>
+      disabled.value
+        ? undefined
+        : editor.registerMutationListener(
+            AutoLinkNode,
+            nodes => {
+              let createdCount = 0;
+              let destroyedCount = 0;
+              for (const [, mutation] of nodes) {
+                if (mutation === 'created') {
+                  createdCount++;
+                } else if (mutation === 'destroyed') {
+                  destroyedCount++;
+                }
+              }
+              // Deleting a selection takes every link in it at once, so say
+              // how many rather than reporting a dozen as one.
+              if (createdCount > 0 && destroyedCount === 0) {
+                announce(
+                  createdCount === 1
+                    ? created.peek()
+                    : createdMany.peek().replace('%s', String(createdCount)),
+                );
+              } else if (destroyedCount > 0 && createdCount === 0) {
+                announce(
+                  destroyedCount === 1
+                    ? destroyed.peek()
+                    : destroyedMany
+                        .peek()
+                        .replace('%s', String(destroyedCount)),
+                );
+              }
+            },
+            {skipInitialization: true},
+          ),
+    );
+  },
+});

--- a/packages/lexical-link/src/LexicalAutoLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalAutoLinkExtension.ts
@@ -24,6 +24,7 @@ import {
   TextNode,
 } from 'lexical';
 
+import {AutoLinkAnnounceExtension} from './AutoLinkAnnounceExtension';
 import {LinkExtension} from './LexicalLinkExtension';
 import {
   $createAutoLinkNode,
@@ -694,7 +695,7 @@ export function registerAutoLink(
  */
 export const AutoLinkExtension = /* @__PURE__ */ defineExtension({
   config: defaultConfig,
-  dependencies: [LinkExtension],
+  dependencies: [AutoLinkAnnounceExtension, LinkExtension],
   mergeConfig(config, overrides) {
     const merged = shallowMergeConfig(config, overrides);
     for (const k of ['matchers', 'changeHandlers', 'excludeParents'] as const) {

--- a/packages/lexical-link/src/__tests__/unit/AutoLinkAnnounceExtension.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/AutoLinkAnnounceExtension.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {AriaLiveRegionExtension} from '@lexical/a11y';
+import {
+  buildEditorFromExtensions,
+  defineExtension,
+  getExtensionDependencyFromEditor,
+  type LexicalEditorWithDispose,
+} from '@lexical/extension';
+import {
+  $createAutoLinkNode,
+  AutoLinkAnnounceExtension,
+  AutoLinkExtension,
+  autoLinkUrlMatcher,
+} from '@lexical/link';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  configExtension,
+  type ElementNode,
+} from 'lexical';
+import {afterEach, describe, expect, onTestFinished, test} from 'vitest';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function mountRoot(editor: LexicalEditorWithDispose): void {
+  const root = document.createElement('div');
+  root.contentEditable = 'true';
+  document.body.appendChild(root);
+  editor.setRootElement(root);
+  onTestFinished(() => root.remove());
+}
+
+function readLiveRegion(): string {
+  // A repeat announcement gets a trailing zero-width space so the DOM registers
+  // a change; strip it so assertions read naturally.
+  return (
+    document.body.querySelector('[aria-live]')!.textContent ?? ''
+  ).replace(/\u200B/g, '');
+}
+
+function clearLiveRegion(): void {
+  const region = document.body.querySelector('[aria-live]');
+  if (region) {
+    region.textContent = '';
+  }
+}
+
+/**
+ * Without matchers the transform unmakes the node it was just given, which is
+ * a different scenario from typing an address.
+ */
+const withMatchers = /* @__PURE__ */ configExtension(AutoLinkExtension, {
+  matchers: [autoLinkUrlMatcher],
+});
+
+function buildEditor(): LexicalEditorWithDispose {
+  const editor = buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [RichTextExtension, withMatchers],
+      name: '[root]',
+    }),
+  );
+  mountRoot(editor);
+  return editor;
+}
+
+/** Put a paragraph holding one automatic link into the document. */
+function addAutoLink(
+  editor: LexicalEditorWithDispose,
+  url = 'https://example.com',
+): void {
+  editor.update(
+    () => {
+      const paragraph = $createParagraphNode();
+      const link = $createAutoLinkNode(url);
+      link.append($createTextNode(url));
+      paragraph.append(link);
+      $getRoot().append(paragraph);
+    },
+    {discrete: true},
+  );
+}
+
+function $onlyLink(): ElementNode {
+  return $getRoot().getLastChild<ElementNode>()!.getFirstChild<ElementNode>()!;
+}
+
+describe('AutoLinkAnnounceExtension', () => {
+  test('announces a typed address becoming a link', () => {
+    using editor = buildEditor();
+    addAutoLink(editor);
+
+    expect(readLiveRegion()).toBe('Link');
+  });
+
+  test('announces a link being removed', () => {
+    using editor = buildEditor();
+    addAutoLink(editor);
+    clearLiveRegion();
+
+    editor.update(() => void $onlyLink().remove(), {discrete: true});
+
+    expect(readLiveRegion()).toBe('Link removed');
+  });
+
+  test('says how many links went when a selection takes several', () => {
+    using editor = buildEditor();
+    addAutoLink(editor, 'https://a.example');
+    addAutoLink(editor, 'https://b.example');
+    addAutoLink(editor, 'https://c.example');
+    clearLiveRegion();
+
+    editor.update(
+      () => {
+        for (const paragraph of $getRoot().getChildren<ElementNode>()) {
+          paragraph.remove();
+        }
+      },
+      {discrete: true},
+    );
+
+    expect(readLiveRegion()).toBe('3 links removed');
+  });
+
+  test('says how many links arrived when several appear at once', () => {
+    using editor = buildEditor();
+    clearLiveRegion();
+
+    // Two addresses on their own lines, arriving together as a paste would
+    // bring them. Side by side in one paragraph they would run together into a
+    // single address, which is a different thing entirely.
+    editor.update(
+      () => {
+        for (const url of ['https://a.example', 'https://b.example']) {
+          const paragraph = $createParagraphNode();
+          const link = $createAutoLinkNode(url);
+          link.append($createTextNode(url));
+          paragraph.append(link);
+          $getRoot().append(paragraph);
+        }
+      },
+      {discrete: true},
+    );
+
+    expect(readLiveRegion()).toBe('2 links');
+  });
+
+  test('stays silent when a link is rebuilt in place', () => {
+    using editor = buildEditor();
+    addAutoLink(editor);
+    clearLiveRegion();
+
+    // What every keystroke does while an address is still being typed: the old
+    // node is destroyed and a new one created in the same update. The link was
+    // already there, so there is nothing to report.
+    editor.update(
+      () => {
+        const replacement = $createAutoLinkNode('https://example.com/deeper');
+        replacement.append($createTextNode('https://example.com/deeper'));
+        $onlyLink().replace(replacement);
+      },
+      {discrete: true},
+    );
+
+    expect(readLiveRegion()).toBe('');
+  });
+
+  test('stays silent while typing inside a link', () => {
+    using editor = buildEditor();
+    addAutoLink(editor);
+    clearLiveRegion();
+
+    editor.update(() => void $onlyLink().append($createTextNode('/more')), {
+      discrete: true,
+    });
+
+    expect(readLiveRegion()).toBe('');
+  });
+
+  test('honours a configured message', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [
+          RichTextExtension,
+          withMatchers,
+          configExtension(AutoLinkAnnounceExtension, {created: 'Linked'}),
+        ],
+        name: '[root]',
+      }),
+    );
+    mountRoot(editor);
+
+    addAutoLink(editor);
+    expect(readLiveRegion()).toBe('Linked');
+  });
+
+  test('says nothing when disabled', () => {
+    using editor = buildEditor();
+    const {disabled} = getExtensionDependencyFromEditor(
+      editor,
+      AutoLinkAnnounceExtension,
+    ).output;
+
+    disabled.value = true;
+    addAutoLink(editor);
+    expect(readLiveRegion()).toBe('');
+
+    disabled.value = false;
+    addAutoLink(editor, 'https://second.example');
+    expect(readLiveRegion()).toBe('Link');
+  });
+
+  test('leaves an editor without automatic links alone', () => {
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [AriaLiveRegionExtension, RichTextExtension],
+        name: '[root]',
+      }),
+    );
+    mountRoot(editor);
+
+    editor.update(() => void $getRoot().append($createParagraphNode()), {
+      discrete: true,
+    });
+
+    expect(readLiveRegion()).toBe('');
+  });
+});

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -7,6 +7,10 @@
  */
 
 export {
+  AutoLinkAnnounceExtension,
+  type AutoLinkAnnounceExtensionConfig,
+} from './AutoLinkAnnounceExtension';
+export {
   type ClickableLinkConfig,
   ClickableLinkExtension,
   registerClickableLink,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,6 +945,9 @@ importers:
 
   packages/lexical-link:
     dependencies:
+      '@lexical/a11y':
+        specifier: workspace:*
+        version: link:../lexical-a11y
       '@lexical/extension':
         specifier: workspace:*
         version: link:../lexical-extension


### PR DESCRIPTION
## Description

### Why

Type a web address into the editor and it becomes a link on its own, partway
through typing it, at the moment the address first matches. There is no
shortcut or button behind it: typing the next character of the address is what
turns the text into a link. The characters themselves do not change — the same
text is simply a link now.

A sighted user sees it happen: the text turns blue and underlines itself. A
screen reader announces nothing at all. The user finishes the address and
carries on, with no idea their document now contains a link.

Removing one is equally quiet. Backspace until what is left no longer looks
like a web address and the link disappears, with nothing said. Delete a line
that had addresses in it and nothing says the links went with it.

`@lexical/a11y` already announces undo, redo and editable/read-only. This adds
the same for links the editor makes on its own.

### What

Announces automatic links through the editor's aria live region:

- typing an address turns it into a link → **"Link"**
- backspacing until it no longer looks like an address → **"Link removed"**
- deleting a selection that spans several → **"3 links removed"**
- pasting text holding several addresses → **"2 links"**

`AutoLinkAnnounceExtension` lives in `@lexical/link` beside `AutoLinkNode`, and
`AutoLinkExtension` depends on it, so an editor with automatic links announces
them without anyone opting in. `@lexical/link` gains a dependency on
`@lexical/a11y`; the dependency does not run the other way.

### Shape

`defineExtension` with `namedSignals` and `safeCast`, a config of message
strings plus a runtime `disabled` signal, gated from an `effect` so a disabled
announcer registers no listener at all. `%s` is substituted with the count, so
the strings stay translatable.

A creation paired with a destruction in the same update is not announced. Every
keystroke that extends an address rebuilds the link — the old node destroyed and
a new one created at once — so announcing every creation would say "Link" at
`www.example.c`, again at `o`, and again at `m`. Only a creation on its own is a
link that was not there a moment ago.

### What this does not announce

**Anything after the link appears.** Once the address has matched, everything
else typed is silent, including the rest of the address itself. The link is
announced once, when it appears, and not again while it grows.

**Where the link points.** The browser puts the address in the accessibility
tree, where a screen reader can read it on request, and the user has just typed
it in any case.

### Notes on scope

**Links made from the toolbar are not announced.** Ctrl+K and the unlink button
are things the user chose to do, through a dialog they filled in themselves, and
the outcome was known before confirming it. Nothing was done to them that they
did not ask for, which is the case this change covers. That case would belong
with `LinkExtension` rather than here.

**Bulk removals say how many went.** Deleting a selection takes every link
inside it in one edit, so this announces "3 links removed" rather than "Link
removed", which is what a single link and a dozen links would otherwise sound
like. Announcing once per link would mean three announcements for one keystroke,
and the live region only holds the last, so the count would be lost. It costs
two more config strings, `createdMany` and `destroyedMany`, in a message that
most of the time carries no number at all.

## Test plan

Nine cases in
`packages/lexical-link/src/__tests__/unit/AutoLinkAnnounceExtension.test.ts`,
including the silence cases — nothing otherwise prevents an announcement on
every keystroke, so that regression would be invisible.

### Before

With `AutoLinkAnnounceExtension` removed from `AutoLinkExtension.dependencies`:

```
$ npx vitest run --project unit packages/lexical-link/src/__tests__/unit/AutoLinkAnnounceExtension.test.ts

 × announces a typed address becoming a link 205ms
 × announces a link being removed 19ms
 × says how many links went when a selection takes several 15ms
 × says how many links arrived when several appear at once 15ms
 × says nothing when disabled 8ms

 Test Files  1 failed (1)
      Tests  5 failed | 4 passed (9)
```

### After

```
$ npx vitest run --project unit packages/lexical-link/src/__tests__/unit/AutoLinkAnnounceExtension.test.ts

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

The whole unit suite:

```
$ npx vitest run --project unit

 Test Files  251 passed (252)
      Tests  4220 passed | 1 skipped (4222)
```

`FastPathCrossParent.test.ts` timed out at the 5s limit during that run and
passes on its own; it is a fuzz test over 100 seeds and the machine was loaded.

End to end against the dev server, in both editor modes. `AutoLinks.spec.mjs`
drives the node this listener watches, and `Markdown.spec.mjs` covers undo:

```
$ E2E_BROWSER=chromium E2E_EDITOR_MODE=rich-text npx playwright test \
    --project=chromium \
    packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs \
    packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs

  116 passed (1.8m)

$ E2E_BROWSER=chromium E2E_EDITOR_MODE=plain-text npx playwright test --project=chromium

  711 skipped
  136 passed (6.0m)
```

Not run on this machine: firefox and webkit, macOS, and anything needing a
production build.
