### PR TITLE
[lexical] Bug Fix: insertNodes no longer leaves an empty paragraph after a block inserted at the end of a paragraph

### DIFF
--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -65,6 +65,7 @@ import {
 } from 'lexical';
 import {
   createTestEditor,
+  DECORATOR_BOUNDARY_ANCHOR_HTML,
   expectHtmlToBeEqual,
   html,
   TestComposer,
@@ -777,6 +778,8 @@ describe('SharedHistoryExtension', () => {
       },
       {discrete: true},
     );
+    // insertNodes at the end of the paragraph no longer leaves a stray empty
+    // paragraph after the block decorator (#9095).
     expectHtmlToBeEqual(
       dom.innerHTML,
       html`
@@ -788,7 +791,7 @@ describe('SharedHistoryExtension', () => {
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">Child editor</span></p>
         </div>
-        <p dir="auto"><br data-lexical-managed-linebreak="true" /></p>
+        ${DECORATOR_BOUNDARY_ANCHOR_HTML}
       `,
     );
     editor.read(() => {
@@ -813,7 +816,7 @@ describe('SharedHistoryExtension', () => {
             <span data-lexical-text="true">Child editor. Updated!</span>
           </p>
         </div>
-        <p dir="auto"><br data-lexical-managed-linebreak="true" /></p>
+        ${DECORATOR_BOUNDARY_ANCHOR_HTML}
       `,
     );
     expect(
@@ -846,7 +849,7 @@ describe('SharedHistoryExtension', () => {
           data-lexical-editor="true">
           <p dir="auto"><span data-lexical-text="true">Child editor</span></p>
         </div>
-        <p dir="auto"><br data-lexical-managed-linebreak="true" /></p>
+        ${DECORATOR_BOUNDARY_ANCHOR_HTML}
       `,
     );
     editor.update(() => editor.dispatchCommand(UNDO_COMMAND), {

--- a/packages/lexical-playground/__tests__/unit/PullQuoteNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/PullQuoteNode.test.ts
@@ -21,10 +21,12 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $getSelection,
   $getSlot,
   $getSlotHost,
   $getSlotNames,
   $isParagraphNode,
+  $isRangeSelection,
   $setSelection,
   $setSlot,
   defineExtension,
@@ -391,6 +393,40 @@ describe('PullQuoteNode atomic decorator host', () => {
         'Quoted',
         'loose',
       ]);
+    });
+  });
+
+  // Regression test for #9095: pasting a PullQuote (a block-level
+  // DecoratorNode) with the caret at the end of a paragraph used to leave a
+  // stray empty paragraph after it, because the insertNodes cleanup only
+  // handled an ElementNode as the last inserted block.
+  it('pastes at the end of a paragraph without leaving an empty paragraph', () => {
+    using editor = buildEditorFromExtensions(PullQuoteTestExtension);
+
+    editor.update(
+      () => {
+        const text = $createTextNode('hello');
+        $getRoot().clear().append($createParagraphNode().append(text));
+        text.select(5, 5);
+      },
+      {discrete: true},
+    );
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertNodes([$createPullQuoteNode()]);
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(2);
+      assert($isParagraphNode(children[0]), 'paragraph keeps its place');
+      expect(children[0].getTextContent()).toBe('hello');
+      assert($isPullQuoteNode(children[1]), 'pullquote is the last child');
     });
   });
 });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1318,13 +1318,24 @@ export class RangeSelection implements BaseSelection {
       INTERNAL_$isBlock,
     );
 
