### PR TITLE
[lexical][lexical-compiler] Bug Fix: Let esbuild drop the editor from a createCommand-only production import

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "concurrently": "^10.0.3",
     "confusing-browser-globals": "^1.0.10",
     "cross-env": "^10.1.0",
+    "esbuild": "^0.27.7",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-compat": "^7.0.2",

--- a/packages/lexical-compiler/src/passes/pureAnnotations.mjs
+++ b/packages/lexical-compiler/src/passes/pureAnnotations.mjs
@@ -48,6 +48,7 @@ export const PURE_FACTORY_FUNCTIONS = [
   'createCommand',
   'createContextState',
   'createImportState',
+  'createRefCountedRegistry',
   'createRenderState',
   'createState',
   'declarePeerDependency',

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1120,7 +1120,7 @@ export class LexicalEditor {
   declare ['constructor']: KlassConstructor<typeof LexicalEditor>;
 
   /** The version with build identifiers for this editor (since 0.17.1) */
-  static version: string | undefined;
+  static version: string | undefined = LEXICAL_VERSION;
 
   /** @internal */
   _headless: boolean;
@@ -1978,5 +1978,3 @@ export class LexicalEditor {
     };
   }
 }
-
-LexicalEditor.version = LEXICAL_VERSION;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -150,29 +150,37 @@ type RootElementEvents = [
 ][];
 const PASS_THROUGH_COMMAND = Object.freeze({});
 const ANDROID_COMPOSITION_LATENCY = 30;
-const rootElementEvents: RootElementEvents = [
-  ['keydown', onKeyDown],
-  ['pointerdown', onPointerDown],
-  ['compositionstart', onCompositionStart],
-  ['compositionend', onCompositionEnd],
-  ['input', onInput],
-  ['click', onClick],
-  ['cut', PASS_THROUGH_COMMAND],
-  ['copy', PASS_THROUGH_COMMAND],
-  ['dragstart', PASS_THROUGH_COMMAND],
-  ['dragover', PASS_THROUGH_COMMAND],
-  ['dragend', PASS_THROUGH_COMMAND],
-  ['paste', PASS_THROUGH_COMMAND],
-  ['focus', PASS_THROUGH_COMMAND],
-  ['blur', PASS_THROUGH_COMMAND],
-  ['drop', PASS_THROUGH_COMMAND],
-];
+let rootElementEvents: RootElementEvents | undefined;
 
