### PR TITLE
[tests] Chore: silence unnecessary stderr warnings in test-unit

### DIFF
--- a/dev-examples/mdast-editor/src/__tests__/browser/MdastEditorChrome.test.ts
+++ b/dev-examples/mdast-editor/src/__tests__/browser/MdastEditorChrome.test.ts
@@ -312,8 +312,16 @@ describe('footnotes', () => {
 
   test('clicking a ref moves the caret into the definition body', async () => {
     const {editor, root} = mountEditor('body[^a]\n\n[^a]: the note');
-    root.querySelector<HTMLElement>('.footnote-ref a')!.click();
+    // The click is inside the waitFor, so the *interaction* retries rather
+    // than only the observation. The selection follow-up rides on the
+    // fragment navigation's settle signal, and the navigation's focus fixup
+    // can land later still (observed intermittently on the windows/firefox
+    // CI runners), clobbering a single application; deferring the follow-up
+    // past the signal just changes who loses that race. A repeat click is a
+    // same-fragment navigation, which takes the timeout fallback and
+    // re-applies — the same recovery a person gets by clicking again.
     await vi.waitFor(() => {
+      root.querySelector<HTMLElement>('.footnote-ref a')!.click();
       const inDefinition = editor.read(() => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
@@ -394,10 +402,16 @@ describe('footnotes', () => {
         const top = selection.anchor.getNode().getTopLevelElement();
         return top === null ? '' : top.getTextContent();
       });
-    backlinks[0].click();
-    await vi.waitFor(() => expect($anchorBlockText()).toContain('first'));
-    backlinks[1].click();
-    await vi.waitFor(() => expect($anchorBlockText()).toContain('second'));
+    // Click inside the waitFor for the same reason as the ref-click test:
+    // retry the interaction, not just the observation.
+    await vi.waitFor(() => {
+      backlinks[0].click();
+      expect($anchorBlockText()).toContain('first');
+    });
+    await vi.waitFor(() => {
+      backlinks[1].click();
+      expect($anchorBlockText()).toContain('second');
+    });
   });
 });
 
@@ -461,9 +475,11 @@ describe('read-only', () => {
     editor.dispatchCommand(INSERT_ALERT_COMMAND, 'note');
     editor.dispatchCommand(FORMAT_KBD_COMMAND);
     expect(markdownOf(editor)).toBe(before);
-    // The one thing read-only still allows: moving the selection.
-    root.querySelector<HTMLElement>('.footnote-ref a')!.click();
+    // The one thing read-only still allows: moving the selection. The click
+    // is inside the waitFor, so the interaction retries rather than only the
+    // observation — see the ref-click test above.
     await vi.waitFor(() => {
+      root.querySelector<HTMLElement>('.footnote-ref a')!.click();
       const inDefinition = editor.read(() => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {

--- a/packages/lexical-react/src/__tests__/unit/LexicalExtensionComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalExtensionComposer.test.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lexical';
 import {act, useEffect} from 'react';
 import {createRoot, type Root} from 'react-dom/client';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 describe('LexicalExtensionComposer', () => {
   const extension = defineExtension({
@@ -92,9 +92,16 @@ describe('LexicalExtensionComposer', () => {
     // editor. This makes editor.focus() → updateEditorSync take the
     // inline path: $onUpdate pushes to _deferred, but NO $beginUpdate,
     // NO pending state, NO microtask. The callback is orphaned.
+    // updateEditorSync warns in DEV because the root listener runs
+    // with a read-only context on the stack — expected for this
+    // deliberate reproduction.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     editor.update(() => {
       editor.setRootElement(rootElement);
     });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/read-only context/);
+    warnSpy.mockRestore();
 
     // _deferred has the stuck focus callback.
     expect(editor._deferred.length).toBeGreaterThan(0);

--- a/packages/lexical-react/src/__tests__/unit/LexicalExtensionEditorComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalExtensionEditorComposer.test.tsx
@@ -286,5 +286,12 @@ describe('LexicalExtensionEditorComposer', () => {
       );
     });
     expect(container?.textContent).toBe('updated');
+
+    // Unmount before `using` disposes the editor so the disposal does not
+    // update the still-mounted EditorComponent outside of act().
+    await act(async () => {
+      reactRoot.render(null);
+      await Promise.resolve();
+    });
   });
 });

--- a/packages/lexical-react/src/__tests__/unit/useExtensionSignalValue.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useExtensionSignalValue.test.tsx
@@ -219,6 +219,12 @@ describe('useExtensionSignalValue', () => {
     });
 
     expect(container?.textContent).toBe('updated');
+
+    // Unmount before `using` disposes the editor so the disposal does not
+    // update the still-mounted EditorComponent outside of act().
+    await act(async () => {
+      reactRoot.unmount();
+    });
   });
 
   test('works with multiple signal properties', async () => {
@@ -317,6 +323,12 @@ describe('useExtensionSignalValue', () => {
     });
 
     expect(container?.textContent).toBe('A: 5B: 5');
+
+    // Unmount before `using` disposes the editor so the disposal does not
+    // update the still-mounted EditorComponent outside of act().
+    await act(async () => {
+      reactRoot.unmount();
+    });
   });
 
   test('works with complex object signals', async () => {
@@ -372,6 +384,12 @@ describe('useExtensionSignalValue', () => {
     });
 
     expect(container?.textContent).toBe('Jane Smith (jane@example.com)');
+
+    // Unmount before `using` disposes the editor so the disposal does not
+    // update the still-mounted EditorComponent outside of act().
+    await act(async () => {
+      reactRoot.unmount();
+    });
   });
 
   test('updates correctly with rapid signal changes', async () => {
@@ -410,5 +428,11 @@ describe('useExtensionSignalValue', () => {
     });
 
     expect(container?.textContent).toBe('10');
+
+    // Unmount before `using` disposes the editor so the disposal does not
+    // update the still-mounted EditorComponent outside of act().
+    await act(async () => {
+      reactRoot.unmount();
+    });
   });
 });

--- a/packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/FormatElementTableRect.test.ts
@@ -41,6 +41,7 @@ function buildTestEditor($initialEditorState?: InitialEditorStateType) {
       },
       dependencies: [TableExtension],
       name: 'format-element-rect-host',
+      theme: {tableScrollableWrapper: 'table-scrollable-wrapper'},
     }),
   );
 }

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableObserver.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableObserver.test.ts
@@ -57,6 +57,7 @@ describe('TableObserver tracking MutationObserver teardown (#9073)', () => {
       defineExtension({
         dependencies: [TableExtension],
         name: 'table-observer-test',
+        theme: {tableScrollableWrapper: 'table-scrollable-wrapper'},
       }),
     );
     editor.setRootElement(container);

--- a/packages/lexical-table/src/__tests__/unit/TableImportExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/TableImportExtension.test.ts
@@ -132,6 +132,7 @@ describe('TableImportExtension', () => {
       defineExtension({
         dependencies: [TableImportExtension],
         name: 'table-alias-host',
+        theme: {tableScrollableWrapper: ''},
       }),
     );
     importInto(editor, '<table><tr><td>a</td></tr></table>');

--- a/packages/lexical-table/src/__tests__/unit/ToggleHeaderStyle.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/ToggleHeaderStyle.test.ts
@@ -23,7 +23,11 @@ function toggle(
   toToggle: TableCellHeaderState,
 ): TableCellHeaderState {
   using editor = buildEditorFromExtensions(
-    defineExtension({dependencies: [TableExtension], name: 'toggle-host'}),
+    defineExtension({
+      dependencies: [TableExtension],
+      name: 'toggle-host',
+      theme: {tableScrollableWrapper: 'table-scrollable-wrapper'},
+    }),
   );
   let result: TableCellHeaderState = NO_STATUS;
   editor.update(

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -4031,6 +4031,9 @@ describe('LexicalEditor tests', () => {
         {discrete: true},
       );
 
+      const mockWarning = vi
+        .spyOn(console, 'warn')
+        .mockImplementationOnce(() => {});
       const legacy = createTestEditor({
         nodes: [
           LegacyParagraph,
@@ -4040,6 +4043,10 @@ describe('LexicalEditor tests', () => {
           throw err;
         },
       });
+      expect(mockWarning).toHaveBeenCalledWith(
+        `Override for ParagraphNode specifies 'replace' without 'withKlass'. 'withKlass' will be required in a future version.`,
+      );
+      mockWarning.mockRestore();
       legacy.update(
         () => {
           expect($create(ParagraphNode)).toBeInstanceOf(LegacyParagraph);
@@ -4056,6 +4063,9 @@ describe('LexicalEditor tests', () => {
       }
       const onError = vi.fn();
 
+      const mockWarning = vi
+        .spyOn(console, 'warn')
+        .mockImplementationOnce(() => {});
       const newEditor = createTestEditor({
         nodes: [
           CustomParagraphNode,
@@ -4066,6 +4076,10 @@ describe('LexicalEditor tests', () => {
         ],
         onError: onError,
       });
+      expect(mockWarning).toHaveBeenCalledWith(
+        `Override for ParagraphNode specifies 'replace' without 'withKlass'. 'withKlass' will be required in a future version.`,
+      );
+      mockWarning.mockRestore();
 
       const json = {
         root: {

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -1979,6 +1979,12 @@ describe('Element-anchored selection on old parent (#6031)', () => {
         ({actNoRestore}) => {
           const {editor} = testEnv;
           let sourceKey = '';
+          // Skipping the shift leaves the offset (3) past the parent's new
+          // child count (2), so applying the selection to the DOM throws an
+          // IndexSizeError that the reconciler catches and warns about.
+          const mockWarning = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
           editor.update(
             () => {
               const refs = {} as Refs;
@@ -1989,6 +1995,8 @@ describe('Element-anchored selection on old parent (#6031)', () => {
             },
             {discrete: true},
           );
+          expect(mockWarning).toHaveBeenCalledWith(expect.any(DOMException));
+          mockWarning.mockRestore();
           editor.read(() => {
             const sel = $getSelection();
             invariant($isRangeSelection(sel));


### PR DESCRIPTION
## Description

`pnpm run test-unit` passes, but the default reporter shows numerous stderr blocks of DEV-mode warnings that are all either missing test configuration or expected warnings from deliberately-exercised anti-patterns. This change makes the unit test run warning-free without changing any library behavior.

Also adds a flakiness fix for a mdast-editor browser unit test in firefox.

## Test plan

Test-only change, tests should still pass and exercise the same code paths without the noise from warning.