### PR TITLE
[lexical-html][lexical-rich-text][lexical-website] Docs: clarify DOMImportExtension rule evaluation order

### DIFF
--- a/packages/lexical-html/src/__tests__/unit/DOMImportExtension.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/DOMImportExtension.test.ts
@@ -39,6 +39,7 @@ import {
   $isParagraphNode,
   $isTextNode,
   $setState,
+  type AnyLexicalExtension,
   configExtension,
   createState,
   defineExtension,
@@ -355,7 +356,7 @@ describe('DOMImportExtension', () => {
     });
   });
 
-  test('rule priority: later-registered rule runs first; can call $next()', () => {
+  test('rule priority: the earlier entry in `rules` runs first; can call $next()', () => {
     using editor = buildTestEditor([
       IdAttributeRule,
       AnchorRule,
@@ -368,6 +369,87 @@ describe('DOMImportExtension', () => {
       assert($isLinkNode(link), 'expected LinkNode');
       expect($getState(link, idState)).toBe('link-x');
     });
+  });
+
+  test('rules contributed by dependents outrank their dependencies', () => {
+    // A rule that records the extension that contributed it and then
+    // defers, so the visit order of the whole chain is observable.
+    const visited: string[] = [];
+    const traceRule = (name: string) =>
+      defineImportRule({
+        $import: (_ctx, _el, $next) => {
+          visited.push(name);
+          return $next();
+        },
+        match: sel.tag('p'),
+        name: `test/trace-${name}`,
+      });
+    const makeExtension = (
+      name: string,
+      dependencies: AnyLexicalExtension[] = [],
+    ) =>
+      defineExtension({
+        dependencies: [
+          ...dependencies,
+          configExtension(DOMImportExtension, {
+            // Two rules from the same extension, to show that a
+            // contribution is inlined as a contiguous chunk.
+            rules: [traceRule(`${name}-a`), traceRule(`${name}-b`)],
+          }),
+        ],
+        name: `test-${name}`,
+      });
+    const leaf = makeExtension('leaf');
+    const mid = makeExtension('mid', [leaf]);
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [mid],
+        name: 'test-root',
+        nodes: [LinkNode],
+      }),
+      // Configuration passed directly to the builder is merged last of
+      // all, so it outranks every extension's contribution.
+      configExtension(DOMImportExtension, {rules: [traceRule('builder')]}),
+    );
+    importInto(editor, '<p>x</p>');
+    // Each extension's chunk keeps its own order (a before b), and the
+    // chunks are ordered from the most dependent contributor to the
+    // least.
+    expect(visited).toEqual(['builder', 'mid-a', 'mid-b', 'leaf-a', 'leaf-b']);
+  });
+
+  test('among sibling dependencies, the later-listed one outranks', () => {
+    // Pins the order that falls out of the topological sort for two
+    // extensions where neither depends on the other. Documented as an
+    // implementation detail rather than an API guarantee — an extension
+    // that must override another's rules should depend on it — but the
+    // behavior is worth knowing about when debugging dispatch.
+    const visited: string[] = [];
+    const traceRule = (name: string) =>
+      defineImportRule({
+        $import: (_ctx, _el, $next) => {
+          visited.push(name);
+          return $next();
+        },
+        match: sel.tag('p'),
+        name: `test/sibling-${name}`,
+      });
+    const makeExtension = (name: string) =>
+      defineExtension({
+        dependencies: [
+          configExtension(DOMImportExtension, {rules: [traceRule(name)]}),
+        ],
+        name: `test-sibling-${name}`,
+      });
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [makeExtension('first'), makeExtension('second')],
+        name: 'test-sibling-root',
+        nodes: [LinkNode],
+      }),
+    );
+    importInto(editor, '<p>x</p>');
+    expect(visited).toEqual(['second', 'first']);
   });
 
   test('CSS parser: parseSelector("p.foo") matches as expected', () => {

--- a/packages/lexical-html/src/__tests__/unit/DOMPreprocess.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/DOMPreprocess.test.ts
@@ -26,6 +26,7 @@ import {
   $getEditor,
   $getRoot,
   $isParagraphNode,
+  type AnyLexicalExtension,
   defineExtension,
   isHTMLElement,
   type LexicalEditor,
@@ -272,5 +273,41 @@ describe('DOMImportExtension preprocess', () => {
     );
     // Per-call appends to the stack (highest index = runs first).
     expect(log).toEqual(['per-call', 'config']);
+  });
+
+  test('preprocessors contributed by dependents run before their dependencies', () => {
+    const log: string[] = [];
+    const trace =
+      (name: string): DOMPreprocessFn =>
+      (_dom, _ctx, $next) => {
+        log.push(name);
+        $next();
+      };
+    const makeExtension = (
+      name: string,
+      dependencies: AnyLexicalExtension[] = [],
+    ) =>
+      defineExtension({
+        dependencies: [
+          ...dependencies,
+          configExtension(DOMImportExtension, {
+            preprocess: [trace(`${name}-a`), trace(`${name}-b`)],
+          }),
+        ],
+        name: `preprocess-${name}`,
+      });
+    const leaf = makeExtension('leaf');
+    const mid = makeExtension('mid', [leaf]);
+    using editor = buildEditorFromExtensions(
+      defineExtension({
+        dependencies: [CoreImportExtension, mid],
+        name: 'preprocess-root',
+      }),
+    );
+    importInto(editor, '<p>x</p>');
+    // The stack is run from its end, so the LAST entry of a contribution
+    // runs first, and a dependent extension's whole contribution runs
+    // before its dependency's.
+    expect(log).toEqual(['mid-b', 'mid-a', 'leaf-b', 'leaf-a']);
   });
 });

