### PR TITLE
[lexical-list] Bug Fix: indenting between two nested lists no longer converts the second list's type

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -79,6 +79,29 @@ function $isExtendedTestListItemNode(node?: LexicalNode | null) {
   return node instanceof ExtendedTestListItemNode;
 }
 
+/**
+ * Builds a ListItemNode that holds a nested list of the given type, one child
+ * per text.
+ */
+function $createNestedListItem(
+  listType: ListType,
+  ...texts: string[]
+): ListItemNode {
+  return $createListItemNode().append(
+    $createListNode(listType).append(
+      ...texts.map(text => $createListItemNode().append($createTextNode(text))),
+    ),
+  );
+}
+
+/** Returns the nested list held by a ListItemNode. */
+function $getNestedList(node: LexicalNode): ListNode {
+  return $assertNodeType(
+    $assertNodeType(node, $isListItemNode).getFirstChild(),
+    $isListNode,
+  );
+}
+
 const initOptions = {
   nodes: [ExtendedTestListNode, ExtendedTestListItemNode],
 };
@@ -415,6 +438,166 @@ describe('$handleIndent', () => {
           expect($isExtendedTestListNode(nestedList)).toBe(true);
           expect(nestedList.getChildren().length).toBe(1);
           expect(nestedList.getChildren()[0].is(listItem2)).toBe(true);
+        });
+      });
+
+      test('merges the surrounding sublists when they are the same type', async () => {
+        const {editor} = testEnv;
+        let middleItem: ListItemNode;
+
+        await editor.update(() => {
+          middleItem = $createListItemNode().append($createTextNode('middle'));
+          $getRoot().append(
+            $createListNode('bullet').append(
+              $createNestedListItem('bullet', 'first child'),
+              middleItem,
+              $createNestedListItem('bullet', 'second child'),
+            ),
+          );
+        });
+
+        await editor.update(() => {
+          $handleIndent(middleItem);
+        });
+
+        editor.read(() => {
+          const listNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isListNode,
+          );
+          const children = listNode.getChildren();
+          expect(children.length).toBe(1);
+
+          const sublist = $getNestedList(children[0]);
+          expect(sublist.getListType()).toBe('bullet');
+          expect(
+            sublist.getChildren().map(item => item.getTextContent()),
+          ).toEqual(['first child', 'middle', 'second child']);
+        });
+      });
+
+      test('does not merge the surrounding sublists of a different listType', async () => {
+        const {editor} = testEnv;
+        let middleItem: ListItemNode;
+
+        await editor.update(() => {
+          middleItem = $createListItemNode().append($createTextNode('middle'));
+          $getRoot().append(
+            $createListNode('bullet').append(
+              $createNestedListItem('bullet', 'bullet child'),
+              middleItem,
+              $createNestedListItem('number', 'number one', 'number two'),
+            ),
+          );
+        });
+
+        await editor.update(() => {
+          $handleIndent(middleItem);
+        });
+
+        editor.read(() => {
+          const listNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isListNode,
+          );
+          const children = listNode.getChildren();
+          // the numbered sublist survives with its type and its children
+          const numberSublist = $getNestedList(children[children.length - 1]);
+          expect(numberSublist.getListType()).toBe('number');
+          expect(
+            numberSublist.getChildren().map(item => item.getTextContent()),
+          ).toEqual(['number one', 'number two']);
+          expect(children.length).toBe(2);
+
+          // the item is still indented into the preceding sublist
+          const bulletSublist = $getNestedList(children[0]);
+          expect(bulletSublist.getListType()).toBe('bullet');
+          expect(
+            bulletSublist.getChildren().map(item => item.getTextContent()),
+          ).toEqual(['bullet child', 'middle']);
+        });
+      });
+
+      test('does not merge the surrounding sublists of a different listType, the other way round', async () => {
+        const {editor} = testEnv;
+        let middleItem: ListItemNode;
+
+        await editor.update(() => {
+          middleItem = $createListItemNode().append($createTextNode('middle'));
+          $getRoot().append(
+            $createListNode('number').append(
+              $createNestedListItem('number', 'number one'),
+              middleItem,
+              $createNestedListItem('bullet', 'bullet one', 'bullet two'),
+            ),
+          );
+        });
+
+        await editor.update(() => {
+          $handleIndent(middleItem);
+        });
+
+        editor.read(() => {
+          const listNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isListNode,
+          );
+          const children = listNode.getChildren();
+          const bulletSublist = $getNestedList(children[children.length - 1]);
+          expect(bulletSublist.getListType()).toBe('bullet');
+          expect(
+            bulletSublist.getChildren().map(item => item.getTextContent()),
+          ).toEqual(['bullet one', 'bullet two']);
+          expect(children.length).toBe(2);
+
+          const numberSublist = $getNestedList(children[0]);
+          expect(numberSublist.getListType()).toBe('number');
+          expect(
+            numberSublist.getChildren().map(item => item.getTextContent()),
+          ).toEqual(['number one', 'middle']);
+        });
+      });
+
+      test('keeps the checked state of a following check sublist', async () => {
+        const {editor} = testEnv;
+        let middleItem: ListItemNode;
+
+        await editor.update(() => {
+          middleItem = $createListItemNode().append($createTextNode('middle'));
+          const checkItem = $createListItemNode();
+          checkItem.setChecked(true);
+          checkItem.append($createTextNode('done'));
+          $getRoot().append(
+            $createListNode('bullet').append(
+              $createNestedListItem('bullet', 'bullet child'),
+              middleItem,
+              $createListItemNode().append(
+                $createListNode('check').append(checkItem),
+              ),
+            ),
+          );
+        });
+
+        await editor.update(() => {
+          $handleIndent(middleItem);
+        });
+
+        editor.read(() => {
+          const listNode = $assertNodeType(
+            $getRoot().getFirstChild(),
+            $isListNode,
+          );
+          const children = listNode.getChildren();
+          // a bullet list swallowing this one would strip checked, because
+          // updateChildrenListItemValue clears it outside a check list
+          const checkSublist = $getNestedList(children[children.length - 1]);
+          expect(checkSublist.getListType()).toBe('check');
+          const checkItem = $assertNodeType(
+            checkSublist.getFirstChild(),
+            $isListItemNode,
+          );
+          expect(checkItem.getChecked()).toBe(true);
+          expect(children.length).toBe(2);
         });
       });
     },
