### PR TITLE
[lexical] Bug Fix: avoid redundant selection change commands

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -318,7 +318,9 @@ function onSelectionChange(
     focusOffset,
   } = getDOMSelectionPoints(domSelection, editor._rootElement);
   const inputState = editor._inputState;
-  if (inputState.isSelectionChangeFromDOMUpdate) {
+  const isSelectionChangeFromDOMUpdate =
+    inputState.isSelectionChangeFromDOMUpdate;
+  if (isSelectionChangeFromDOMUpdate) {
     inputState.isSelectionChangeFromDOMUpdate = false;
     const appliedPoints = inputState.selectionChangeFromDOMUpdatePoints;
     inputState.selectionChangeFromDOMUpdatePoints = null;
@@ -488,7 +490,18 @@ function onSelectionChange(
       }
     }
 
-    dispatchCommand(editor, SELECTION_CHANGE_COMMAND);
+    const previousSelection = $getPreviousSelection();
+    const hasSelectionChanged =
+      isSelectionChangeFromDOMUpdate ||
+      (selection !== null
+        ? selection.dirty ||
+          !$isRangeSelection(selection) ||
+          !selection.is(previousSelection)
+        : previousSelection !== null);
+
+    if (hasSelectionChanged) {
+      dispatchCommand(editor, SELECTION_CHANGE_COMMAND);
+    }
   });
 }
 

--- a/packages/lexical/src/__tests__/browser/Issue8885SafariLinkSelectionChange.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8885SafariLinkSelectionChange.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Regression test for #8885 — Safari/WebKit fires redundant `selectionchange`
+ * events on interactions outside the editor (such as clicking the floating link
+ * menu). Lexical must only dispatch SELECTION_CHANGE_COMMAND when the selection
+ * has actually changed.
+ */
+
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  COMMAND_PRIORITY_CRITICAL,
+  type NodeKey,
+  SELECTION_CHANGE_COMMAND,
+} from 'lexical';
+import {describe, expect, onTestFinished, test, vi} from 'vitest';
+
+const ext = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '[8885-selection-change-browser]',
+});
+
+/**
+ * Give the browser a beat to deliver any native selectionchange task from focus
+ * before registering the listener.
+ */
+function settle(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 50));
+}
+
+function mountEditor() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const contentEditable = document.createElement('div');
+  contentEditable.contentEditable = 'true';
+  container.appendChild(contentEditable);
+
+  const editor = buildEditorFromExtensions(ext);
+  editor.setRootElement(contentEditable);
+
+  onTestFinished(() => {
+    editor.setRootElement(null);
+    document.body.removeChild(container);
+    editor.dispose();
+  });
+
+  return {contentEditable, editor};
+}
+
+describe('Issue #8885: SELECTION_CHANGE_COMMAND on redundant selectionchange', () => {
+  test('suppresses redundant selectionchange without suppressing legitimate selection changes', async () => {
+    const {contentEditable, editor} = mountEditor();
+
+    let textKey: NodeKey = '';
+    editor.update(
+      () => {
+        const text = $createTextNode('Hello world');
+        textKey = text.getKey();
+        $getRoot().clear().append($createParagraphNode().append(text));
+        text.select(5, 5);
+      },
+      {discrete: true},
+    );
+
+    contentEditable.focus();
+    await settle();
+
+    let selectionChangeCount = 0;
+    const unregister = editor.registerCommand(
+      SELECTION_CHANGE_COMMAND,
+      () => {
+        selectionChangeCount += 1;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+    onTestFinished(() => {
+      unregister();
+    });
+
+    // 1. A redundant selectionchange event where the selection did not change.
+    // On unmodified base, onSelectionChange blindly dispatches SELECTION_CHANGE_COMMAND.
+    document.dispatchEvent(new Event('selectionchange'));
+    expect(selectionChangeCount).toBe(0);
+
+    // 2. Legitimate caret movement within the node must still dispatch.
+    const textDOM = editor.getElementByKey(textKey);
+    expect(textDOM).not.toBeNull();
+    const domTextNode = textDOM!.firstChild as Text;
+    document.getSelection()!.setBaseAndExtent(domTextNode, 2, domTextNode, 2);
+    await vi.waitFor(() => expect(selectionChangeCount).toBe(1));
+
+    // Another redundant selectionchange at the new position must not dispatch.
+    document.dispatchEvent(new Event('selectionchange'));
+    expect(selectionChangeCount).toBe(1);
+
+    // 3. Legitimate range expansion must still dispatch.
+    document.getSelection()!.setBaseAndExtent(domTextNode, 2, domTextNode, 8);
+    await vi.waitFor(() => expect(selectionChangeCount).toBe(2));
+
+    // Redundant selectionchange with range selection must not dispatch.
+    document.dispatchEvent(new Event('selectionchange'));
+    expect(selectionChangeCount).toBe(2);
+  });
+});


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

Safari/WebKit can dispatch a native `selectionchange` event when interacting with links outside the editor, even when the Lexical selection has not actually changed.

Previously, `onSelectionChange` unconditionally dispatched `SELECTION_CHANGE_COMMAND` for every `selectionchange` event. This caused an unnecessary `SELECTION_CHANGE_COMMAND` when clicking the link in the floating link menu in Safari.

This change checks the previous Lexical selection before dispatching the command. The command is dispatched when:
- the selection value has changed;
- the selection is marked dirty; or
- the selection changes between `null` and a non-null selection.

A browser regression test was added to verify that redundant `selectionchange` events are ignored while legitimate caret and range selection changes continue to dispatch `SELECTION_CHANGE_COMMAND`.

Closes #8885

## Test plan

### Before

On the unmodified implementation, the regression test fails because a redundant `selectionchange` dispatches `SELECTION_CHANGE_COMMAND`:

```text
Expected: 0
Received: 1
```

The failure was reproduced in WebKit against the unmodified base implementation.

### After

The regression test passes with the fix in:

- WebKit
- Chromium
- Firefox

The test verifies that:

- redundant `selectionchange` events do not dispatch `SELECTION_CHANGE_COMMAND`;
- legitimate caret movement still dispatches the command;
- legitimate range expansion still dispatches the command;
- redundant events after legitimate selection changes remain suppressed.

Additional validation:

- `pnpm run test-unit packages/lexical/src/__tests__/unit/LexicalSelection*.test.ts`
- `pnpm run ci-check`
- Prettier
- ESLint
- `git diff --check`