-    if (
-      insertedParagraph &&
-      $isElementNode(lastInsertedBlock) &&
-      (insertedParagraph.canMergeWhenEmpty() || INTERNAL_$isBlock(lastToInsert))
-    ) {
-      lastInsertedBlock.append(...insertedParagraph.getChildren());
-      insertedParagraph.remove();
+    if (insertedParagraph) {
+      if (
+        $isElementNode(lastInsertedBlock) &&
+        (insertedParagraph.canMergeWhenEmpty() ||
+          INTERNAL_$isBlock(lastToInsert))
+      ) {
+        lastInsertedBlock.append(...insertedParagraph.getChildren());
+        insertedParagraph.remove();
+      } else if (insertedParagraph.isEmpty()) {
+        // The split-off paragraph could not be merged into the last inserted
+        // block (a block-level DecoratorNode is not an ElementNode, and a
+        // container element such as a ListNode is not INTERNAL_$isBlock), but
+        // it holds no content either: it only exists because the caret sat at
+        // the end of the target block. Keeping it would leave a stray empty
+        // paragraph after the inserted node, while the non-empty case (a
+        // mid-block caret) keeps the content after the caret.
+        insertedParagraph.remove();
+      }
     }
     if ($isElementNode(firstBlock) && firstBlock.isEmpty()) {
       firstBlock.remove();

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -19,10 +19,12 @@ import {
 import {
   $createListItemNode,
   $createListNode,
+  $isListNode,
   ListExtension,
   type ListItemNode,
   type ListNode,
 } from '@lexical/list';
+import {$createQuoteNode, QuoteNode} from '@lexical/rich-text';
 import {
   $caretRangeFromSelection,
   $comparePointCaretNext,
@@ -1161,6 +1163,216 @@ describe('Regression tests for #8707', () => {
       expect(children).toHaveLength(2);
       assert($isParagraphNode(children[0]));
       assert($isDecoratorNode(children[1]));
+    });
+  });
+});
+
+describe('Regression tests for #9095', () => {
+  // insertNodes with block-level content at a collapsed selection first
+  // splits the target paragraph (insertParagraph), then tries to merge the
+  // split-off paragraph into the last inserted block. The merge branch
+  // required $isElementNode(lastInsertedBlock), so a pasted block-level
+  // DecoratorNode (which is its own INTERNAL_$isBlock ancestor) skipped the
+  // cleanup entirely, and a container element such as a ListNode failed the
+  // INTERNAL_$isBlock(lastToInsert) clause instead (its first child is a
+  // ListItemNode). Both left a stray empty paragraph after the pasted node
+  // whenever the caret sat at the end of a paragraph, while pasting a plain
+  // paragraph or quote at the same caret cleaned up correctly. The split-off
+  // paragraph is now also removed when it is empty, which keeps the
+  // mid-paragraph case (where it holds the text after the caret) intact.
+  const insertBlockTestExtension = defineExtension({
+    dependencies: [selectionTestExtension],
+    name: '@test/selection-insert-block',
+    nodes: [QuoteNode],
+  });
+
+  const $placeCaretInFirstText = (offset: number) => {
+    const paragraph = $getRoot().getFirstChildOrThrow();
+    assert($isParagraphNode(paragraph), 'Expected a paragraph');
+    const text = paragraph.getFirstChildOrThrow();
+    assert($isTextNode(text), 'Expected a text node');
+    text.select(offset, offset);
+  };
+
+  const setupParagraph = (
+    editor: LexicalEditorWithDispose,
+    text: string,
+    caretOffset: number,
+  ) => {
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode(text)));
+        $placeCaretInFirstText(caretOffset);
+      },
+      {discrete: true},
+    );
+  };
+
+  const insertBlocks = (
+    editor: LexicalEditorWithDispose,
+    $makeNodes: () => LexicalNode[],
+  ) => {
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertNodes($makeNodes());
+      },
+      {discrete: true},
+    );
+  };
+
+  const $makeList = () =>
+    $createListNode('bullet').append(
+      $createListItemNode().append($createTextNode('item')),
+    );
+
+  test('pasting a block decorator at the end of a paragraph leaves no empty paragraph', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'hello', 5);
+    insertBlocks(editor, () => [$createTestDecoratorNode().setIsInline(false)]);
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(2);
+      assert($isParagraphNode(children[0]));
+      expect(children[0].getTextContent()).toBe('hello');
+      assert($isDecoratorNode(children[1]));
+    });
+  });
+
+  test('pasting a block decorator in the middle of a paragraph keeps the trailing text', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'helloworld', 5);
+    insertBlocks(editor, () => [$createTestDecoratorNode().setIsInline(false)]);
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(3);
+      assert($isParagraphNode(children[0]));
+      expect(children[0].getTextContent()).toBe('hello');
+      assert($isDecoratorNode(children[1]));
+      assert($isParagraphNode(children[2]));
+      expect(children[2].getTextContent()).toBe('world');
+    });
+  });
+
+  test('pasting a block decorator at the start of a paragraph keeps the paragraph after it', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'hello', 0);
+    insertBlocks(editor, () => [$createTestDecoratorNode().setIsInline(false)]);
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(2);
+      assert($isDecoratorNode(children[0]));
+      assert($isParagraphNode(children[1]));
+      expect(children[1].getTextContent()).toBe('hello');
+    });
+  });
+
+  test('pasting a list at the end of a paragraph leaves no empty paragraph', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'hello', 5);
+    insertBlocks(editor, () => [$makeList()]);
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(2);
+      assert($isParagraphNode(children[0]));
+      expect(children[0].getTextContent()).toBe('hello');
+      assert($isListNode(children[1]));
+      expect(children[1].getTextContent()).toBe('item');
+    });
+  });
+
+  test('pasting a list in the middle of a paragraph keeps the trailing text', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'helloworld', 5);
+    insertBlocks(editor, () => [$makeList()]);
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(3);
+      assert($isParagraphNode(children[0]));
+      expect(children[0].getTextContent()).toBe('hello');
+      assert($isListNode(children[1]));
+      assert($isParagraphNode(children[2]));
+      expect(children[2].getTextContent()).toBe('world');
+    });
+  });
+
+  test('pasting a list at the start of a paragraph keeps the paragraph after it', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'hello', 0);
+    insertBlocks(editor, () => [$makeList()]);
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(2);
+      assert($isListNode(children[0]));
+      assert($isParagraphNode(children[1]));
+      expect(children[1].getTextContent()).toBe('hello');
+    });
+  });
+
+  // Control cases: at the same caret, a leaf block element merges through
+  // the existing branch and never leaves a stray paragraph. This is the
+  // in-function inconsistency the regression tests above pin down.
+  test('pasting a quote at the end of a paragraph merges into it (control)', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'hello', 5);
+    insertBlocks(editor, () => [
+      $createQuoteNode().append($createTextNode('quoted')),
+    ]);
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(1);
+      assert($isParagraphNode(children[0]));
+      expect(children[0].getTextContent()).toBe('helloquoted');
+    });
+  });
+
+  test('pasting a paragraph at the end of a paragraph merges into it (control)', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'hello', 5);
+    insertBlocks(editor, () => [
+      $createParagraphNode().append($createTextNode('world')),
+    ]);
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(1);
+      assert($isParagraphNode(children[0]));
+      expect(children[0].getTextContent()).toBe('helloworld');
+    });
+  });
+
+  test('typing after pasting a block decorator at the end creates a paragraph on demand', () => {
+    using editor = buildEditorFromExtensions(insertBlockTestExtension);
+    setupParagraph(editor, 'hello', 5);
+    insertBlocks(editor, () => [$createTestDecoratorNode().setIsInline(false)]);
+
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        assert($isRangeSelection(selection), 'Expected RangeSelection');
+        selection.insertText('x');
+      },
+      {discrete: true},
+    );
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(3);
+      assert($isParagraphNode(children[0]));
+      expect(children[0].getTextContent()).toBe('hello');
+      assert($isDecoratorNode(children[1]));
+      assert($isParagraphNode(children[2]));
+      expect(children[2].getTextContent()).toBe('x');
     });
   });
 });


