### PR TITLE
[lexical-code] Breaking change: drop the deprecated prism re-exports and the @lexical/code-prism dependency

### DIFF
--- a/packages/lexical-code/README.md
+++ b/packages/lexical-code/README.md
@@ -2,7 +2,10 @@
 
 [![See API Documentation](https://lexical.dev/img/see-api-documentation.svg)](https://lexical.dev/docs/api/modules/lexical_code)
 
-This package contains the functionality for the code blocks and code highlighting for Lexical.
+This package contains the functionality for the code blocks for Lexical. It is a
+thin re-export of `@lexical/code-core` and contains no syntax highlighting.
 
-Note that the prism highlighting functionality from this module is deprecated and will be removed in a future version of lexical.
-If you intend to use code highlighting, depend directly on `@lexical/code-shiki` or `@lexical/code-prism`.
+Code highlighting lives in its own packages: depend directly on
+`@lexical/code-shiki` or `@lexical/code-prism` for that. The deprecated prism
+re-exports that this package used to forward from `@lexical/code-prism` have
+been removed; import them from `@lexical/code-prism` instead.

--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -14,7 +14,6 @@ import type {
   ParagraphNode,
   RangeSelection,
   EditorThemeClasses,
-  LexicalEditor,
   LineBreakNode,
   SerializedElementNode,
   SerializedTabNode,
@@ -112,33 +111,3 @@ export type CodeIndentConfig = {
 };
 
 declare export var CodeIndentExtension: LexicalExtension<CodeIndentConfig, "@lexical/code-indent", unknown, unknown>;
-
-/**
- * Deprecated @lexical/code-prism re-exports
- */
-
-type TokenContent = string | Token | (string | Token)[];
-export interface Token {
-  type: string;
-  content: TokenContent;
-}
-export interface Tokenizer {
-  defaultLanguage: string | null;
-  tokenize(code: string, language?: string): (string | Token)[];
-}
-declare export var PrismTokenizer: Tokenizer;
-
-declare export function registerCodeHighlighting(
-  editor: LexicalEditor,
-  tokenizer?: Tokenizer,
-): () => void;
-
-/** @deprecated renamed to {@link normalizeCodeLanguage} and moved to `@lexical/code-prism` */
-declare export function normalizeCodeLang(lang: string): string;
-declare export function normalizeCodeLanguage(lang: string): string;
-
-declare export var getCodeLanguages: () => string[];
-declare export function getLanguageFriendlyName(lang: string): string;
-
-declare export var CODE_LANGUAGE_FRIENDLY_NAME_MAP: {[string]: string};
-declare export var CODE_LANGUAGE_MAP: {[string]: string};

--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -13,7 +13,6 @@
   "types": "./dist/typescript-too-old.d.ts",
   "dependencies": {
     "@lexical/code-core": "workspace:*",
-    "@lexical/code-prism": "workspace:*",
     "@lexical/extension": "workspace:*",
     "lexical": "workspace:*"
   },
@@ -23,7 +22,7 @@
     "directory": "packages/lexical-code"
   },
   "module": "./dist/LexicalCode.js",
-  "sideEffects": true,
+  "sideEffects": false,
   "exports": {
     ".": {
       "source": "./src/index.ts",

--- a/packages/lexical-code/src/index.ts
+++ b/packages/lexical-code/src/index.ts
@@ -6,8 +6,6 @@
  *
  */
 
-import * as LexicalCodePrism from '@lexical/code-prism';
-
 export type {SerializedCodeNode} from '@lexical/code-core';
 export {
   $createCodeHighlightNode,
@@ -28,26 +26,3 @@ export {
   DEFAULT_CODE_LANGUAGE,
   getDefaultCodeLanguage,
 } from '@lexical/code-core';
-
-/** @deprecated moved to `@lexical/code-prism` */
-export const CODE_LANGUAGE_FRIENDLY_NAME_MAP =
-  LexicalCodePrism.CODE_LANGUAGE_FRIENDLY_NAME_MAP;
-/** @deprecated moved to `@lexical/code-prism` */
-export const CODE_LANGUAGE_MAP = LexicalCodePrism.CODE_LANGUAGE_MAP;
-/** @deprecated moved to `@lexical/code-prism` */
-export const getCodeLanguageOptions = LexicalCodePrism.getCodeLanguageOptions;
-/** @deprecated moved to `@lexical/code-prism` */
-export const getCodeLanguages = LexicalCodePrism.getCodeLanguages;
-/** @deprecated moved to `@lexical/code-prism` */
-export const getCodeThemeOptions = LexicalCodePrism.getCodeThemeOptions;
-/** @deprecated moved to `@lexical/code-prism` */
-export const getLanguageFriendlyName = LexicalCodePrism.getLanguageFriendlyName;
-/** @deprecated renamed to `normalizeCodeLanguage` and moved to `@lexical/code-prism` */
-export const normalizeCodeLang = LexicalCodePrism.normalizeCodeLanguage;
-/** @deprecated moved to `@lexical/code-prism` */
-export const normalizeCodeLanguage = LexicalCodePrism.normalizeCodeLanguage;
-/** @deprecated moved to `@lexical/code-prism` */
-export const PrismTokenizer = LexicalCodePrism.PrismTokenizer;
-/** @deprecated moved to `@lexical/code-prism` */
-export const registerCodeHighlighting =
-  LexicalCodePrism.registerCodeHighlighting;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,9 +680,6 @@ importers:
       '@lexical/code-core':
         specifier: workspace:*
         version: link:../lexical-code-core
-      '@lexical/code-prism':
-        specifier: workspace:*
-        version: link:../lexical-code-prism
       '@lexical/extension':
         specifier: workspace:*
         version: link:../lexical-extension

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package.json
@@ -14,6 +14,7 @@
     "@astrojs/check": "^0.9.9",
     "@astrojs/react": "^5.0.5",
     "@lexical/code": "0.50.0",
+    "@lexical/code-prism": "0.50.0",
     "@lexical/react": "0.50.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.1.9",

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/src/components/App.tsx
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/src/components/App.tsx
@@ -11,13 +11,8 @@ import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
-import {
-  CodeHighlightNode,
-  CodeNode,
-  // TODO: Using deprecated re-exports from @lexical/code-prism to test #8198, this can be refactored after that release
-  getCodeLanguages,
-  registerCodeHighlighting,
-} from "@lexical/code";
+import { CodeHighlightNode, CodeNode } from "@lexical/code";
+import { getCodeLanguages, registerCodeHighlighting } from "@lexical/code-prism";
 
 // import * as React from 'react';
 


### PR DESCRIPTION
## Description

`@lexical/code` depended on `@lexical/code-prism` purely to forward a set of `@deprecated` compatibility aliases (`registerCodeHighlighting`, `PrismTokenizer`, `getCodeLanguages`, `getCodeLanguageOptions`, `getCodeThemeOptions`, `getLanguageFriendlyName`, `normalizeCodeLang`, `normalizeCodeLanguage`, `CODE_LANGUAGE_MAP`,
`CODE_LANGUAGE_FRIENDLY_NAME_MAP`). Because `@lexical/code-prism` registers its grammars on the global `Prism` object at import time, that forwarding pulled all of prismjs into any bundle that imported `@lexical/code` for `CodeNode` alone, and `@lexical/code` had to be declared `"sideEffects": true`.

This removes those re-exports along with the `@lexical/code-prism` dependency, so `@lexical/code` is now a side-effect-free re-export of `@lexical/code-core` and prism highlighting lives only in `@lexical/code-prism`. The same symbols are still exported from `@lexical/code-prism`, which is where the deprecation notices pointed; `normalizeCodeLang` is `normalizeCodeLanguage` there.

Nothing under `examples/` or `dev-examples/` imported the removed symbols — they use `@lexical/code-shiki` or `@lexical/code-core`. The playground already declares `@lexical/code-prism` directly. The one consumer was the `lexical-esm-astro-react` integration fixture, which used them deliberately ("TODO: Using deprecated re-exports ... this can be refactored after that release"); it now imports them from `@lexical/code-prism` and declares that package, so it keeps exercising the same prismjs ESM bundling path.

## Test plan

Bundling `import {CodeNode} from '@lexical/code'` with esbuild (`--bundle --format=esm --conditions=source`) before and after:

### Before

```
bytes: 776411 | mentions Prism: true | prismjs in tree: true
```

### After

```
bytes: 556652 | mentions Prism: false | prismjs in tree: false
```

`packages/lexical-code/dist/LexicalCode.js` and `LexicalCode.dev.js` after `pnpm run build` contain zero occurrences of `prism` (case-insensitive).

`pnpm run test-unit`:

```
 Test Files  324 passed (324)
      Tests  7278 passed | 1 skipped (7279)
```

`pnpm run ci-check` (tsc, tsc-scripts, tsc-extension, tsc-website, flow, prettier, lint) passes with no errors, as does `pnpm run build-types`.

The Playwright integration run for the `lexical-esm-astro-react` fixture was not exercised here: it runs against packed tarballs produced by `prepare-release`, which this environment does not build.
