### PR TITLE
fix(playground): clear card placeholder after paste

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -1015,22 +1015,27 @@
   margin-top: 12px;
 }
 /* CSS placeholders for the empty title / body fields. Shown only while a
-   field holds just its empty-paragraph <br> (the codebase's
-   :has(br:only-child) idiom), hidden the moment the user types, so the model
-   seeds no placeholder TextNodes. Absolutely positioned and pointer-inert so
-   they overlay the empty line without shifting the caret or blocking clicks. */
-.lexical-card-node [data-lexical-slot='title'] > p:has(br:only-child),
-.lexical-card-node > p:only-of-type:has(br:only-child) {
+   field holds just its empty-paragraph <br>, hidden the moment the user types,
+   so the model seeds no placeholder TextNodes. Written as
+   :has(> br):not(:has(> * + *)) instead of :has(br:only-child) for
+   Safari/WebKit compatibility. Absolutely positioned and pointer-inert so they
+   overlay the empty line without shifting the caret or blocking clicks. */
+.lexical-card-node [data-lexical-slot='title'] > p:has(> br):not(:has(> * + *)),
+.lexical-card-node > p:only-of-type:has(> br):not(:has(> * + *)) {
   position: relative;
 }
-.lexical-card-node [data-lexical-slot='title'] > p:has(br:only-child)::before {
+.lexical-card-node
+  [data-lexical-slot='title']
+  > p:has(> br):not(:has(> * + *))::before {
   content: 'Title';
 }
-.lexical-card-node > p:only-of-type:has(br:only-child)::before {
+.lexical-card-node > p:only-of-type:has(> br):not(:has(> * + *))::before {
   content: 'Body';
 }
-.lexical-card-node [data-lexical-slot='title'] > p:has(br:only-child)::before,
-.lexical-card-node > p:only-of-type:has(br:only-child)::before {
+.lexical-card-node
+  [data-lexical-slot='title']
+  > p:has(> br):not(:has(> * + *))::before,
+.lexical-card-node > p:only-of-type:has(> br):not(:has(> * + *))::before {
   color: #9ca3af;
   left: 0;
   pointer-events: none;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

When pasting text into an empty CardNode title field in Safari, the placeholder could remain visible even after the field contained text. The placeholder would sometimes disappear only after a browser redraw or zoom.

This PR fixes the Safari-specific styling issue by replacing the CardNode placeholder selector's `:has(br:only-child)` pattern with an equivalent structural selector that avoids WebKit's invalidation issue.

### Changes

- Updated CardNode title and body placeholder selectors in `PlaygroundEditorTheme.css`.
- Replaced `:has(br:only-child)` with `:has(> br):not(:has(> * + *))`.
- Added a focused E2E regression test covering pasting text into an empty CardNode title.
- No changes were made to the CardNode implementation or core Lexical packages.

Closes #9126

## Test plan

### Before

When text was pasted into an empty CardNode title in Safari, the `Title` placeholder could remain visible even though the field was no longer empty.

The issue could be reproduced by:
1. Inserting an empty CardNode.
2. Pasting text into the title field.
3. Observing that the `Title` placeholder may remain visible.
4. Triggering a redraw/zoom could cause the placeholder to disappear.

### After

Added an automated regression test:

- Pasting text into an empty CardNode title.
- Verifying that the `::before` placeholder content is cleared.

Validation performed locally:

- `git diff --check` — passed
- Focused WebKit E2E — unable to run locally because `@playwright/test` was not installed
- Focused Chromium E2E — unable to run locally because `@playwright/test` was not installed