### PR TITLE
[lexical] Fix: make the extension Flow types usable (defineExtension was uncallable)

### DIFF
--- a/packages/lexical/flow/Lexical.flowtest.js.flow
+++ b/packages/lexical/flow/Lexical.flowtest.js.flow
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+/**
+ * Type-only smoke test for the hand-maintained Flow declarations.
+ *
+ * `pnpm lint-flow` checks that the `.flow` files export the same names as the
+ * generated `.d.ts`, and `pnpm flow` checks that the declarations are
+ * internally consistent. Neither one ever *calls* the declared API, so a
+ * declaration can be exported, self-consistent, and still impossible to use
+ * from a Flow codebase — which is how the extension types came to ship with
+ * `defineExtension` uncallable.
+ *
+ * This file is that missing coverage: it consumes the public extension API
+ * the way a downstream Flow app does. It is never imported at runtime, and
+ * `flow/` is not in the package's published `files`.
+ *
+ * The `.js.flow` extension is load-bearing. Flow type-checks the contents of
+ * `.js.flow` files, but `tsc` (which runs over the packages tree with
+ * `allowJs`) does not recognise the extension, and both ESLint and Prettier
+ * already ignore every `.js.flow` path. A plain `.js` file here fails
+ * `pnpm tsc` on the Flow syntax (`error TS8006: 'import type' declarations
+ * can only be used in TypeScript files`), because tsconfig's `exclude` only
+ * covers `.js` files one directory below `packages`, which is one level
+ * above this directory.
+ */
+
+import type {
+  LexicalEditor,
+  LexicalExtensionConfig,
+  LexicalExtensionOutput,
+} from 'lexical';
+
+import {defineExtension} from 'lexical';
+
+type SmokeConfig = {greeting: string};
+
+// An extension that declares no config, build, or init.
+const minimalExtension = defineExtension({
+  name: '@lexical/flow-smoke-test/Minimal',
+});
+
+// An extension carrying config and an output built at editor build time.
+const configuredExtension = defineExtension({
+  build(editor: LexicalEditor, config: SmokeConfig): {upper: string} {
+    return {upper: config.greeting.toUpperCase()};
+  },
+  config: {greeting: 'hello'} as SmokeConfig,
+  name: '@lexical/flow-smoke-test/Configured',
+});
+
+// The Config/Output helpers must still extract from a defined extension.
+const extractedConfig: LexicalExtensionConfig<typeof configuredExtension> = {
+  greeting: 'hi',
+};
+const extractedOutput: LexicalExtensionOutput<typeof configuredExtension> = {
+  upper: 'HI',
+};
+
+export function flowSmokeTest(): string {
+  return [
+    minimalExtension.name,
+    configuredExtension.name,
+    extractedConfig.greeting,
+    extractedOutput.upper,
+  ].join(',');
+}

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1973,10 +1973,15 @@ declare export function declarePeerDependency<
   config?: Partial<LexicalExtensionConfig<Extension>>,
 ): NormalizedPeerDependency<Extension>;
 declare export function defineExtension<
-  Config extends ExtensionConfigBase,
-  Name extends string,
-  Output,
-  Init,
+  Config extends ExtensionConfigBase = ExtensionConfigBase,
+  Name extends string = string,
+  // `Config`, `Output` and `Init` are only reachable through the optional
+  // `config`, `build` and `init` members, so an extension that declares none
+  // of them leaves the parameters unconstrained. TypeScript silently infers
+  // there; Flow reports `underconstrained-implicit-instantiation` unless a
+  // default is supplied.
+  Output = void,
+  Init = void,
 >(
   extension: LexicalExtension<Config, Name, Output, Init>,
 ): LexicalExtension<Config, Name, Output, Init>;
@@ -2076,7 +2081,7 @@ export type LexicalExtensionArgument<
   | LexicalExtension<Config, Name, Output, Init>
   | NormalizedLexicalExtensionArgument<Config, Name, Output, Init>;
 export type LexicalExtensionConfig<out Extension extends AnyLexicalExtension> =
-  NonNullable<Extension[typeof configTypeSymbol]>;
+  NonNullable<Extension['__configType']>;
 export interface LexicalExtensionDependency<
   out Dependency extends AnyLexicalExtension,
 > {
@@ -2084,22 +2089,42 @@ export interface LexicalExtensionDependency<
   readonly output: LexicalExtensionOutput<Dependency>;
 }
 export type LexicalExtensionInit<Extension extends AnyLexicalExtension> =
