### PR TITLE
[lexical-table] Bug Fix: $mergeCells no longer keeps the empty paragraph of the target cell

### DIFF
--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -920,6 +920,11 @@ export function $mergeCells(cellNodes: TableCellNode[]): TableCellNode | null {
         seenCells.add(key);
         const isEmpty = $cellContainsEmptyParagraph(currentCell);
         if (!isEmpty) {
+          // The loop skips the target, so drop its own empty paragraph before
+          // real content lands underneath it.
+          if ($cellContainsEmptyParagraph(targetCell)) {
+            targetCell.clear();
+          }
           targetCell.append(...currentCell.getChildren());
         }
         currentCell.remove();

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableUtils.test.ts
@@ -16,6 +16,7 @@ import {
   $isTableCellNode,
   $isTableNode,
   $isTableRowNode,
+  $mergeCells,
   $moveTableColumn,
   $moveTableRow,
   $setTableColumnIsHeader,
@@ -29,6 +30,7 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $isParagraphNode,
   defineExtension,
   type LexicalEditorWithDispose,
 } from 'lexical';
@@ -1429,6 +1431,133 @@ describe('$insertTableColumnAtNode', () => {
         ['A', 'B', 'V', 'X', 'X', ''],
         ['C0', 'C1', 'V', 'X', 'X', ''],
       ]);
+    });
+  });
+});
+
+describe('$mergeCells', () => {
+  // An empty string gives the cell a single empty paragraph, which is what
+  // $mergeCells treats as having no content.
+  function $cell(text: string): TableCellNode {
+    const paragraph = $createParagraphNode();
+    if (text !== '') {
+      paragraph.append($createTextNode(text));
+    }
+    return $createTableCellNode().append(paragraph);
+  }
+
+  function $appendTable(rows: TableCellNode[][]): void {
+    const table = $createTableNode();
+    for (const cells of rows) {
+      table.append($createTableRowNode().append(...cells));
+    }
+    $getRoot().append(table);
+  }
+
+  function $getAllCells(): TableCellNode[] {
+    const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
+    return table.getChildren().flatMap(row =>
+      $assertNodeType(row, $isTableRowNode)
+        .getChildren()
+        .map(cell => $assertNodeType(cell, $isTableCellNode)),
+    );
+  }
+
+  function $getMergedCell(): TableCellNode {
+    const table = $assertNodeType($getRoot().getFirstChild(), $isTableNode);
+    const row = $assertNodeType(table.getFirstChild(), $isTableRowNode);
+    return $assertNodeType(row.getFirstChild(), $isTableCellNode);
+  }
+
+  function $getBlockTexts(cell: TableCellNode): string[] {
+    return cell.getChildren().map(child => child.getTextContent());
+  }
+
+  test('drops the empty paragraph of the target cell', () => {
+    editor.update(() => $appendTable([[$cell(''), $cell('hello')]]), {
+      discrete: true,
+    });
+
+    editor.update(() => void $mergeCells($getAllCells()), {discrete: true});
+
+    editor.read('latest', () => {
+      const merged = $getMergedCell();
+      expect($getBlockTexts(merged)).toEqual(['hello']);
+      expect(merged.getColSpan()).toBe(2);
+      expect(merged.getRowSpan()).toBe(1);
+    });
+  });
+
+  test("keeps every cell's content in order, and the spans", () => {
+    editor.update(
+      () =>
+        $appendTable([
+          [$cell(''), $cell('b')],
+          [$cell('c'), $cell('d')],
+        ]),
+      {discrete: true},
+    );
+
+    editor.update(() => void $mergeCells($getAllCells()), {discrete: true});
+
+    editor.read('latest', () => {
+      const merged = $getMergedCell();
+      expect($getBlockTexts(merged)).toEqual(['b', 'c', 'd']);
+      expect(merged.getColSpan()).toBe(2);
+      expect(merged.getRowSpan()).toBe(2);
+    });
+  });
+
+  test('keeps the same empty paragraph when every cell is empty', () => {
+    editor.update(() => $appendTable([[$cell(''), $cell(''), $cell('')]]), {
+      discrete: true,
+    });
+
+    let paragraphKey = '';
+    editor.read('latest', () => {
+      paragraphKey = $getMergedCell().getFirstChildOrThrow().getKey();
+    });
+
+    editor.update(() => void $mergeCells($getAllCells()), {discrete: true});
+
+    editor.read('latest', () => {
+      const merged = $getMergedCell();
+      expect(merged.getChildrenSize()).toBe(1);
+      const firstChild = merged.getFirstChildOrThrow();
+      expect($isParagraphNode(firstChild) && firstChild.isEmpty()).toBe(true);
+      // Nothing clears the target unless content is about to land, so this is
+      // the paragraph the cell started with rather than a replacement.
+      expect(firstChild.getKey()).toBe(paragraphKey);
+      expect(merged.getColSpan()).toBe(3);
+    });
+  });
+
+  test('leaves the target alone when only it has content', () => {
+    editor.update(() => $appendTable([[$cell('keep'), $cell(''), $cell('')]]), {
+      discrete: true,
+    });
+
+    editor.update(() => void $mergeCells($getAllCells()), {discrete: true});
+
+    editor.read('latest', () => {
+      const merged = $getMergedCell();
+      expect($getBlockTexts(merged)).toEqual(['keep']);
+      expect(merged.getColSpan()).toBe(3);
+    });
+  });
+
+  test('keeps the content of a non empty target ahead of the rest', () => {
+    editor.update(
+      () => $appendTable([[$cell('one'), $cell('two'), $cell('three')]]),
+      {discrete: true},
+    );
+
+    editor.update(() => void $mergeCells($getAllCells()), {discrete: true});
+
+    editor.read('latest', () => {
+      const merged = $getMergedCell();
+      expect($getBlockTexts(merged)).toEqual(['one', 'two', 'three']);
+      expect(merged.getColSpan()).toBe(3);
     });
   });
 });


### PR DESCRIPTION
Merging cells where the top left one is empty leaves a blank line at the top of the merged cell.

One row, two columns, cell 0 empty and cell 1 holding "hello":

```
before: ["", "hello"]
after:  ["hello"]
```

`$mergeCells` seeds `seenCells` with the target cell, so the loop skips it. Every other cell goes through `$cellContainsEmptyParagraph` and loses its blank paragraph. The target never does.

I clear it the first time real content is about to land. If nothing in the range has content the clear never runs, so an all empty merge keeps the paragraph node it started with.

Same limit as the rest of the function: that check only matches a cell holding exactly one empty paragraph, so a target with a blank line plus other content merges the way it does today.

`$mergeCells` is exported from `@lexical/table`, so callers will see the difference.

Five tests in `LexicalTableUtils.test.ts`, two of which fail on main. The all empty one asserts the paragraph key, so the clear can't be hoisted out of the loop without something failing. 47 pass in the file and the neighbouring table files are unchanged.