--- a/packages/lexical-html/src/import/DOMImportExtension.ts
+++ b/packages/lexical-html/src/import/DOMImportExtension.ts
@@ -41,18 +41,39 @@ import {selBase} from './sel';
  */
 export interface DOMImportConfig {
   /**
-   * The set of rules contributed by this extension and its dependencies.
+   * The ordered list of rules compiled into the import dispatcher.
    * Entries can be raw {@link DOMImportRule}s or a
    * {@link CompiledOverlayRules} produced by {@link defineOverlayRules}
-   * (the latter is inlined in priority order — useful for libraries
-   * that already publish a compiled overlay).
+   * (the latter is inlined at its position in the list — useful for
+   * libraries that already publish a compiled overlay).
    *
-   * Rules are dispatched in priority order: rules contributed by
-   * extensions merged later (i.e. closer to the editor root) run first
-   * and may call `$next()` to delegate to lower-priority rules.
+   * **Rules are evaluated in list order.** For a given DOM node the
+   * dispatcher visits every rule whose `match` accepts that node, front
+   * to back, and the first one that returns without calling `$next()`
+   * decides the outcome. "Higher priority" and "earlier in this list"
+   * mean the same thing.
    *
-   * `mergeConfig` prepends `partial.rules` to existing `rules`, so later
-   * configuration carries higher priority.
+   * **Composition prepends.** `mergeConfig` puts `partial.rules` in
+   * FRONT of the rules accumulated so far, and configs are merged in
+   * dependency order — a dependency's contribution is merged before the
+   * contribution of the extension that depends on it. So:
+   *
+   * - Each contributor's array is inlined as one contiguous chunk that
+   *   keeps its own internal order: within a single
+   *   `configExtension(DOMImportExtension, {rules})` call the first
+   *   entry has the highest priority.
+   * - The chunks are ordered from the most dependent contributor to the
+   *   least. An extension's rules therefore outrank the rules
+   *   contributed by its dependencies, and rules passed directly to
+   *   `buildEditorFromExtensions` (merged last of all) outrank every
+   *   extension's. This extension's own default entry
+   *   ({@link DefaultHoistRule}) is the base of the list and so is
+   *   always tried last.
+   *
+   * The relative order of two extensions where neither transitively
+   * depends on the other falls out of the topological sort and is not
+   * part of the API. Make the intended precedence explicit by having the
+   * overriding extension depend on the one whose rules it overrides.
    */
   readonly rules: readonly DOMImportRuleEntry[];
   /**
@@ -62,16 +83,29 @@ export interface DOMImportConfig {
    */
   readonly contextDefaults: readonly ImportContextPairOrUpdater[];
   /**
-   * Functions run in order on the DOM before walking begins, mutating in
-   * place. The default config registers
-   * {@link $inlineStylesFromStyleSheets} (resolves `<style>` rules to
-   * inline styles so the rules' style-driven matchers see them); apps
-   * append additional preprocessors (e.g. strip unsafe elements,
-   * normalize attributes, resolve relative URLs).
+   * Middleware run on the DOM before walking begins, mutating it in
+   * place. Each function receives `$next` and may wrap or short-circuit
+   * the rest of the chain (see {@link DOMPreprocessFn}). The default
+   * config registers {@link $inlineStylesFromStyleSheets} (resolves
+   * `<style>` rules to inline styles so the rules' style-driven matchers
+   * see them); apps add more (e.g. strip unsafe elements, normalize
+   * attributes, resolve relative URLs).
    *
-   * `mergeConfig` appends, so each contributing extension's preprocessors
-   * run in dependency order. Per-call preprocessors registered via
-   * {@link GenerateNodesFromDOMOptions.preprocess} run AFTER these.
+   * **Composition appends, and the stack is run from the end.**
+   * `mergeConfig` puts `partial.preprocess` AFTER the functions
+   * accumulated so far, and the runner starts at the last entry and
+   * works backwards. This is the opposite array direction from
+   * {@link DOMImportConfig.rules} but reaches the same outcome: an
+   * extension's preprocessors run before — and can wrap, via `$next()` —
+   * those of its dependencies, and the default
+   * `$inlineStylesFromStyleSheets` runs last of all (only if every
+   * preprocessor above it calls `$next()`). Within a single
+   * contribution the LAST entry runs first.
+   *
+   * Per-call preprocessors registered via
+   * {@link GenerateNodesFromDOMOptions.preprocess} are appended on top of
+   * the configured stack, so they run BEFORE the configured ones and can
+   * wrap them.
    */
   readonly preprocess: readonly DOMPreprocessFn[];
 }
