### PR TITLE
[lexical-link] Bug Fix: read the latest state in LinkNode and AutoLinkNode getters

### DIFF
--- a/packages/lexical-link/src/LexicalLinkNode.ts
+++ b/packages/lexical-link/src/LexicalLinkNode.ts
@@ -303,22 +303,21 @@ export class LinkNode extends ElementNode {
   }
 
   isEmailURI(): boolean {
-    return this.__url.startsWith('mailto:');
+    return this.getURL().startsWith('mailto:');
   }
 
   isWebSiteURI(): boolean {
-    return (
-      this.__url.startsWith('https://') || this.__url.startsWith('http://')
-    );
+    const url = this.getURL();
+    return url.startsWith('https://') || url.startsWith('http://');
   }
 
   shouldMergeAdjacentLink(otherLink: LinkNode): boolean {
     return (
       this.getType() === otherLink.getType() &&
-      this.__url === otherLink.__url &&
-      this.__target === otherLink.__target &&
-      this.__rel === otherLink.__rel &&
-      this.__title === otherLink.__title
+      this.getURL() === otherLink.getURL() &&
+      this.getTarget() === otherLink.getTarget() &&
+      this.getRel() === otherLink.getRel() &&
+      this.getTitle() === otherLink.getTitle()
     );
   }
 }
@@ -516,7 +515,7 @@ export class AutoLinkNode extends LinkNode {
   }
 
   getIsUnlinked(): boolean {
-    return this.__isUnlinked;
+    return this.getLatest().__isUnlinked;
   }
 
   setIsUnlinked(value: boolean): this {

--- a/packages/lexical-link/src/__tests__/unit/LinkNodeStaleState.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LinkNodeStaleState.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createAutoLinkNode,
+  $createLinkNode,
+  AutoLinkNode,
+  LinkNode,
+} from '@lexical/link';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+describe('LinkNode stale state readers', () => {
+  initializeUnitTest(
+    testEnv => {
+      test('isEmailURI and isWebSiteURI agree with getURL after setURL', async () => {
+        const {editor} = testEnv;
+        let link!: LinkNode;
+
+        await editor.update(() => {
+          link = $createLinkNode('https://lexical.dev/');
+          link.append($createTextNode('Hello'));
+          $getRoot().append($createParagraphNode().append(link));
+        });
+
+        await editor.update(() => {
+          // setURL() goes through getWritable(), which in a later update
+          // clones the node. `link` still points at the previous version, so
+          // any reader that skips getLatest() answers from stale state.
+          link.setURL('mailto:someone@example.com');
+
+          expect(link.getURL()).toBe('mailto:someone@example.com');
+          expect(link.isEmailURI()).toBe(true);
+          expect(link.isWebSiteURI()).toBe(false);
+        });
+      });
+
+      test('shouldMergeAdjacentLink compares the latest urls', async () => {
+        const {editor} = testEnv;
+        let first!: LinkNode;
+        let second!: LinkNode;
+
+        await editor.update(() => {
+          const paragraph = $createParagraphNode();
+          first = $createLinkNode('https://lexical.dev/');
+          second = $createLinkNode('https://lexical.dev/');
+          first.append($createTextNode('a'));
+          second.append($createTextNode('b'));
+          paragraph.append(first, second);
+          $getRoot().append(paragraph);
+        });
+
+        await editor.update(() => {
+          first.setURL('https://example.com/');
+
+          expect(first.getURL()).not.toBe(second.getURL());
+          expect(first.shouldMergeAdjacentLink(second)).toBe(false);
+        });
+      });
+
+      test('getIsUnlinked reflects the latest value', async () => {
+        const {editor} = testEnv;
+        let autoLink!: AutoLinkNode;
+
+        await editor.update(() => {
+          autoLink = $createAutoLinkNode('https://lexical.dev/');
+          autoLink.append($createTextNode('Hello'));
+          $getRoot().append($createParagraphNode().append(autoLink));
+        });
+
+        await editor.update(() => {
+          autoLink.setIsUnlinked(true);
+
+          expect(autoLink.getIsUnlinked()).toBe(true);
+        });
+      });
+    },
+    {nodes: [LinkNode, AutoLinkNode]},
+  );
+});


### PR DESCRIPTION
## Description

`LinkNode`'s four public accessors all read through `getLatest()`:

```js
getURL(): string { return this.getLatest().__url; }
getTarget(): null | string { return this.getLatest().__target; }
getRel(): null | string { return this.getLatest().__rel; }
getTitle(): null | string { return this.getLatest().__title; }
```

but four other readers on the same class read the fields off `this` directly:

```js
isEmailURI(): boolean { return this.__url.startsWith('mailto:'); }
isWebSiteURI(): boolean { return this.__url.startsWith('https://') || this.__url.startsWith('http://'); }
shouldMergeAdjacentLink(otherLink) {
  return this.getType() === otherLink.getType() &&
    this.__url === otherLink.__url && this.__target === otherLink.__target &&
    this.__rel === otherLink.__rel && this.__title === otherLink.__title;
}
```

plus `AutoLinkNode.getIsUnlinked()`, which returns `this.__isUnlinked`.

`setURL()` and friends go through `getWritable()`, which clones the node when it has not already been written to in the current update. A reference obtained in an earlier update therefore keeps pointing at the previous version, and these four readers answer from it while `getURL()` on the very same object answers from the latest one. So after `setURL('mailto:...')`, `getURL()` returns the mailto URL and `isEmailURI()` returns `false`.

This is reachable from library code, not just from user code holding a node across updates: `handleBadNeighbors` and `$linkNodeTransform` in `LexicalAutoLinkExtension.ts` call `shouldMergeAdjacentLink` and `getIsUnlinked` on nodes they hold while mutating them.

## Fix

Route these readers through the existing accessors, so the whole class agrees on which version it is reading:

- `isEmailURI` / `isWebSiteURI` use `this.getURL()`
- `shouldMergeAdjacentLink` compares `getURL()` / `getTarget()` / `getRel()` / `getTitle()` on both sides
- `AutoLinkNode.getIsUnlinked` uses `this.getLatest().__isUnlinked`, matching how `LinkNode`'s own getters are written

No behaviour changes for a node that has not been cloned, which is why the existing tests did not catch it.

## Test plan

Added `packages/lexical-link/src/__tests__/unit/LinkNodeStaleState.test.ts`. Each case creates the node in one `editor.update()` and mutates it in a second one, which is what makes `getWritable()` clone:

- after `setURL('mailto:...')`, `getURL()`, `isEmailURI()` and `isWebSiteURI()` must agree
- after changing one link's URL, `shouldMergeAdjacentLink` against its neighbour must be `false`
- after `setIsUnlinked(true)`, `getIsUnlinked()` must be `true`

```
npx vitest --project unit --no-watch packages/lexical-link
```

All three fail on `main` (e.g. `expected false to be true` for `getIsUnlinked`) and pass with this change. The `lexical-link` suite is green (8 files, 172 tests), and `lexical-markdown`, `lexical-html` and `lexical-clipboard` are green too (17 files, 547 tests). `prettier` and `eslint` are clean.
