### PR TITLE
[lexical] Feature: build the node with $create when importing JSON

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -3273,11 +3273,9 @@ export function getStaticNodeConfig(
           String(klass.length),
         );
       }
-      // TODO: replace $applyNodeReplacement with $create once `withKlass` is required.
       klass.importJSON =
         (ownNodeConfig && ownNodeConfig.$importJSON) ||
-        (serializedNode =>
-          $applyNodeReplacement(new klass()).updateFromJSON(serializedNode));
+        (serializedNode => $create(klass).updateFromJSON(serializedNode));
     }
     if (!hasOwnStaticMethod(klass, 'importDOM') && ownNodeConfig) {
       const {importDOM} = ownNodeConfig;
@@ -3349,10 +3347,14 @@ export function getRegisteredSubtypeMap(
 /**
  * Create an node from its class.
  *
- * Note that this will directly construct the final `withKlass` node type,
- * and will ignore the deprecated `with` functions. This allows `$create` to
- * skip any intermediate steps where the replaced node would be created and
- * then immediately discarded (once per configured replacement of that node).
+ * This directly constructs the final `withKlass` node type, skipping the
+ * intermediate steps where each replaced node would be created and then
+ * immediately discarded — once per configured replacement of that node.
+ *
+ * A deprecated `replace` given without a `withKlass` is the one case that
+ * cannot be resolved ahead of construction, since only its `with` function
+ * knows what to build. Such a replacement is still applied, the old way, to
+ * the node this constructs.
  *
  * This does not support any arguments to the constructor.
  * Setters can be used to initialize your node, and they can
@@ -3372,7 +3374,13 @@ export function $create<T extends LexicalNode>(klass: Klass<T>): T {
   const registeredNode = editor.resolveRegisteredNodeAfterReplacements(
     editor.getRegisteredNode(klass),
   );
-  return new registeredNode.klass() as T;
+  const node = new registeredNode.klass() as T;
+  // The resolve above follows `withKlass` as far as it goes, so a `replace`
+  // still set on the node it stopped at has no `withKlass` to follow: it is a
+  // deprecated one, and its `with` can only be given a constructed node.
+  return registeredNode.replace === null
+    ? node
+    : ($applyNodeReplacement(node) as T);
 }
 
 /**

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -28,6 +28,7 @@ import {
 import {JSDOM} from 'jsdom';
 import * as lexical from 'lexical';
 import {
+  $create,
   $createLineBreakNode,
   $createNodeSelection,
   $createParagraphNode,
@@ -3990,6 +3991,61 @@ describe('LexicalEditor tests', () => {
       });
 
       expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('$create resolves withKlass directly, and still honors a `with` without one', () => {
+      // $create looks the replacement class up rather than building the
+      // replaced node and throwing it away, which is why importing a document
+      // is not paying for a construction per replaced node. A `with` given
+      // without a `withKlass` is the case that cannot be resolved ahead of
+      // construction — only its function knows what to build — so it is
+      // applied the old way instead of being skipped.
+      class ResolvedParagraph extends ParagraphNode {
+        $config() {
+          return this.config('resolved-paragraph', {extends: ParagraphNode});
+        }
+      }
+      class LegacyParagraph extends ParagraphNode {
+        $config() {
+          return this.config('legacy-paragraph', {extends: ParagraphNode});
+        }
+      }
+
+      const resolved = createTestEditor({
+        nodes: [
+          ResolvedParagraph,
+          {
+            replace: ParagraphNode,
+            with: () => new ResolvedParagraph(),
+            withKlass: ResolvedParagraph,
+          },
+        ],
+        onError: err => {
+          throw err;
+        },
+      });
+      resolved.update(
+        () => {
+          expect($create(ParagraphNode)).toBeInstanceOf(ResolvedParagraph);
+        },
+        {discrete: true},
+      );
+
+      const legacy = createTestEditor({
+        nodes: [
+          LegacyParagraph,
+          {replace: ParagraphNode, with: () => new LegacyParagraph()},
+        ],
+        onError: err => {
+          throw err;
+        },
+      });
+      legacy.update(
+        () => {
+          expect($create(ParagraphNode)).toBeInstanceOf(LegacyParagraph);
+        },
+        {discrete: true},
+      );
     });
 
     it('applies the replacement on import for `with` without `withKlass`', async () => {


### PR DESCRIPTION
## Description

Follow-up to #9061 to replace `$applyNodeReplacement(new klass())` with `$create(klass)` in importJSON by making `$create` compatible with node replacements that are missing `withKlass`.

In situations where node replacement with `withKlass` this halves the cost of importing a node. The majority of the cost is in the constructor, and `$applyNodeReplacement` constructs *two* nodes when any replacement is configured. `$create` only constructs a single node when `withKlass` is specified for the entire chain.

## Test plan

New unit tests to confirm that `$create` directly handles replacement for configurations using `with` without `withKlass`.