-if (CAN_USE_BEFORE_INPUT) {
-  rootElementEvents.push([
-    'beforeinput',
-    (event, editor) => onBeforeInput(event as InputEvent, editor),
-  ]);
+function getRootElementEvents(): RootElementEvents {
+  if (rootElementEvents !== undefined) {
+    return rootElementEvents;
+  }
+  const events: RootElementEvents = [
+    ['keydown', onKeyDown],
+    ['pointerdown', onPointerDown],
+    ['compositionstart', onCompositionStart],
+    ['compositionend', onCompositionEnd],
+    ['input', onInput],
+    ['click', onClick],
+    ['cut', PASS_THROUGH_COMMAND],
+    ['copy', PASS_THROUGH_COMMAND],
+    ['dragstart', PASS_THROUGH_COMMAND],
+    ['dragover', PASS_THROUGH_COMMAND],
+    ['dragend', PASS_THROUGH_COMMAND],
+    ['paste', PASS_THROUGH_COMMAND],
+    ['focus', PASS_THROUGH_COMMAND],
+    ['blur', PASS_THROUGH_COMMAND],
+    ['drop', PASS_THROUGH_COMMAND],
+  ];
+  if (CAN_USE_BEFORE_INPUT) {
+    events.push([
+      'beforeinput',
+      (event, editor) => onBeforeInput(event as InputEvent, editor),
+    ]);
+  }
+  rootElementEvents = events;
+  return events;
 }
 
 // Node can be moved between documents (for example using createPortal), so we
@@ -2023,8 +2031,9 @@ export function addRootElementEvents(
   // with this root element's other listeners in removeRootElementEvents.
   removeHandles.push(documentSelectionChange.register(doc));
 
-  for (let i = 0; i < rootElementEvents.length; i++) {
-    const [eventName, onEvent] = rootElementEvents[i];
+  const events = getRootElementEvents();
+  for (let i = 0; i < events.length; i++) {
+    const [eventName, onEvent] = events[i];
     const eventHandler =
       typeof onEvent === 'function'
         ? (event: Event) => {

--- a/packages/lexical/src/LexicalGenMap.ts
+++ b/packages/lexical/src/LexicalGenMap.ts
@@ -220,9 +220,7 @@ export class GenMap<K, V> implements Map<K, V> {
     // Skip per-entry override checks for an unmodified snapshot.
     if (!nursery) {
       if (old) {
-        for (const pair of old) {
-          yield pair;
-        }
+        yield* old;
       }
       return;
     }
@@ -233,9 +231,9 @@ export class GenMap<K, V> implements Map<K, V> {
         if (v === TOMBSTONE) {
           continue;
         } else if (v !== undefined) {
-          (pair as [K, V])[1] = v as V;
+          pair[1] = v;
         }
-        yield pair as [K, V];
+        yield pair;
       }
     }
     for (const pair of nursery) {

--- a/packages/lexical/src/LexicalGenMap.ts
+++ b/packages/lexical/src/LexicalGenMap.ts
@@ -217,10 +217,19 @@ export class GenMap<K, V> implements Map<K, V> {
   *entries(): MapIterator<[K, V]> {
     const nursery = this._nursery;
     const old = this._old;
+    // Skip per-entry override checks for an unmodified snapshot.
+    if (!nursery) {
+      if (old) {
+        for (const pair of old) {
+          yield pair;
+        }
+      }
+      return;
+    }
     if (old) {
       for (const pair of old) {
         const k = pair[0];
-        const v = nursery ? nursery.get(k) : undefined;
+        const v = nursery.get(k);
         if (v === TOMBSTONE) {
           continue;
         } else if (v !== undefined) {
@@ -229,11 +238,9 @@ export class GenMap<K, V> implements Map<K, V> {
         yield pair as [K, V];
       }
     }
-    if (nursery) {
-      for (const pair of nursery) {
-        if (pair[1] !== TOMBSTONE && !(old && old.has(pair[0]))) {
-          yield pair as [K, V];
-        }
+    for (const pair of nursery) {
+      if (pair[1] !== TOMBSTONE && !(old && old.has(pair[0]))) {
+        yield pair as [K, V];
       }
     }
   }

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -732,7 +732,7 @@ export class LexicalNode {
   /** @internal */
   __state?: NodeState<this>;
   /** @internal */
-  [CACHED_TEXT_SIZE_KEY]?: number;
+  declare [CACHED_TEXT_SIZE_KEY]?: number;
 
   // Flow doesn't support abstract classes unfortunately, so we can't _force_
   // subclasses of Node to implement statics. All subclasses of Node should have

--- a/packages/lexical/src/LexicalRefCountedRegistry.ts
+++ b/packages/lexical/src/LexicalRefCountedRegistry.ts
@@ -40,6 +40,7 @@ export interface RefCountedRegistry<Key, Options = void> {
  *
  * @param activate - Wires `key` and returns its teardown. Called on the first
  *   registration of each key.
+ * @__NO_SIDE_EFFECTS__
  */
 export function createRefCountedRegistry<Key, Options = void>(
   activate: (key: Key, options: Options | undefined) => () => void,

--- a/packages/lexical/src/__bench__/dom/_utils.ts
+++ b/packages/lexical/src/__bench__/dom/_utils.ts
@@ -13,16 +13,30 @@ import {
   type LexicalEditor,
 } from '../../';
 
+let attachedEditor: LexicalEditor | null = null;
+let attachedRoot: HTMLElement | null = null;
+
 /**
  * Attach a fresh contentEditable host to `document.body` and bind the
  * editor's root element to it. Returns the host so callers can inspect
  * or detach it.
  */
 export function attachToDOM(editor: LexicalEditor): HTMLElement {
+  // Benchmark setup runs again for warmup and measurement. Detach the previous
+  // editor so earlier documents do not remain in document.body and affect
+  // later samples through DOM size or memory pressure.
+  if (attachedEditor !== null) {
+    attachedEditor.setRootElement(null);
+    if (attachedRoot !== null) {
+      attachedRoot.remove();
+    }
+  }
   const root = document.createElement('div');
   root.contentEditable = 'true';
   document.body.appendChild(root);
   editor.setRootElement(root);
+  attachedEditor = editor;
+  attachedRoot = root;
   return root;
 }
 

--- a/packages/lexical/src/__bench__/dom/editorOperations.bench.ts
+++ b/packages/lexical/src/__bench__/dom/editorOperations.bench.ts
@@ -19,6 +19,7 @@ import {
   $isRangeSelection,
   $isTextNode,
   $selectAll,
+  type EditorState,
   type LexicalEditor,
 } from '../../';
 import {createTestEditor} from '../../__tests__/utils';
@@ -173,10 +174,17 @@ for (const size of SIZES) {
     );
   });
 
-  // Accumulative: inserts 10 paragraphs at the end per iteration.
+  // Insert 10 paragraphs into the same initial document each iteration.
+  // Tinybench runs task hooks outside the timed body, so restoring the state
+  // keeps the paste workload at the requested size throughout the run. Vitest
+  // passes options to Bench but creates Task without options: install its task
+  // hooks through the setup callback instead of bench options.
   describe(`size=${size} :: paste 10 paragraphs`, () => {
     let editor: LexicalEditor;
+    let initialState: EditorState;
     let cycle = 0;
+    let pasted = 0;
+    let checked = 0;
 
     bench(
       '$insertNodes at end',
@@ -204,17 +212,46 @@ for (const size of SIZES) {
             }
             $insertNodes(nodes);
             cycle++;
+            pasted++;
           },
           {discrete: true},
         );
       },
       {
-        setup: () => {
+        setup: task => {
           editor = createTestEditor();
           attachToDOM(editor);
           buildLargeDoc(editor, size);
+          initialState = editor.getEditorState();
           cycle = 0;
+          pasted = 0;
+          checked = 0;
+          task.opts.beforeEach = () => {
+            editor.setEditorState(initialState);
+            cycle = 0;
+          };
+          task.opts.afterEach = () => {
+            checked++;
+            editor.read(() => {
+              const actual = $getRoot().getChildrenSize();
+              invariant(
+                // The first pasted paragraph merges into the original last
+                // paragraph because the caret is at the end of its text.
+                actual === size + 9,
+                'Paste should leave %s paragraphs, got %s',
+                String(size + 9),
+                String(actual),
+              );
+            });
+          };
         },
+        teardown: () => {
+          invariant(
+            pasted === checked && cycle === 1,
+            'Paste benchmark hooks did not run on every iteration',
+          );
+        },
+        throws: true,
       },
     );
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
+      esbuild:
+        specifier: ^0.27.7
+        version: 0.27.7
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)

--- a/scripts/__tests__/integration/tree-shaking.test.mjs
+++ b/scripts/__tests__/integration/tree-shaking.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+// @ts-check
+import {build} from 'esbuild';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+import {packagesManager} from '../../shared/packagesManager.mjs';
+
+describe('built production tree shaking', () => {
+  test('a createCommand-only consumer does not retain the editor', async () => {
+    const lexical = packagesManager
+      .getPublicPackages()
+      .find(pkg => pkg.getNpmName() === 'lexical');
+    if (lexical === undefined) {
+      throw new Error('lexical package was not found');
+    }
+    const productionExport = lexical.packageJson.exports['.'].import.production;
+    const productionFile = lexical.resolve(productionExport);
+
+    // Vite's test aliases and the root tsconfig both resolve "lexical" to its
+    // TypeScript source. Point just this import at the built production
+    // export so the test measures the distributed artifact.
+    const result = await build({
+      absWorkingDir: process.cwd(),
+      bundle: true,
+      conditions: ['production'],
+      format: 'esm',
+      logLevel: 'silent',
+      metafile: true,
+      minify: true,
+      platform: 'browser',
+      plugins: [
+        {
+          name: 'production-lexical',
+          setup(esbuildBuild) {
+            esbuildBuild.onResolve({filter: /^lexical$/}, () => ({
+              path: productionFile,
+            }));
+          },
+        },
+      ],
+      stdin: {
+        contents:
+          "import {createCommand} from 'lexical'; export {createCommand};",
+        resolveDir: process.cwd(),
+        sourcefile: 'tree-shaking-consumer.js',
+      },
+      write: false,
+    });
+
+    // A small bundle from the wrong export (for example the source condition)
+    // is not evidence that the built production artifact tree-shakes.
+    expect(
+      Object.keys(result.metafile.inputs).map(input => path.resolve(input)),
+    ).toContain(path.resolve(productionFile));
+    const output = result.outputFiles[0];
+    expect(output.text).toContain('createCommand');
+    expect(output.contents.byteLength).toBeLessThan(16 * 1024);
+  });
+});


### PR DESCRIPTION
## Description

A consumer that imports only `createCommand` from the production ESM `lexical` package retains most of the core when bundled with esbuild. Rollup already drops the unused editor graph in the same scenario; esbuild does not because four module-initialization points in `Lexical.prod.mjs` are not provably side-effect free:

1. The root event table was built (and mutated with `beforeinput`) at module evaluation time. It is now built lazily on the first `addRootElementEvents` call.
2. `createRefCountedRegistry` is now in the compiler's pure-factory list (its definition already carried `@__NO_SIDE_EFFECTS__`), so the module-scope `documentSelectionChange` registry gets a `/* @__PURE__ */` annotation. The factory allocates a `Map` and closures and never invokes the activation callback.
3. `LexicalEditor.version` is initialized as a static class field instead of a post-class assignment. Same value, same (writable/enumerable/configurable) property descriptor.
4. The `[CACHED_TEXT_SIZE_KEY]` field on `LexicalNode` is now `declare`-only, so the class body no longer references the reconciler's symbol at definition time. The constructor still defines the same non-enumerable own property.

A new integration test bundles the built production artifact with esbuild and enforces a 16 KiB ceiling for a `createCommand`-only consumer. It resolves `lexical` to the built production export explicitly, since the workspace tsconfig and vitest aliases would otherwise resolve to TypeScript source (which already tree-shakes well and would give a false pass).

Two independent improvements found while measuring are included and can be reviewed (or split out) separately:

- `GenMap.entries()` takes a fast path with no per-entry override checks when there is no nursery. Local paired microbenchmarks showed roughly 9–20% higher iteration throughput on unmodified snapshots (100–100,000 entries); edited maps were near parity. This is a local microbenchmark only and does not establish a typing or paste latency improvement.
- The paste benchmark now resets its editor state through tinybench task hooks outside the timed body and asserts the resulting child count on every sample. Vitest 4.1.x constructs the tinybench `Task` without forwarding `beforeEach`/`afterEach` from `bench()` options, so the previous hooks never ran and the benchmark accumulated paragraphs across iterations. The shared DOM benchmark helper also detaches the previous editor host between setups.

This lands the patch proposed in #9120 as a PR. The change is limited to module initialization order and annotations; no public API changes.

Closes #9120

## Test plan

Sizes are minified esbuild 0.27.7 output (`--bundle --minify --format=esm --platform=browser --conditions=production`), gzip via `gzip -n -9`. Full repro steps are in #9120.

| Minified output | Before (`main`) | After |
| --- | ---: | ---: |
| esbuild `createCommand` consumer | 148,429 B (48,493 B gzip) | 1,538 B (867 B gzip) |
| esbuild `createEditor` consumer | 162,908 B (53,380 B gzip) | 163,009 B (53,414 B gzip) |
| Shipped `Lexical.prod.mjs` | 181,023 B (56,942 B gzip) | 181,145 B (57,017 B gzip) |

The shipped production ESM grows by 122 bytes; the narrow-import case shrinks by ~99%.

### Before

- `scripts/__tests__/integration/tree-shaking.test.mjs` fails against the `main` production artifact (`expected 148441 to be less than 16384`).

### After

- `pnpm run tsc`, `pnpm run tsc-scripts`, `pnpm run flow`, ESLint and Prettier on the changed files: pass.
- Unit tests for `lexical`, `@lexical/compiler`, and the internal ESLint plugin: 1,555 passed (74 files).
- `pnpm run test-integration`: 189 passed, including the new tree-shaking test. The 5 failures are the example-fixture "tests pass" steps, which need Playwright browser system dependencies my container does not have (`Host system is missing dependencies to run browsers`); they are unrelated to this change.
- `vitest bench --project bench-dom` on the paste benchmark: runs with the task hooks and the per-sample `size + 9` child-count assertion for both sizes.
- Built `Lexical.prod.mjs` inspected: lazy root event table, `static version=…` inside the class, and no `CachedTextSize` symbol reference in the class body.