@@ -98,13 +132,16 @@ function $runPreprocessStack(
 }
 
 /**
- * Lowest-priority catch-all rule used as the default `config.rules` entry
- * for {@link DOMImportExtension}: descends into the element's children
- * and returns whatever they produced. With no other matching rule, an
- * element vanishes and its contents are inserted in its place — the
- * legacy `$createNodesFromDOM` hoisting behavior, but now expressed as a
- * regular rule that apps can override (e.g. with a `sel.any()` rule that
- * captures and discards unknown elements).
+ * Catch-all rule used as the default `config.rules` entry for
+ * {@link DOMImportExtension}. Because every other contribution is
+ * prepended to the base config (see {@link DOMImportConfig.rules}), it
+ * sits at the end of the list and is the last rule tried: it descends
+ * into the element's children and returns whatever they produced. With
+ * no other matching rule, an element vanishes and its contents are
+ * inserted in its place — the legacy `$createNodesFromDOM` hoisting
+ * behavior, but now expressed as a regular rule that apps can override
+ * (e.g. with a `sel.any()` rule that captures and discards unknown
+ * elements).
  *
  * @experimental
  */
@@ -122,6 +159,11 @@ export const DefaultHoistRule = /* @__PURE__ */ defineImportRule({
  * {@link DOMImportConfig.rules}), compiled into a tag-bucketed dispatcher at
  * editor build time, and consumed via the extension's
  * {@link DOMImportExtensionOutput.$generateNodesFromDOM} output.
+ *
+ * There is no numeric priority: rules are tried in the order they appear
+ * in `config.rules`, and that list is assembled so that an extension's
+ * own rules come ahead of the rules its dependencies contributed. See
+ * {@link DOMImportConfig.rules} for the exact composition order.
  *
  * The legacy `$generateNodesFromDOM` continues to work in parallel; the
  * intent is to migrate node packages over to this extension incrementally.
@@ -190,6 +232,12 @@ export const DOMImportExtension = /* @__PURE__ */ defineExtension<
     preprocess: [$inlineStylesFromStyleSheets],
     rules: [DefaultHoistRule],
   },