### PR DESCRIPTION

## Description

Current behavior: `RangeSelection.insertNodes` treats block content inconsistently at the same caret. With the caret at the end of a paragraph, pasting another paragraph or a quote merges cleanly, but pasting a block `DecoratorNode` (the reporter's PullQuote, a YouTube embed, an image, a horizontal rule) or a container element (a list, a table) leaves a stray empty paragraph after the pasted node. Pasting the same nodes in the middle of a paragraph is correct. The contradiction lives inside one function: `insertNodes` first splits the target paragraph with `insertParagraph`, then tries to merge the paragraph it split off into the last inserted block. That merge requires `$isElementNode(lastInsertedBlock)`, and for a pasted block decorator the `$findMatchingParent(nodeToSelect, INTERNAL_$isBlock)` walk starts at the decorator itself, so `INTERNAL_$isBlock` admits it, `$isElementNode` rejects it, and the cleanup is skipped. A container element such as a `ListNode` fails the other clause instead: the split paragraph reports `canMergeWhenEmpty()` false and `INTERNAL_$isBlock(lastToInsert)` is false because the list's first child is a `ListItemNode`. The reporter noted it reproduces with "even regular Element nodes", which is this second clause. The result is deterministic structural noise, one empty paragraph after the pasted node, gone with one Backspace, but it should never appear.

This change splits the conditional: when the merge branch does not apply and the paragraph split off by `insertParagraph` is empty, it is removed. The `isEmpty()` guard is what keeps the mid paragraph case intact, because there the split paragraph holds the text after the caret and must stay. Pasting at the start of a paragraph is likewise unchanged, since there the split paragraph holds the whole original text. Typing after a paste at the end still works: with the block decorator as the last child of its parent, `$transferStartingElementPointToTextPoint` creates a paragraph on demand, so removing the stray paragraph strands nothing.

The same shape exists inside list items: pasting a block decorator at the end of a non empty `ListItemNode` previously left a stray empty list item, and the split conditional removes it the same way.

Two collateral notes:

1. The `SharedHistoryExtension` test in `packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx` asserted the stray paragraph. It inserts a block decorator with `insertNodes` at the end of a paragraph, and three of its HTML assertions included the trailing `<p><br></p>` that this bug produced. Those assertions now expect the decorator as the last block, followed by the reconciler's `DECORATOR_BOUNDARY_ANCHOR_HTML` (the invisible zero size `<img>` parked outside a trailing block decorator since #8922, which the trailing paragraph previously made unnecessary). The undo and redo sequence the test exercises is untouched.
2. The HorizontalRule e2e assertions of a trailing paragraph go through a different code path and stay valid. `INSERT_HORIZONTAL_RULE_COMMAND` calls `$insertNodeToNearestRoot` (in `packages/lexical-extension/src/HorizontalRuleExtension.ts` and `packages/lexical-react/src/LexicalHorizontalRulePlugin.ts`), which never enters `insertNodes`, and the paste portions of `HorizontalRule.spec.mjs` target empty paragraphs, where `insertNodes` creates no split paragraph at all (`shouldInsert` is false). A scan of the other e2e specs that assert a trailing empty paragraph after a block found only command insertions through `$insertNodeToNearestRoot` (tables, horizontal rules), markdown shortcut transformers, Enter key behavior, and pastes into empty paragraphs, none of which reach the changed branch.

Closes #9095

## Test plan

New unit tests in `packages/lexical/src/__tests__/unit/LexicalSelection.test.ts` (`Regression tests for #9095`) cover block decorator and list pastes at the end, middle and start of a paragraph, quote and paragraph pastes at the same end of paragraph caret as controls, plus typing after a paste at the end:

1. pasting a block decorator at the end of a paragraph leaves no empty paragraph (failed before this change)
2. pasting a block decorator in the middle of a paragraph keeps the trailing text
3. pasting a block decorator at the start of a paragraph keeps the paragraph after it
4. pasting a list at the end of a paragraph leaves no empty paragraph (failed before this change)
5. pasting a list in the middle of a paragraph keeps the trailing text
6. pasting a list at the start of a paragraph keeps the paragraph after it
7. pasting a quote at the end of a paragraph merges into it (control: the existing branch already handled it)
8. pasting a paragraph at the end of a paragraph merges into it (control)
9. typing after pasting a block decorator at the end creates a paragraph on demand

The reporter's exact scenario is a new test in `packages/lexical-playground/__tests__/unit/PullQuoteNode.test.ts`: pasting a `PullQuoteNode` with the caret at the end of a paragraph leaves no empty paragraph (failed before this change).

### Before

The three new end of paragraph tests against the previous `LexicalSelection.ts`, each expecting two root children and finding three, the third being the stray empty paragraph:

```
 FAIL  |unit| packages/lexical/src/__tests__/unit/LexicalSelection.test.ts > Regression tests for #9095 > pasting a block decorator at the end of a paragraph leaves no empty paragraph
 FAIL  |unit| packages/lexical/src/__tests__/unit/LexicalSelection.test.ts > Regression tests for #9095 > pasting a list at the end of a paragraph leaves no empty paragraph
AssertionError: expected [ ParagraphNode{ …(17), …(1) }, …(2) ] to have a length of 2 but got 3
      Tests  2 failed | 7 passed
```

```
 FAIL  |unit| packages/lexical-playground/__tests__/unit/PullQuoteNode.test.ts > PullQuoteNode atomic decorator host > pastes at the end of a paragraph without leaving an empty paragraph
      Tests  1 failed | 9 passed (10)
```

The six other matrix tests and the typing test pass before and after, pinning the behavior that must not change.

### After

`vitest --project unit --project scripts-unit --no-watch`:

```
 Test Files  271 passed (271)
      Tests  5434 passed | 1 skipped (5435)
```

The one skipped test predates this change. Reverting only the `LexicalSelection.ts` change (keeping the tests) brings back the three failures above, and the updated `SharedHistoryExtension` assertions fail as well, since they now expect the decorator on the trailing edge. `tsc --noEmit` is clean, and `eslint` and `prettier` report nothing for the changed files. The browser, integration and e2e suites were not run.
