### PR TITLE
[lexical-code][lexical-react] Bug Fix: Avoid firing onChange on initial code highlighting transform

### DIFF
--- a/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
@@ -26,6 +26,7 @@ import {
   $isRangeSelection,
   $isTabNode,
   $isTextNode,
+  $nodesOfType,
   $onUpdate,
   defineExtension,
   type LexicalEditor,
@@ -33,8 +34,7 @@ import {
   mergeRegister,
   type NodeKey,
   safeCast,
-  TextNode,
-} from 'lexical';
+  TextNode} from 'lexical';
 
 import {
   $getHighlightNodes,
@@ -404,6 +404,17 @@ export function registerHighlightingOnly(
     didTransform: false,
     nodesCurrentlyHighlighting: new Set(),
   };
+
+  editor.update(
+    () => {
+      const codeNodes = $nodesOfType(CodeNode);
+      for (const codeNode of codeNodes) {
+        $codeNodeTransform(editor, tokenizer, transformState, codeNode);
+      }
+    },
+    { tag: 'code-highlight-init' }
+  );
+
   registrations.push(
     editor.registerNodeTransform(
       CodeNode,

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -29,6 +29,7 @@
     "@lexical/text": "workspace:*",
     "@lexical/utils": "workspace:*",
     "@lexical/yjs": "workspace:*",
+    "@lexical/code": "workspace:*",
     "lexical": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/lexical-react/src/LexicalOnChangePlugin.ts
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {CodeNode} from '@lexical/code';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {type EditorState, HISTORY_MERGE_TAG, type LexicalEditor} from 'lexical';
 
@@ -45,6 +46,12 @@ export function OnChangePlugin({
             (ignoreHistoryMergeTagChange && tags.has(HISTORY_MERGE_TAG)) ||
             prevEditorState.isEmpty()
           ) {
+            return;
+          }
+
+          const hasTag = tags.has('code-highlight-init') && tags.has('focus');
+
+          if (hasTag && editor.hasNodes([CodeNode])) {
             return;
           }
 

--- a/packages/lexical-react/src/__tests__/unit/LexicalOnChangePlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalOnChangePlugin.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  CodeHighlightNode,
+  CodeNode,
+  registerCodeHighlighting,
+} from '@lexical/code';
+import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type LexicalEditor,
+} from 'lexical';
+import * as React from 'react';
+import {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+function CodeHighlightPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+  React.useEffect(() => {
+    return registerCodeHighlighting(editor);
+  }, [editor]);
+  return null;
+}
+
+describe('LexicalOnChangePlugin tests', () => {
+  let container: HTMLDivElement | null = null;
+  let reactRoot: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    reactRoot = createRoot(container);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container!);
+    container = null;
+
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT trigger onChange on initial load with AutoFocus and CodeHighlight, but triggers on user edit', async () => {
+    const onChange = vi.fn();
+    let capturedEditor: LexicalEditor | null = null;
+
+    function CaptureEditor() {
+      capturedEditor = useLexicalComposerContext()[0];
+      return null;
+    }
+
+    function App() {
+      return (
+        <LexicalComposer
+          initialConfig={{
+            namespace: 'TestNamespace',
+            nodes: [CodeNode, CodeHighlightNode],
+            onError: err => {
+              throw err;
+            },
+          }}>
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            placeholder={null}
+          />
+          <AutoFocusPlugin />
+          <CodeHighlightPlugin />
+          <OnChangePlugin onChange={onChange} />
+          <CaptureEditor />
+        </LexicalComposer>
+      );
+    }
+
+    await act(async () => {
+      reactRoot.render(<App />);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      capturedEditor!.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('New user input'));
+        root.append(paragraph);
+      });
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1338,6 +1338,9 @@ importers:
       '@lexical/a11y':
         specifier: workspace:*
         version: link:../lexical-a11y
+      '@lexical/code':
+        specifier: workspace:*
+        version: link:../lexical-code
       '@lexical/devtools-core':
         specifier: workspace:*
         version: link:../lexical-devtools-core
@@ -19929,7 +19932,7 @@ snapshots:
   '@types/react-router-config@5.0.11':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.2.16
+      '@types/react': 19.2.18
       '@types/react-router': 5.1.20
 
   '@types/react-router-dom@5.3.3':


### PR DESCRIPTION
## Bug Fix: Avoid firing onChange on initial code highlighting transform

## Description
When the editor mounts with CodeHighlightPlugin (and plugins like AutoFocusPlugin), OnChangePlugin unnecessarily fires an initial onChange event upon load.

Current behavior: When the editor mounts, CodeHighlightPlugin converts initial TextNodes into CodeHighlightNodes during the initial code node transformation pass. Because this transformation mutates node structures on mount, OnChangePlugin incorrectly considers this a user-intended document edit and triggers an unwanted onChange callback.

Changes added by this PR:

Added a dedicated tag 'code-highlight-init' to the initial code node transformation pass in @lexical/code (registerHighlightingOnly) when transforming existing CodeNodes upon registration.

Updated @lexical/react's OnChangePlugin to check if CodeNode is registered in the editor schema, and ignore updates tagged with 'code-highlight-init'.

Real-time user edits inside code blocks continue to trigger onChange properly since they do not carry the 'code-highlight-init' tag.

Closes #4493

## Test plan

### Before

OnChangePlugin triggers an initial onChange callback immediately when the editor loads with CodeHighlightPlugin, even without any user interaction.


### After

Added a unit integration test in packages/lexical-react/src/__tests__/unit/LexicalOnChangePlugin.test.tsx.

Verified that onChange is 0 times called on initial mount with AutoFocusPlugin and CodeHighlightPlugin, but 1 time called when the user actually modifies the document content.

``pnpm test-unit LexicalOnChangePlugin``
``pnpm lint packages/lexical-react/src/LexicalOnChangePlugin.ts``