### PR TITLE
[lexical] Performance: Skip the sibling walk when no selection point reads the index

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1780,13 +1780,26 @@ export class LexicalNode {
     const selection = $getSelection();
     let elementAnchorSelectionOnNode = false;
     let elementFocusSelectionOnNode = false;
-    if (oldParent !== null) {
-      // TODO: this is O(n), can we improve?
-      const oldIndex = nodeToInsert.getIndexWithinParent();
-      if ($isRangeSelection(selection)) {
-        const oldParentKey = oldParent.__key;
-        const anchor = selection.anchor;
-        const focus = selection.focus;
+    // nodeToInsert's index in oldParent, or -1 when it was never computed
+    // because nothing below can observe it.
+    let oldIndex = -1;
+    if (
+      oldParent !== null &&
+      restoreSelection &&
+      $isRangeSelection(selection)
+    ) {
+      const oldParentKey = oldParent.__key;
+      const anchor = selection.anchor;
+      const focus = selection.focus;
+      // getIndexWithinParent walks oldParent's children from the first one,
+      // so calling it unconditionally makes a bulk insert quadratic (#5194).
+      // The index is only ever read through the selection: the comparisons
+      // below arm a flag only for a point whose key is oldParentKey, and
+      // $updateElementSelectionOnCreateDeleteNode returns early unless anchor
+      // or focus resolves to the parent it is passed. restoreSelection gates
+      // the block because the flags are read only under it, further down.
+      if (anchor.key === oldParentKey || focus.key === oldParentKey) {
+        oldIndex = nodeToInsert.getIndexWithinParent();
         elementAnchorSelectionOnNode =
           anchor.type === 'element' &&
           anchor.key === oldParentKey &&
@@ -1796,23 +1809,21 @@ export class LexicalNode {
           focus.key === oldParentKey &&
           focus.offset === oldIndex + 1;
       }
-      $removeFromParent(writableNodeToInsert);
-      // Adjust element-anchored offsets in oldParent to track its reduced
-      // child count. The boolean flags captured above
-      // (elementAnchorSelectionOnNode / elementFocusSelectionOnNode) recorded
-      // whether anchor/focus sat at oldIndex+1 before this removal; the
-      // post-insertion block below uses them to re-anchor onto the moved
-      // node in its new parent. See #6031.
-      if (restoreSelection && $isRangeSelection(selection)) {
-        $updateElementSelectionOnCreateDeleteNode(
-          selection,
-          oldParent,
-          oldIndex,
-          -1,
-        );
-      }
-    } else {
-      $removeFromParent(writableNodeToInsert);
+    }
+    $removeFromParent(writableNodeToInsert);
+    // Adjust element-anchored offsets in oldParent to track its reduced
+    // child count. The boolean flags captured above
+    // (elementAnchorSelectionOnNode / elementFocusSelectionOnNode) recorded
+    // whether anchor/focus sat at oldIndex+1 before this removal; the
+    // post-insertion block below uses them to re-anchor onto the moved
+    // node in its new parent. See #6031.
+    if (oldIndex !== -1 && oldParent !== null && $isRangeSelection(selection)) {
+      $updateElementSelectionOnCreateDeleteNode(
+        selection,
+        oldParent,
+        oldIndex,
+        -1,
+      );
     }
     const nextSibling = this.getNextSibling();
     const writableParent = this.getParentOrThrow().getWritable();
@@ -1830,18 +1841,30 @@ export class LexicalNode {
     writableNodeToInsert.__prev = writableSelf.__key;
     writableNodeToInsert.__parent = writableSelf.__parent;
     if (restoreSelection && $isRangeSelection(selection)) {
-      const index = this.getIndexWithinParent();
-      $updateElementSelectionOnCreateDeleteNode(
-        selection,
-        writableParent,
-        index + 1,
-      );
       const writableParentKey = writableParent.__key;
-      if (elementAnchorSelectionOnNode) {
-        selection.anchor.set(writableParentKey, index + 2, 'element');
-      }
-      if (elementFocusSelectionOnNode) {
-        selection.focus.set(writableParentKey, index + 2, 'element');
+      // Same reasoning as the oldParent block above, plus one more consumer:
+      // when the node was moved out of a different parent, the flags re-anchor
+      // the selection onto it here (#6031) and need the index even though no
+      // selection point is on writableParent yet. Check the flags as well as
+      // the points before paying for the sibling walk.
+      if (
+        elementAnchorSelectionOnNode ||
+        elementFocusSelectionOnNode ||
+        selection.anchor.key === writableParentKey ||
+        selection.focus.key === writableParentKey
+      ) {
+        const index = this.getIndexWithinParent();
+        $updateElementSelectionOnCreateDeleteNode(
+          selection,
+          writableParent,
+          index + 1,
+        );
+        if (elementAnchorSelectionOnNode) {
+          selection.anchor.set(writableParentKey, index + 2, 'element');
+        }
+        if (elementFocusSelectionOnNode) {
+          selection.focus.set(writableParentKey, index + 2, 'element');
+        }
       }
     }
     return nodeToInsert;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -42,6 +42,7 @@ import {
   $isNodeSelection,
   $isRangeSelection,
   $moveSelectionPointToEnd,
+  $selectionTouchesElement,
   $updateElementSelectionOnCreateDeleteNode,
   type BaseSelection,
   moveSelectionPointToSibling,
@@ -531,8 +532,14 @@ export function $removeNode(
     nodeToRemove.selectPrevious();
   }
 
-  if ($isRangeSelection(selection) && restoreSelection && !selectionMoved) {
-    // Doing this is O(n) so lets avoid it unless we need to do it
+  if (
+    $isRangeSelection(selection) &&
+    restoreSelection &&
+    !selectionMoved &&
+    // getIndexWithinParent is O(n) in the parent's child count, so skip it
+    // unless the update below can observe the index (#5194).
+    $selectionTouchesElement(selection, parent)
+  ) {
     const index = nodeToRemove.getIndexWithinParent();
     $removeFromParent(nodeToRemove);
     $updateElementSelectionOnCreateDeleteNode(selection, parent, index, -1);
@@ -1663,12 +1670,22 @@ export class LexicalNode {
     // cloned selection's element offsets in that old parent can be adjusted
     // afterwards. See #6031.
     const replaceWithOldParent = writableReplaceWith.getParent();
-    const replaceWithOldIndex =
-      replaceWithOldParent !== null
-        ? writableReplaceWith.getIndexWithinParent()
-        : -1;
+    // getIndexWithinParent is O(n) in that parent's child count and the index
+    // is only read by the update below, which is a no-op unless a selection
+    // point sits on replaceWithOldParent itself (#5194).
+    const restoreInReplaceWithOldParent =
+      replaceWithOldParent !== null &&
+      $isRangeSelection(selection) &&
+      $selectionTouchesElement(selection, replaceWithOldParent);
+    const replaceWithOldIndex = restoreInReplaceWithOldParent
+      ? writableReplaceWith.getIndexWithinParent()
+      : -1;
     $removeFromParent(writableReplaceWith);
-    if (replaceWithOldParent !== null && $isRangeSelection(selection)) {
+    if (
+      restoreInReplaceWithOldParent &&
+      replaceWithOldParent !== null &&
+      $isRangeSelection(selection)
+    ) {
       $updateElementSelectionOnCreateDeleteNode(
         selection,
         replaceWithOldParent,
@@ -1783,32 +1800,31 @@ export class LexicalNode {
     // nodeToInsert's index in oldParent, or -1 when it was never computed
     // because nothing below can observe it.
     let oldIndex = -1;
+    // getIndexWithinParent walks oldParent's children from the first one, so
+    // calling it unconditionally makes a bulk insert quadratic (#5194). The
+    // index is only ever read through the selection: the comparisons below
+    // arm a flag only for a point whose key is oldParentKey, and
+    // $updateElementSelectionOnCreateDeleteNode is a no-op under the same
+    // condition $selectionTouchesElement tests. restoreSelection gates the
+    // block because the flags are read only under it, further down.
     if (
       oldParent !== null &&
       restoreSelection &&
-      $isRangeSelection(selection)
+      $isRangeSelection(selection) &&
+      $selectionTouchesElement(selection, oldParent)
     ) {
       const oldParentKey = oldParent.__key;
       const anchor = selection.anchor;
       const focus = selection.focus;
-      // getIndexWithinParent walks oldParent's children from the first one,
-      // so calling it unconditionally makes a bulk insert quadratic (#5194).
-      // The index is only ever read through the selection: the comparisons
-      // below arm a flag only for a point whose key is oldParentKey, and
-      // $updateElementSelectionOnCreateDeleteNode returns early unless anchor
-      // or focus resolves to the parent it is passed. restoreSelection gates
-      // the block because the flags are read only under it, further down.
-      if (anchor.key === oldParentKey || focus.key === oldParentKey) {
-        oldIndex = nodeToInsert.getIndexWithinParent();
-        elementAnchorSelectionOnNode =
-          anchor.type === 'element' &&
-          anchor.key === oldParentKey &&
-          anchor.offset === oldIndex + 1;
-        elementFocusSelectionOnNode =
-          focus.type === 'element' &&
-          focus.key === oldParentKey &&
-          focus.offset === oldIndex + 1;
-      }
+      oldIndex = nodeToInsert.getIndexWithinParent();
+      elementAnchorSelectionOnNode =
+        anchor.type === 'element' &&
+        anchor.key === oldParentKey &&
+        anchor.offset === oldIndex + 1;
+      elementFocusSelectionOnNode =
+        focus.type === 'element' &&
+        focus.key === oldParentKey &&
+        focus.offset === oldIndex + 1;
     }
     $removeFromParent(writableNodeToInsert);
     // Adjust element-anchored offsets in oldParent to track its reduced
@@ -1850,8 +1866,7 @@ export class LexicalNode {
       if (
         elementAnchorSelectionOnNode ||
         elementFocusSelectionOnNode ||
-        selection.anchor.key === writableParentKey ||
-        selection.focus.key === writableParentKey
+        $selectionTouchesElement(selection, writableParent)
       ) {
         const index = this.getIndexWithinParent();
         $updateElementSelectionOnCreateDeleteNode(
@@ -1894,14 +1909,22 @@ export class LexicalNode {
     // selection's element offsets in that old parent can be adjusted
     // afterwards. See #6031.
     const insertOldParent = writableNodeToInsert.getParent();
-    const insertOldIndex =
-      insertOldParent !== null
-        ? writableNodeToInsert.getIndexWithinParent()
-        : -1;
-    $removeFromParent(writableNodeToInsert);
-    if (
+    // getIndexWithinParent walks insertOldParent's children from the first
+    // one, so calling it unconditionally makes a bulk insert quadratic
+    // (#5194). The index is only read by the update below, which is a no-op
+    // unless a selection point sits on insertOldParent itself.
+    const restoreInOldParent =
       insertOldParent !== null &&
       restoreSelection &&
+      $isRangeSelection(selection) &&
+      $selectionTouchesElement(selection, insertOldParent);
+    const insertOldIndex = restoreInOldParent
+      ? writableNodeToInsert.getIndexWithinParent()
+      : -1;
+    $removeFromParent(writableNodeToInsert);
+    if (
+      restoreInOldParent &&
+      insertOldParent !== null &&
       $isRangeSelection(selection)
     ) {
       $updateElementSelectionOnCreateDeleteNode(
@@ -1914,8 +1937,15 @@ export class LexicalNode {
     const prevSibling = this.getPreviousSibling();
     const writableParent = this.getParentOrThrow().getWritable();
     const prevKey = writableSelf.__prev;
-    // TODO: this is O(n), can we improve?
-    const index = this.getIndexWithinParent();
+    // Same reasoning as the insertOldParent block above. Unlike insertAfter
+    // there is no #6031 re-anchor here, so the points are the only consumer.
+    // This node's index before the splice is where nodeToInsert lands, so it
+    // has to be read now rather than after the pointers are rewired.
+    const restoreInNewParent =
+      restoreSelection &&
+      $isRangeSelection(selection) &&
+      $selectionTouchesElement(selection, writableParent);
+    const index = restoreInNewParent ? this.getIndexWithinParent() : -1;
     if (prevSibling === null) {
       writableParent.__first = insertKey;
     } else {
@@ -1927,9 +1957,12 @@ export class LexicalNode {
     writableNodeToInsert.__prev = prevKey;
     writableNodeToInsert.__next = writableSelf.__key;
     writableNodeToInsert.__parent = writableSelf.__parent;
-    if (restoreSelection && $isRangeSelection(selection)) {
-      const parent = this.getParentOrThrow();
-      $updateElementSelectionOnCreateDeleteNode(selection, parent, index);
+    if (restoreInNewParent && $isRangeSelection(selection)) {
+      $updateElementSelectionOnCreateDeleteNode(
+        selection,
+        writableParent,
+        index,
+      );
     }
     return nodeToInsert;
   }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3692,19 +3692,47 @@ export function $getPreviousSelection(): null | BaseSelection {
   return editor._editorState._selection;
 }
 
+/**
+ * Whether `selection` has a point directly on `parentNode`, which is exactly
+ * the condition under which
+ * {@link $updateElementSelectionOnCreateDeleteNode} does anything at all.
+ * @internal
+ *
+ * Every caller of that function has to compute a child offset first, and
+ * `getIndexWithinParent` walks the parent's children from the first one, so
+ * doing it unconditionally makes a bulk insert or removal quadratic (#5194).
+ * Guarding the walk with this predicate skips it whenever the update would
+ * be a no-op. It is the same test the early return uses, so the two cannot
+ * drift apart.
+ *
+ * Note that a point *inside* `parentNode` (a text point on one of its
+ * descendants, say) does not count: the function only shifts offsets that
+ * are element-anchored on `parentNode` itself.
+ *
+ * This function is for internal use of the library.
+ * Please do not use it as it may change in the future.
+ */
+export function $selectionTouchesElement(
+  selection: RangeSelection,
+  parentNode: LexicalNode,
+): boolean {
+  const parentKey = parentNode.__key;
+  return (
+    selection.anchor.key === parentKey || selection.focus.key === parentKey
+  );
+}
+
 export function $updateElementSelectionOnCreateDeleteNode(
   selection: RangeSelection,
   parentNode: LexicalNode,
   nodeOffset: number,
   times = 1,
 ): void {
-  const anchor = selection.anchor;
-  const focus = selection.focus;
-  const anchorNode = anchor.getNode();
-  const focusNode = focus.getNode();
-  if (!parentNode.is(anchorNode) && !parentNode.is(focusNode)) {
+  if (!$selectionTouchesElement(selection, parentNode)) {
     return;
   }
+  const anchor = selection.anchor;
+  const focus = selection.focus;
   const parentKey = parentNode.__key;
   // Single node. We shift selection but never redimension it
   if (selection.isCollapsed()) {

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -2061,6 +2061,257 @@ describe('Element-anchored selection on old parent (#6031)', () => {
   });
 });
 
+describe('insertAfter selection side effects', () => {
+  initializeUnitTest(testEnv => {
+    // insertAfter reads getIndexWithinParent for two reasons only: to shift
+    // element-anchored offsets in the parent that loses the node and in the
+    // parent that gains it, and to re-anchor a point that was sitting on the
+    // node itself when it moves between parents (#6031). These pin every one
+    // of those effects, including the offsets, so that any change to when the
+    // index is computed has to keep producing the same selection.
+    type Refs = {
+      source: ElementNode;
+      target: ElementNode;
+      mover: ElementNode;
+      inTarget: ElementNode;
+    };
+    // source holds [mover, a2, a3]; target holds [inTarget]. Moving mover
+    // into target puts it at target offset 1, so a point that was on mover
+    // (source offset 1) belongs at target offset 2 afterwards.
+    const $setupTwoContainers = (out: Refs) => {
+      const root = $getRoot().clear();
+      out.source = $createTestElementNode();
+      out.target = $createTestElementNode();
+      out.mover = $createParagraphNode();
+      out.inTarget = $createParagraphNode();
+      out.source.append(
+        out.mover,
+        $createParagraphNode(),
+        $createParagraphNode(),
+      );
+      out.target.append(out.inTarget);
+      root.append(out.source, out.target);
+    };
+
+    test('cross-parent move re-anchors a collapsed point that sat on the moved node', () => {
+      const {editor} = testEnv;
+      let targetKey = '';
+      editor.update(
+        () => {
+          const refs = {} as Refs;
+          $setupTwoContainers(refs);
+          targetKey = refs.target.__key;
+          // Collapsed at source offset 1, which is mover's index (0) plus
+          // one: the point is immediately after the node being moved, so it
+          // has to follow the node into target rather than stay behind.
+          refs.source.select(1, 1);
+          refs.inTarget.insertAfter(refs.mover);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(targetKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(2);
+        expect(sel.focus.key).toBe(targetKey);
+        expect(sel.focus.offset).toBe(2);
+      });
+    });
+
+    test('cross-parent move re-anchors only the point that sat on the moved node', () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      let targetKey = '';
+      editor.update(
+        () => {
+          const refs = {} as Refs;
+          $setupTwoContainers(refs);
+          sourceKey = refs.source.__key;
+          targetKey = refs.target.__key;
+          // Anchor at source offset 0 is at the removed index, so it stays
+          // put; focus at 1 sat on mover and follows it into target.
+          refs.source.select(0, 1);
+          refs.inTarget.insertAfter(refs.mover);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(sourceKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(0);
+        expect(sel.focus.key).toBe(targetKey);
+        expect(sel.focus.type).toBe('element');
+        expect(sel.focus.offset).toBe(2);
+      });
+    });
+
+    test('cross-parent move shifts a source point past the removed index (times=-1)', () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const refs = {} as Refs;
+          $setupTwoContainers(refs);
+          sourceKey = refs.source.__key;
+          // Offset 2 is past mover's index (0) but not on it, so the removal
+          // shift applies and no re-anchor does.
+          refs.source.select(2, 2);
+          refs.inTarget.insertAfter(refs.mover);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(sourceKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(1);
+        expect(sel.focus.offset).toBe(1);
+      });
+    });
+
+    test('collapsed point on the destination parent shifts by one', () => {
+      const {editor} = testEnv;
+      let parentKey = '';
+      editor.update(
+        () => {
+          const root = $getRoot().clear();
+          const parent = $createTestElementNode();
+          const a = $createParagraphNode();
+          parent.append(a, $createParagraphNode());
+          root.append(parent);
+          parentKey = parent.__key;
+          // Collapsed at the end of [a, b]. Inserting after a lands at
+          // offset 1, so the cursor moves to 3.
+          parent.select(2, 2);
+          a.insertAfter($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(parentKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(3);
+        expect(sel.focus.offset).toBe(3);
+      });
+    });
+
+    test('non-collapsed selection on the destination parent shifts only the side past the insert', () => {
+      const {editor} = testEnv;
+      let parentKey = '';
+      editor.update(
+        () => {
+          const root = $getRoot().clear();
+          const parent = $createTestElementNode();
+          const a = $createParagraphNode();
+          parent.append(a, $createParagraphNode());
+          root.append(parent);
+          parentKey = parent.__key;
+          // Anchor at 0 is before the insert point (1) and stays; focus at 2
+          // is past it and shifts to 3.
+          parent.select(0, 2);
+          a.insertAfter($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(parentKey);
+        expect(sel.anchor.offset).toBe(0);
+        expect(sel.focus.key).toBe(parentKey);
+        expect(sel.focus.offset).toBe(3);
+      });
+    });
+
+    test('restoreSelection=false leaves the destination parent offset alone', () => {
+      const {editor} = testEnv;
+      let parentKey = '';
+      editor.update(
+        () => {
+          const root = $getRoot().clear();
+          const parent = $createTestElementNode();
+          const a = $createParagraphNode();
+          parent.append(a, $createParagraphNode());
+          root.append(parent);
+          parentKey = parent.__key;
+          parent.select(2, 2);
+          a.insertAfter($createParagraphNode(), false);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(parentKey);
+        expect(sel.anchor.offset).toBe(2);
+        expect(sel.focus.offset).toBe(2);
+      });
+    });
+
+    test('a point in an unrelated parent survives a cross-parent move untouched', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      editor.update(
+        () => {
+          const refs = {} as Refs;
+          $setupTwoContainers(refs);
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          other.select(1, 1);
+          refs.inTarget.insertAfter(refs.mover);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(otherKey);
+        expect(sel.anchor.offset).toBe(1);
+        expect(sel.focus.key).toBe(otherKey);
+        expect(sel.focus.offset).toBe(1);
+      });
+    });
+
+    test('selectPrevious and selectNext land on the sibling index', () => {
+      const {editor} = testEnv;
+      let paragraphKey = '';
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          const first = $createLineBreakNode();
+          const middle = $createLineBreakNode();
+          const last = $createLineBreakNode();
+          paragraph.append(first, middle, last);
+          $getRoot().clear().append(paragraph);
+          paragraphKey = paragraph.__key;
+          // A LineBreakNode sibling is neither an element nor a text node,
+          // so both helpers resolve it through its index in the parent.
+          const sel = last.selectPrevious();
+          expect(sel.anchor.key).toBe(paragraphKey);
+          expect(sel.anchor.type).toBe('element');
+          expect(sel.anchor.offset).toBe(2);
+          expect(sel.focus.offset).toBe(2);
+          const nextSel = first.selectNext();
+          expect(nextSel.anchor.key).toBe(paragraphKey);
+          expect(nextSel.anchor.type).toBe('element');
+          expect(nextSel.anchor.offset).toBe(1);
+          expect(nextSel.focus.offset).toBe(1);
+        },
+        {discrete: true},
+      );
+    });
+  });
+});
+
 describe('replace(other, includeChildren) selection mapping', () => {
   initializeUnitTest(testEnv => {
     // When `replace` transfers `this`'s children into `other`, the

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -2255,6 +2255,179 @@ describe('insertAfter selection side effects', () => {
       });
     });
 
+    // Every scenario above moves `mover`, which is source's *first* child, so
+    // an oldIndex of 0 would satisfy them by accident. These two move a node
+    // from the middle instead, pinning the index value that the guarded walk
+    // computes.
+    const $setupMoverAtIndexOne = () => {
+      const root = $getRoot().clear();
+      const source = $createTestElementNode();
+      const target = $createTestElementNode();
+      const mover = $createParagraphNode();
+      const inTarget = $createParagraphNode();
+      source.append($createParagraphNode(), mover, $createParagraphNode());
+      target.append(inTarget);
+      root.append(source, target);
+      return {inTarget, mover, source, target};
+    };
+
+    test('cross-parent move leaves a point at the moved node index alone', () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {inTarget, mover, source} = $setupMoverAtIndexOne();
+          sourceKey = source.__key;
+          // Offset 1 is exactly mover's index, so the removal must not shift
+          // it and it is not the point that sat on mover either.
+          source.select(1, 1);
+          inTarget.insertAfter(mover);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(sourceKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(1);
+        expect(sel.focus.offset).toBe(1);
+      });
+    });
+
+    test('cross-parent move re-anchors onto a moved node that is not the first child', () => {
+      const {editor} = testEnv;
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {inTarget, mover, source, target} = $setupMoverAtIndexOne();
+          targetKey = target.__key;
+          // Offset 2 is mover's index (1) plus one, so the point sat on mover
+          // and follows it into target, landing after inTarget at offset 2.
+          source.select(2, 2);
+          inTarget.insertAfter(mover);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(targetKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(2);
+        expect(sel.focus.key).toBe(targetKey);
+        expect(sel.focus.offset).toBe(2);
+      });
+    });
+
+    // The two tests below put the anchor in a container the move does not
+    // touch, so the parent that loses (or gains) the node is reachable only
+    // through the focus. A guard that inspected the anchor alone would skip
+    // the index walk here and silently leave the focus behind.
+    test('cross-parent move re-anchors a focus-only point that sat on the moved node', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let targetKey = '';
+      editor.update(
+        () => {
+          const refs = {} as Refs;
+          $setupTwoContainers(refs);
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          targetKey = refs.target.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(otherKey, 1, 'element');
+          // source offset 1 is mover's index (0) plus one, so the focus sat
+          // on mover and has to follow it into target.
+          sel.focus.set(refs.source.__key, 1, 'element');
+          $setSelection(sel);
+          refs.inTarget.insertAfter(refs.mover);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(otherKey);
+        expect(sel.anchor.offset).toBe(1);
+        expect(sel.focus.key).toBe(targetKey);
+        expect(sel.focus.type).toBe('element');
+        expect(sel.focus.offset).toBe(2);
+      });
+    });
+
+    test('insert shifts a focus-only point on the destination parent', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let parentKey = '';
+      editor.update(
+        () => {
+          const root = $getRoot().clear();
+          const parent = $createTestElementNode();
+          const a = $createParagraphNode();
+          parent.append(a, $createParagraphNode());
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          root.append(parent, other);
+          parentKey = parent.__key;
+          otherKey = other.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(otherKey, 1, 'element');
+          sel.focus.set(parentKey, 2, 'element');
+          $setSelection(sel);
+          // The fresh node lands at offset 1, so the focus at 2 moves to 3.
+          a.insertAfter($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(otherKey);
+        expect(sel.anchor.offset).toBe(1);
+        expect(sel.focus.key).toBe(parentKey);
+        expect(sel.focus.type).toBe('element');
+        expect(sel.focus.offset).toBe(3);
+      });
+    });
+
+    test('cross-parent move re-anchors an anchor-only point that sat on the moved node', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let targetKey = '';
+      editor.update(
+        () => {
+          const refs = {} as Refs;
+          $setupTwoContainers(refs);
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          targetKey = refs.target.__key;
+          const sel = $createRangeSelection();
+          // The mirror of the test above: this time the focus is the one in
+          // the untouched container, so the move is reachable only through
+          // the anchor.
+          sel.anchor.set(refs.source.__key, 1, 'element');
+          sel.focus.set(otherKey, 1, 'element');
+          $setSelection(sel);
+          refs.inTarget.insertAfter(refs.mover);
+        },
+        {discrete: true},
+      );
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(targetKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(2);
+        expect(sel.focus.key).toBe(otherKey);
+        expect(sel.focus.offset).toBe(1);
+      });
+    });
+
     test('a point in an unrelated parent survives a cross-parent move untouched', () => {
       const {editor} = testEnv;
       let otherKey = '';
@@ -2280,8 +2453,12 @@ describe('insertAfter selection side effects', () => {
         expect(sel.focus.offset).toBe(1);
       });
     });
+  });
+});
 
-    test('selectPrevious and selectNext land on the sibling index', () => {
+describe('selectPrevious and selectNext', () => {
+  initializeUnitTest(testEnv => {
+    test('both land on the sibling index', () => {
       const {editor} = testEnv;
       let paragraphKey = '';
       editor.update(
@@ -2308,6 +2485,427 @@ describe('insertAfter selection side effects', () => {
         },
         {discrete: true},
       );
+    });
+  });
+});
+
+describe('insertBefore, remove and replace selection side effects', () => {
+  initializeUnitTest(testEnv => {
+    // insertBefore, $removeNode and replace each read getIndexWithinParent
+    // purely to shift element-anchored offsets in the parent whose child
+    // count changed. Like the insertAfter block above, these pin the offsets
+    // so that skipping the walk when no selection point can observe it has
+    // to keep producing the same selection.
+    // source holds [s0, s1, s2]; target holds [t0, t1].
+    const $setup = () => {
+      const root = $getRoot().clear();
+      const source = $createTestElementNode();
+      const target = $createTestElementNode();
+      source.append(
+        $createParagraphNode(),
+        $createParagraphNode(),
+        $createParagraphNode(),
+      );
+      target.append($createParagraphNode(), $createParagraphNode());
+      root.append(source, target);
+      return {source, target};
+    };
+
+    const expectSelection = (
+      editor: LexicalEditor,
+      anchorKey: string,
+      anchorOffset: number,
+      focusKey = anchorKey,
+      focusOffset = anchorOffset,
+    ) => {
+      editor.read(() => {
+        const sel = $getSelection();
+        invariant($isRangeSelection(sel));
+        expect(sel.anchor.key).toBe(anchorKey);
+        expect(sel.anchor.type).toBe('element');
+        expect(sel.anchor.offset).toBe(anchorOffset);
+        expect(sel.focus.key).toBe(focusKey);
+        expect(sel.focus.type).toBe('element');
+        expect(sel.focus.offset).toBe(focusOffset);
+      });
+    };
+
+    test('insertBefore shifts a point past the removed index in the old parent', () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          sourceKey = source.__key;
+          // Offset 2 is past s1's index (1), so the removal shifts it to 1.
+          source.select(2, 2);
+          target.getLastChildOrThrow().insertBefore(source.getChildAtIndex(1)!);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 1);
+    });
+
+    test('insertBefore leaves a point at the removed index in the old parent alone', () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          sourceKey = source.__key;
+          // Offset 1 is exactly s1's index, so the removal must not shift it.
+          // This pins the index value itself, not just that an update ran.
+          source.select(1, 1);
+          target.getLastChildOrThrow().insertBefore(source.getChildAtIndex(1)!);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 1);
+    });
+
+    test('insertBefore shifts a point at or past the insert index in the new parent', () => {
+      const {editor} = testEnv;
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {target} = $setup();
+          targetKey = target.__key;
+          // t1 is at index 1, so the fresh node lands there and the collapsed
+          // point at the end of [t0, t1] moves from 2 to 3.
+          target.select(2, 2);
+          target.getLastChildOrThrow().insertBefore($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, targetKey, 3);
+    });
+
+    test('insertBefore leaves a point before the insert index alone', () => {
+      const {editor} = testEnv;
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {target} = $setup();
+          targetKey = target.__key;
+          // Anchor at 0 is before the insert index (1) and stays; focus at 2
+          // is past it and shifts to 3.
+          target.select(0, 2);
+          target.getLastChildOrThrow().insertBefore($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, targetKey, 0, targetKey, 3);
+    });
+
+    test('insertBefore with restoreSelection=false leaves both parents alone', () => {
+      const {editor} = testEnv;
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {target} = $setup();
+          targetKey = target.__key;
+          target.select(2, 2);
+          target
+            .getLastChildOrThrow()
+            .insertBefore($createParagraphNode(), false);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, targetKey, 2);
+    });
+
+    test('insertBefore leaves a point in an unrelated parent untouched', () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          sourceKey = source.__key;
+          // The selection is on source, which neither loses nor gains a child.
+          source.select(1, 1);
+          target.getLastChildOrThrow().insertBefore($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 1);
+    });
+
+    test('remove shifts a point past the removed index', () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source} = $setup();
+          sourceKey = source.__key;
+          // Offset 3 is past s1's index (1), so it shifts to 2.
+          source.select(3, 3);
+          source.getChildAtIndex(1)!.remove();
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 2);
+    });
+
+    test('remove leaves a point at or before the removed index alone', () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source} = $setup();
+          sourceKey = source.__key;
+          // Anchor at 1 is *at* the removed index so it stays; focus at 3 is
+          // past it and shifts to 2.
+          source.select(1, 3);
+          source.getChildAtIndex(1)!.remove();
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 1, sourceKey, 2);
+    });
+
+    test('remove leaves a point in an unrelated parent untouched', () => {
+      const {editor} = testEnv;
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          targetKey = target.__key;
+          target.select(2, 2);
+          source.getChildAtIndex(1)!.remove();
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, targetKey, 2);
+    });
+
+    test("replace shifts a point past the replacement's index in its old parent", () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          sourceKey = source.__key;
+          // s1 leaves source at index 1 to replace t0, so the point at 2
+          // shifts to 1.
+          source.select(2, 2);
+          target.getFirstChildOrThrow().replace(source.getChildAtIndex(1)!);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 1);
+    });
+
+    test("replace leaves a point at the replacement's index in its old parent alone", () => {
+      const {editor} = testEnv;
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          sourceKey = source.__key;
+          // Offset 1 is exactly s1's index, so its departure must not shift
+          // the point. Pins the index value, not just that an update ran.
+          source.select(1, 1);
+          target.getFirstChildOrThrow().replace(source.getChildAtIndex(1)!);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 1);
+    });
+
+    test('replace leaves a point in an unrelated parent untouched', () => {
+      const {editor} = testEnv;
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          targetKey = target.__key;
+          // The point is on target, which keeps its child count across the
+          // replace, so nothing should move it.
+          target.select(2, 2);
+          target.getFirstChildOrThrow().replace(source.getChildAtIndex(1)!);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, targetKey, 2);
+    });
+
+    // As in the insertAfter block, these reach the affected parent only
+    // through the focus, so a guard that inspected the anchor alone would
+    // skip the walk and leave the focus stale.
+    test('insertBefore shifts a focus-only point in the old parent', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          sourceKey = source.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(otherKey, 1, 'element');
+          sel.focus.set(sourceKey, 2, 'element');
+          $setSelection(sel);
+          target.getLastChildOrThrow().insertBefore(source.getChildAtIndex(1)!);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, otherKey, 1, sourceKey, 1);
+    });
+
+    test('insertBefore shifts a focus-only point in the new parent', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {target} = $setup();
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          targetKey = target.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(otherKey, 1, 'element');
+          sel.focus.set(targetKey, 2, 'element');
+          $setSelection(sel);
+          target.getLastChildOrThrow().insertBefore($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, otherKey, 1, targetKey, 3);
+    });
+
+    test('remove shifts a focus-only point past the removed index', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source} = $setup();
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          sourceKey = source.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(otherKey, 1, 'element');
+          sel.focus.set(sourceKey, 3, 'element');
+          $setSelection(sel);
+          source.getChildAtIndex(1)!.remove();
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, otherKey, 1, sourceKey, 2);
+    });
+
+    test("replace shifts a focus-only point in the replacement's old parent", () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          sourceKey = source.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(otherKey, 1, 'element');
+          sel.focus.set(sourceKey, 2, 'element');
+          $setSelection(sel);
+          target.getFirstChildOrThrow().replace(source.getChildAtIndex(1)!);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, otherKey, 1, sourceKey, 1);
+    });
+
+    test('insertBefore shifts an anchor-only point in the new parent', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {target} = $setup();
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          targetKey = target.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(targetKey, 2, 'element');
+          sel.focus.set(otherKey, 1, 'element');
+          $setSelection(sel);
+          target.getLastChildOrThrow().insertBefore($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, targetKey, 3, otherKey, 1);
+    });
+
+    test('remove shifts an anchor-only point past the removed index', () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source} = $setup();
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          sourceKey = source.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(sourceKey, 3, 'element');
+          sel.focus.set(otherKey, 1, 'element');
+          $setSelection(sel);
+          source.getChildAtIndex(1)!.remove();
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 2, otherKey, 1);
+    });
+
+    test("replace shifts an anchor-only point in the replacement's old parent", () => {
+      const {editor} = testEnv;
+      let otherKey = '';
+      let sourceKey = '';
+      editor.update(
+        () => {
+          const {source, target} = $setup();
+          const other = $createTestElementNode();
+          other.append($createParagraphNode(), $createParagraphNode());
+          $getRoot().append(other);
+          otherKey = other.__key;
+          sourceKey = source.__key;
+          const sel = $createRangeSelection();
+          sel.anchor.set(sourceKey, 2, 'element');
+          sel.focus.set(otherKey, 1, 'element');
+          $setSelection(sel);
+          target.getFirstChildOrThrow().replace(source.getChildAtIndex(1)!);
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, sourceKey, 1, otherKey, 1);
+    });
+
+    test('replace with a fresh node leaves the parent offsets alone', () => {
+      const {editor} = testEnv;
+      let targetKey = '';
+      editor.update(
+        () => {
+          const {target} = $setup();
+          targetKey = target.__key;
+          target.select(2, 2);
+          target.getFirstChildOrThrow().replace($createParagraphNode());
+        },
+        {discrete: true},
+      );
+      expectSelection(editor, targetKey, 2);
     });
   });
 });


