### PR TITLE
[lexical-list] Feature: opt-in Word list paste overlay

### DIFF
--- a/dev-examples/dom-import/README.md
+++ b/dev-examples/dom-import/README.md
@@ -23,14 +23,16 @@ all the configuration the pipeline needs —
   paste consolidation preprocess).
 - **Markdown shortcuts** — type `# `, `* `, `1. `, `> `, ``` ``` ```, etc.
   to convert on the fly.
-- **MS Word paste** — a preprocess detects the
+- **MS Word paste** — `$installWordListPasteOverlay` from
+  `@lexical/list` detects the
   `<meta name="Generator" content="Microsoft Word…">` tag and pushes
   a Word-specific overlay onto `ImportOverlays`. The overlay groups
   flat `<p class="MsoListParagraph*">` runs into proper nested
   `ListNode` trees. Pastes from other sources pay nothing for Word
-  handling. See [`src/wordPaste.ts`](src/wordPaste.ts) for the rule
-  and preprocess; [`src/fixtures/word.html`](src/fixtures/word.html)
-  is the bundled clipboard payload the dialog uses to demo it.
+  handling. It is opt-in — `ListExtension` does not install it, so
+  `App.tsx` adds it through the `DOMImportExtension` config.
+  [`src/fixtures/word.html`](src/fixtures/word.html) is the bundled
+  clipboard payload the dialog uses to demo it.
 - **VS Code paste** — a preprocess shipped by `@lexical/code-core`
   detects either browser's VS Code paste shape (Chrome's outer
   monospace+pre wrapper, Safari's flat sibling run) and pushes a

--- a/dev-examples/dom-import/src/App.tsx
+++ b/dev-examples/dom-import/src/App.tsx
@@ -15,12 +15,11 @@ import {
   TabIndentationExtension,
 } from '@lexical/extension';
 import {HistoryExtension} from '@lexical/history';
-import {DOMImportExtension} from '@lexical/html';
 import {LinkExtension} from '@lexical/link';
 import {
-  $installWordListPasteOverlay,
   CheckListExtension,
   ListExtension,
+  WordListImportExtension,
 } from '@lexical/list';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
@@ -59,9 +58,7 @@ const editorExtension = defineExtension({
     ToolbarExtension,
     // Word list handling is opt-in: the preprocess installs the
     // overlay only when the paste carries Word's Generator meta tag.
-    configExtension(DOMImportExtension, {
-      preprocess: [$installWordListPasteOverlay],
-    }),
+    WordListImportExtension,
     // Route real `text/html` pastes through the DOMImportExtension
     // pipeline so the rules / overlays above actually fire on pastes,
     // not just on the "Import HTML" dialog.

--- a/dev-examples/dom-import/src/App.tsx
+++ b/dev-examples/dom-import/src/App.tsx
@@ -15,8 +15,13 @@ import {
   TabIndentationExtension,
 } from '@lexical/extension';
 import {HistoryExtension} from '@lexical/history';
+import {DOMImportExtension} from '@lexical/html';
 import {LinkExtension} from '@lexical/link';
-import {CheckListExtension, ListExtension} from '@lexical/list';
+import {
+  $installWordListPasteOverlay,
+  CheckListExtension,
+  ListExtension,
+} from '@lexical/list';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
 import {RichTextExtension} from '@lexical/rich-text';
@@ -27,7 +32,6 @@ import ExampleTheme from './ExampleTheme';
 import {ImportHtmlButton} from './ImportHtmlDialog';
 import {MarkdownShortcutsExtension} from './MarkdownShortcutsExtension';
 import {Toolbar, ToolbarExtension} from './ToolbarExtension';
-import {WordPasteExtension} from './wordPaste';
 
 const placeholder =
   'Try pasting from Word, GitHub, a webpage, or click "Import HTML"…';
@@ -53,8 +57,11 @@ const editorExtension = defineExtension({
     CodeShikiExtension,
     MarkdownShortcutsExtension,
     ToolbarExtension,
-    // Word-only overlay, installed conditionally by a preprocess.
-    WordPasteExtension,
+    // Word list handling is opt-in: the preprocess installs the
+    // overlay only when the paste carries Word's Generator meta tag.
+    configExtension(DOMImportExtension, {
+      preprocess: [$installWordListPasteOverlay],
+    }),
     // Route real `text/html` pastes through the DOMImportExtension
     // pipeline so the rules / overlays above actually fire on pastes,
     // not just on the "Import HTML" dialog.

--- a/packages/lexical-list/src/WordListImportExtension.ts
+++ b/packages/lexical-list/src/WordListImportExtension.ts
@@ -6,36 +6,36 @@
  *
  */
 
-import {configExtension} from '@lexical/extension';
 import {
   createImportState,
   defineImportRule,
   defineOverlayRules,
   type DOMImportContext,
-  DOMImportExtension,
   type DOMPreprocessFn,
   ImportOverlays,
   InlineSchema,
   sel,
 } from '@lexical/html';
-import {
-  $createListItemNode,
-  $createListNode,
-  type ListNode,
-} from '@lexical/list';
-import {defineExtension, getStyleObjectFromCSS, isHTMLElement} from 'lexical';
+import {getStyleObjectFromCSS, isHTMLElement} from 'lexical';
+
+import {$createListItemNode} from './LexicalListItemNode';
+import {$createListNode, type ListNode} from './LexicalListNode';
 
 const WORD_LIST_CLASS_RE = /^MsoListParagraph(CxSp(First|Middle|Last))?$/;
 const WORD_NUMBERED_RE = /^[A-Za-z0-9]+[.)]/;
 const WORD_GENERATOR_RE = /Microsoft Word/i;
 
-// The default `$inlineStylesFromStyleSheets` preprocess mutates each
-// element's inline style through CSSStyleDeclaration.setProperty, which
-// makes JSDOM (and real browsers) re-serialize the style attribute and
-// drop unknown properties like `mso-list`. The Word preprocess runs
-// FIRST (it's appended to the stack so it's on top), so it stashes
-// `mso-list` onto a `data-*` attribute that survives the later
-// stylesheet-inlining pass.
+/**
+ * `mso-list` is a Microsoft non-standard CSS property, so neither
+ * browsers nor JSDOM surface it through `el.style`. Worse, the default
+ * `$inlineStylesFromStyleSheets` preprocess writes each element's
+ * inline style through `CSSStyleDeclaration.setProperty`, which
+ * re-serializes the `style` attribute and drops the unknown property
+ * altogether. {@link $installWordListPasteOverlay} runs first (it is
+ * pushed onto the preprocess stack, so it sits on top) and snapshots
+ * `mso-list` onto this `data-*` attribute, which survives the later
+ * stylesheet-inlining pass.
+ */
 const MSO_LIST_DATA_ATTR = 'data-mso-list';
 
 function readMsoListAttr(el: Element): string {
@@ -47,11 +47,12 @@ function readMsoListAttr(el: Element): string {
 }
 
 function readWordListLevel(el: HTMLElement): number {
+  // mso-list looks like "l<N> level<M> lfo<X>"; pluck the level number.
   const m = readMsoListAttr(el).match(/level(\d+)/);
   return m ? parseInt(m[1], 10) : 1;
 }
 
-function $findMarkerSpan(el: HTMLElement): HTMLElement | null {
+function findMarkerSpan(el: HTMLElement): HTMLElement | null {
   for (const span of Array.from(el.querySelectorAll('span'))) {
     if (readMsoListAttr(span) === 'Ignore') {
       return span;
@@ -60,8 +61,8 @@ function $findMarkerSpan(el: HTMLElement): HTMLElement | null {
   return null;
 }
 
-function $readWordMarker(el: HTMLElement): string {
-  const span = $findMarkerSpan(el);
+function readWordMarker(el: HTMLElement): string {
+  const span = findMarkerSpan(el);
   return span ? (span.textContent || '').trim() : '';
 }
 
@@ -69,10 +70,10 @@ function classifyWordListType(marker: string): 'number' | 'bullet' {
   return WORD_NUMBERED_RE.test(marker) ? 'number' : 'bullet';
 }
 
-function $stripWordMarker(el: HTMLElement): void {
+function stripWordMarker(el: HTMLElement): void {
   // The marker span is wrapped in an outer <span> directly under the
   // <p>; remove that outer wrapper.
-  const inner = $findMarkerSpan(el);
+  const inner = findMarkerSpan(el);
   if (!inner) {
     return;
   }
@@ -109,21 +110,23 @@ function $buildWordListTree(
       stack.pop();
     }
     if (item.level > stack[stack.length - 1].level) {
-      // Lexical's nested-list convention (see `$isNestedListNode` in
-      // @lexical/list): a sublist lives inside its OWN ListItemNode
-      // wrapper that is a sibling of the items above it, not inside
-      // the previous content item. The wrapper has no own content,
-      // just the sublist as its first child.
+      // Lexical's nested-list convention (see `$isNestedListNode`): a
+      // sublist lives inside its OWN ListItemNode wrapper that is a
+      // sibling of the items above it, not inside the previous content
+      // item. The wrapper has no own content, just the sublist as its
+      // first child.
       const sub = $createListNode(classifyWordListType(item.marker));
-      const wrapper = $createListItemNode();
-      wrapper.append(sub);
-      stack[stack.length - 1].list.append(wrapper);
+      stack[stack.length - 1].list.append($createListItemNode().append(sub));
       stack.push({level: item.level, list: sub});
     }
-    $stripWordMarker(item.el);
-    const li = $createListItemNode();
-    li.splice(0, 0, ctx.$importChildren(item.el, {schema: InlineSchema}));
-    stack[stack.length - 1].list.append(li);
+    stripWordMarker(item.el);
+    stack[stack.length - 1].list.append(
+      $createListItemNode().splice(
+        0,
+        0,
+        ctx.$importChildren(item.el, {schema: InlineSchema}),
+      ),
+    );
   }
   return root;
 }
@@ -132,17 +135,17 @@ function $buildWordListTree(
  * Per-import session WeakSet tracking `<p class="MsoListParagraph*">`
  * elements already absorbed by an earlier sibling's list-construction
  * pass, so the framework's normal child iteration treats them as
- * no-ops. The state's default is `null`; the rule lazily initializes
- * a fresh WeakSet into the session on first use, since
- * `createImportState`'s default factory is called once at state
- * creation and the result is shared (see ImportContext.ts).
+ * no-ops. The default is `null` and the rule lazily installs a fresh
+ * WeakSet per session, because `createImportState`'s default factory
+ * runs once at state creation and its result is shared across sessions.
  */
-const WordListConsumed = createImportState<WeakSet<Element> | null>(
-  'word/consumed-list-items',
-  () => null,
-);
+const WordListConsumed =
+  /* @__PURE__ */ createImportState<WeakSet<Element> | null>(
+    '@lexical/list/word-consumed-list-items',
+    () => null,
+  );
 
-const WordListParagraphRule = defineImportRule({
+const WordListParagraphRule = /* @__PURE__ */ defineImportRule({
   $import: (ctx, el) => {
     let consumed = ctx.session.get(WordListConsumed);
     if (consumed === null) {
@@ -159,8 +162,9 @@ const WordListParagraphRule = defineImportRule({
       items.push({
         el: cur,
         level: readWordListLevel(cur),
-        marker: $readWordMarker(cur),
+        marker: readWordMarker(cur),
       });
+      // MsoListParagraph (no CxSp suffix) is a single-item run.
       if (
         cur.classList.contains('MsoListParagraphCxSpLast') ||
         cur.className === 'MsoListParagraph'
@@ -171,7 +175,7 @@ const WordListParagraphRule = defineImportRule({
     }
     return [$buildWordListTree(ctx, items)];
   },
-  match: sel
+  match: /* @__PURE__ */ sel
     .tag('p')
     .classAny(
       'MsoListParagraph',
@@ -179,27 +183,63 @@ const WordListParagraphRule = defineImportRule({
       'MsoListParagraphCxSpMiddle',
       'MsoListParagraphCxSpLast',
     ),
-  name: 'word/list-paragraph',
+  name: '@lexical/list/word-list-paragraph',
 });
 
-// <o:p> is Office's "paragraph end" marker; always produces nothing.
-const WordOPRule = defineImportRule({
+// <o:p> is Office's "paragraph end" marker, emitted inside every Word
+// paragraph including the list ones; it always produces nothing.
+const WordOfficeParagraphRule = /* @__PURE__ */ defineImportRule({
   $import: () => [],
-  match: sel.tag('o:p'),
-  name: 'word/o-p',
+  match: /* @__PURE__ */ sel.tag('o:p'),
+  name: '@lexical/list/word-o-p',
 });
 
-const WordPasteOverlay = defineOverlayRules([
-  WordOPRule,
+const WordListPasteOverlay = /* @__PURE__ */ defineOverlayRules([
+  WordOfficeParagraphRule,
   WordListParagraphRule,
 ]);
 
-const $installWordOverlay: DOMPreprocessFn = (dom, ctx, $next) => {
+/**
+ * MS Word pastes have no `<ol>`/`<ul>`/`<li>` at all: a list is a flat
+ * run of `<p class="MsoListParagraph*">` siblings whose marker ("1.",
+ * "·", "a)") lives in a nested `<span style="mso-list:Ignore">`, with
+ * `style="mso-list:l<N> level<M> lfo<X>"` on the paragraph naming the
+ * list and its nesting depth.
+ *
+ * This preprocess looks once for
+ * `<meta name="Generator" content="Microsoft Word…">` and, only when it
+ * matches, snapshots the `mso-list` declarations (see
+ * {@link MSO_LIST_DATA_ATTR}) and pushes a Word-specific overlay onto
+ * {@link ImportOverlays}. The overlay's rule walks forward through
+ * siblings to collect a complete run and rebuilds it as a nested
+ * {@link ListNode} tree. Pastes from other sources pay only the
+ * detection cost.
+ *
+ * Opt in through the `DOMImportExtension` config — {@link ListExtension}
+ * does not install it, so an editor that never pastes from Word does not
+ * bundle it:
+ *
+ * ```ts
+ * defineExtension({
+ *   dependencies: [
+ *     ListExtension,
+ *     configExtension(DOMImportExtension, {
+ *       preprocess: [$installWordListPasteOverlay],
+ *     }),
+ *   ],
+ *   name: 'my-editor',
+ * });
+ * ```
+ *
+ * @experimental
+ */
+export const $installWordListPasteOverlay: DOMPreprocessFn = (
+  dom,
+  ctx,
+  $next,
+) => {
   const meta = dom.querySelector('meta[name="Generator"]');
   if (meta && WORD_GENERATOR_RE.test(meta.getAttribute('content') || '')) {
-    // Snapshot `mso-list` onto data-mso-list before the later
-    // stylesheet-inlining preprocess re-serializes the style attribute
-    // and drops unknown CSS properties.
     for (const el of Array.from(dom.querySelectorAll('[style*="mso-list"]'))) {
       const msoList = getStyleObjectFromCSS(el.getAttribute('style') || '')[
         'mso-list'
@@ -208,22 +248,7 @@ const $installWordOverlay: DOMPreprocessFn = (dom, ctx, $next) => {
         el.setAttribute(MSO_LIST_DATA_ATTR, msoList);
       }
     }
-    ctx.session.update(ImportOverlays, prev => [...prev, WordPasteOverlay]);
+    ctx.session.update(ImportOverlays, prev => [...prev, WordListPasteOverlay]);
   }
   $next();
 };
-
-/**
- * Extension that registers a DOM preprocess hook: if the input
- * carries `<meta name="Generator" content="Microsoft Word…">`, push a
- * Word-specific overlay onto {@link ImportOverlays} so the rest of the
- * walk picks it up. Pastes from other sources pay nothing.
- */
-export const WordPasteExtension = defineExtension({
-  dependencies: [
-    configExtension(DOMImportExtension, {
-      preprocess: [$installWordOverlay],
-    }),
-  ],
-  name: '@lexical/examples/word-paste',
-});

--- a/packages/lexical-list/src/WordListImportExtension.ts
+++ b/packages/lexical-list/src/WordListImportExtension.ts
@@ -38,27 +38,14 @@ const WORD_GENERATOR_RE = /Microsoft Word/i;
  */
 const MSO_LIST_DATA_ATTR = 'data-mso-list';
 
-function readMsoListAttr(el: Element): string {
-  return (
-    el.getAttribute(MSO_LIST_DATA_ATTR) ||
-    getStyleObjectFromCSS(el.getAttribute('style') || '')['mso-list'] ||
-    ''
-  );
-}
-
 function readWordListLevel(el: HTMLElement): number {
   // mso-list looks like "l<N> level<M> lfo<X>"; pluck the level number.
-  const m = readMsoListAttr(el).match(/level(\d+)/);
+  const m = (el.getAttribute(MSO_LIST_DATA_ATTR) || '').match(/level(\d+)/);
   return m ? parseInt(m[1], 10) : 1;
 }
 
-function findMarkerSpan(el: HTMLElement): HTMLElement | null {
-  for (const span of Array.from(el.querySelectorAll('span'))) {
-    if (readMsoListAttr(span) === 'Ignore') {
-      return span;
-    }
-  }
-  return null;
+function findMarkerSpan(el: HTMLElement): Element | null {
+  return el.querySelector(`span[${MSO_LIST_DATA_ATTR}="Ignore"]`);
 }
 
 function readWordMarker(el: HTMLElement): string {

--- a/packages/lexical-list/src/WordListImportExtension.ts
+++ b/packages/lexical-list/src/WordListImportExtension.ts
@@ -11,13 +11,20 @@ import {
   defineImportRule,
   defineOverlayRules,
   type DOMImportContext,
+  DOMImportExtension,
   type DOMPreprocessFn,
   ImportOverlays,
   InlineSchema,
   sel,
 } from '@lexical/html';
-import {getStyleObjectFromCSS, isHTMLElement} from 'lexical';
+import {
+  configExtension,
+  defineExtension,
+  getStyleObjectFromCSS,
+  isHTMLElement,
+} from 'lexical';
 
+import {ListExtension} from './LexicalListExtension';
 import {$createListItemNode} from './LexicalListItemNode';
 import {$createListNode, type ListNode} from './LexicalListNode';
 
@@ -202,29 +209,9 @@ const WordListPasteOverlay = /* @__PURE__ */ defineOverlayRules([
  * {@link ListNode} tree. Pastes from other sources pay only the
  * detection cost.
  *
- * Opt in through the `DOMImportExtension` config — {@link ListExtension}
- * does not install it, so an editor that never pastes from Word does not
- * bundle it:
- *
- * ```ts
- * defineExtension({
- *   dependencies: [
- *     ListExtension,
- *     configExtension(DOMImportExtension, {
- *       preprocess: [$installWordListPasteOverlay],
- *     }),
- *   ],
- *   name: 'my-editor',
- * });
- * ```
- *
- * @experimental
+ * Installed by {@link WordListImportExtension}.
  */
-export const $installWordListPasteOverlay: DOMPreprocessFn = (
-  dom,
-  ctx,
-  $next,
-) => {
+const $installWordListPasteOverlay: DOMPreprocessFn = (dom, ctx, $next) => {
   const meta = dom.querySelector('meta[name="Generator"]');
   if (meta && WORD_GENERATOR_RE.test(meta.getAttribute('content') || '')) {
     for (const el of Array.from(dom.querySelectorAll('[style*="mso-list"]'))) {
@@ -239,3 +226,28 @@ export const $installWordListPasteOverlay: DOMPreprocessFn = (
   }
   $next();
 };
+
+/**
+ * Word list paste support for {@link ListNode}: opt in by adding this to
+ * an editor's dependencies. {@link ListExtension} does not depend on it,
+ * so an editor that never pastes from Word does not bundle any of it.
+ *
+ * ```ts
+ * defineExtension({
+ *   dependencies: [WordListImportExtension],
+ *   name: 'my-editor',
+ * });
+ * ```
+ *
+ * @experimental
+ */
+export const WordListImportExtension = /* @__PURE__ */ defineExtension({
+  dependencies: [
+    // The overlay builds ListNodes, so the nodes have to be registered.
+    ListExtension,
+    /* @__PURE__ */ configExtension(DOMImportExtension, {
+      preprocess: [$installWordListPasteOverlay],
+    }),
+  ],
+  name: '@lexical/list/WordListImport',
+});

--- a/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
@@ -12,20 +12,9 @@ import {
   getExtensionDependencyFromEditor,
   HorizontalRuleExtension,
 } from '@lexical/extension';
+import {DOMImportExtension} from '@lexical/html';
 import {
-  createImportState,
-  defineImportRule,
-  defineOverlayRules,
-  type DOMImportContext,
-  DOMImportExtension,
-  type DOMPreprocessFn,
-  ImportOverlays,
-  InlineSchema,
-  sel,
-} from '@lexical/html';
-import {
-  $createListItemNode,
-  $createListNode,
+  $installWordListPasteOverlay,
   $isListItemNode,
   $isListNode,
   ListExtension,
@@ -38,8 +27,6 @@ import {
   $getEditor,
   $getRoot,
   defineExtension,
-  getStyleObjectFromCSS,
-  isHTMLElement,
   type LexicalEditor,
   type LexicalNode,
 } from 'lexical';
@@ -167,7 +154,7 @@ describe('ListImportExtension', () => {
 });
 
 // ----------------------------------------------------------------------------
-// Word paste example
+// MS Word paste
 //
 // MS Word produces HTML where "lists" are actually flat runs of
 // <p class="MsoListParagraph*"> with a marker like "1." or "·" inside a
@@ -175,169 +162,12 @@ describe('ListImportExtension', () => {
 // or <li> elements. The <p>'s carry style='mso-list:l<N> level<M> lfo<X>'
 // where <N> identifies the list and <M> the nesting depth.
 //
-// The trick is twofold:
-//   (1) The preprocess only installs the Word-paste overlay when the
-//       generator meta tag is present, so pastes from other sources pay
-//       nothing for Word handling.
-//   (2) The overlay rule walks forward through siblings to collect a
-//       complete list run, uses a session-tracked WeakSet to mark the
-//       siblings as consumed, and builds a nested list tree from the
-//       level transitions.
+// `$installWordListPasteOverlay` (shipped by this package, opt-in) is the
+// preprocess that handles this: it only installs the Word overlay when the
+// generator meta tag is present, so pastes from other sources pay nothing,
+// and the overlay's rule walks forward through siblings to collect a
+// complete list run and rebuild it as a nested list tree.
 // ----------------------------------------------------------------------------
-
-const WordListConsumed = createImportState<WeakSet<Element>>(
-  'word/consumed-list-items',
-  () => new WeakSet(),
-);
-
-const WORD_LIST_CLASS_RE = /^MsoListParagraph(CxSp(First|Middle|Last))?$/;
-const WORD_NUMBERED_RE = /^[A-Za-z0-9]+[.)]/;
-
-function readMsoStyles(el: Element): Record<string, string> {
-  // mso-* are Microsoft non-standard CSS properties; browsers and JSDOM
-  // don't surface them via el.style, so parse the raw style attribute.
-  return getStyleObjectFromCSS(el.getAttribute('style') || '');
-}
-
-function readWordListLevel(el: HTMLElement): number {
-  // mso-list looks like "l<N> level<M> lfo<X>"; pluck the level number.
-  const msoList = readMsoStyles(el)['mso-list'] || '';
-  const m = msoList.match(/level(\d+)/);
-  return m ? parseInt(m[1], 10) : 1;
-}
-
-function $findMarkerSpan(el: HTMLElement): HTMLElement | null {
-  for (const span of Array.from(el.querySelectorAll('span'))) {
-    if (readMsoStyles(span)['mso-list'] === 'Ignore') {
-      return span;
-    }
-  }
-  return null;
-}
-
-function $readWordMarker(el: HTMLElement): string {
-  const span = $findMarkerSpan(el);
-  return span ? (span.textContent || '').trim() : '';
-}
-
-function classifyWordListType(marker: string): 'number' | 'bullet' {
-  return WORD_NUMBERED_RE.test(marker) ? 'number' : 'bullet';
-}
-
-function $stripWordMarker(el: HTMLElement): void {
-  // The marker span is wrapped in an outer <span> directly under the
-  // <p>; remove that outer wrapper.
-  const inner = $findMarkerSpan(el);
-  if (!inner) {
-    return;
-  }
-  let outer: Element = inner;
-  while (
-    outer.parentElement &&
-    outer.parentElement !== el &&
-    outer.parentElement.nodeName === 'SPAN'
-  ) {
-    outer = outer.parentElement;
-  }
-  outer.remove();
-}
-
-function isWordListParagraph(node: Node): node is HTMLElement {
-  return isHTMLElement(node) && WORD_LIST_CLASS_RE.test(node.className);
-}
-
-function $buildWordListTree(
-  ctx: DOMImportContext,
-  items: readonly {el: HTMLElement; level: number; marker: string}[],
-): ListNode {
-  const root = $createListNode(classifyWordListType(items[0].marker));
-  type Frame = {list: ListNode; level: number};
-  const stack: Frame[] = [{level: items[0].level, list: root}];
-  for (const item of items) {
-    // Close levels deeper than this one.
-    while (stack.length > 1 && stack[stack.length - 1].level > item.level) {
-      stack.pop();
-    }
-    // Open a new sublist if we just stepped deeper. Lexical's
-    // nested-list convention (see `$isNestedListNode` in @lexical/list):
-    // a sublist lives inside its OWN ListItemNode wrapper that is a
-    // sibling of the content items above it, not inside the previous
-    // one. The wrapper holds the sublist as its first (and only) child.
-    if (item.level > stack[stack.length - 1].level) {
-      const sub = $createListNode(classifyWordListType(item.marker));
-      const wrapper = $createListItemNode();
-      wrapper.append(sub);
-      stack[stack.length - 1].list.append(wrapper);
-      stack.push({level: item.level, list: sub});
-    }
-    $stripWordMarker(item.el);
-    const li = $createListItemNode();
-    li.splice(0, 0, ctx.$importChildren(item.el, {schema: InlineSchema}));
-    stack[stack.length - 1].list.append(li);
-  }
-  return root;
-}
-
-const WordListParagraphRule = defineImportRule({
-  $import: (ctx, el) => {
-    const consumed = ctx.session.get(WordListConsumed);
-    if (consumed.has(el)) {
-      // Already collected by an earlier sibling's run.
-      return [];
-    }
-    const items: {el: HTMLElement; level: number; marker: string}[] = [];
-    let cur: Node | null = el;
-    while (cur && isWordListParagraph(cur)) {
-      consumed.add(cur);
-      items.push({
-        el: cur,
-        level: readWordListLevel(cur),
-        marker: $readWordMarker(cur),
-      });
-      // Stop at the explicitly-terminal class. The standalone
-      // MsoListParagraph (no CxSp suffix) is a single-item run.
-      if (
-        cur.classList.contains('MsoListParagraphCxSpLast') ||
-        cur.className === 'MsoListParagraph'
-      ) {
-        break;
-      }
-      cur = cur.nextElementSibling;
-    }
-    return [$buildWordListTree(ctx, items)];
-  },
-  match: sel
-    .tag('p')
-    .classAny(
-      'MsoListParagraph',
-      'MsoListParagraphCxSpFirst',
-      'MsoListParagraphCxSpMiddle',
-      'MsoListParagraphCxSpLast',
-    ),
-  name: 'word/list-paragraph',
-});
-
-// <o:p> is Office's "paragraph end" marker; it always produces nothing.
-const WordOPRule = defineImportRule({
-  $import: () => [],
-  match: sel.tag('o:p'),
-  name: 'word/o-p',
-});
-
-const WordPasteOverlay = defineOverlayRules([
-  WordOPRule,
-  WordListParagraphRule,
-]);
-
-const WORD_GENERATOR_RE = /Microsoft Word/i;
-
-const $installWordOverlay: DOMPreprocessFn = (dom, ctx, $next) => {
-  const meta = dom.querySelector('meta[name="Generator"]');
-  if (meta && WORD_GENERATOR_RE.test(meta.getAttribute('content') || '')) {
-    ctx.session.update(ImportOverlays, prev => [...prev, WordPasteOverlay]);
-  }
-  $next();
-};
 
 function buildWordPasteEditor() {
   return buildEditorFromExtensions(
@@ -345,7 +175,7 @@ function buildWordPasteEditor() {
       dependencies: [
         ListExtension,
         configExtension(DOMImportExtension, {
-          preprocess: [$installWordOverlay],
+          preprocess: [$installWordListPasteOverlay],
         }),
       ],
       name: 'word-paste-host',
@@ -462,6 +292,42 @@ describe('MS Word paste — preprocess-installed overlay', () => {
       const lastContent = outlineItems[2].getFirstChild();
       assert(lastContent !== null, 'expected last content child');
       expect(lastContent.getTextContent().trim()).toBe('Outline numbered 2');
+    });
+  });
+
+  test('survives the stylesheet-inlining preprocess', () => {
+    // Real Word output carries a <style> block, which makes the default
+    // `$inlineStylesFromStyleSheets` preprocess rewrite every element's
+    // style attribute through CSSStyleDeclaration and drop the unknown
+    // `mso-list` property. The overlay's preprocess runs first and
+    // snapshots `mso-list` onto data-mso-list precisely so the levels and
+    // markers still resolve afterwards; without that snapshot every item
+    // reads as level 1 with no marker and the nesting collapses.
+    using editor = buildWordPasteEditor();
+    importHTMLDocument(
+      editor,
+      WORD_HTML_WITH_LISTS.replace(
+        '</head>',
+        `<style>
+          p.MsoListParagraphCxSpFirst, p.MsoListParagraphCxSpMiddle,
+          p.MsoListParagraphCxSpLast, p.MsoListParagraph
+            {margin-top:0in; margin-left:.5in;}
+        </style></head>`,
+      ),
+    );
+    editor.read(() => {
+      const lists = $getRoot().getChildren().filter($isListNode);
+      expect(lists).toHaveLength(3);
+      expect(lists[0].getListType()).toBe('number');
+      expect(lists[1].getListType()).toBe('bullet');
+      const outlineItems = $items(lists[2]);
+      expect(outlineItems).toHaveLength(3);
+      const nested = outlineItems[1].getFirstChild();
+      assert($isListNode(nested), 'expected nested sublist on wrapper item');
+      expect($items(nested).map(li => li.getTextContent().trim())).toEqual([
+        'Outline numbered 1.a',
+        'Outline numbered 1.b',
+      ]);
     });
   });
 

--- a/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts
@@ -8,19 +8,18 @@
 
 import {
   buildEditorFromExtensions,
-  configExtension,
   getExtensionDependencyFromEditor,
   HorizontalRuleExtension,
 } from '@lexical/extension';
 import {DOMImportExtension} from '@lexical/html';
 import {
-  $installWordListPasteOverlay,
   $isListItemNode,
   $isListNode,
   ListExtension,
   ListImportExtension,
   type ListItemNode,
   type ListNode,
+  WordListImportExtension,
 } from '@lexical/list';
 import {JSDOM} from 'jsdom';
 import {
@@ -162,22 +161,17 @@ describe('ListImportExtension', () => {
 // or <li> elements. The <p>'s carry style='mso-list:l<N> level<M> lfo<X>'
 // where <N> identifies the list and <M> the nesting depth.
 //
-// `$installWordListPasteOverlay` (shipped by this package, opt-in) is the
-// preprocess that handles this: it only installs the Word overlay when the
-// generator meta tag is present, so pastes from other sources pay nothing,
-// and the overlay's rule walks forward through siblings to collect a
-// complete list run and rebuild it as a nested list tree.
+// `WordListImportExtension` (shipped by this package, opt-in) installs the
+// preprocess that handles this: the overlay goes on only when the generator
+// meta tag is present, so pastes from other sources pay nothing, and its
+// rule walks forward through siblings to collect a complete list run and
+// rebuild it as a nested list tree.
 // ----------------------------------------------------------------------------
 
 function buildWordPasteEditor() {
   return buildEditorFromExtensions(
     defineExtension({
-      dependencies: [
-        ListExtension,
-        configExtension(DOMImportExtension, {
-          preprocess: [$installWordListPasteOverlay],
-        }),
-      ],
+      dependencies: [WordListImportExtension],
       name: 'word-paste-host',
     }),
   );

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -45,6 +45,7 @@ export {
   REMOVE_LIST_COMMAND,
   UPDATE_LIST_START_COMMAND,
 } from './registerList';
+export {$installWordListPasteOverlay} from './WordListImportExtension';
 
 export {
   $createListItemNode,

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -45,7 +45,7 @@ export {
   REMOVE_LIST_COMMAND,
   UPDATE_LIST_START_COMMAND,
 } from './registerList';
-export {$installWordListPasteOverlay} from './WordListImportExtension';
+export {WordListImportExtension} from './WordListImportExtension';
 
 export {
   $createListItemNode,

--- a/packages/lexical-website/docs/serialization/dom-import.md
+++ b/packages/lexical-website/docs/serialization/dom-import.md
@@ -833,6 +833,27 @@ const $installWordOverlay: DOMPreprocessFn = (dom, ctx, $next) => {
 };
 ```
 
