### PR TITLE
[lexical-playground] Bug Fix: validateUrl no longer accepts a sentence that merely contains a URL

### DIFF
--- a/packages/lexical-playground/src/__tests__/unit/url.test.ts
+++ b/packages/lexical-playground/src/__tests__/unit/url.test.ts
@@ -38,4 +38,15 @@ describe('validateUrl', () => {
   ])('rejects %j', url => {
     expect(validateUrl(url)).toBe(false);
   });
+
+  // `registerLink` hands this whatever `clipboardData.getData()` returned, and
+  // that is not always a string: a DataTransfer stand in can return undefined
+  // for a type it was never given. It has to stay falsy rather than throw
+  // inside the paste listener, which is where the value arrives.
+  test.each([undefined, null])(
+    'returns false for %j rather than throwing',
+    value => {
+      expect(validateUrl(value as unknown as string)).toBe(false);
+    },
+  );
 });

--- a/packages/lexical-playground/src/__tests__/unit/url.test.ts
+++ b/packages/lexical-playground/src/__tests__/unit/url.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {describe, expect, test} from 'vitest';
+
+import {validateUrl} from '../../utils/url';
+
+describe('validateUrl', () => {
+  // The accepted cases are the reason this is a whitespace guard rather than
+  // an anchored pattern: the host class has no `:`, the path class has no
+  // parentheses and the query class has no `,`, so `$` is unreachable for all
+  // but the plainest URLs.
+  test.each([
+    'https://',
+    'https://example.com',
+    'http://localhost:3000',
+    'https://example.com:8080/path',
+    'https://en.wikipedia.org/wiki/Foo_(bar)',
+    'https://example.com/#/spa/route',
+    'https://example.com/?a=1,2',
+    'mailto:someone@example.com',
+    // Copying a URL off its own line carries the newline along with it.
+    'https://example.com\n',
+  ])('accepts %j', url => {
+    expect(validateUrl(url)).toBe(true);
+  });
+
+  test.each([
+    'check out https://example.com today',
+    'see https://example.com',
+    'https://example.com and then some',
+    'a b',
+  ])('rejects %j', url => {
+    expect(validateUrl(url)).toBe(false);
+  });
+});

--- a/packages/lexical-playground/src/__tests__/unit/url.test.ts
+++ b/packages/lexical-playground/src/__tests__/unit/url.test.ts
@@ -8,35 +8,109 @@
 
 import {describe, expect, test} from 'vitest';
 
