### PR TITLE
[lexical-playground][lexical-react] Bug Fix: only one collab client bootstraps a nested editor's document

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -102,16 +102,31 @@ test.describe('Selection', () => {
         parentSelector,
       );
 
+    // Which of the two editors currently owns the selection. Focusing an
+    // editor only moves the *DOM* selection; ownership moves when Lexical
+    // handles the `selectionchange` the browser dispatches for it, and that
+    // dispatch is asynchronous. Reading once right after `.focus()` therefore
+    // races the handover -- the DOM selection is already inside the newly
+    // focused editor while both editors still hold their previous Lexical
+    // state. Poll until the pair settles instead, and read both editors in
+    // one assertion so the editor that is losing the selection is checked
+    // against the same handover the winning editor waits for.
+    const expectSelectionOwner = async owner =>
+      await expect
+        .poll(async () => ({
+          caption: await hasSelection('.image-caption-container'),
+          shell: await hasSelection('.editor-shell'),
+        }))
+        .toEqual({caption: owner === 'caption', shell: owner === 'shell'});
+
     await focusEditor(page);
     await insertSampleImage(page);
     await insertImageCaption(page, 'Hello world');
-    expect(await hasSelection('.image-caption-container')).toBe(true);
-    expect(await hasSelection('.editor-shell')).toBe(false);
+    await expectSelectionOwner('caption');
 
     // Click outside of the editor and check that selection remains the same
     await click(page, 'header .logo');
-    expect(await hasSelection('.image-caption-container')).toBe(true);
-    expect(await hasSelection('.editor-shell')).toBe(false);
+    await expectSelectionOwner('caption');
 
     // Back to root editor
     if (browserName === 'firefox') {
@@ -123,18 +138,15 @@ test.describe('Selection', () => {
     } else {
       await focusEditor(page);
     }
-    expect(await hasSelection('.image-caption-container')).toBe(false);
-    expect(await hasSelection('.editor-shell')).toBe(true);
+    await expectSelectionOwner('shell');
 
     // Click outside of the editor and check that selection remains the same
     await click(page, 'header .logo');
-    expect(await hasSelection('.image-caption-container')).toBe(false);
-    expect(await hasSelection('.editor-shell')).toBe(true);
+    await expectSelectionOwner('shell');
 
     // Back to nested editor editor
     await focusEditor(page, '.image-caption-container');
-    expect(await hasSelection('.image-caption-container')).toBe(true);
-    expect(await hasSelection('.editor-shell')).toBe(false);
+    await expectSelectionOwner('caption');
   });
 
   test('can wrap post-linebreak nodes into new element', async ({

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -68,6 +68,7 @@ import {isDevPlayground} from './appSettings';
 import {
   createWebsocketProvider,
   createWebsocketProviderWithDoc,
+  skipCollaborationInit,
 } from './collaboration';
 import {FlashMessageContext} from './context/FlashMessageContext';
 import {SettingsContext, useSettings} from './context/SettingsContext';
@@ -123,10 +124,6 @@ console.warn(
 );
 
 const COLLAB_DOC_ID = 'main';
-
-const skipCollaborationInit =
-  // @ts-expect-error
-  window.parent != null && window.parent.frames.right === window;
 
 function $prepopulatedRichText() {
   const root = $getRoot();

--- a/packages/lexical-playground/src/collaboration.ts
+++ b/packages/lexical-playground/src/collaboration.ts
@@ -18,6 +18,27 @@ const WEBSOCKET_ENDPOINT =
 const WEBSOCKET_SLUG = 'playground';
 const WEBSOCKET_ID = params.get('collabId') || '0';
 
+/**
+ * True in the `right` frame of the `/split/` two-client view, which exists to
+ * simulate a second user joining a document the `left` frame already created.
+ *
+ * `CollaborationPlugin`'s client-side `shouldBootstrap` seeds an empty Yjs
+ * document with a single empty paragraph once the provider reports `sync`. That
+ * write is an ordinary Yjs insert, not a compare-and-set, so two clients that
+ * both find the document empty each insert a paragraph and Yjs keeps both. Only
+ * one client may bootstrap a given document.
+ *
+ * For the main document only the `left` frame creates content, but a nested
+ * editor's document (an image caption, a sticky note) is reached by both
+ * clients the moment the node itself syncs -- `syncPropertiesToYjs` gives the
+ * nested editor a sub-`Doc` and uses that doc's `guid` as the editor key, so
+ * both frames resolve the same collab room at the same time. Nested editors
+ * therefore have to make the same choice the main document does.
+ */
+export const skipCollaborationInit =
+  // @ts-expect-error -- `frames.right` is the named `/split/` iframe
+  window.parent != null && window.parent.frames.right === window;
+
 // parent dom -> child doc
 export function createWebsocketProvider(
   id: string,

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -49,7 +49,7 @@ import {
   useState,
 } from 'react';
 
-import {createWebsocketProvider} from '../collaboration';
+import {createWebsocketProvider, skipCollaborationInit} from '../collaboration';
 import {useSettings} from '../context/SettingsContext';
 import brokenImage from '../images/image-broken.svg';
 import TreeViewPlugin from '../plugins/TreeViewPlugin';
@@ -495,7 +495,7 @@ export default function ImageComponent({
                 <CollaborationPlugin
                   id={caption.getKey()}
                   providerFactory={createWebsocketProvider}
-                  shouldBootstrap={true}
+                  shouldBootstrap={!skipCollaborationInit}
                   selectionHighlight={true}
                 />
               ) : null}

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -24,7 +24,7 @@ import {
 import * as React from 'react';
 import {type JSX, useEffect, useLayoutEffect, useRef} from 'react';
 
-import {createWebsocketProvider} from '../collaboration';
+import {createWebsocketProvider, skipCollaborationInit} from '../collaboration';
 import {$isStickyNode} from './StickyNode';
 
 interface Positioning {
@@ -238,7 +238,7 @@ export default function StickyComponent({
             <CollaborationPlugin
               id={caption.getKey()}
               providerFactory={createWebsocketProvider}
-              shouldBootstrap={true}
+              shouldBootstrap={!skipCollaborationInit}
               selectionHighlight={true}
             />
           ) : null}

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -39,6 +39,19 @@ type ProviderFactory = (id: string, yjsDocMap: Map<string, Doc>) => Provider;
 type CollaborationPluginProps = {
   id: string;
   providerFactory: ProviderFactory;
+  /**
+   * Seed the document with an empty paragraph (or `initialEditorState`) once
+   * the provider reports `sync` and the document is still empty.
+   *
+   * At most one client may pass `true` for a given document. The seed is an
+   * ordinary Yjs insert rather than a compare-and-set, so two clients that both
+   * observe an empty document each insert a paragraph and Yjs keeps both,
+   * leaving every client with a spurious leading empty block. This is easy to
+   * hit with a nested editor (an image caption, a sticky note), where every
+   * client mounts the editor -- and so connects to its document -- at the same
+   * moment the node itself syncs. Prefer bootstrapping the document
+   * server-side; see the collaboration docs.
+   */
   shouldBootstrap: boolean;
   username?: string;
   cursorColor?: string;


### PR DESCRIPTION
## Description

`ImageComponent` (image caption) and `StickyComponent` (sticky note) mount `CollaborationPlugin` with `shouldBootstrap={true}` unconditionally, while the main document uses `shouldBootstrap={!skipCollaborationInit}` so that only the `left` frame of the `/split/` two-client view seeds it.

That is unsafe for a nested editor. `syncPropertiesToYjs` gives the nested editor a sub-`Doc` and uses that doc's `guid` as the editor key, so every client resolves the same collab room -- and unlike the main document, every client mounts the nested editor at the same moment the node itself syncs. Bootstrap is an ordinary Yjs insert rather than a compare-and-set, so when both clients' `sync` arrives before either's paragraph has propagated, each inserts an empty paragraph and Yjs keeps both. The caption ends up with a leading empty paragraph and the user's text in the second one, which is what made `SelectBlock › Select within nested editor` fail intermittently in the collab e2e job:

    Array [
      3, 1, 1, 0,
    -   0,
    +   1,
      0, 0,
    ]

`skipCollaborationInit` moves from `App.tsx` to `collaboration.ts` so both nested editors can share it, and `CollaborationPlugin`'s `shouldBootstrap` prop gains a doc comment recording that at most one client may set it.

## Test plan

### Before

`SelectBlock › Select within nested editor`, collab mode, 40 repeats over 8 workers on a 4-core box (oversubscribed to widen the race):

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Array [ 3, 1, 1, 0,
    -   0,
    +   1,
        0,
        0,
      ]
       at assertSelectionOnPageOrFrame (packages/lexical-playground/__tests__/utils/index.mjs:660:32)

    1 failed
    39 passed (3.3m)

A reduced spec asserting the caption editor's HTML directly, 24 repeats over 8 workers, caught the extra paragraph itself:

    Expected: "<p class=\"PlaygroundEditorTheme__paragraph\" dir=\"auto\"><span data-lexical-text=\"true\">caption text</span></p>"
    Received: "<p class=\"PlaygroundEditorTheme__paragraph\" dir=\"auto\"><br data-lexical-managed-linebreak=\"true\"></p><p class=\"PlaygroundEditorTheme__paragraph\" dir=\"auto\"><span data-lexical-text=\"true\">caption text</span></p>"

Instrumenting `onBootstrap` showed both frames on the same caption document, with the second frame only just losing the race:

    DBG onBootstrap {"_f":"left","id":"a421fdae-b83b-4706-8283-b7761fdff588","shouldBootstrap":true,"yEmpty":true,"len":0}
    DBG bootstrap:initializeEditor {"_f":"left","empty":true,"hasSel":true,"active":true,"size":0}
    DBG onBootstrap {"_f":"right","id":"a421fdae-b83b-4706-8283-b7761fdff588","shouldBootstrap":true,"yEmpty":false,"len":1}

### After

Same test, same oversubscribed configuration, 58 repeats completed with no failures before the run was stopped:

    Running 100 tests using 8 workers
      ✓  ... SelectBlock › Select within nested editor
      (58 completed, 0 failed)

Full `SelectBlock.spec.mjs` and `Images.spec.mjs` in collab mode:

    4 skipped
    23 passed (1.5m)

`pnpm run tsc`, `npx prettier --list-different` and `npx eslint` are clean on the changed files. Only chromium was exercised; firefox and webkit were not run in this environment.
