### PR TITLE
[lexical-table] Bug Fix: disconnect trackTable MutationObserver in removeListeners

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -308,6 +308,7 @@ export class TableObserver {
         this.table = getTable(tableNode, tableElement);
       });
     });
+    this.listenersToRemove.add(() => observer.disconnect());
     this.editor.read('latest', () => {
       const {tableNode, tableElement} = this.$lookup();
       this.table = getTable(tableNode, tableElement);

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableObserver.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableObserver.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {
+  $createTableNodeWithDimensions,
+  getTableObserverFromTableElement,
+  type HTMLTableElementWithWithTableSelectionState,
+  TableExtension,
+} from '@lexical/table';
+import {
+  $getRoot,
+  defineExtension,
+  type LexicalEditorWithDispose,
+} from 'lexical';
+import {afterEach, assert, beforeEach, describe, expect, it, vi} from 'vitest';
+
+interface TrackedObserver {
+  disconnectCount: number;
+  targets: Node[];
+}
+
+describe('TableObserver tracking MutationObserver teardown (#9073)', () => {
+  let editor: LexicalEditorWithDispose;
+  let container: HTMLDivElement;
+  let trackedObservers: TrackedObserver[];
+  let RealMutationObserver: typeof MutationObserver;
+
+  beforeEach(() => {
+    // Instrument MutationObserver so the test can see the observer that
+    // TableObserver.trackTable() creates (it is not otherwise reachable).
+    trackedObservers = [];
+    RealMutationObserver = globalThis.MutationObserver;
+    globalThis.MutationObserver = class extends RealMutationObserver {
+      tracked: TrackedObserver = {disconnectCount: 0, targets: []};
+      constructor(callback: MutationCallback) {
+        super(callback);
+        trackedObservers.push(this.tracked);
+      }
+      observe(target: Node, options?: MutationObserverInit) {
+        this.tracked.targets.push(target);
+        super.observe(target, options);
+      }
+      disconnect() {
+        this.tracked.disconnectCount++;
+        super.disconnect();
+      }
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [TableExtension],
+        name: 'table-observer-test',
+      }),
+    );
+    editor.setRootElement(container);
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createTableNodeWithDimensions(2, 2, false));
+      },
+      {discrete: true},
+    );
+  });
+
+  afterEach(() => {
+    editor.dispose();
+    document.body.removeChild(container);
+    globalThis.MutationObserver = RealMutationObserver;
+  });
+
+  function getTableElement(): HTMLTableElementWithWithTableSelectionState {
+    const tableElement = container.querySelector('table');
+    assert(tableElement !== null, 'Expected table element');
+    return tableElement as HTMLTableElementWithWithTableSelectionState;
+  }
+
+  function getTrackingObserver(
+    tableElement: HTMLTableElement,
+  ): TrackedObserver {
+    const tracking = trackedObservers.filter(tracked =>
+      tracked.targets.includes(tableElement),
+    );
+    expect(tracking.length).toBe(1);
+    return tracking[0];
+  }
+
+  it('disconnects the tracking MutationObserver in removeListeners()', () => {
+    const tableElement = getTableElement();
+    const trackingObserver = getTrackingObserver(tableElement);
+    expect(trackingObserver.disconnectCount).toBe(0);
+
+    const tableObserver = getTableObserverFromTableElement(tableElement);
+    assert(tableObserver !== null, 'Expected TableObserver on table element');
+    tableObserver.removeListeners();
+
+    expect(trackingObserver.disconnectCount).toBe(1);
+  });
+
+  it('does not fire the tracking MutationObserver for mutations of the detached table after editor teardown', async () => {
+    const tableElement = getTableElement();
+    const trackingObserver = getTrackingObserver(tableElement);
+
+    // Swallow errors reported from MutationObserver microtasks (they bypass
+    // editor onError) so a regression fails this test's assertions instead
+    // of crashing the run with an unhandled error.
+    const uncaughtErrors: string[] = [];
+    const onWindowError = (event: ErrorEvent) => {
+      uncaughtErrors.push(event.message);
+      event.preventDefault();
+    };
+    window.addEventListener('error', onWindowError);
+    try {
+      // Queue a mutation record in the same task as teardown; disconnect()
+      // must also clear the record queue so it is never delivered.
+      tableElement.classList.add('queued-before-teardown');
+      editor.dispose();
+      expect(trackingObserver.disconnectCount).toBe(1);
+
+      // The leaked-observer callback ran through editor.read(); after
+      // teardown it must not run at all.
+      const readSpy = vi.spyOn(editor, 'read');
+      tableElement.classList.add('mutated-after-teardown');
+      // Flush the MutationObserver microtask checkpoint.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(readSpy).not.toHaveBeenCalled();
+      expect(uncaughtErrors).toEqual([]);
+    } finally {
+      window.removeEventListener('error', onWindowError);
+    }
+  });
+});


### PR DESCRIPTION
## Description

`TableObserver.trackTable()` creates a `MutationObserver` on the table element (`attributes` + `childList` + `subtree`), but nothing ever calls `observer.disconnect()`. `removeListeners()` aborts the DOM event listeners and undoes the command registrations, but the tracking observer outlives the `TableObserver` and the editor itself. After teardown, any mutation of the detached `<table>` subtree fires the leaked observer, whose callback calls `$getTableAndElementByKey()` and throws invariant #232 (`TableObserver: Expected to find TableElement in DOM for key %s`) from a MutationObserver microtask — uncatchable by `onError` or React error boundaries. It also leaks one observer plus the retained table subtree per table per editor mount.

This change registers `observer.disconnect()` in `listenersToRemove`, so `removeListeners()` disconnects the tracking observer — mirroring what `resetEditor()` already does for the core mutation observer. `disconnect()` also empties the observer's record queue, which closes the race where records queued in the same task as teardown would still be delivered afterwards. No behavioral change while the editor is alive.

Closes #9073

## Test plan

Added `packages/lexical-table/src/__tests__/unit/LexicalTableObserver.test.ts` covering both that `removeListeners()` disconnects the tracking observer and that mutations of the detached table after editor teardown no longer fire it (including records queued in the same task as teardown).

### Before

`pnpm run test-unit packages/lexical-table/src/__tests__/unit/LexicalTableObserver.test.ts` (new tests against unmodified `LexicalTableObserver.ts`):

```
 ❯ |unit| packages/lexical-table/src/__tests__/unit/LexicalTableObserver.test.ts (2 tests | 2 failed) 134ms
     × disconnects the tracking MutationObserver in removeListeners() 116ms
     × does not fire the tracking MutationObserver for mutations of the detached table after editor teardown 17ms

 FAIL  |unit| ... > disconnects the tracking MutationObserver in removeListeners()
AssertionError: expected +0 to be 1 // Object.is equality
 Test Files  1 failed (1)
      Tests  2 failed (2)
```

### After

`pnpm run test-unit packages/lexical-table`:

```
 Test Files  13 passed (13)
      Tests  158 passed (158)
```

`pnpm run tsc`, `npx prettier --check` and `npx eslint` on the changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