+  // `contextDefaults` and `preprocess` append (last wins / runs first,
+  // since the preprocess stack is run from the end) while `rules`
+  // prepends (first entry wins, and dispatch reads the list front to
+  // back). Configs are merged in dependency order, so in every case the
+  // more dependent contributor ends up with the higher priority. See
+  // `DOMImportConfig` for the full explanation.
   mergeConfig(config, partial) {
     return shallowMergeConfig(config, {
       ...partial,

--- a/packages/lexical-html/src/import/compileImportRules.ts
+++ b/packages/lexical-html/src/import/compileImportRules.ts
@@ -60,9 +60,10 @@ function mergeSortedAsc(a: readonly number[], b: readonly number[]): number[] {
 
 /**
  * Compile an ordered list of {@link DOMImportRule}s into the dispatch tables
- * used by the import runtime. The rule at index 0 is the highest-priority
- * (`mergeConfig` prepends partial.rules so later-merged extensions land
- * first).
+ * used by the import runtime. Dispatch reads the list front to back, so the
+ * rule at index 0 is the highest-priority one. `DOMImportExtension.mergeConfig`
+ * prepends each contribution to the list, so the rules of the most dependent
+ * contributor occupy the lowest indices.
  *
  * @internal
  */

--- a/packages/lexical-html/src/import/defineOverlayRules.ts
+++ b/packages/lexical-html/src/import/defineOverlayRules.ts
@@ -17,7 +17,10 @@ import {type CompiledDispatch, compileImportRules} from './compileImportRules';
  *
  * To merge two or more overlays into a single one, pass them (alongside
  * raw {@link DOMImportRule}s if desired) to a fresh
- * {@link defineOverlayRules} — earlier arguments are higher priority.
+ * {@link defineOverlayRules} — the entries are flattened into a single
+ * ordered list that is dispatched front to back, so earlier entries are
+ * higher priority. (Unlike {@link DOMImportConfig.rules}, nothing
+ * prepends here: what you write is the evaluation order.)
  *
  * The internal shape is intentionally not part of the public API: it's a
  * compiled dispatch table tagged with `__type` so callers cannot pass a
@@ -83,8 +86,12 @@ function isCompiledOverlayRules(
  *
  * Entries can be raw {@link DOMImportRule}s or other
  * {@link CompiledOverlayRules} (the latter are inlined at their
- * position in priority order, so the same call composes any number of
- * overlays). Earlier entries are higher priority.
+ * position in the list, so the same call composes any number of
+ * overlays). The resulting list is dispatched front to back: earlier
+ * entries are higher priority, and a rule defers to the next matching
+ * entry by calling `$next()`. When the overlay is installed via
+ * `$importChildren({rules})` its whole list is tried before the rules
+ * from {@link DOMImportConfig.rules}.
  *
  * Overlay rules installed as a raw array would be re-compiled on every
  * `$importChildren` call. For overlays that are reused (e.g. a GitHub

--- a/packages/lexical-html/src/import/types.ts
+++ b/packages/lexical-html/src/import/types.ts
@@ -251,9 +251,12 @@ export interface ImportChildrenOpts {
   /**
    * Additional {@link DOMImportRule}s active only for this children
    * traversal (and any nested `$importChildren` calls that don't push
-   * their own overlay). The overlay is checked BEFORE the main
-   * dispatcher, so its rules take precedence; calling `$next()` from an
-   * overlay rule falls through to the next overlay-or-main rule.
+   * their own overlay). Overlays form a stack: the most recently pushed
+   * one is checked first, then the ones below it, then the main
+   * dispatcher — so an overlay's rules take precedence over everything
+   * in {@link DOMImportConfig.rules}. Within one overlay, rules are
+   * tried in their own list order. Calling `$next()` from an overlay
+   * rule falls through to the next overlay-or-main rule.
    *
    * Use this to scope cost-bearing rules to where they apply. For
    * example, a GitHub code-table rule installs an overlay that
@@ -345,6 +348,13 @@ export interface ChildSchema {
  * the next-matching rule for this node (returning its result, which may then
  * be inspected or wrapped); return `[]` to drop the node.
  *
+ * "Next" means the next rule in `DOMImportConfig.rules` order — rules are
+ * tried front to back, there is no numeric priority. Since each
+ * extension's contribution is prepended to its dependencies'
+ * contributions, `$next()` from a rule typically lands on the equivalent
+ * rule from a lower-level package, and finally on
+ * `DefaultHoistRule`. See {@link DOMImportConfig.rules}.
+ *
  * @experimental
  */
 export type DOMImportFn<
@@ -417,9 +427,12 @@ export interface DOMPreprocessContext {
  * editor-context expectation visible to readers and lints.
  *
  * Append-style merge applies: an extension's preprocessors are appended
- * to the existing stack, so later-registered preprocessors run first
- * and may delegate to earlier (lower-priority) ones via `$next()`. Same
- * convention as {@link ExportMimeTypeFunction} on the export side.
+ * to the existing stack and the stack is run from its END, so the last
+ * entry runs first and may delegate to the entries below it via
+ * `$next()`. Because configs merge in dependency order, that means an
+ * extension's preprocessors wrap those of its dependencies, and the
+ * built-in `$inlineStylesFromStyleSheets` runs last. Same convention as
+ * {@link ExportMimeTypeFunction} on the export side.
  *
  * @experimental
  */
@@ -441,9 +454,11 @@ export interface GenerateNodesFromDOMOptions {
    */
   readonly context?: readonly ImportContextPairOrUpdater[];
   /**
-   * Additional preprocessors to run on this call only, on top of the
-   * extension's configured {@link DOMImportConfig.preprocess}. Per-call
-   * preprocessors run AFTER the configured ones.
+   * Additional preprocessors to run on this call only, appended to the
+   * extension's configured {@link DOMImportConfig.preprocess}. The stack
+   * is run from its end, so per-call preprocessors run BEFORE the
+   * configured ones and can wrap them via `$next()`; the last entry of
+   * this array is the very first function to run.
    */
   readonly preprocess?: readonly DOMPreprocessFn[];
 }

--- a/packages/lexical-rich-text/src/RichTextImportExtension.ts
+++ b/packages/lexical-rich-text/src/RichTextImportExtension.ts
@@ -68,13 +68,28 @@ const QuoteRule = /* @__PURE__ */ defineImportRule({
  * inline content.
  *
  * Not part of {@link RichTextImportRules}; without it `<blockquote>`
- * import behavior is unchanged. To opt in, register it with a higher
- * priority than the default rules, e.g.:
+ * import behavior is unchanged. To opt in, contribute it from somewhere
+ * that outranks {@link RichTextImportRules} in the compiled rule list —
+ * either directly to the editor builder:
  * ```ts
- * configExtension(DOMImportExtension, {rules: [ShadowRootQuoteRule]})
+ * buildEditorFromExtensions(
+ *   MyExtension,
+ *   configExtension(DOMImportExtension, {rules: [ShadowRootQuoteRule]}),
+ * )
  * ```
- * (rules from later configuration take priority, so this shadows the
- * default `@lexical/rich-text/blockquote` rule).
+ * or from an extension that depends on {@link RichTextExtension}:
+ * ```ts
+ * defineExtension({
+ *   dependencies: [
+ *     RichTextExtension,
+ *     configExtension(DOMImportExtension, {rules: [ShadowRootQuoteRule]}),
+ *   ],
+ *   name: '@app/quotes',
+ * })
+ * ```
+ * Either way the contribution is merged after rich-text's and therefore
+ * prepended in front of it, so this rule is reached first and shadows the
+ * default `@lexical/rich-text/blockquote` rule.
  *
  * @experimental
  */
@@ -121,9 +136,11 @@ const GoogleDocsTitleSpanRule = /* @__PURE__ */ defineImportRule({
 /**
  * Import rules for {@link HeadingNode} and {@link QuoteNode}, including
  * the Google Docs title heuristic that the legacy `HeadingNode.importDOM`
- * declared. The Google-Docs rules are registered last (highest priority)
- * so they precede the generic `<p>` and `<span>` rules from
- * {@link CoreImportRules}.
+ * declared. This whole array is contributed by {@link RichTextExtension},
+ * which depends on `CoreImportExtension`, so it is prepended in front of
+ * {@link CoreImportRules}: the Google-Docs `<p>` / `<span>` rules here are
+ * reached before the generic `<p>` and `<span>` rules from core, and defer
+ * to them via `$next()` when the Google-Docs heuristic doesn't match.
  *
  * Registered by {@link RichTextExtension} itself (together with
  * `CoreImportExtension`), so any editor that uses the rich-text

--- a/packages/lexical-website/docs/serialization/dom-import.md
+++ b/packages/lexical-website/docs/serialization/dom-import.md
@@ -149,11 +149,15 @@ A rule has three parts:
 
 ### Dispatch order
 
-When multiple rules match the same element, the one registered LATER
-wins (higher priority). `mergeConfig` prepends `partial.rules` to the
-existing list, so an extension's rules run before the rules its
-dependencies contributed. Within a single extension's `rules` array,
-the first entry has highest priority.
+There is no numeric priority. `DOMImportConfig.rules` is a single flat,
+ordered list, and dispatch walks it **front to back**: for a given DOM
+node the dispatcher visits each rule whose `match` accepts that node, in
+list order, and the first rule that returns without calling `$next()`
+decides the outcome. "Higher priority" and "earlier in the list" are the
+same thing.
+
+So within one `configExtension(DOMImportExtension, {rules})` call, the
+rules run in the order you wrote them:
 
 ```ts
 configExtension(DOMImportExtension, {
@@ -166,11 +170,56 @@ configExtension(DOMImportExtension, {
 })
 ```
 
-Calling `$next()` from a rule walks the chain — the next-lower
-matching rule fires; if none, the framework's catch-all
-`DefaultHoistRule` descends into the element's children. Returning
-`[]` from a rule short-circuits: nothing else runs and the element is
+Calling `$next()` from a rule walks the chain — the next matching rule
+in the list fires; if none is left, the framework's catch-all
+`DefaultHoistRule` descends into the element's children. Returning `[]`
+from a rule short-circuits: nothing else runs and the element is
 dropped.
+
+#### How the list is assembled
+
+Many extensions contribute to the same list. `DOMImportExtension`'s
+`mergeConfig` **prepends** each contribution to what has accumulated so
+far, and the extension builder merges configs in dependency order — a
+dependency's contribution is merged before the contribution of the
+extension that depends on it. Two consequences:
+
+- **Each contribution stays contiguous and keeps its own order.** Your
+  `rules` array is inlined as one chunk, first entry first. Ordering
+  *within* your own rules is entirely up to you.
+- **The chunks run most-dependent first.** An extension's rules are
+  tried before the rules contributed by its dependencies. That is what
+  makes overriding work: `@lexical/rich-text` depends on
+  `CoreImportExtension`, so its `<p>` rule is reached before the core
+  one, and an app extension that depends on `@lexical/rich-text` gets to
+  go ahead of both.
+
+Concretely, for an app extension that depends on `RichTextExtension`
+(which in turn depends on `CoreImportExtension`), the compiled list is:
+
+```
+[ …rules passed to buildEditorFromExtensions… ]  ← merged last, highest priority
+[ …the app extension's rules…                 ]
+[ …@lexical/rich-text's rules…                ]
+[ …CoreImportExtension's rules…               ]
+[ DefaultHoistRule                            ]  ← the base config, always last
+```
+
+Configuration handed straight to `buildEditorFromExtensions` is merged
+after every extension's, so it outranks all of them. `DefaultHoistRule`
+is `DOMImportExtension`'s own default `config.rules` entry, so
+everything else lands in front of it and it is always the last rule
+tried.
+
+:::caution
+
+The relative order of two extensions where neither transitively depends
+on the other falls out of the topological sort and is not part of the
+API. If extension **A** must override a rule from extension **B**, say
+so structurally — make **B** a dependency of **A** — rather than relying
+on the order they happen to be listed in.
+
+:::
 
 ### `$next()` as a wrapper
 
@@ -192,10 +241,10 @@ const IdAttributeRule = defineImportRule({
 });
 ```
 
-Registered late (i.e. early in your `rules` array), this rule fires
-for every styled element BEFORE the tag-specific rule, calls `$next()`
-to get the produced node, and tags it with state. No tag-specific
-machinery needs to know about `id`.
+Placed early in your `rules` array, this rule fires for every element
+carrying an `id` BEFORE the tag-specific rule, calls `$next()` to get
+the produced node, and tags it with state. No tag-specific machinery
+needs to know about `id`.
 
 ## Selectors
 
@@ -671,6 +720,27 @@ configExtension(DOMImportExtension, {
 })
 ```
 
+### Preprocess order
+
+`preprocess` composes in the opposite array direction from
+[`rules`](#dispatch-order) but produces the same precedence. `mergeConfig`
+**appends** each contribution to the accumulated stack, and the runner
+starts at the **last** entry and works backwards. So:
+
+- Within one contribution, the **last** entry runs first and wraps the
+  ones written before it.
+- Because configs are merged in dependency order, an extension's
+  preprocessors run before — and can wrap, via `$next()` — those of its
+  dependencies. `$inlineStylesFromStyleSheets`, sitting in the extension's
+  own base config, runs last of all, and only if every preprocessor above
+  it calls `$next()`.
+- Per-call preprocessors from `GenerateNodesFromDOMOptions.preprocess` are
+  appended on top of the configured stack, so they run **before** the
+  configured ones.
+
+Skipping `$next()` is therefore a real decision: it drops every
+lower-priority preprocessor, including the built-in stylesheet inlining.
+
 ### Reading meta tags into context
 
 A common pattern: a preprocess step inspects a `<meta>` tag (or any
@@ -710,13 +780,18 @@ import {$inlineStylesFromStyleSheets} from '@lexical/html';
 
 configExtension(DOMImportExtension, {
   preprocess: [
-    // Run before the default — useful if your custom preprocess
-    // expects the styles to already be inlined.
-    $inlineStylesFromStyleSheets,
     $appPreprocess,
+    // The stack runs from the END of the array, so listing the inliner
+    // last makes it run FIRST — useful when `$appPreprocess` expects the
+    // styles to already be inlined. (The copy in the extension's base
+    // config runs at the very bottom of the stack, after everything
+    // else, so re-listing it here is how you pull it forward.)
+    $inlineStylesFromStyleSheets,
   ],
 });
 ```
+
+See [Preprocess order](#preprocess-order) for the full composition rules.
 
 ## `$importChildren` rules overlay
 
@@ -1018,7 +1093,7 @@ ready to move a custom node, the translation is mechanical:
 | Legacy concept | New equivalent |
 | --- | --- |
 | `static importDOM(): DOMConversionMap` returning `{tag: () => ({conversion, priority})}` | One or more `defineImportRule({match, $import})` entries |
-| Numeric `priority` (0–4) | Rule registration order (later-registered runs first) plus `$next()` for deferring |
+| Numeric `priority` (0–4) | Position in the compiled `rules` list (earlier entry runs first; an extension's rules come ahead of its dependencies') plus `$next()` for deferring — see [Dispatch order](#dispatch-order) |
 | `forChild(node, parent)` | `ctx.$importChildren(el, {context: [...], $onChild})` |
 | `after(children)` | `ctx.$importChildren(el, {$after})` |
 | `wrapContinuousInlines` (block ancestor case) | `ctx.$importChildren(el, {schema: BlockSchema})` |


### PR DESCRIPTION
## Description

The docs for `DOMImportExtension` described rule precedence as "the one registered LATER wins", which wasn't precise because the rules are in-order but the rule array is composed in reverse topological order. This PR is explicit about how the rules array is assembled.

## Test plan

New unit tests that verify the composition order matches this new documentation