### PR TITLE
[lexical] Bug Fix: $removeTextFromCaretRange no longer leaves a childless list or table as the root's only child

### DIFF
--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -412,7 +412,11 @@ export function $removeTextFromCaretRange<D extends CaretDirection>(
         if (
           grandparent &&
           $isRootNode(grandparent) &&
-          grandparent.getChildrenSize() <= 1
+          grandparent.getChildrenSize() <= 1 &&
+          // Only keep the root's last child when it is valid while empty. One
+          // that declares `canBeEmpty()` false is removed like any other
+          // emptied ancestor, and the empty root is repaired below.
+          parent.canBeEmpty()
         ) {
           break;
         }

--- a/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
+++ b/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   $caretRangeFromSelection,
   $comparePointCaretNext,
+  $createLineBreakNode,
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
@@ -35,6 +36,7 @@ import {
   $getSelection,
   $getSiblingCaret,
   $getTextPointCaret,
+  $isLineBreakNode,
   $isParagraphNode,
   $isSiblingCaret,
   $isTextNode,
@@ -61,8 +63,10 @@ import {beforeEach, describe, expect, test} from 'vitest';
 import {
   $assertRangeSelection,
   $createTestDecoratorNode,
+  $createTestElementNode,
   initializeUnitTest,
   invariant,
+  TestElementNode,
 } from '../../../__tests__/utils';
 
 const DIRECTIONS = ['next', 'previous'] as const;
@@ -2186,6 +2190,217 @@ describe('LexicalSelectionHelpers', () => {
           },
           {discrete: true},
         );
+      });
+    });
+
+    // The cases above remove inline wrappers around a range. These cover the
+    // empty ancestor walk that runs after the last block of the document is
+    // emptied, where the ancestor is the root's only remaining child.
+    describe("the root's last child after select all delete", () => {
+      test('a list is replaced with an empty paragraph', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const list = $createListNode('bullet');
+            list.append($createListItemNode().append($createTextNode('item')));
+            root.append($createTestDecoratorNode().setIsInline(false), list);
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.update(
+          () => {
+            $selectAll().removeText();
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          expect($isParagraphNode(root.getFirstChild())).toBe(true);
+          expect(root.getTextContent()).toBe('');
+        });
+      });
+
+      // The leftover list is not merely untidy: it has no block ancestor, so
+      // the next inline insert raises an uncaught invariant.
+      test('an inline insert after the list deletion does not throw', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const list = $createListNode('bullet');
+            list.append($createListItemNode().append($createTextNode('item')));
+            root.append($createTestDecoratorNode().setIsInline(false), list);
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.update(
+          () => {
+            $selectAll().removeText();
+          },
+          {discrete: true},
+        );
+
+        expect(() => {
+          testEnv.editor.update(
+            () => {
+              $assertRangeSelection($getSelection()).insertNodes([
+                $createLineBreakNode(),
+              ]);
+            },
+            {discrete: true},
+          );
+        }).not.toThrow();
+
+        testEnv.editor.read(() => {
+          const paragraph = $getRoot().getFirstChild();
+          invariant($isParagraphNode(paragraph), 'Expected a ParagraphNode');
+          expect($isLineBreakNode(paragraph.getFirstChild())).toBe(true);
+        });
+      });
+
+      test('a table is replaced with an empty paragraph', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const cell = $createTableCellNode();
+            cell.append($createParagraphNode().append($createTextNode('cell')));
+            const table = $createTableNode();
+            table.append($createTableRowNode().append(cell));
+            root.append($createTestDecoratorNode().setIsInline(false), table);
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.update(
+          () => {
+            $selectAll().removeText();
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          expect($isParagraphNode(root.getFirstChild())).toBe(true);
+          expect(root.getTextContent()).toBe('');
+        });
+      });
+
+      // A leftover table does not throw on the next insert, because an element
+      // point on a shadow root takes an earlier branch of insertNodes. It
+      // silently takes the inline content as a child instead, which a table
+      // that holds only rows cannot render.
+      test('an inline insert after the table deletion does not land in a table', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const cell = $createTableCellNode();
+            cell.append($createParagraphNode().append($createTextNode('cell')));
+            const table = $createTableNode();
+            table.append($createTableRowNode().append(cell));
+            root.append($createTestDecoratorNode().setIsInline(false), table);
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.update(
+          () => {
+            $selectAll().removeText();
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.update(
+          () => {
+            $assertRangeSelection($getSelection()).insertNodes([
+              $createLineBreakNode(),
+            ]);
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          const paragraph = root.getFirstChild();
+          invariant($isParagraphNode(paragraph), 'Expected a ParagraphNode');
+          expect($isLineBreakNode(paragraph.getFirstChild())).toBe(true);
+        });
+      });
+
+      // Control for the other side of the break condition. This container is
+      // reached by the same walk at the same depth as the list and the table,
+      // but it may be empty, so it is kept rather than replaced.
+      test('a container that may be empty is kept', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const container = $createTestElementNode();
+            container.append(
+              $createParagraphNode().append($createTextNode('inner')),
+            );
+            root.append(
+              $createTestDecoratorNode().setIsInline(false),
+              container,
+            );
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.update(
+          () => {
+            $selectAll().removeText();
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          const container = root.getFirstChild();
+          expect(container).toBeInstanceOf(TestElementNode);
+          expect($isParagraphNode(container)).toBe(false);
+        });
+      });
+
+      // The ordinary document this path has always handled correctly. The walk
+      // is never entered here, since the emptied block's parent is the root.
+      test('a paragraph is kept', () => {
+        testEnv.editor.update(
+          () => {
+            const root = $getRoot();
+            root.clear();
+            const paragraph = $createParagraphNode();
+            paragraph.append($createTextNode('text'));
+            root.append(
+              $createTestDecoratorNode().setIsInline(false),
+              paragraph,
+            );
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.update(
+          () => {
+            $selectAll().removeText();
+          },
+          {discrete: true},
+        );
+
+        testEnv.editor.read(() => {
+          const root = $getRoot();
+          expect(root.getChildrenSize()).toBe(1);
+          expect($isParagraphNode(root.getFirstChild())).toBe(true);
+          expect(root.getTextContent()).toBe('');
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

Current behavior: in a document whose first block is a block decorator and whose last is a list, Cmd+A then Backspace leaves the root holding a `ListNode` with no children, and the next inline insert throws `Expected node ListNode of type list to have a block ElementNode ancestor` out of `insertNodes`. The invariant is uncaught, so it reaches the application's `onError`.

Expected, and what this produces: `root[paragraph]`, with the next Shift+Enter inserting normally.

### Mechanism

`$removeTextFromCaretRange` removes the emptied focus block, then walks up removing ancestors emptied with it. The walk breaks when removing `parent` would empty the root:

```ts
if (grandparent && $isRootNode(grandparent) && grandparent.getChildrenSize() <= 1) {
  break;
}
```

That applies unconditionally, so it stops on a container that has declared it cannot be empty. The fix adds `&& parent.canBeEmpty()`.

Three things say the guard is stale. Main has no policy of preserving lists, only one about the root's child count: the same keystrokes over `[paragraph, list]` remove the list today, because the root then has two children and the guard never fires. The sibling branch of the same function does the same climb with the comment `// remove empty parent node even if parent node is canBeEmpty` and no guard. And the case the guard protects is now handled below it by `$restoreEmptyContainerParagraph`, which arrived in #9058 two months after the guard arrived in #8751.

### This is not specific to lists

`TableNode` and the playground's `LayoutContainerNode` also return `canBeEmpty(): false` and can sit under the root, so `[block decorator, table]` goes from `root[table[]]` to `root[paragraph[]]` too. The table failure is quieter than the list one: it does not throw, because `insertNodes` catches an element point on a shadow root first, and the content is spliced into the `TableNode` instead, giving a table holding a paragraph where its rows belong. One rule looks right for both and both are tested, but happy to split the table half out.

This is visible to consumers: any third party `ElementNode` returning `canBeEmpty(): false` that can be a direct child of the root now disappears on this path instead of surviving empty.

## Test plan

Six tests in `LexicalCaret.test.ts`. Four cover the changed branch, a list and a table each replaced with an empty paragraph plus the follow up insert for each. Two are controls that pass in either state.

`a container that may be empty is kept` is the control that bears on the guard: `TestElementNode` at the same depth reaches the guard and takes the preserved branch, and replacing the new conjunct with `false` flips it. Nothing else pins that branch, `Issue8745Repro.test.ts` from #8751 still passes all 14 with the break neutralized, which is part of why the guard reads as stale.

Reverting only `LexicalCaretUtils.ts`: 4 failed, 179 passed. Restoring it: 183 passed. Neighbouring suites each pass unchanged, including `Issue8745Repro` 14, `LexicalSelection` 100, `LexicalLinkNode` 74 and `LexicalTableNode` 42. `tsc --noEmit`, `eslint` and `prettier --check` clean.

I did not run the browser project, so `Issue8745DeleteLine.test.ts` from #8751 is unexercised. Every element registered there returns `canBeEmpty()` true, so the added conjunct is a no op and the break expression is identical to main, but that is an argument from the node definitions rather than a run.