+That is the pattern, not something you have to write for Word lists
+specifically: `@lexical/list` ships this exact preprocess as
+`$installWordListPasteOverlay`. It is opt-in — `ListExtension` does not
+install it, so an editor that never pastes from Word does not bundle it:
+
+```ts
+import {DOMImportExtension} from '@lexical/html';
+import {$installWordListPasteOverlay, ListExtension} from '@lexical/list';
+import {configExtension, defineExtension} from 'lexical';
+
+defineExtension({
+  dependencies: [
+    ListExtension,
+    configExtension(DOMImportExtension, {
+      preprocess: [$installWordListPasteOverlay],
+    }),
+  ],
+  name: 'my-editor',
+});
+```
+
 See `packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts`
 ("MS Word paste — preprocess-installed overlay") for a worked unit
 test, and [`dev-examples/dom-import`](https://github.com/facebook/lexical/tree/main/dev-examples/dom-import)

--- a/packages/lexical-website/docs/serialization/dom-import.md
+++ b/packages/lexical-website/docs/serialization/dom-import.md
@@ -835,21 +835,15 @@ const $installWordOverlay: DOMPreprocessFn = (dom, ctx, $next) => {
 
 That is the pattern, not something you have to write for Word lists
 specifically: `@lexical/list` ships this exact preprocess as
-`$installWordListPasteOverlay`. It is opt-in — `ListExtension` does not
-install it, so an editor that never pastes from Word does not bundle it:
+`WordListImportExtension`. It is opt-in — `ListExtension` does not depend
+on it, so an editor that never pastes from Word does not bundle it:
 
 ```ts
-import {DOMImportExtension} from '@lexical/html';
-import {$installWordListPasteOverlay, ListExtension} from '@lexical/list';
-import {configExtension, defineExtension} from 'lexical';
+import {WordListImportExtension} from '@lexical/list';
+import {defineExtension} from 'lexical';
 
 defineExtension({
-  dependencies: [
-    ListExtension,
-    configExtension(DOMImportExtension, {
-      preprocess: [$installWordListPasteOverlay],
-    }),
-  ],
+  dependencies: [WordListImportExtension],
   name: 'my-editor',
 });
 ```


### PR DESCRIPTION
Closes #4922.

MS Word pastes have no `<ol>`/`<ul>`/`<li>` at all: a list is a flat run of `<p class="MsoListParagraph*">` siblings whose marker ("1.", "·", "a)") lives in a nested `<span style="mso-list:Ignore">`, with `style="mso-list:l<N> level<M> lfo<X>"` on the paragraph naming the list and its nesting depth. Nothing in the import pipeline reads that, so a pasted Word list arrives as a run of paragraphs.

Per @etrepum on #4922 ("If it can be opt-in and tree-shakeable in `@lexical/list` that should be fine"), this ships the handling as an opt-in extension. `ListExtension` does not depend on it, so an editor that never pastes from Word pays nothing:

```ts
defineExtension({
  dependencies: [WordListImportExtension],
  name: 'my-editor',
});
```

The preprocess looks once for `<meta name="Generator" content="Microsoft Word…">` and only then pushes the overlay onto `ImportOverlays`; the overlay's rule walks forward through siblings to collect a complete run and rebuilds it as a nested `ListNode` tree following the `$isNestedListNode` convention. Pastes from other sources pay only the detection cost.

The rules, the overlay, the import state and the extension are module-scope `/* @__PURE__ */` calls in a module of their own, so a bundle that never names `WordListImportExtension` drops all of it. The preprocess itself is module-private.

## Deduplication

The logic was already in the repo twice, in two versions that disagreed. Both are deleted and now use the shipped export:

- `dev-examples/dom-import/src/wordPaste.ts`
- the inline copy in `packages/lexical-list/src/__tests__/unit/ListImportExtension.test.ts`

Net −112 lines.

## The `data-mso-list` snapshot

The shipped version keeps the example's behaviour, which the test copy lacked. Real Word output carries a `<style>` block, so the default `$inlineStylesFromStyleSheets` preprocess rewrites every matched element's style attribute through `CSSStyleDeclaration.setProperty` — which re-serializes it and silently drops `mso-list`, a non-standard property. The overlay's preprocess runs first and snapshots `mso-list` onto `data-mso-list`, which survives that pass.

The test copy had no snapshot and its fixture had no `<style>` block, so nothing exercised it. `survives the stylesheet-inlining preprocess` closes that gap with realistic Word CSS: without the snapshot every item reads as level 1 and the nested outline collapses (3 top-level items become 4); with it, the tree is correct.

## Test plan

`pnpm run test-unit packages/lexical-list` — 126 passed. `tsc`, `flow`, `eslint` and `prettier --check` all clean.

The `<o:p>` rule (Office's paragraph-end marker, emitted inside every Word paragraph) rides along in the overlay since the list paragraphs contain them. Happy to drop it if it doesn't belong in `@lexical/list`.

The docs section in `serialization/dom-import.md` that hand-rolled this same overlay now points at the shipped extension.
