### PR TITLE
[lexical-list] Bug Fix: stop throttling rapid mouse clicks on the same checklist checkbox

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/checkList.test.tsx
+++ b/packages/lexical-list/src/__tests__/unit/checkList.test.tsx
@@ -194,4 +194,55 @@ describe('CheckListExtension mobile tap toggle', () => {
     expect(readChecked(editor, 0)).toBe(true);
     expect(readChecked(editor, 1)).toBe(true);
   });
+
+  it('rapid mouse clicks on the same item all toggle (desktop not throttled)', () => {
+    using editor = buildEditor();
+    expect(readChecked(editor, 0)).toBe(false);
+
+    const baseTimeStamp = 1000;
+    const click = (offsetMs: number) => {
+      const event = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 5,
+      });
+      Object.defineProperty(event, 'timeStamp', {
+        value: baseTimeStamp + offsetMs,
+      });
+      getCheckListItem(0).dispatchEvent(event);
+    };
+
+    // Two rapid mouse clicks within the dedup window must both toggle.
+    click(0);
+    click(100);
+
+    expect(readChecked(editor, 0)).toBe(false);
+  });
+
+  it('rapid touch taps on the same item are throttled (mobile preserved)', () => {
+    using editor = buildEditor();
+    expect(readChecked(editor, 0)).toBe(false);
+
+    const baseTimeStamp = 1000;
+    const tap = (offsetMs: number) => {
+      const event = new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 5,
+        pointerType: 'touch',
+      });
+      Object.defineProperty(event, 'timeStamp', {
+        value: baseTimeStamp + offsetMs,
+      });
+      getCheckListItem(0).dispatchEvent(event);
+    };
+
+    // First tap toggles, second tap within DEDUP_WINDOW_MS is throttled.
+    tap(0);
+    tap(100);
+
+    expect(readChecked(editor, 0)).toBe(true);
+  });
 });

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -69,9 +69,13 @@ export function registerCheckList(
   // and run the same toggle logic, deduplicating against any click that
   // does fire on browsers where preventDefault doesn't suppress it.
   //
-  // Dedup state is per-target: recorded as `__lexicalCheckListLastHandled`
-  // on the target element. A global window would
-  // block tapping a second checkbox within 500ms of toggling the first.
+  // Dedup state is per-target: recorded as `__lexicalCheckListLastTouchHandled`
+  // on the target element, and written ONLY by the touch pointerup path. A
+  // global window would block tapping a second checkbox within 500ms of
+  // toggling the first. The click path reads the timestamp but never writes
+  // it, so rapid mouse clicks on the same desktop checkbox are not throttled
+  // — only synthesized mobile clicks (which always follow a touch pointerup)
+  // are absorbed.
   const DEDUP_WINDOW_MS = 500;
   const isWithinDedupWindow = (
     event: PointerEvent | MouseEvent | TouchEvent,
@@ -81,21 +85,24 @@ export function registerCheckList(
       return false;
     }
     // @ts-ignore internal field
-    const last = target.__lexicalCheckListLastHandled as number | undefined;
+    const last = target.__lexicalCheckListLastTouchHandled as
+      | number
+      | undefined;
     return last !== undefined && event.timeStamp - last < DEDUP_WINDOW_MS;
   };
-  const recordHandled = (event: PointerEvent | MouseEvent | TouchEvent) => {
+  const recordTouchHandled = (
+    event: PointerEvent | MouseEvent | TouchEvent,
+  ) => {
     const target = event.target;
     if (isHTMLElement(target)) {
       // @ts-ignore internal field
-      target.__lexicalCheckListLastHandled = event.timeStamp;
+      target.__lexicalCheckListLastTouchHandled = event.timeStamp;
     }
   };
   const configHandleClick = (event: PointerEvent | MouseEvent | TouchEvent) => {
     if (isWithinDedupWindow(event)) {
       return;
     }
-    recordHandled(event);
     handleClick(event, peekDisableTakeFocusOnClick());
   };
   const configHandlePointerUp = (event: PointerEvent) => {
@@ -105,7 +112,7 @@ export function registerCheckList(
     if (isWithinDedupWindow(event)) {
       return;
     }
-    recordHandled(event);
+    recordTouchHandled(event);
     handleClick(event, peekDisableTakeFocusOnClick());
   };
   const configHandleSelectDefaults = (

--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -69,13 +69,12 @@ export function registerCheckList(
   // and run the same toggle logic, deduplicating against any click that
   // does fire on browsers where preventDefault doesn't suppress it.
   //
-  // Dedup state is per-target: recorded as `__lexicalCheckListLastTouchHandled`
-  // on the target element, and written ONLY by the touch pointerup path. A
-  // global window would block tapping a second checkbox within 500ms of
-  // toggling the first. The click path reads the timestamp but never writes
-  // it, so rapid mouse clicks on the same desktop checkbox are not throttled
-  // — only synthesized mobile clicks (which always follow a touch pointerup)
-  // are absorbed.
+  // Dedup state is per-target: recorded as `__lexicalCheckListLastHandled`
+  // on the target element, and written only by the touch pointerup path.
+  // A global window would block tapping a second checkbox within 500ms of
+  // toggling the first. The click path only reads the timestamp, so rapid
+  // mouse clicks on the same desktop checkbox are not throttled — only the
+  // synthesized click that follows a touch pointerup is absorbed.
   const DEDUP_WINDOW_MS = 500;
   const isWithinDedupWindow = (
     event: PointerEvent | MouseEvent | TouchEvent,
@@ -85,18 +84,14 @@ export function registerCheckList(
       return false;
     }
     // @ts-ignore internal field
-    const last = target.__lexicalCheckListLastTouchHandled as
-      | number
-      | undefined;
+    const last = target.__lexicalCheckListLastHandled as number | undefined;
     return last !== undefined && event.timeStamp - last < DEDUP_WINDOW_MS;
   };
-  const recordTouchHandled = (
-    event: PointerEvent | MouseEvent | TouchEvent,
-  ) => {
+  const recordHandled = (event: PointerEvent | MouseEvent | TouchEvent) => {
     const target = event.target;
     if (isHTMLElement(target)) {
       // @ts-ignore internal field
-      target.__lexicalCheckListLastTouchHandled = event.timeStamp;
+      target.__lexicalCheckListLastHandled = event.timeStamp;
     }
   };
   const configHandleClick = (event: PointerEvent | MouseEvent | TouchEvent) => {
@@ -112,7 +107,7 @@ export function registerCheckList(
     if (isWithinDedupWindow(event)) {
       return;
     }
-    recordTouchHandled(event);
+    recordHandled(event);
     handleClick(event, peekDisableTakeFocusOnClick());
   };
   const configHandleSelectDefaults = (


### PR DESCRIPTION
## Description

The checklist dedup mechanism (introduced in #8390 to prevent mobile double-toggle from `pointerup` + synthesized `click`) was applied **symmetrically**: both `configHandleClick` and `configHandlePointerUp` checked the dedup window **and** recorded a timestamp. As a side effect, rapid mouse clicks on the **same** desktop checkbox were throttled to one toggle per 500ms — the second click within the window was silently dropped.

The dedup only needs to be **unidirectional**: a synthesized mobile `click` must be absorbed when it follows a touch `pointerup` for the same tap. Mouse clicks never have a preceding touch `pointerup`, so they should never be throttled.

This change makes the dedup write-path touch-only:
- `configHandlePointerUp` still checks + records (mobile throttle preserved, including spam-tap protection).
- `configHandleClick` still checks (absorbs synthesized mobile clicks) but no longer records a timestamp, so rapid desktop clicks on the same checkbox all toggle.

The internal field is renamed `__lexicalCheckListLastHandled` → `__lexicalCheckListLastTouchHandled` to reflect that it is now written exclusively by the touch path.

Mobile behavior is unchanged: spam-tap on the same checkbox remains throttled at 500ms, and the `pointerup` + `click` double-toggle guard still works.

## Test plan

### Before

```
$ npx vitest run --project unit packages/lexical-list/src/__tests__/unit/checkList.test.tsx
```
No test covered rapid desktop clicks on the same item; the throttle was an undocumented side effect, so a second mouse click within 500ms was silently dropped (the checkbox stayed in its post-first-click state).

### After

```
$ npx vitest run --project unit packages/lexical-list/src/__tests__/unit/checkList.test.tsx

 ✓  unit  packages/lexical-list/src/__tests__/unit/checkList.test.tsx (6 tests) 104ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Two new tests lock in the behavior:
- "rapid mouse clicks on the same item all toggle (desktop not throttled)" — two mouse clicks within the dedup window produce `false → true → false`.
- "rapid touch taps on the same item are throttled (mobile preserved)" — two touch `pointerup`s within the dedup window produce a single toggle (`false → true`), confirming the mobile throttle is unchanged.

`pnpm run lint`, `pnpm run tsc`, and `pnpm run prettier` are clean on the affected package.