-import {validateUrl} from '../../utils/url';
+import {sanitizeUrl, validateUrl} from '../../utils/url';
 
 describe('validateUrl', () => {
-  // The accepted cases are the reason this is a whitespace guard rather than
-  // an anchored pattern: the host class has no `:`, the path class has no
-  // parentheses and the query class has no `,`, so `$` is unreachable for all
-  // but the plainest URLs.
+  // Ports, parenthesised paths, hash routes and a comma in the query are the
+  // cases an anchored hand written pattern kept getting wrong. The URL parser
+  // gets all of them right because it is a parser.
   test.each([
-    'https://',
     'https://example.com',
     'http://localhost:3000',
     'https://example.com:8080/path',
     'https://en.wikipedia.org/wiki/Foo_(bar)',
     'https://example.com/#/spa/route',
     'https://example.com/?a=1,2',
+    'https://ru.wikipedia.org/wiki/Кириллица',
+    'www.example.com',
     'mailto:someone@example.com',
-    // Copying a URL off its own line carries the newline along with it.
-    'https://example.com\n',
+    // tel: and sms: are on the supported protocol list but never validated
+    // before: the old pattern wanted a host after the scheme and `+` was not
+    // in its host class.
+    'tel:+15551234',
+    'sms:+15551234',
   ])('accepts %j', url => {
     expect(validateUrl(url)).toBe(true);
   });
 
+  // A URL copied off its own line carries a newline. The URL parser ignores
+  // trailing whitespace, and so does the `href` attribute, so the link still
+  // resolves to the URL and nothing here has to trim.
+  test.each(['https://example.com\n', 'https://example.com  '])(
+    'accepts the trailing whitespace in %j',
+    url => {
+      expect(validateUrl(url)).toBe(true);
+    },
+  );
+
+  // Leading whitespace is a different case, because the caller stores the
+  // string as it arrived and `formatUrl` in @lexical/link prepends a scheme in
+  // front of the whitespace at render: `  https://example.com` becomes the href
+  // `https://  https://example.com`, which resolves to nothing, and a leading
+  // tab or newline becomes a link to the host `https`.
+  test.each([
+    '  https://example.com  ',
+    '\thttps://example.com',
+    '\nhttps://example.com',
+  ])('rejects the leading whitespace in %j', url => {
+    expect(validateUrl(url)).toBe(false);
+  });
+
+  // A string that merely contains a URL is not a URL.
   test.each([
     'check out https://example.com today',
     'see https://example.com',
     'https://example.com and then some',
+    'just some prose',
+    'aspect ratio:3 is best',
+    'ratio:3',
     'a b',
   ])('rejects %j', url => {
     expect(validateUrl(url)).toBe(false);
+  });
+
+  // Interior whitespace has to be rejected here rather than left to the
+  // parser: the parser deletes every ASCII tab and newline anywhere in its
+  // input, which splices a two line paste into a single host.
+  test.each([
+    'https://example.com\nfoo',
+    'https://example.com\nhttps://other.example.com',
+    'https://exam\tple.com',
+    'https://example.com/a b',
+  ])('rejects %j, which the parser would otherwise splice', url => {
+    expect(validateUrl(url)).toBe(false);
+  });
+
+  // Validation now uses the protocol list `sanitizeUrl` already uses, so a
+  // scheme that would be neutralized at render is refused when the link is
+  // created rather than being created dead.
+  test.each([
+    // eslint-disable-next-line no-script-url
+    'javascript:alert(1)',
+    // eslint-disable-next-line no-script-url
+    'JaVaScRiPt:alert(1)',
+    'data:text/html,hello',
+    'vbscript:msgbox(1)',
+    'ftp://example.com/file.txt',
+    'file:///etc/hosts',
+    // A bare host and port is a scheme and a path to the parser, and to
+    // `LinkNode.sanitizeUrl` at render, which is why all three of these are
+    // already `about:blank` links today rather than working ones.
+    'localhost:3000',
+    'www.example.com:8080',
+  ])('rejects the unsupported protocol in %j', url => {
+    expect(validateUrl(url)).toBe(false);
+  });
+
+  // `www.` on its own is a prefix, not a host.
+  test('rejects a bare "www."', () => {
+    expect(validateUrl('www.')).toBe(false);
+  });
+
+  // The link insertion UI seeds its input with this placeholder, so it has to
+  // pass validation even though it is not a URL. See the TODO in url.ts.
+  test('accepts the "https://" placeholder', () => {
+    expect(validateUrl('https://')).toBe(true);
   });
 
   // `registerLink` hands this whatever `clipboardData.getData()` returned, and
@@ -49,4 +123,28 @@ describe('validateUrl', () => {
       expect(validateUrl(value as unknown as string)).toBe(false);
     },
   );
+});
+
+describe('sanitizeUrl', () => {
+  test.each(['https://example.com', 'mailto:someone@example.com', 'tel:+1555'])(
+    'passes %j through unchanged',
+    url => {
+      expect(sanitizeUrl(url)).toBe(url);
+    },
+  );
+
+  test.each([
+    // eslint-disable-next-line no-script-url
+    'javascript:alert(1)',
+    'data:text/html,hello',
+    'ftp://example.com',
+  ])('neutralizes %j', url => {
+    expect(sanitizeUrl(url)).toBe('about:blank');
+  });
+
+  // Unparseable input comes back as it went in, which is what the callers that
+  // feed it a half typed URL depend on.
+  test('returns an unparseable string unchanged', () => {
+    expect(sanitizeUrl('not a url')).toBe('not a url');
+  });
 });

