### PR TITLE
[lexical-playground] Bug Fix: avoid node selection on CardNode drag release

### DIFF
--- a/packages/lexical-playground/__tests__/unit/CardNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/CardNode.test.ts
@@ -619,4 +619,61 @@ describe('CardNode named slots', () => {
 
     container.remove();
   });
+
+  // Regression test for #9115: when selecting text inside an editable slot and
+  // releasing the mouse over the host chrome, the click synthesized by the
+  // browser must NOT promote the host to a NodeSelection. Promotion requires
+  // that the interaction began with a mousedown on the host chrome.
+  it('releasing mouse over card chrome after mousedown in slot does not promote to NodeSelection (#9115)', () => {
+    using editor = buildEditorFromExtensions(CardTestExtension);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    editor.setRootElement(container);
+
+    editor.update(
+      () => {
+        $getRoot().clear().append($createCardNode());
+      },
+      {discrete: true},
+    );
+
+    const cardElement = container.querySelector('.lexical-card-node');
+    assert(cardElement instanceof HTMLElement);
+    const slotParagraph = container.querySelector(
+      '[data-lexical-slot="title"] p',
+    );
+    assert(slotParagraph instanceof HTMLElement);
+
+    // 1. Mousedown starts inside the slot (e.g. text selection drag)
+    slotParagraph.dispatchEvent(
+      new MouseEvent('mousedown', {bubbles: true, cancelable: true}),
+    );
+
+    // 2. Mouse released over card chrome -> click dispatched targeting cardElement
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(clickEvent, 'target', {value: cardElement});
+    editor.dispatchCommand(CLICK_COMMAND, clickEvent);
+
+    // 3. Must NOT become a NodeSelection
+    editor.read(() => {
+      const selection = $getSelection();
+      expect($isNodeSelection(selection)).toBe(false);
+    });
+
+    // 4. Positive case: explicit click on chrome (mousedown + click on chrome) DOES promote
+    cardElement.dispatchEvent(
+      new MouseEvent('mousedown', {bubbles: true, cancelable: true}),
+    );
+    editor.dispatchCommand(CLICK_COMMAND, clickEvent);
+
+    editor.read(() => {
+      const selection = $getSelection();
+      expect($isNodeSelection(selection)).toBe(true);
+    });
+
+    container.remove();
+  });
 });

--- a/packages/lexical-playground/src/nodes/hostChromeSelection.ts
+++ b/packages/lexical-playground/src/nodes/hostChromeSelection.ts
@@ -80,7 +80,7 @@ export function registerHostChromeSelection<T extends LexicalNode>(
     if (!isHTMLElement(target)) {
       return;
     }
-    const node = editor.read(() => $resolveChromeTarget(target));
+    const node = editor.read('latest', () => $resolveChromeTarget(target));
     if (node !== null) {
       mouseDownHostKey = node.getKey();
       event.preventDefault();

--- a/packages/lexical-playground/src/nodes/hostChromeSelection.ts
+++ b/packages/lexical-playground/src/nodes/hostChromeSelection.ts
@@ -18,6 +18,7 @@ import {
   type LexicalEditor,
   type LexicalNode,
   mergeRegister,
+  type NodeKey,
 } from 'lexical';
 
 /**
@@ -34,6 +35,8 @@ export function registerHostChromeSelection<T extends LexicalNode>(
   editor: LexicalEditor,
   $isHost: (node: LexicalNode | null | undefined) => node is T,
 ): () => void {
+  let mouseDownHostKey: NodeKey | null = null;
+
   // Resolve a click / mousedown target to the host node a chrome interaction
   // should select, or null when the target is inside one of the host's editable
   // slots (where the caret must enter the slot normally). The slots ride in
@@ -68,6 +71,7 @@ export function registerHostChromeSelection<T extends LexicalNode>(
   // dispatches to the slot's range path instead of the host-delete path.
   // Editable-slot mousedowns fall through so the caret still enters the slot.
   const onChromeMouseDown = (event: MouseEvent) => {
+    mouseDownHostKey = null;
     // Read-only mode: leave the reader's native selection alone.
     if (!editor.isEditable()) {
       return;
@@ -76,7 +80,9 @@ export function registerHostChromeSelection<T extends LexicalNode>(
     if (!isHTMLElement(target)) {
       return;
     }
-    if (editor.read(() => $resolveChromeTarget(target) !== null)) {
+    const node = editor.read(() => $resolveChromeTarget(target));
+    if (node !== null) {
+      mouseDownHostKey = node.getKey();
       event.preventDefault();
       const root = editor.getRootElement();
       if (root !== null && root !== getActiveElement(root)) {
@@ -97,6 +103,8 @@ export function registerHostChromeSelection<T extends LexicalNode>(
     editor.registerCommand(
       CLICK_COMMAND,
       event => {
+        const activeMouseDownKey = mouseDownHostKey;
+        mouseDownHostKey = null;
         // Read-only mode never promotes — mirrors the mousedown gate.
         if (!editor.isEditable()) {
           return false;
@@ -106,7 +114,7 @@ export function registerHostChromeSelection<T extends LexicalNode>(
           return false;
         }
         const node = $resolveChromeTarget(target);
-        if (node === null) {
+        if (node === null || node.getKey() !== activeMouseDownKey) {
           return false;
         }
         event.preventDefault();
@@ -118,6 +126,7 @@ export function registerHostChromeSelection<T extends LexicalNode>(
       COMMAND_PRIORITY_BEFORE_EDITOR,
     ),
     editor.registerRootListener((rootElement, prevRootElement) => {
+      mouseDownHostKey = null;
       if (prevRootElement !== null) {
         prevRootElement.removeEventListener('mousedown', onChromeMouseDown);
       }


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore

PR Title:
[lexical-playground] Bug Fix: Avoid node selection on drag release
-->

## Description

When selecting text inside an editable slot of a `CardNode`, releasing the mouse over the node's chrome area could incorrectly trigger a `NodeSelection` for the entire card.

This happened because `registerHostChromeSelection` handled the `mousedown` and subsequent `CLICK_COMMAND` independently. It checked only the target of the click, so a click synthesized after dragging from a slot to the card chrome could be interpreted as an intentional click on the host node.

This PR fixes the issue by tracking the host node on which the `mousedown` started and only promoting that node to a `NodeSelection` when the subsequent click corresponds to the same host.

### Changes

- Track the host `NodeKey` when a mousedown occurs on host chrome.
- Require the click target to resolve to the same host node before creating a `NodeSelection`.
- Clear the tracked key after each click and when the editor root changes to prevent stale interaction state.
- Preserve the existing behavior for intentional clicks directly on host chrome.
- Add a regression test covering text-selection drag release over CardNode chrome.

Closes #9115

## Test plan

### Before

The new regression test was run against the unpatched implementation.

The test **failed as expected** because releasing over the card chrome incorrectly promoted the card to a `NodeSelection`:

```text
FAIL ... CardNode.test.ts
AssertionError: expected true to be false

Tests 1 failed | 16 passed (17)
```

This reproduces the behavior described in #9115.

### After

After applying the fix:

- CardNode regression test: 17/17 passed
- PullQuoteNode tests: 10/10 passed
- lexical-playground unit test suite: 357/357 passed
- TypeScript: passed
- Flow: passed
- ESLint: passed with 0 errors/warnings
- Prettier: passed
- git diff --check: passed

The regression test also verifies that an intentional mousedown + click on the host chrome still correctly creates a NodeSelection.