### PR TITLE
[lexical-list] Bug Fix: remove the stale depth theme class when a list changes depth

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -264,7 +264,7 @@ function $setListThemeClassNames(
       classesToAdd.push(...normalizeClassNames(listLevelClassName));
       for (let i = 0; i < listLevelsClassNames.length; i++) {
         if (i !== normalizedListDepth) {
-          classesToRemove.push(node.__tag + i);
+          classesToRemove.push(...normalizeClassNames(listLevelsClassNames[i]));
         }
       }
     }

--- a/packages/lexical-list/src/__tests__/unit/ListNodeDepthThemeClass.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListNodeDepthThemeClass.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createListItemNode,
+  $createListNode,
+  type ListNode,
+} from '@lexical/list';
+import {$createTextNode, $getRoot} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+describe('ListNode depth theme classes', () => {
+  initializeUnitTest(
+    testEnv => {
+      test('the previous depth class is removed when a list changes depth', async () => {
+        const {editor} = testEnv;
+        let listKey = '';
+
+        await editor.update(() => {
+          const list = $createListNode('bullet');
+          list.append($createListItemNode().append($createTextNode('a')));
+          $getRoot().append(list);
+          listKey = list.getKey();
+        });
+
+        expect(editor.getElementByKey(listKey)!.className).toBe(
+          'my-ul-list-class depth-1',
+        );
+
+        // Nest the existing list one level deeper. The DOM element is reused,
+        // so updateDOM() has to swap depth-1 for depth-2.
+        await editor.update(() => {
+          const list = $getRoot().getFirstChild() as ListNode;
+          const outer = $createListNode('bullet');
+          const listItem = $createListItemNode();
+          outer.append(listItem);
+          $getRoot().append(outer);
+          listItem.append(list);
+        });
+
+        expect(editor.getElementByKey(listKey)!.className).toBe(
+          'my-ul-list-class depth-2',
+        );
+      });
+    },
+    {
+      namespace: 'test',
+      theme: {
+        list: {
+          ul: 'my-ul-list-class',
+          ulDepth: ['depth-1', 'depth-2', 'depth-3'],
+        },
+      },
+    },
+  );
+});


### PR DESCRIPTION
## Description

`$setListThemeClassNames` picks the depth class for a list out of the theme's `ulDepth` / `olDepth` array, then tries to strip the depth classes belonging to the other levels:

```js
if (listLevelClassName !== undefined) {
  classesToAdd.push(...normalizeClassNames(listLevelClassName));
  for (let i = 0; i < listLevelsClassNames.length; i++) {
    if (i !== normalizedListDepth) {
      classesToRemove.push(node.__tag + i);
    }
  }
}
```

The removal list is built from `node.__tag + i`, i.e. the literal strings `"ul0"`, `"ul1"`, `"ol0"` and so on. Those are not the theme's class names, they're just the tag with an index glued on, so they are never present on the element and `removeClassNamesFromElement` does nothing.

That is invisible on a freshly created element, because `createDOM` starts from a clean class list. It shows up through `updateDOM`, which reuses the existing element: when a list changes depth the new depth class is added while the old one stays, and the element ends up with two conflicting depth classes. Since these classes exist to set `list-style-type` per level (see `packages/lexical-tailwind/src/index.ts`, where `ulDepth` maps to `list-disc` / `list-[circle]` / `list-[square]`), the list renders with whichever marker wins by CSS order rather than the one for its actual depth.

`$setListItemThemeClassNames` in `LexicalListItemNode.ts` does the equivalent removal correctly, pushing the real theme class names, so the two functions currently disagree.

## Fix

Push the actual theme class names, matching what the add path directly above already does:

```js
classesToRemove.push(...normalizeClassNames(listLevelsClassNames[i]));
```

`normalizeClassNames` is already imported in this file.

## Test plan

Added `packages/lexical-list/src/__tests__/unit/ListNodeDepthThemeClass.test.ts`. It builds a top level list, checks the element has the depth-1 class, then nests it one level deeper so the same element is updated in place, and checks the class list.

```
npx vitest --project unit --no-watch packages/lexical-list
```

On `main` the second assertion fails with:

```
expected 'my-ul-list-class depth-1 depth-2' to be 'my-ul-list-class depth-2'
```

With this change it passes, and the whole `lexical-list` unit suite is green (11 files, 126 tests).
