### PR TITLE
[lexical-utils] Bug Fix: notify when selection overlay rectangles are removed

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/positionNodeOnRange.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/positionNodeOnRange.test.tsx
@@ -89,6 +89,38 @@ describe('positionNodeOnRange', () => {
     }
   });
 
+  it.each([0, 1])(
+    'notifies when overlay rectangles shrink to %i',
+    async remaining => {
+      const rootElement = createRootElement();
+      const editor = createTestEditor();
+      editor.setRootElement(rootElement);
+      const range = document.createRange();
+      range.selectNodeContents(rootElement);
+      let rects = [new DOMRect(0, 0, 10, 10), new DOMRect(0, 20, 10, 10)];
+      vi.spyOn(range, 'getClientRects').mockImplementation(
+        () => rects as unknown as DOMRectList,
+      );
+      const onReposition = vi.fn();
+      const cleanup = positionNodeOnRange(editor, range, onReposition);
+
+      try {
+        expect(onReposition).toHaveBeenCalledTimes(1);
+        expect(onReposition.mock.lastCall![0]).toHaveLength(2);
+        rects = rects.slice(0, remaining);
+        rootElement.setAttribute('data-layout', 'hidden');
+
+        await vi.waitFor(() => {
+          expect(onReposition).toHaveBeenCalledTimes(2);
+        });
+        expect(onReposition.mock.lastCall![0]).toHaveLength(remaining);
+      } finally {
+        cleanup();
+        editor.setRootElement(null);
+      }
+    },
+  );
+
   it('removes the overlay of an invocation that lands after it was disposed of', () => {
     const firstRootElement = createRootElement();
     const secondRootElement = createRootElement();

--- a/packages/lexical-utils/src/positionNodeOnRange.ts
+++ b/packages/lexical-utils/src/positionNodeOnRange.ts
@@ -101,6 +101,7 @@ export default function mlcPositionNodeOnRange(
       const node = lastNodes.pop();
       if (node != null) {
         node.remove();
+        hasRepositioned = true;
       }
     }
     if (hasRepositioned) {


### PR DESCRIPTION
## Description

`positionNodeOnRange` removes surplus overlay elements when a range produces fewer rectangles, but does not call `onReposition` if the surviving rectangles keep their geometry. Consumers therefore miss the update when the overlay shrinks or disappears.

Mark removal as a reposition so the callback receives the updated elements. Add regression cases for two rectangles shrinking to one or zero. The tests use controlled rectangles to exercise callback bookkeeping, without relying on jsdom layout.

## Test plan

### Before

With the regression tests added and the production fix removed:

```text
vitest run --project unit positionNodeOnRange
AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
Test Files  1 failed (1)
     Tests  2 failed | 2 passed (4)
```

### After

```text
vitest run --project unit packages/lexical-utils/src/__tests__/unit
Test Files  16 passed (16)
     Tests  232 passed (232)
```

ESLint and Prettier passed for both changed files. `tsc --noEmit` passed. Browser/E2E tests were not run; the change concerns callback delivery after existing rectangle removal. Prepared with AI assistance.