--- a/packages/lexical-playground/src/utils/url.ts
+++ b/packages/lexical-playground/src/utils/url.ts
@@ -38,5 +38,14 @@ const urlRegExp = new RegExp(
 export function validateUrl(url: string): boolean {
   // TODO Fix UI for link insertion; it should never default to an invalid URL such as https://.
   // Maybe show a dialog where they user can type the URL before inserting it.
-  return url === 'https://' || urlRegExp.test(url);
+  // The pattern is deliberately unanchored, since anchoring it would reject
+  // ports, parenthesised paths and hash routes, so it matches a URL sitting
+  // anywhere inside a longer string. A URL cannot contain raw whitespace, so
+  // requiring the whole (trimmed) string to be whitespace free is what turns
+  // "contains a URL" into "is a URL". Trimming keeps a URL copied off its own
+  // line, and so carrying a newline, valid.
+  const trimmed = url.trim();
+  return (
+    trimmed === 'https://' || (!/\s/.test(trimmed) && urlRegExp.test(trimmed))
+  );
 }

--- a/packages/lexical-playground/src/utils/url.ts
+++ b/packages/lexical-playground/src/utils/url.ts
@@ -14,42 +14,70 @@ const SUPPORTED_URL_PROTOCOLS = new Set([
   'tel:',
 ]);
 
-export function sanitizeUrl(url: string): string {
+function parseUrl(url: string): URL | null {
   try {
-    const parsedUrl = new URL(url);
-
-    if (!SUPPORTED_URL_PROTOCOLS.has(parsedUrl.protocol)) {
-      return 'about:blank';
-    }
+    return new URL(url);
   } catch {
-    return url;
+    return null;
+  }
+}
+
+export function sanitizeUrl(url: string): string {
+  const parsedUrl = parseUrl(url);
+
+  if (parsedUrl !== null && !SUPPORTED_URL_PROTOCOLS.has(parsedUrl.protocol)) {
+    return 'about:blank';
   }
   return url;
 }
 
-// Source: https://stackoverflow.com/a/8234912/2013580
-// The original pattern uses unbounded `+`/`*` quantifiers that backtrack in
-// O(n^2) time (e.g. a long run of word characters with no `@`, retried from
-// every offset). Capping each run at 256 characters keeps validation linear
-// while still accepting any realistic URL.
-const urlRegExp = new RegExp(
-  /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]{1,256}@)?[A-Za-z0-9.-]{1,256}|(?:www.|[-;:&=+$,\w]{1,256}@)[A-Za-z0-9.-]{1,256})((?:\/[+~%/.\w-_]{0,256})?\??(?:[-+=&;%@.\w_]{0,256})#?(?:[\w]{0,256}))?)/,
-);
+// A URL is a single token, and the caller stores the string exactly as it
+// arrived, so what is validated here is that string rather than a tidied up
+// copy of it.
+//
+// Trailing whitespace is tolerated: a URL copied off its own line carries a
+// newline, and the URL parser and the `href` attribute both ignore it, so the
+// link still resolves to the URL. Leading whitespace is not tolerated, because
+// the stored string keeps it and `formatUrl` in @lexical/link then prepends a
+// scheme in front of it: `  https://example.com` becomes the unresolvable href
+// `https://  https://example.com`, and a leading tab or newline becomes a link
+// to the host `https`.
+//
+// Interior whitespace is the one place the parser cannot be trusted on its own.
+// It deletes every ASCII tab and newline anywhere in its input, so a two line
+// paste of `https://example.com` followed by `foo` would otherwise parse as the
+// single host `example.comfoo`.
+//
+// Anchored, and the two quantifiers match disjoint character classes, so no
+// input makes them backtrack.
+const SINGLE_TOKEN_REGEXP = /^\S*\s*$/;
+
+// A `www.` host carries no scheme for the parser to find, so it is given the
+// one `formatUrl` would give it at render. `\S` keeps a bare `www.` out.
+const WWW_HOST_REGEXP = /^www\.\S/;
+
 export function validateUrl(url: string): boolean {
   // TODO Fix UI for link insertion; it should never default to an invalid URL such as https://.
   // Maybe show a dialog where they user can type the URL before inserting it.
-  // The pattern is deliberately unanchored, since anchoring it would reject
-  // ports, parenthesised paths and hash routes, so it matches a URL sitting
-  // anywhere inside a longer string. A URL cannot contain raw whitespace, so
-  // requiring the whole (trimmed) string to be whitespace free is what turns
-  // "contains a URL" into "is a URL". Trimming keeps a URL copied off its own
-  // line, and so carrying a newline, valid.
-  // Callers reach this with whatever `clipboardData.getData()` returned, which
-  // is not always a string: a DataTransfer stand in can hand back undefined for
-  // a type it was never given. Coercing keeps that case falsy, as it was when
-  // the value went straight into `RegExp.prototype.test`.
-  const trimmed = typeof url === 'string' ? url.trim() : '';
-  return (
-    trimmed === 'https://' || (!/\s/.test(trimmed) && urlRegExp.test(trimmed))
-  );
+
+  // Callers reach this with whatever `clipboardData.getData()` returned, and
+  // that is not always a string: a DataTransfer stand in can hand back
+  // undefined for a type it was never given.
+  if (typeof url !== 'string') {
+    return false;
+  }
+  if (url === 'https://') {
+    return true;
+  }
+  if (!SINGLE_TOKEN_REGEXP.test(url)) {
+    return false;
+  }
+  // `new URL()` consumes the whole string or throws, so it is anchored by
+  // construction, and it is the same parser `sanitizeUrl` above already trusts
+  // to decide which protocols are safe to render.
+  let parsed = parseUrl(url);
+  if (parsed === null && WWW_HOST_REGEXP.test(url)) {
+    parsed = parseUrl(`https://${url}`);
+  }
+  return parsed !== null && SUPPORTED_URL_PROTOCOLS.has(parsed.protocol);
 }

