### PR TITLE
[lexical-playground] Bug Fix: clear Card/Review CSS placeholders reliably on paste in Safari

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CardSlot.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CardSlot.spec.mjs
@@ -112,6 +112,17 @@ async function bodyText(page) {
   });
 }
 
+async function placeholderBefore(page, selector) {
+  return evaluate(
+    page,
+    sel => {
+      const el = document.querySelector(sel);
+      return el && window.getComputedStyle(el, '::before').content;
+    },
+    selector,
+  );
+}
+
 async function assertCardIntact(page, {title, body}) {
   expect(await cardCount(page)).toBe(1);
   expect(await slotCount(page, 'title')).toBe(1);
@@ -417,34 +428,87 @@ test.describe('Card empty-field placeholders', () => {
     expect(await bodyText(page)).toBe('');
 
     // the placeholder text comes from CSS ::before, not from the DOM text
-    const placeholders = await evaluate(page, () => {
-      const titleP = document.querySelector(
-        '.lexical-card-node [data-lexical-slot="title"] p',
-      );
-      const bodyP = document.querySelector('.lexical-card-node > p');
-      const before = el =>
-        el && window.getComputedStyle(el, '::before').content;
-      return {body: before(bodyP), title: before(titleP)};
-    });
-    expect(placeholders.title).toContain('Title');
-    expect(placeholders.body).toContain('Body');
+    const titleSelector = '.lexical-card-node [data-lexical-slot="title"] p';
+    const bodySelector = '.lexical-card-node > p';
+    expect(await placeholderBefore(page, titleSelector)).toContain('Title');
+    expect(await placeholderBefore(page, bodySelector)).toContain('Body');
 
     // typing into the title clears its placeholder but not the body's
     await click(page, '[data-lexical-slot="title"] p');
     await page.keyboard.type('Hi');
     await sleep(120);
-    const afterTyping = await evaluate(page, () => {
-      const titleP = document.querySelector(
-        '.lexical-card-node [data-lexical-slot="title"] p',
-      );
-      const bodyP = document.querySelector('.lexical-card-node > p');
-      const before = el =>
-        el && window.getComputedStyle(el, '::before').content;
-      return {body: before(bodyP), title: before(titleP)};
-    });
-    // a non-empty title no longer matches :has(br:only-child); body still does
-    expect(afterTyping.title === 'none' || afterTyping.title === '').toBe(true);
-    expect(afterTyping.body).toContain('Body');
+    const titleAfterTyping = await placeholderBefore(page, titleSelector);
+    expect(titleAfterTyping === 'none' || titleAfterTyping === '').toBe(true);
+    expect(await placeholderBefore(page, bodySelector)).toContain('Body');
+  });
+
+  test('pasting text into an empty title clears its placeholder immediately (#9126)', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await insertEmptyCard(page);
+    await sleep(120);
+
+    await click(page, '[data-lexical-slot="title"] p');
+    await pasteFromClipboard(page, {'text/plain': 'Pasted Title'});
+    await sleep(120);
+
+    expect(await slotText(page, 'title')).toBe('Pasted Title');
+    const before = await placeholderBefore(
+      page,
+      '.lexical-card-node [data-lexical-slot="title"] p',
+    );
+    expect(before === 'none' || before === '').toBe(true);
+  });
+
+  test('pasting text into an empty body clears its placeholder immediately (#9126)', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await insertEmptyCard(page);
+    await sleep(120);
+
+    await click(page, '.lexical-card-node > p');
+    await pasteFromClipboard(page, {'text/plain': 'Pasted Body'});
+    await sleep(120);
+
+    expect(await bodyText(page)).toBe('Pasted Body');
+    const before = await placeholderBefore(page, '.lexical-card-node > p');
+    expect(before === 'none' || before === '').toBe(true);
+  });
+
+  test('a soft line break inside non-empty title/body does not resurrect the placeholder', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await insertEmptyCard(page);
+    await sleep(120);
+
+    await click(page, '[data-lexical-slot="title"] p');
+    await page.keyboard.type('Hello');
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Enter');
+    await page.keyboard.up('Shift');
+    await page.keyboard.type('World');
+    await sleep(120);
+
+    expect(await slotText(page, 'title')).toBe('HelloWorld');
+    const titleBefore = await placeholderBefore(
+      page,
+      '.lexical-card-node [data-lexical-slot="title"] p',
+    );
+    expect(titleBefore === 'none' || titleBefore === '').toBe(true);
+
+    await click(page, '.lexical-card-node > p');
+    await page.keyboard.type('Great');
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Enter');
+    await page.keyboard.up('Shift');
+    await page.keyboard.type('Product');
+    await sleep(120);
+
+    const bodyBefore = await placeholderBefore(page, '.lexical-card-node > p');
+    expect(bodyBefore === 'none' || bodyBefore === '').toBe(true);
   });
 
   test('the body placeholder shows only for a single empty body paragraph', async ({

--- a/packages/lexical-playground/__tests__/e2e/ReviewSlot.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ReviewSlot.spec.mjs
@@ -80,6 +80,17 @@ async function reviewCount(page) {
   );
 }
 
+async function placeholderBefore(page, selector) {
+  return evaluate(
+    page,
+    sel => {
+      const p = document.querySelector(`${sel} p`);
+      return p && window.getComputedStyle(p, '::before').content;
+    },
+    selector,
+  );
+}
+
 // Reset the document to a single empty paragraph via the editor API. A
 // document-wide range Backspace leaves a first-block shadow-root host (the
 // Review, which now starts the document since insertion seeds no leading
@@ -448,5 +459,75 @@ test.describe('Review React-chromed ElementNode', () => {
         ).map(c => c.tagName.toLowerCase()),
       ),
     ).toEqual(['p']);
+  });
+});
+
+test.describe('Review empty-field placeholders', () => {
+  test.beforeEach(({isCollab, isPlainText, page}) => {
+    test.skip(isPlainText);
+    return initialize({isCollab, page});
+  });
+
+  test('pasting text into the empty author slot clears its placeholder immediately (#9126)', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await insertReview(page);
+    await waitForSelector(page, '.lexical-review-chrome');
+
+    await click(page, `${AUTHOR} p`);
+    await pasteFromClipboard(page, {'text/plain': 'Jane Doe'});
+    await sleep(120);
+
+    expect(await regionText(page, AUTHOR)).toBe('Jane Doe');
+    const before = await placeholderBefore(page, AUTHOR);
+    expect(before === 'none' || before === '').toBe(true);
+  });
+
+  test('pasting text into the empty body clears its placeholder immediately (#9126)', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await insertReview(page);
+    await waitForSelector(page, '.lexical-review-chrome');
+
+    await click(page, `${BODY} p`);
+    await pasteFromClipboard(page, {'text/plain': 'Loved it'});
+    await sleep(120);
+
+    expect(await regionText(page, BODY)).toBe('Loved it');
+    const before = await placeholderBefore(page, BODY);
+    expect(before === 'none' || before === '').toBe(true);
+  });
+
+  test('a soft line break inside non-empty author/body does not resurrect the placeholder', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await insertReview(page);
+    await waitForSelector(page, '.lexical-review-chrome');
+
+    await click(page, `${AUTHOR} p`);
+    await page.keyboard.type('Jane');
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Enter');
+    await page.keyboard.up('Shift');
+    await page.keyboard.type('Doe');
+    await sleep(120);
+
+    expect(await regionText(page, AUTHOR)).toBe('JaneDoe');
+    const authorBefore = await placeholderBefore(page, AUTHOR);
+    expect(authorBefore === 'none' || authorBefore === '').toBe(true);
+
+    await click(page, `${BODY} p`);
+    await page.keyboard.type('Loved');
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Enter');
+    await page.keyboard.up('Shift');
+    await page.keyboard.type('it');
+    await sleep(120);
+
+    const bodyBefore = await placeholderBefore(page, BODY);
+    expect(bodyBefore === 'none' || bodyBefore === '').toBe(true);
   });
 });

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -968,22 +968,24 @@
    the moment the user types, so the model seeds no placeholder TextNodes. The
    author placeholder is just 'Author' now — the '— ' prefix above is
    permanent. */
