### PR TITLE
[lexical-utils] Bug Fix: objectKlassEquals throws on undefined and prototype-less objects

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
@@ -28,5 +28,14 @@ describe('LexicalUtilsKlassEqual tests', () => {
       expect(eventInstance instanceof MyEventShadow).toBeFalsy();
       expect(objectKlassEquals(eventInstance, MyEventShadow)).toBeTruthy();
     });
+    it('objectKlassEquals with a nullish or prototype-less value', async () => {
+      // The parameter is typed `unknown`, and the existing `!== null` guard
+      // shows nullish input is expected to be answered, not thrown on.
+      expect(objectKlassEquals(null, MyEvent)).toBe(false);
+      expect(objectKlassEquals(undefined, MyEvent)).toBe(false);
+      // Object.getPrototypeOf() returns null for these, so reading
+      // .constructor off it throws.
+      expect(objectKlassEquals(Object.create(null), MyEvent)).toBe(false);
+    });
   });
 });

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -848,9 +848,14 @@ export function objectKlassEquals<T>(
   object: unknown,
   objectClass: ObjectKlass<T>,
 ): object is T {
-  return object !== null
-    ? Object.getPrototypeOf(object).constructor.name === objectClass.name
-    : false;
+  if (object == null) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(object);
+  if (prototype == null || prototype.constructor == null) {
+    return false;
+  }
+  return prototype.constructor.name === objectClass.name;
 }
 
 // Clipboard may contain files that we aren't allowed to read. While the event is arguably useless,


### PR DESCRIPTION
## Description

`objectKlassEquals` takes `object: unknown` and returns a type predicate:

```js
export function objectKlassEquals<T>(object: unknown, objectClass: ObjectKlass<T>): object is T {
  return object !== null
    ? Object.getPrototypeOf(object).constructor.name === objectClass.name
    : false;
}
```

The guard only excludes `null`, so two ordinary values that its own `unknown` parameter type permits make it throw instead of returning an answer:

- `objectKlassEquals(undefined, SomeClass)` throws `TypeError: Cannot convert undefined or null to object` from `Object.getPrototypeOf`.
- `objectKlassEquals(Object.create(null), SomeClass)` throws too: `Object.getPrototypeOf` returns `null` for a prototype-less object and `.constructor` is then read off `null`.

The existing `!== null` branch shows the intent was to answer `false` for nullish input rather than throw; it just covers half of it. A predicate function that throws on part of its declared input domain is awkward for callers, since `objectKlassEquals(x, Foo)` cannot be used to narrow an `unknown` without a separate nullish check first.

## Fix

Return `false` for any nullish input, and for a value whose prototype chain does not yield a constructor, instead of letting either case throw. The behaviour for every value that already worked is unchanged.

The repo's `@lexical/internal/no-optional-chaining` rule rules out the one-liner, so this is written with explicit early returns.

## Test plan

Extended the existing `packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts` rather than adding a new file, since it already covers this function:

```
npx vitest --project unit --no-watch packages/lexical-utils
```

On `main` the new case fails with `TypeError: Cannot convert undefined or null to object` at `objectKlassEquals`. With this change it passes, and the `lexical-utils` suite is green (15 files, 226 tests).

I also ran the suites for the packages that call this helper (`lexical-clipboard`, `lexical-html`, `lexical-rich-text`) to confirm nothing depended on the old behaviour: 31 files, 259 tests, all passing. `prettier` and `eslint` are clean.