@@ -782,18 +965,12 @@ describe('mergeNextSiblingListIfSameType', () => {
 
       await editor.update(
         () => {
-          const $nested = (listType: ListType, text: string) =>
-            $createListItemNode().append(
-              $createListNode(listType).append(
-                $createListItemNode().append($createTextNode(text)),
-              ),
-            );
           const list1 = $createListNode('bullet').append(
             $createListItemNode().append($createTextNode('a')),
-            $nested('number', 'one'),
+            $createNestedListItem('number', 'one'),
           );
           const list2 = $createListNode('bullet').append(
-            $nested('bullet', 'two'),
+            $createNestedListItem('bullet', 'two'),
             $createListItemNode().append($createTextNode('b')),
           );
           $getRoot().clear().append(list1, list2);

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -432,7 +432,12 @@ export function $handleIndent(listItemNode: ListItemNode): void {
       innerList.append(listItemNode);
       const nextInnerList = nextSibling.getFirstChild();
 
-      if ($isListNode(nextInnerList)) {
+      if (
+        $isListNode(nextInnerList) &&
+        // Only pull in the following sublist when it is the same kind of
+        // list, otherwise it loses its listType.
+        innerList.getListType() === nextInnerList.getListType()
+      ) {
         const children = nextInnerList.getChildren();
         append(innerList, children);
         nextSibling.remove();


### PR DESCRIPTION
## Description

Pressing Tab on a list item between two nested sublists of different types silently rewrites the second sublist. Tab routes `INDENT_CONTENT_COMMAND` to `ListItemNode.setIndent`, which calls `$handleIndent`. The item indents into the sublist above it, and the sublist below is emptied into it, so a nested `<ol>` and every item in it come back as bullets. A check sublist loses more: `updateChildrenListItemValue` clears `checked` outside a check list.

The caret is on `middle`, between a nested bullet sublist and a nested numbered sublist. After Tab on main the numbered list is gone and its items are bullets:

```
list (bullet)
  listitem > list (bullet)
    listitem "bullet child"
    listitem "middle"
    listitem "number one"
    listitem "number two"
```

After Tab with this change, the item still indents and the numbered list keeps its type and children:

```
list (bullet)
  listitem > list (bullet)
    listitem "bullet child"
    listitem "middle"
  listitem > list (number)
    listitem "number one"
    listitem "number two"
```

`mergeNextSiblingListIfSameType` has long stated this rule at the top level: "`<ul>` will merge with `<ul>`, but NOT `<ul>` with `<ol>`." #9050 carried it to two nested merge sites, `mergeLists` and `ListItemNode.remove`, the latter handling this very shape and joining the surrounding sublists only when `getListType()` matches. The branch of `$handleIndent` with a nested sublist on both sides merges the same way and was missed.

This change guards that merge on the same `getListType()` equality, so a sublist of another type stays where it is instead of being appended and removed.

## Test plan

Three tests in the `$handleIndent` block of `packages/lexical-list/src/__tests__/unit/formatList.test.ts` cover bullet then number, number then bullet, and bullet then check, the last asserting `checked` survives. A fourth pins the same type case.

### Before

The three new tests against the previous `formatList.ts`:

```
 × does not merge the surrounding sublists of a different listType
 × does not merge the surrounding sublists of a different listType, the other way round
 × keeps the checked state of a following check sublist
AssertionError: expected 'bullet' to be 'number' // Object.is equality
      Tests  3 failed | 23 passed (26)
```

### After

26 passed. All 15 unit files in `packages/lexical-list` pass, 146 tests, plus `LexicalListPlugin.test.tsx`. `eslint` and `prettier` are clean. Browser and e2e not run.
