### PR TITLE
[lexical-extension] Fix: use Array.from over iterable spread so extension editors build under loose-mode transpilation

### DIFF
--- a/packages/lexical-extension/src/LexicalBuilder.ts
+++ b/packages/lexical-extension/src/LexicalBuilder.ts
@@ -494,7 +494,13 @@ export class LexicalBuilder {
       config.theme = theme;
     }
     if (nodes.size) {
-      config.nodes = [...nodes];
+      // `Array.from` rather than `[...nodes]` on purpose. Some downstream
+      // builds lower iterable spread in loose mode, where `[...x]` becomes
+      // `[].concat(x)` — correct for arrays, but it wraps any other iterable
+      // instead of expanding it. That turned this into `[Set]`, which
+      // `createEditor` then read as a `{replace, with}` node replacement and
+      // rejected with "nodes[0] undefined is not a constructor".
+      config.nodes = Array.from(nodes);
     }
     const hasImport = Object.keys(htmlImport).length > 0;
     const hasExport = htmlExport.size > 0;

--- a/packages/lexical-extension/src/editorStateFamily.ts
+++ b/packages/lexical-extension/src/editorStateFamily.ts
@@ -155,7 +155,10 @@ function serializeSelection(
     };
   }
   if ($isNodeSelection(selection)) {
-    return {keys: [...selection._nodes], type: 'node'};
+    // Array.from rather than spread: see the note in LexicalBuilder, some
+    // downstream builds lower `[...x]` to `[].concat(x)`, which wraps a Set
+    // instead of expanding it. `_nodes` is a Set<NodeKey>.
+    return {keys: Array.from(selection._nodes), type: 'node'};
   }
   // A TableSelection (or any other implementation) is left behind rather than
   // half-restored.
@@ -185,7 +188,9 @@ function $serializeNodeVersion(node: LexicalNode): SerializedNodeVersion {
   }
   const {__slotHost, __slots} = node as LexicalNode & SlotLinks;
   if (__slots != null) {
-    version.slots = [...__slots];
+    // Array.from rather than spread: `__slots` is a Map, and a loose-mode
+    // spread lowering would store the Map itself instead of its entries.
+    version.slots = Array.from(__slots);
   }
   if (__slotHost != null) {
     version.slotHost = __slotHost;


### PR DESCRIPTION
`buildEditorFromExtensions` and `LexicalExtensionComposer` cannot build an
editor at all in Meta's www monorepo. Every attempt throws at construction:

    createEditor: nodes[0] undefined is not a constructor that subclasses
    LexicalNode from the lexical package used by this editor
      at LexicalBuilder#constructEditor
      at LexicalBuilder#buildEditor
      at LexicalExtensionComposer

Even an extension with no nodes at all fails:
`buildEditorFromExtensions(defineExtension({name: '[root]'}))`.

The cause is downstream, not a bug in Lexical under native semantics: www
lowers iterable spread in **loose mode**, where `[...x]` compiles to
`[].concat(x)`. That is correct for arrays and silently wrong for every other
iterable, which gets wrapped rather than expanded. Measured in that
environment, with no Lexical involved:

    [].concat(new Set([1,2,3])).length  === 1   // native spread: 3
    [].concat(new Map([[1,2],[3,4]])).length === 1   // native spread: 2
    [].concat('abc').length             === 1   // native spread: 3
    [].concat([1,2,3]).length           === 3   // arrays unaffected

`LexicalBuilder.buildCreateEditorArgs()` accumulates nodes into a `Set` and
then does `config.nodes = [...nodes]`, so under that lowering `config.nodes`
becomes `[Set]`. `createEditor` sees a non-function at `nodes[0]`, treats it
as a `{replace, with}` node-replacement descriptor, reads `.replace`, gets
`undefined`, and throws the error above.

`Array.from` is not rewritten by the transform and is equivalent under native
semantics, so this costs nothing and makes the extension packages robust for
consumers whose build lowers spread this way.

Three call sites in `@lexical/extension` spread a non-array iterable:

- `LexicalBuilder.ts` — `config.nodes = [...nodes]` where `nodes` is a `Set`.
  This is the one that breaks every extension-built editor.
- `editorStateFamily.ts` — `[...selection._nodes]` where `_nodes` is a
  `Set<NodeKey>`, so a serialized node selection would carry `[Set]` as its
  keys.
- `editorStateFamily.ts` — `[...__slots]` where `__slots` is a
  `Map<string, NodeKey>`, so a serialized node version would carry the Map
  itself instead of its entries.

`NodeSelectionDataSelectedExtension.ts:92` also spreads, but both operands are
arrays, so it is unaffected and left alone.

I have only audited `@lexical/extension`, because that is where I have a
reproduction. Other packages contain spreads of possibly-non-array iterables
(by a rough count of the built bundles: `@lexical/html` 7, `@lexical/table` 4,
`lexical` 2) and may hold the same latent problem on paths a loose-mode
consumer has not exercised yet. Happy to follow up if you would like those
swept too.

Test Plan:
Verified against www's synced copy of the built bundles, which is the
environment that reproduces the bug.

Before: a jest probe in that environment calling
`buildEditorFromExtensions(defineExtension({name: '[root]'}))` throws
`nodes[0] undefined ...`. The same happens in a real browser rendering a
migrated editor — this was first caught by a human clicking through the page,
after I wrongly concluded from a jest-only repro that it would not affect
browsers.

After (this change, applied to `LexicalExtension.dev.js` and
`LexicalExtension.prod.js` in that checkout):

- an extension with no nodes builds an editor and registers the 6 core types
- an extension carrying a real product node list (14 classes) builds and
  registers all of them:
  `["artificial","autolink","chunk-container","chunk-header","code",
    "code-highlight","heading","image","linebreak","link","list","listitem",
    "paragraph","quote","root","tab","table","tablecell","tablerow","text"]`

A guard assertion in that probe confirms the loose lowering is still in effect
in the environment under test (`[...new Set([1,2,3])].length === 1`), so the
result is not an accident of a changed toolchain.

Not run: this repo's own `pnpm test` / `pnpm flow` (the sandbox used could not
install the pinned toolchain). `Array.from(set)` and `[...set]` are equivalent
under native semantics, so no behaviour change is expected for consumers who
do not lower spread; please let CI confirm.