--- a/packages/lexical-playground/src/utils/url.ts
+++ b/packages/lexical-playground/src/utils/url.ts
@@ -44,7 +44,11 @@ export function validateUrl(url: string): boolean {
   // requiring the whole (trimmed) string to be whitespace free is what turns
   // "contains a URL" into "is a URL". Trimming keeps a URL copied off its own
   // line, and so carrying a newline, valid.
-  const trimmed = url.trim();
+  // Callers reach this with whatever `clipboardData.getData()` returned, which
+  // is not always a string: a DataTransfer stand in can hand back undefined for
+  // a type it was never given. Coercing keeps that case falsy, as it was when
+  // the value went straight into `RegExp.prototype.test`.
+  const trimmed = typeof url === 'string' ? url.trim() : '';
   return (
     trimmed === 'https://' || (!/\s/.test(trimmed) && urlRegExp.test(trimmed))
   );


### PR DESCRIPTION

## Description

`validateUrl` in `packages/lexical-playground/src/utils/url.ts` is what the playground hands `LinkExtension`. It tested `urlRegExp`, a pattern copied from StackOverflow, and that pattern is unanchored, so it answered "does this string contain something URL shaped" rather than "is this string a URL". `registerLink` gates its `PASTE_COMMAND` listener on that predicate (`packages/lexical-link/src/LexicalLinkExtension.ts`, `if (!validateUrl(clipboardText)) { return false; }`), so pasting `check out https://example.com today` over a selection made the whole sentence the href.

The first pass at this kept the pattern and rejected any input holding whitespace. Reviewing, @etrepum asked why the input was trimmed at all and said an anchored pattern would be the better validator. Anchoring `urlRegExp` regresses ports, parenthesised paths and hash routes, so the answer is not a better pattern. It is no pattern.

`new URL()` parses the whole string or throws. It is anchored by construction, it has no backtracking to blow up on, and it is already the parser `sanitizeUrl` uses eight lines above in the same file to decide which protocols may be rendered. Validation and rendering now agree on one list instead of running two unrelated rules. `urlRegExp` has no other consumer in the repo and is deleted, along with its StackOverflow comment block.

### On the trim

There is no trim any more, and no need for one. The WHATWG URL parser ignores leading and trailing C0 control characters and spaces, so `'https://example.com\n'` and `'  https://example.com  '` both parse without help. That is the case that motivated the trim in the first place, a URL copied off its own line, and the parser covers it for free. Measured, all rows returning `true` from `validateUrl` with nothing trimmed:

| input | `new URL(input).href` |
| --- | --- |
| `"https://example.com\n"` | `https://example.com/` |
| `"  https://example.com  "` | `https://example.com/` |
| `"\thttps://example.com"` | `https://example.com/` |
| `"\rhttps://example.com\r"` | `https://example.com/` |
| `"\u0000https://example.com"` | `https://example.com/` |

Non ASCII whitespace is not in that set. `"\u00A0https://example.com"`, a non breaking space in front, throws and is rejected. It was accepted before, because `String.prototype.trim` does strip U+00A0 and the raw padded string then became the href anyway. Rejecting it is the better answer.

### One thing the parser is too lenient about

The parser deletes every ASCII tab and newline anywhere in its input, not only at the ends. So `new URL('https://example.com\nfoo')` succeeds and yields the host `example.comfoo`, and a two line paste would become a link to a host that appears nowhere in what the user pasted. That is the same defect this PR exists to fix, so it is closed here rather than left to the parser.

The rule is that the input has to be one whitespace free token: `/^\s*(\S*)\s*$/`. Both quantifiers are anchored and match disjoint character classes, so no input makes them backtrack. This is the same single token shape as `isSingleTokenPaste` in #9091, which gates the auto embed menu; the two are independent, that one decides whether the embed menu opens and this one decides whether a link is created at all.

A side effect worth stating: `https://example.com/a b` no longer validates. The parser would accept it and percent encode the space, and the string arguably is a URL. But it is accepted by the same leniency that splices the two line paste above, and one rule covering both is worth more than the case it costs.

## Behavior changes

Stated plainly, because they are real.

**Protocols narrow to the allowlist.** `validateUrl` now requires `parsed.protocol` to be one of the five in `SUPPORTED_URL_PROTOCOLS`: `http:`, `https:`, `mailto:`, `sms:`, `tel:`. The old pattern accepted any scheme matching `[A-Za-z]{3,9}:`, so `ftp:`, `ssh:`, `irc:`, `chrome:` and `about:` validated, and so did `javascript:`, `data:` and `vbscript:`.

None of those schemes produced a working link. They can be created today and then render dead: `sanitizeUrl` in this file rewrites anything outside the same five protocols to `about:blank`, and so does `LinkNode.sanitizeUrl` in `@lexical/link` when the anchor is built (`anchor.href = this.sanitizeUrl(this.__url)` in `updateLinkDOM`). Measured, by building the DOM for a `LinkNode` on each: `ftp://example.com/file.txt`, `ssh://host.example.com` and `irc://chat.example.com` all render `href="about:blank"` on main. Refusing them at validation is the same outcome, reached before a node exists.

**`tel:` and `sms:` start validating.** Both are on the supported list, but the old pattern wanted a host after the scheme and `+` was not in its host class, so `tel:+15551234` was rejected while `mailto:foo@bar.com` was accepted. That inconsistency goes away.

**A bare email address stops validating.** This is the one case that did work and now does not. `someone@example.com` matched the old pattern's `@` alternative, and `formatUrl` in `@lexical/link` turns it into `mailto:` at render, so the anchor came out as `href="mailto:someone@example.com"`. It is not a URL, so it no longer passes here. Typing one still auto links, because the playground registers `autoLinkEmailMatcher` and that is a separate path. Happy to add a `mailto:` fallback next to the `www.` one if you would rather keep it.

**`ratio:3` stops validating.** The old pattern read `[A-Za-z]{3,9}:` followed by `3` as a host. This is why `aspect ratio:3 is best` used to make it through.

`TOGGLE_LINK_COMMAND` consults `validateUrl` too, so all of the above applies to setting a link from the link editor, not only to paste.

`sanitizeUrl` is refactored onto the same `parseUrl` helper. Its behavior is unchanged and the new tests pin it.

Closes #9094

## Test plan

`packages/lexical-playground/src/__tests__/unit/url.test.ts` is rewritten around protocols rather than whitespace. 41 tests. The non string cases stay, because the e2e clipboard stand in returns `undefined` for a type it was never given and a throw inside the paste listener breaks paste.

| expect | input | why |
| --- | --- | --- |
| accept | `https://example.com` | plain |
| accept | `http://localhost:3000` | port |
| accept | `https://example.com:8080/path` | port and path |
| accept | `https://en.wikipedia.org/wiki/Foo_(bar)` | parentheses in the path |
| accept | `https://example.com/#/spa/route` | hash route |
| accept | `https://example.com/?a=1,2` | comma in the query |
| accept | `https://ru.wikipedia.org/wiki/Кириллица` | non ASCII path |
| accept | `www.example.com` | bare `www.` host, as before |
| accept | `mailto:someone@example.com` | allowlisted protocol |
| accept | `tel:+15551234` | allowlisted, newly passing |
| accept | `sms:+15551234` | allowlisted, newly passing |
| accept | `https://` | the placeholder the link UI seeds |
| accept | `"https://example.com\n"` | copied off its own line, no trim |
| accept | `"  https://example.com  "` | padded, no trim |
| accept | `"\thttps://example.com"` | padded, no trim |
| reject | `check out https://example.com today` | contains a URL, is not one |
| reject | `see https://example.com` | same |
| reject | `https://example.com and then some` | same |
| reject | `just some prose` | same |
| reject | `aspect ratio:3 is best` | same |
| reject | `ratio:3` | scheme shaped, is not a URL |
| reject | `a b` | same |
| reject | `"https://example.com\nfoo"` | parser would splice to `example.comfoo` |
| reject | `"https://example.com\nhttps://other.example.com"` | same |
| reject | `"https://exam\tple.com"` | same |
| reject | `https://example.com/a b` | interior space |
| reject | `javascript:alert(1)` | protocol not allowlisted |
| reject | `JaVaScRiPt:alert(1)` | case does not help |
| reject | `data:text/html,hello` | protocol not allowlisted |
| reject | `vbscript:msgbox(1)` | protocol not allowlisted |
| reject | `ftp://example.com/file.txt` | protocol not allowlisted |
| reject | `file:///etc/hosts` | protocol not allowlisted |
| reject | `undefined` | clipboard stand in, must not throw |
| reject | `null` | same |

Plus three `sanitizeUrl` blocks pinning that the refactor changed nothing: allowlisted protocols pass through unchanged, non allowlisted ones become `about:blank`, and unparseable input comes back as it went in.

### Before

The new tests against the previous commit on this branch, the whitespace guard version, `vitest run --project unit packages/lexical-playground/src/__tests__/unit/url.test.ts`:

```
 ❯ |unit| packages/lexical-playground/src/__tests__/unit/url.test.ts (41 tests | 8 failed) 7ms
     × accepts "tel:+15551234" 3ms
     × accepts "sms:+15551234" 0ms
     × rejects "ratio:3" 0ms
     × rejects the unsupported protocol in "javascript:alert(1)" 0ms
     × rejects the unsupported protocol in "JaVaScRiPt:alert(1)" 0ms
     × rejects the unsupported protocol in "data:text/html,hello" 0ms
     × rejects the unsupported protocol in "vbscript:msgbox(1)" 0ms
     × rejects the unsupported protocol in "ftp://example.com/file.txt" 0ms

 Test Files  1 failed (1)
      Tests  8 failed | 33 passed (41)
```

The same tests against `url.ts` as it is on main:

```
 ❯ |unit| packages/lexical-playground/src/__tests__/unit/url.test.ts (41 tests | 16 failed) 7ms
     × accepts "tel:+15551234" 3ms
     × accepts "sms:+15551234" 0ms
     × rejects "check out https://example.com today" 0ms
     × rejects "see https://example.com" 0ms
     × rejects "https://example.com and then some" 0ms
     × rejects "aspect ratio:3 is best" 0ms
     × rejects "ratio:3" 0ms
     × rejects "https://example.com\nfoo", which the parser would otherwise splice 0ms
     × rejects "https://example.com\nhttps://other.example.com", which the parser would otherwise splice 0ms
     × rejects "https://exam\tple.com", which the parser would otherwise splice 0ms
     × rejects "https://example.com/a b", which the parser would otherwise splice 0ms
     × rejects the unsupported protocol in "javascript:alert(1)" 0ms
     × rejects the unsupported protocol in "JaVaScRiPt:alert(1)" 0ms
     × rejects the unsupported protocol in "data:text/html,hello" 0ms
     × rejects the unsupported protocol in "vbscript:msgbox(1)" 0ms
     × rejects the unsupported protocol in "ftp://example.com/file.txt" 0ms

 Test Files  1 failed (1)
      Tests  16 failed | 25 passed (41)
```

### After

```
 Test Files  1 passed (1)
      Tests  41 passed (41)
```

`vitest run --project unit packages/lexical-playground packages/lexical-link`:

```
 Test Files  34 passed (34)
      Tests  516 passed (516)
```

Whole unit project, `vitest run --project unit`:

```
 Test Files  265 passed (265)
      Tests  4397 passed | 1 skipped (4398)
```

`tsc --noEmit` exits 0. `eslint` and `prettier --list-different` report nothing on the two changed files.

### Backtracking

The pattern on main is already capped at `{1,256}` per run, so it is linear, and this is not a ReDoS fix. It is worth recording anyway that the parser has no backtracking at all, and is faster on the input the caps were added for, a long run of word characters with no `@`:

```
n        old urlRegExp (ms)    new validateUrl (ms)
5000     4.11                  0.07
10000    8.24                  0.06
20000    16.49                 0.11
40000    32.63                 0.10
80000    65.08                 0.15
```

### Not run

Browser mode and e2e were not run. I read the paste paths for what this could move. `registerLink` in `packages/lexical-link/src/LexicalLinkExtension.ts` only calls the predicate it is configured with and passes the raw clipboard text on to `TOGGLE_LINK_COMMAND`; it does not depend on any particular scheme being accepted, and both of its own test files supply their own validators rather than the playground's. `packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs` does mention `ftp://example.com`, as a protocol that must not auto link, and auto linking does not go through `validateUrl` at all.
