### PR TITLE
[lexical-html] Bug Fix: reject an empty selector group in parseSelector

### DIFF
--- a/packages/lexical-html/src/__tests__/unit/DOMImportExtension.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/DOMImportExtension.test.ts
@@ -433,6 +433,17 @@ describe('DOMImportExtension', () => {
     expect(importedTags('p, .foo, article')).toEqual(['p', 'div', 'article']);
   });
 
+  test('CSS parser rejects an empty selector or a hole in a selector list', () => {
+    for (const selector of ['', '   ', 'h1,', ',h1', 'h1,,h2', 'h1, ,h2']) {
+      expect(() => parseSelector(selector)).toThrow(/expected a selector/);
+    }
+    // A lone `*` is the one group that legitimately has neither tag nor
+    // refinement, so it and any list containing it still parse.
+    expect(() => parseSelector('*')).not.toThrow();
+    expect(() => parseSelector('h1, *')).not.toThrow();
+    expect(() => parseSelector('*.foo')).not.toThrow();
+  });
+
   test('isElementOfTag narrows correctly without instanceof', () => {
     const dom = new JSDOM(
       '<!doctype html><html><body><a href="x"></a><p></p></body></html>',

--- a/packages/lexical-html/src/import/parseCss.ts
+++ b/packages/lexical-html/src/import/parseCss.ts
@@ -79,18 +79,25 @@ class Cursor {
 interface ParsedSimpleSelector {
   readonly tags: Set<string>;
   readonly predicates: Predicate[];
+  /**
+   * True when the group came from an explicit `*`, which is the one way a
+   * group can legitimately end up with no tag and no refinement.
+   */
+  readonly isUniversal: boolean;
 }
 
 function parseSimpleSelector(c: Cursor): ParsedSimpleSelector {
   const tags = new Set<string>();
   const predicates: Predicate[] = [];
   const classes: string[] = [];
+  let isUniversal = false;
 
   c.skipWhitespace();
 
   // Optional tag or '*'
   if (c.peek() === '*') {
     c.consume();
+    isUniversal = true;
   } else if (IDENT_CHAR.test(c.peek())) {
     const tag = c.readIdent();
     if (tag) {
@@ -142,7 +149,7 @@ function parseSimpleSelector(c: Cursor): ParsedSimpleSelector {
     predicates.push(buildClassAllPredicate(classes));
   }
 
-  return {predicates, tags};
+  return {isUniversal, predicates, tags};
 }
 
 /**
@@ -169,11 +176,13 @@ export function parseSelector(
 
   while (true) {
     const group = parseSimpleSelector(c);
-    if (group.tags.size === 0 && group.predicates.length === 0) {
-      // Empty group with neither tag nor refinement — only OK if it came
-      // from the lone `*` (which produces zero tags but no preds either).
-      // We accept this as "wildcard element".
-    }
+    // A group with neither tag nor refinement is only legitimate when it came
+    // from a lone `*`. Otherwise the source is empty or has a hole in its list,
+    // and accepting it would silently turn a typo into a universal selector.
+    c.assert(
+      group.isUniversal || group.tags.size > 0 || group.predicates.length > 0,
+      'expected a selector',
+    );
     groups.push(group);
     c.skipWhitespace();
     if (c.eof()) {

--- a/packages/lexical-html/src/import/parseCss.ts
+++ b/packages/lexical-html/src/import/parseCss.ts
@@ -79,11 +79,6 @@ class Cursor {
 interface ParsedSimpleSelector {
   readonly tags: Set<string>;
   readonly predicates: Predicate[];
-  /**
-   * True when the group came from an explicit `*`, which is the one way a
-   * group can legitimately end up with no tag and no refinement.
-   */
-  readonly isUniversal: boolean;
 }
 
 function parseSimpleSelector(c: Cursor): ParsedSimpleSelector {
@@ -149,7 +144,15 @@ function parseSimpleSelector(c: Cursor): ParsedSimpleSelector {
     predicates.push(buildClassAllPredicate(classes));
   }
 
-  return {isUniversal, predicates, tags};
+  // Neither tag nor refinement is only legitimate when the group came from a
+  // lone `*`. Otherwise the source is empty or its list has a hole, and
+  // accepting it would silently turn a typo into a universal selector.
+  c.assert(
+    isUniversal || tags.size > 0 || predicates.length > 0,
+    'expected a selector',
+  );
+
+  return {predicates, tags};
 }
 
 /**
@@ -175,15 +178,7 @@ export function parseSelector(
   const groups: ParsedSimpleSelector[] = [];
 
   while (true) {
-    const group = parseSimpleSelector(c);
-    // A group with neither tag nor refinement is only legitimate when it came
-    // from a lone `*`. Otherwise the source is empty or has a hole in its list,
-    // and accepting it would silently turn a typo into a universal selector.
-    c.assert(
-      group.isUniversal || group.tags.size > 0 || group.predicates.length > 0,
-      'expected a selector',
-    );
-    groups.push(group);
+    groups.push(parseSimpleSelector(c));
     c.skipWhitespace();
     if (c.eof()) {
       break;


### PR DESCRIPTION
## Description

`parseSelector` builds one `ParsedSimpleSelector` per comma separated group, and a group with no tag and no refinement is treated as a wildcard. That is right for `*`, which is exactly that shape, but the parser cannot tell `*` from a group that is simply empty, so a hole in a selector list, a stray comma, or an empty string all come back as a selector that matches every element.

Measured through `getSelectorImpl`, on `main`, asking whether the compiled selector matches a `<div>`:

| source | matches `<div>` |
| --- | --- |
| `h1,,h2` | yes |
| `h1,` | yes |
| `,h1` | yes |
| `h1, ,h2` | yes |
| `""` | yes |
| `"   "` | yes |
| `h1` | no |

`parseSelector` is exported from `@lexical/html` and is what `sel.css()` calls, so an import rule written with any of those sources quietly captures every element instead of the handful the author meant, and the rule that should have won is shadowed. The file already says what it wants to do with input outside its subset:

```
 * Anything outside the subset (regex attribute, inline-style match,
 * combinators, pseudo-classes) is intentionally rejected — chain combinator
 * methods off the returned builder instead.
```

and it has the position annotated `Cursor.assert` for exactly that. The empty group was the one case that slipped through, and the old code says so in a comment on an empty `if`.

So `parseSimpleSelector` now reports whether it consumed a `*`, and `parseSelector` asserts that every group has a tag, a refinement, or that star. Nothing else changes: `*`, `h1, *` and `*.foo` still parse, and the tag dispatch and the OR predicate for lists are untouched.

## Test plan

### Before

`CSS parser rejects an empty selector or a hole in a selector list` fails on `main`: none of the six malformed sources throws.

### After

That test passes, and the rest of the file is unaffected.

```
npx vitest run packages/lexical-html
 Test Files  11 passed (11)
      Tests  92 passed (92)
```

Full `npx vitest run` for the repo is green as well, with the same result as on a clean checkout here.
