### PR TITLE
[lexical-table] Bug Fix: disconnect the table MutationObserver with its listeners

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -308,6 +308,7 @@ export class TableObserver {
         this.table = getTable(tableNode, tableElement);
       });
     });
+    this.listenersToRemove.add(() => observer.disconnect());
     this.editor.read('latest', () => {
       const {tableNode, tableElement} = this.$lookup();
       this.table = getTable(tableNode, tableElement);

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelectionHelpers.test.ts
@@ -14,6 +14,8 @@ import {
   $isTableCellNode,
   $isTableNode,
   $isTableRowNode,
+  getTableElement,
+  getTableObserverFromTableElement,
   TableExtension,
 } from '@lexical/table';
 import {
@@ -367,6 +369,77 @@ describe('LexicalTableSelectionHelpers', () => {
       editor.dispatchCommand(DELETE_LINE_COMMAND, false);
       expect(propagated).toBe(true);
       unregister();
+    });
+  });
+
+  describe('regression #9073', () => {
+    let editor: LexicalEditorWithDispose;
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      editor = buildEditorFromExtensions(
+        defineExtension({
+          dependencies: [TableExtension],
+          name: 'regression-9073-test',
+          theme: {tableScrollableWrapper: ''},
+        }),
+      );
+      editor.setRootElement(container);
+    });
+
+    afterEach(() => {
+      editor.dispose();
+      document.body.removeChild(container);
+    });
+
+    test('the table MutationObserver is disconnected by removeListeners', async () => {
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createTableNodeWithDimensions(2, 2, false));
+        },
+        {discrete: true},
+      );
+
+      const tableElement = editor.read(() => {
+        const tableNode = $assertNodeType(
+          $getRoot().getLastChild(),
+          $isTableNode,
+        );
+        return getTableElement(
+          tableNode,
+          editor.getElementByKey(tableNode.getKey()),
+        );
+      });
+      if (tableElement === null) {
+        throw new Error('Expected the table to be mounted');
+      }
+      const tableObserver = getTableObserverFromTableElement(tableElement);
+      if (tableObserver === null) {
+        throw new Error('Expected a TableObserver for the table');
+      }
+
+      let lookups = 0;
+      const $lookup = tableObserver.$lookup.bind(tableObserver);
+      tableObserver.$lookup = () => {
+        lookups++;
+        return $lookup();
+      };
+
+      tableObserver.removeListeners();
+
+      // A detached table can still be mutated after teardown -- a framework
+      // cleanup removing a class, say. The MutationObserver must be
+      // disconnected by then, or its callback runs against an editor that no
+      // longer has the element mapped and throws from a microtask, where
+      // neither onError nor an error boundary can catch it.
+      tableElement.classList.add('after-teardown');
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(lookups).toBe(0);
     });
   });
 });


### PR DESCRIPTION
Closes #9073.

`TableObserver.trackTable()` creates a `MutationObserver` on the table element but nothing ever disconnects it. `removeListeners()` aborts the DOM event listeners and undoes the command registrations, so the observer outlives both the `TableObserver` and the editor.

After teardown, `setRootElement(null)` has cleared `_keyToDOMMap` while the editor state still contains the table node. Any later mutation of the detached `<table>` subtree fires the leaked observer, whose callback reaches `$lookup()` -> `$getTableAndElementByKey()`, where `editor.getElementByKey(tableNodeKey)` is now `null`, and throws invariant #232. Because that happens in a MutationObserver microtask, neither the editor `onError` nor a React error boundary can catch it, so it surfaces as an uncaught `window.onerror`.

The observer is registered in `listenersToRemove`, which `removeListeners()` already drains, so this needs no new field and no new teardown path.

## Test

`regression #9073` in `LexicalTableSelectionHelpers.test.ts` tears the observer down, then mutates the table element and asserts the observer's callback did not run. It fails on `main` (`expected 1 to be +0`) and passes with the fix.

Note that the mutation has to be an attribute change rather than an inserted row: the reconciler reverts foreign structural changes to the table, so a `<tr>` injected by the test is undone before the assertion and the test can never fail.