-  NonNullable<Extension[typeof initTypeSymbol]>;
+  NonNullable<Extension['__initType']>;
+/**
+ * The phantom brand properties that carry an extension's Config, Output and
+ * Init types.
+ *
+ * The TypeScript source keys these off `unique symbol`s
+ * (`configTypeSymbol`, `outputTypeSymbol`, `initTypeSymbol`), which Flow has
+ * no equivalent for: a computed key whose type is `symbol` is parsed as an
+ * *indexer* over all symbol keys, not as a single named property. That makes
+ * every other property of an extension (`name`, `nodes`, `config`, ...) have
+ * to conform to the indexer's value type, so no object literal can satisfy
+ * `LexicalExtension` and `defineExtension` cannot be called at all. Declaring
+ * all three at once additionally trips Flow's "Multiple indexers are not
+ * supported".
+ *
+ * Named optional read-only properties reproduce the TypeScript semantics that
+ * matter here — the three types are carried, the properties are never
+ * supplied by callers, and the `LexicalExtension{Config,Output,Init}` helpers
+ * still extract them. The symbols above remain exported to match the
+ * generated `.d.ts` surface.
+ */
 export interface LexicalExtensionInternal<Config, Output, Init> extends LexicalExtensionInternalConfig<Config>, LexicalExtensionInternalOutput<Output> {
-  [typeof initTypeSymbol]: Init;
+  readonly __initType?: Init;
 }
 interface LexicalExtensionInternalConfig<Config> {
-  [typeof configTypeSymbol]: Config;
+  readonly __configType?: Config;
 }
 interface LexicalExtensionInternalOutput<Output> {
-  [typeof outputTypeSymbol]: Output;
+  readonly __outputType?: Output;
 }
 
 export type LexicalExtensionName<Extension extends AnyLexicalExtension> =
   Extension['name'];
 
 export type LexicalExtensionOutput<out Extension extends AnyLexicalExtension> =
-  NonNullable<Extension[typeof outputTypeSymbol]>;
+  NonNullable<Extension['__outputType']>;
 declare export const peerDependencySymbol: symbol;
 export type NormalizedLexicalExtensionArgument<
   Config extends ExtensionConfigBase,


### PR DESCRIPTION
The hand-maintained Flow declarations mistranslate the `unique symbol`
brands that carry an extension's Config/Output/Init types, which makes
`defineExtension` — and therefore every extension-built editor — impossible
to call from a Flow codebase.

`packages/lexical/src/extension-core/internal.ts` declares three *optional*
properties keyed by `unique symbol`:

    export declare const configTypeSymbol: unique symbol;
    export interface LexicalExtensionInternal<Config, Output, Init> {
      readonly [configTypeSymbol]?: Config;
      readonly [outputTypeSymbol]?: Output;
      readonly [initTypeSymbol]?: Init;
    }

The Flow mirror drops both halves of that: the symbols become plain
`symbol`, and the properties become required.

    declare export const configTypeSymbol: symbol;
    interface LexicalExtensionInternalConfig<Config> {
      [typeof configTypeSymbol]: Config;
    }

Flow has no `unique symbol`. A computed key whose type is `symbol` is an
*indexer* over all symbol keys, not a single named property, so every other
property of an extension has to conform to the indexer's value type. The
result is that no object literal can satisfy `LexicalExtension`:

    Cannot call `defineExtension` with object literal bound to `extension`
    because property `name` is missing in `LexicalExtensionInternal` but
    exists in object literal. Any property that does not exist in
    `LexicalExtensionInternal` must be compatible with its indexer
    `typeof initTypeSymbol`.

Declaring all three also trips `Multiple indexers are not supported`.

There is no caller-side workaround: explicit type arguments do not help,
because the object literal itself is rejected.

This replaces the symbol-keyed brands with named optional read-only
properties, which reproduce the TypeScript semantics that matter — the three
types are carried, callers never supply the properties, and
`LexicalExtension{Config,Output,Init}` still extract them. The symbols stay
exported so the `.flow` surface keeps matching the generated `.d.ts` that
`pnpm lint-flow` compares against.

It also gives `defineExtension`'s type parameters defaults. `Config`,
`Output` and `Init` are reachable only through the optional `config`,
`build` and `init` members, so an extension declaring none of them leaves
them unconstrained; TypeScript infers silently there, Flow reports
`underconstrained-implicit-instantiation`. This surfaced only once the
indexer error was gone.

Finally, this adds `packages/lexical/flow/Lexical.flowtest.js`, a type-only
consumer of the public extension API. `pnpm lint-flow` compares export
*names* between the `.flow` and `.d.ts` files, and `pnpm flow` checks the
declarations for internal consistency, but nothing in the repo ever calls
the declared API — which is why a completely uncallable `defineExtension`
passed CI. The new file closes that gap. It is type-only, is never imported
at runtime, and `flow/` is not in the package's published `files`.

Test Plan:
Verified against the identical declarations as synced into Meta's www
monorepo, using www's Flow (0.331) — the same `Lexical.js.flow` content, so
the reproduction and the fix both apply to this file.

Before: a file calling `defineExtension` produces the indexer errors quoted
above. Four spellings were tried — bare object literal, explicit type
arguments, with and without `config` — and all four fail.

After (this change, applied to that copy): `flow status` reports
`No errors!` for a consumer that
  - calls `defineExtension` with no config/build/init,
  - calls it with a `config` and a `build` returning an output,
  - and reads both back through `LexicalExtensionConfig<typeof ext>` and
    `LexicalExtensionOutput<typeof ext>`.
That consumer is what `Lexical.flowtest.js` contains.

Not verified with this repo's own `pnpm flow` (flow-bin 0.321 could not be
installed in the sandbox used), so please let CI confirm the new test file
parses cleanly under the pinned version.