-.lexical-review-author [data-lexical-slot='author'] > p:has(br:only-child),
-.lexical-review-children > p:only-of-type:has(br:only-child) {
+.lexical-review-author
+  [data-lexical-slot='author']
+  > p:has(> br):not(:has(> * + *)),
+.lexical-review-children > p:only-of-type:has(> br):not(:has(> * + *)) {
   position: relative;
 }
 .lexical-review-author
   [data-lexical-slot='author']
-  > p:has(br:only-child)::before {
+  > p:has(> br):not(:has(> * + *))::before {
   content: 'Author';
 }
-.lexical-review-children > p:only-of-type:has(br:only-child)::before {
+.lexical-review-children > p:only-of-type:has(> br):not(:has(> * + *))::before {
   content: 'Write a review…';
 }
 .lexical-review-author
   [data-lexical-slot='author']
-  > p:has(br:only-child)::before,
-.lexical-review-children > p:only-of-type:has(br:only-child)::before {
+  > p:has(> br):not(:has(> * + *))::before,
+.lexical-review-children > p:only-of-type:has(> br):not(:has(> * + *))::before {
   color: #a8a29e;
   left: 0;
   pointer-events: none;
@@ -1015,22 +1017,26 @@
   margin-top: 12px;
 }
 /* CSS placeholders for the empty title / body fields. Shown only while a
-   field holds just its empty-paragraph <br> (the codebase's
-   :has(br:only-child) idiom), hidden the moment the user types, so the model
-   seeds no placeholder TextNodes. Absolutely positioned and pointer-inert so
-   they overlay the empty line without shifting the caret or blocking clicks. */
-.lexical-card-node [data-lexical-slot='title'] > p:has(br:only-child),
-.lexical-card-node > p:only-of-type:has(br:only-child) {
+   field holds just its empty-paragraph <br>, hidden the moment the user
+   types, so the model seeds no placeholder TextNodes. Absolutely positioned
+   and pointer-inert so they overlay the empty line without shifting the
+   caret or blocking clicks. */
+.lexical-card-node [data-lexical-slot='title'] > p:has(> br):not(:has(> * + *)),
+.lexical-card-node > p:only-of-type:has(> br):not(:has(> * + *)) {
   position: relative;
 }
-.lexical-card-node [data-lexical-slot='title'] > p:has(br:only-child)::before {
+.lexical-card-node
+  [data-lexical-slot='title']
+  > p:has(> br):not(:has(> * + *))::before {
   content: 'Title';
 }
-.lexical-card-node > p:only-of-type:has(br:only-child)::before {
+.lexical-card-node > p:only-of-type:has(> br):not(:has(> * + *))::before {
   content: 'Body';
 }
-.lexical-card-node [data-lexical-slot='title'] > p:has(br:only-child)::before,
-.lexical-card-node > p:only-of-type:has(br:only-child)::before {
+.lexical-card-node
+  [data-lexical-slot='title']
+  > p:has(> br):not(:has(> * + *))::before,
+.lexical-card-node > p:only-of-type:has(> br):not(:has(> * + *))::before {
   color: #9ca3af;
   left: 0;
   pointer-events: none;


### PR DESCRIPTION
## Description

When pasting text into an empty Card title or body field, or into an empty Review author or prose field, the CSS `::before` placeholder (`Title`, `Body`, `Author`, or `Write a review…`) could remain visible on top of the pasted text in Safari.

The placeholder would only disappear after an unrelated action caused a repaint, such as zooming the page. Typing the same content character-by-character did not reproduce the issue.

The affected placeholders use `:has(br:only-child)` to detect an empty field. This matches the `<br>` that the reconciler inserts to represent an empty paragraph.

The issue appears to be a WebKit invalidation bug. When pasting into an empty field, the reconciler performs an insert-and-remove DOM mutation in a single pass. WebKit fails to properly invalidate the `:has()` selector when its argument contains the `:only-child` pseudo-class, leaving the placeholder's matched state stale until another style recalculation is triggered.

Typing doesn't follow the same reconciliation path, which is why it wasn't affected.

### Fix

The four affected selectors (Card title, Card body, Review author, and Review prose) have been updated from:

```css
:has(br:only-child)
```

to:

```css
:has(> br):not(:has(> * + *))
```

This is equivalent to checking that the paragraph contains a `<br>` and that it has no other element children — effectively, that the `<br>` is the paragraph's only element child.

The new selector also avoids treating a real `<br>` created by a user's **Shift+Enter** as an empty field.

Closes #9126.

## Test Plan

### Before

https://github.com/user-attachments/assets/7b68b310-29cd-4d51-bc8e-f55fece66e6e




### After


https://github.com/user-attachments/assets/ead07e18-b3ae-46f8-9e0c-78049c5e8b76