### PR DESCRIPTION
## Description

`LexicalCaret` implements insertion as `this.origin.insertAfter(node)` (`SiblingCaretNext.insert` and `TextPointCaretNext.insert`), so the caret API inherits whatever `insertAfter` costs. `insertAfter` calls `getIndexWithinParent()` twice, and that walks the parent's sibling list from the first child, so filling one parent with n nodes is quadratic. Pasting goes through `insertRangeAfter`, which is exactly that loop. Making `insertAfter` cheaper speeds up caret insertion too, instead of adding a parallel fast path that would have to be kept in step with it.

Both indices are only observable through the selection. `$updateElementSelectionOnCreateDeleteNode` returns early unless a selection point resolves to the parent it is passed, and the offset comparisons around it only match a point whose key is that parent's. So each walk now happens only when a selection point is on the parent in question. During a paste the caret is inside a text node, so neither is.

`insertBefore`, `$removeNode` and `replace` have the same shape — an unconditional `getIndexWithinParent()` feeding the same helper — so they get the same guard. Bulk removal and bulk replace were quadratic for the same reason, and `insertBefore` is on the `insertRangeBefore` path.

The condition lives in one place rather than being restated at each call site. `$selectionTouchesElement(selection, parentNode)` in `LexicalSelection.ts` is both what the helper's early return tests and what each caller checks before paying for the walk, so a future change to one cannot silently leave the other behind. That coupling is the only thing keeping the guards honest, and it is easy to break by accident if the two are written out separately.

