### PR TITLE
[lexical-markdown] Bug Fix: text left outside a markdown link keeps its format

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -1285,13 +1285,17 @@ export const LINK: TextMatchTransformer = {
       outsideLinkText = '[' + linkTextParts[0];
       parsedLinkText = linkTextParts.slice(1).join('[');
     }
+    // Both new nodes stand in for the TextNode being replaced, so the text
+    // left outside the link carries its inline format just like the link's own
+    // text node does. Read the format before the replace below detaches it.
+    const format = textNode.getFormat();
     const linkTextNode = $createTextNode(parsedLinkText);
-    linkTextNode.setFormat(textNode.getFormat());
+    linkTextNode.setFormat(format);
     linkNode.append(linkTextNode);
     textNode.replace(linkNode);
 
     if (outsideLinkText) {
-      linkNode.insertBefore($createTextNode(outsideLinkText));
+      linkNode.insertBefore($createTextNode(outsideLinkText).setFormat(format));
     }
     return linkTextNode;
   },

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -945,6 +945,11 @@ describe('Markdown', () => {
       md: '[h[ello](https://lexical.dev)[world](https://lexical.dev)',
     },
     {
+      html: '<p><i><em style="white-space: pre-wrap;">[h</em></i><a href="https://lexical.dev"><i><em style="white-space: pre-wrap;">ello</em></i></a></p>',
+      md: '*[h[ello](https://lexical.dev)*',
+      mdAfterExport: '*[h*[*ello*](https://lexical.dev)',
+    },
+    {
       html: '<p><span style="white-space: pre-wrap;">[](https://lexical.dev)</span></p>',
       md: '[](https://lexical.dev)',
     },


### PR DESCRIPTION
## Description

Importing `*[h[ello](https://lexical.dev)*` loses the italic on `[h`.

`importRegExp` matches here with a `linkText` of `h[ello`, which has more opening than closing brackets, so the LINK transformer splits it: `ello` goes inside the link and `[h` goes back as a sibling TextNode ahead of it. The link's own text node is given the format of the TextNode being replaced, but the sibling is a bare `$createTextNode`, so the format on that half is dropped. One italic run comes back as a plain `[h` next to an italic `ello`.

Both new nodes stand in for the same TextNode, so it's inconsistent for only one of them to keep its format. The rest of the import path already preserves it: `importTextMatchTransformer` hands `replace` a node that came out of `splitText`, and `splitText` copies format, style and detail onto every piece it makes. `$createAutoLinkNode_` in `@lexical/link` gets it right for the same reason. The markdown LINK transformer is the one place that builds its leftover node by hand.

The fix reads the format once before the replace detaches the node, then applies it to both nodes.

I kept this to the format alone. The link's text node doesn't copy style or detail today either, so putting those on just the sibling would swap one mismatch for another.

## Test plan

Added the italic case to the `IMPORT_AND_EXPORT` table right beside the existing `[h[ello](...)` split case, so it runs through import, export and the selection check. It needs an `mdAfterExport` because the exporter writes the italic as two runs, `*[h*[*ello*](https://lexical.dev)`.

```
node_modules/.bin/vitest --project unit --no-watch run packages/lexical-markdown
```

### Before

New test in place, `MarkdownTransformers.ts` still at `main`:

```
 × can import "*[h[ello](https://lexical.dev)*"

AssertionError: expected '<p><span style="white-space: pre-wrap…' to be '<p><i><em style="white-space: pre-wra…'

Expected: "<p><i><em style="white-space: pre-wrap;">[h</em></i><a href="https://lexical.dev"><i><em style="white-space: pre-wrap;">ello</em></i></a></p>"
Received: "<p><span style="white-space: pre-wrap;">[h</span><a href="https://lexical.dev"><i><em style="white-space: pre-wrap;">ello</em></i></a></p>"

 Test Files  1 failed | 6 passed (7)
      Tests  1 failed | 633 passed (634)
```

### After

```
 Test Files  7 passed (7)
      Tests  634 passed (634)
```

`packages/lexical-link` stays green too, 10 files and 187 tests.