The second index in `insertAfter` has one more consumer, which is easy to miss. When a node moves between parents, `insertAfter` records whether a selection point sat immediately after it, then uses the new index to put that point back onto the node in its new parent (#6031). At that moment the point is still on the old parent, so a guard that only looked at where the selection points are would skip the walk and drop the selection. The condition checks those two flags as well.

Pasting with `$insertGeneratedNodes` from `@lexical/clipboard` into a rich text editor, caret inside a paragraph's text node, node v22, `performance.now()`, one warmup pass then best of three. Sibling steps counted by wrapping `getIndexWithinParent` and adding the children it visits before it stops.

| Nodes | Before | After | Steps before | Steps after |
|---|---|---|---|---|
| 500 | 26.0 ms | 6.1 ms | 125,749 | 1 |
| 1000 | 82.6 ms | 9.6 ms | 501,499 | 1 |
| 2000 | 295.7 ms | 18.0 ms | 2,002,999 | 1 |
| 4000 | 1217.2 ms | 37.1 ms | 8,005,999 | 1 |

Calls to `getIndexWithinParent` during a 4000 node paste drop from 7,999 to 1. That path is `insertAfter` end to end, so it is the first change that moves it; the other three show up on their own bulk paths, 3000 sequential operations against a single parent with the caret in a text node:

| | Before | After |
|---|---|---|
| `insertAfter` | 751.9 ms | 39.4 ms |
| `insertBefore` | 779.0 ms | 40.4 ms |
| `remove` | 793.3 ms | 14.3 ms |
| `replace` | 842.9 ms | 47.5 ms |

#5194 points at the `// TODO: this is O(n), can we improve?` comments in this file. Both are gone. The remaining unguarded call is in `TextNode.splitText`, where the index feeds `splice` as well and cannot be skipped.

## Test plan

Nothing here changes behavior, so no existing expectation moved. The one edit to an existing test is positional: `selectPrevious` / `selectNext` was sitting in the `insertAfter` block without exercising `insertAfter`, and moved to its own `describe` with its assertions untouched.

The new tests in `LexicalNode.test.ts` pin the selection each guarded walk is standing in for, so that skipping the walk has to keep producing the same selection:

- A point that sat on a node moved between parents, collapsed and as one side of a range; a point on the source parent past the removed index (the `times = -1` shift); collapsed and ranged points on the destination parent; `restoreSelection` false; a point in an unrelated parent.
- Cases where only the **anchor** or only the **focus** is on the affected parent, with the other point in an untouched container. A guard that inspected one point and not the other passes every other test in the file, including a `#6031` re-anchor driven by the focus alone.
- Cases where the **index value** matters rather than just the fact that an update ran: a point sitting exactly at the removed index, where the shift must not apply, and a moved node that is not its parent's first child, so an index of `0` no longer satisfies the assertions by accident.
- The same coverage for `insertBefore`, `remove` and `replace`.

All of them pass with the source change reverted, which is the point — they characterize current behavior rather than the new code. Separately, a scripted matrix of 4319 scenarios (the four methods × element points on the source, destination, unrelated and root containers × forward and backward ranges × `restoreSelection` both ways) produced identical selection and tree output before and after.