### PR TITLE
[lexical-playground] Bug Fix: keep the link toolbar active when a whole link is selected by element points

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -23,8 +23,11 @@ import {
   assertHTML,
   assertSelection,
   click,
+  evaluate,
+  expect,
   focus,
   focusEditor,
+  getPageOrFrame,
   html,
   initialize,
   insertSampleImage,
@@ -42,6 +45,62 @@ test.beforeEach(({isPlainText}) => {
 
 test.describe('Links', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  for (const boundary of ['paragraph', 'root']) {
+    for (const autoLink of [false, true]) {
+      test(`keeps the ${autoLink ? 'autolink' : 'link'} toolbar active for ${boundary} element points (#9137)`, async ({
+        page,
+      }) => {
+        await focusEditor(page);
+        if (autoLink) {
+          await page.keyboard.type('https://lexical.dev ');
+          await deleteBackward(page);
+        } else {
+          await page.keyboard.type('Hello');
+          await selectAll(page);
+          await click(page, '.link');
+          await click(page, '.link-confirm');
+        }
+        await selectAll(page);
+
+        // Preserve element points to cover browsers that represent select-all
+        // this way, instead of normalizing them to the linked text.
+        await evaluate(
+          page,
+          selectedBoundary => {
+            const editor = window.lexicalEditor;
+            return new Promise(resolve => {
+              editor.update(
+                () => {
+                  const root = editor.getEditorState()._nodeMap.get('root');
+                  const element =
+                    selectedBoundary === 'root'
+                      ? root
+                      : root.getFirstChildOrThrow();
+                  element.select(0, element.getChildrenSize());
+                },
+                {onUpdate: resolve, tag: 'skip-dom-selection'},
+              );
+            });
+          },
+          boundary,
+        );
+
+        const frame = getPageOrFrame(page);
+        await expect(
+          frame.locator('.toolbar button[aria-label="Insert link"]'),
+        ).toHaveClass(/active/);
+        await expect(frame.locator('.link-editor .link-edit')).toBeVisible();
+        await expect(
+          frame.locator('.link-editor .link-view a'),
+        ).toHaveAttribute(
+          'href',
+          autoLink ? 'https://lexical.dev' : 'https://',
+        );
+        await expect(frame.locator('.floating-text-format-popup')).toBeHidden();
+      });
+    }
+  }
+
   test(`Can convert a text node into a link`, async ({page}) => {
     await focusEditor(page);
     await page.keyboard.type('Hello');

--- a/packages/lexical-playground/__tests__/unit/FloatingTextFormatToolbar.test.tsx
+++ b/packages/lexical-playground/__tests__/unit/FloatingTextFormatToolbar.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import {RovingTabIndexExtension} from '@lexical/a11y';
+import {$createLinkNode, LinkExtension} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {LexicalExtensionComposer} from '@lexical/react/LexicalExtensionComposer';
 import {RichTextExtension} from '@lexical/rich-text';
@@ -14,6 +15,7 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $isElementNode,
   $selectAll,
   defineExtension,
   type LexicalEditor,
@@ -31,7 +33,7 @@ const ToolbarTestExtension = defineExtension({
       .clear()
       .append($createParagraphNode().append($createTextNode('hello')));
   },
-  dependencies: [RichTextExtension, RovingTabIndexExtension],
+  dependencies: [RichTextExtension, RovingTabIndexExtension, LinkExtension],
   name: '[test-floating-toolbar]',
 });
 
@@ -91,6 +93,29 @@ describe('FloatingTextFormatToolbarPlugin', () => {
       '.floating-text-format-popup button[aria-label^="Format text"]',
     ).length;
   }
+
+  it('hides the text toolbar when an entire linked paragraph is selected', async () => {
+    await act(async () => {
+      editor.update(
+        () => {
+          const paragraph = $getRoot().getFirstChildOrThrow();
+          if (!$isElementNode(paragraph)) {
+            throw new Error('Expected paragraph');
+          }
+          paragraph
+            .clear()
+            .append(
+              $createLinkNode('https://lexical.dev').append(
+                $createTextNode('hello'),
+              ),
+            );
+          paragraph.select(0, 1);
+        },
+        {discrete: true},
+      );
+    });
+    expect(anchorElem.querySelector('.floating-text-format-popup')).toBe(null);
+  });
 
   it('hides its format buttons when the editor becomes read-only', async () => {
     expect(anchorElem.querySelector('.floating-text-format-popup')).not.toBe(

--- a/packages/lexical-playground/__tests__/unit/SelectionLinkNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/SelectionLinkNode.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$createLinkNode, LinkExtension} from '@lexical/link';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  defineExtension,
+} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+import {$getSelectionLinkNode} from '../../src/utils/getSelectionLinkNode';
+
+const extension = defineExtension({
+  dependencies: [RichTextExtension, LinkExtension],
+  name: '[test-selection-link]',
+});
+
+describe('$getSelectionLinkNode', () => {
+  test.each(['root', 'paragraph', 'link'] as const)(
+    'resolves a link from %s element points in either direction',
+    boundary => {
+      using editor = buildEditorFromExtensions(extension);
+      editor.update(
+        () => {
+          const link = $createLinkNode('https://lexical.dev').append(
+            $createTextNode('hello'),
+            $createTextNode('world').toggleFormat('bold'),
+          );
+          const paragraph = $createParagraphNode().append(link);
+          const root = $getRoot().clear().append(paragraph);
+          const element =
+            boundary === 'root'
+              ? root
+              : boundary === 'paragraph'
+                ? paragraph
+                : link;
+          for (const backward of [false, true]) {
+            const selection = element.select(
+              backward ? element.getChildrenSize() : 0,
+              backward ? 0 : element.getChildrenSize(),
+            );
+            expect($getSelectionLinkNode(selection)).toBe(link);
+          }
+        },
+        {discrete: true},
+      );
+    },
+  );
+
+  test.each(['plain text', 'another link', 'empty paragraph'] as const)(
+    'does not treat a whole selection containing %s as one link',
+    extra => {
+      using editor = buildEditorFromExtensions(extension);
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode().append(
+            $createLinkNode('https://lexical.dev').append(
+              $createTextNode('hello'),
+            ),
+          );
+          const root = $getRoot().clear().append(paragraph);
+          if (extra === 'empty paragraph') {
+            root.append($createParagraphNode());
+          } else {
+            paragraph.append(
+              extra === 'plain text'
+                ? $createTextNode('world')
+                : $createLinkNode('https://example.com').append(
+                    $createTextNode('world'),
+                  ),
+            );
+          }
+          expect(
+            $getSelectionLinkNode(root.select(0, root.getChildrenSize())),
+          ).toBe(null);
+          expect(
+            $getSelectionLinkNode(root.select(root.getChildrenSize(), 0)),
+          ).toBe(null);
+        },
+        {discrete: true},
+      );
+    },
+  );
+
+  test('preserves collapsed and partial text selections inside a link', () => {
+    using editor = buildEditorFromExtensions(extension);
+    editor.update(
+      () => {
+        const text = $createTextNode('hello');
+        const link = $createLinkNode('https://lexical.dev').append(text);
+        $getRoot().clear().append($createParagraphNode().append(link));
+        expect($getSelectionLinkNode(text.select(2, 2))).toBe(link);
+        expect($getSelectionLinkNode(text.select(1, 4))).toBe(link);
+        expect($getSelectionLinkNode(text.select(4, 1))).toBe(link);
+      },
+      {discrete: true},
+    );
+  });
+
+  test('does not activate a link for a collapsed paragraph point', () => {
+    using editor = buildEditorFromExtensions(extension);
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode().append(
+          $createLinkNode('https://lexical.dev').append(
+            $createTextNode('hello'),
+          ),
+        );
+        $getRoot().clear().append(paragraph);
+        expect($getSelectionLinkNode(paragraph.select(0, 0))).toBe(null);
+      },
+      {discrete: true},
+    );
+  });
+});

--- a/packages/lexical-playground/__tests__/unit/SelectionLinkNode.test.ts
+++ b/packages/lexical-playground/__tests__/unit/SelectionLinkNode.test.ts
@@ -10,6 +10,7 @@ import {buildEditorFromExtensions} from '@lexical/extension';
 import {$createLinkNode, LinkExtension} from '@lexical/link';
 import {RichTextExtension} from '@lexical/rich-text';
 import {
+  $createLineBreakNode,
   $createParagraphNode,
   $createTextNode,
   $getRoot,
@@ -56,7 +57,12 @@ describe('$getSelectionLinkNode', () => {
     },
   );
 
-  test.each(['plain text', 'another link', 'empty paragraph'] as const)(
+  test.each([
+    'plain text',
+    'another link',
+    'empty paragraph',
+    'line break',
+  ] as const)(
     'does not treat a whole selection containing %s as one link',
     extra => {
       using editor = buildEditorFromExtensions(extension);
@@ -70,13 +76,15 @@ describe('$getSelectionLinkNode', () => {
           const root = $getRoot().clear().append(paragraph);
           if (extra === 'empty paragraph') {
             root.append($createParagraphNode());
+          } else if (extra === 'plain text') {
+            paragraph.append($createTextNode('world'));
+          } else if (extra === 'line break') {
+            paragraph.append($createLineBreakNode());
           } else {
             paragraph.append(
-              extra === 'plain text'
-                ? $createTextNode('world')
-                : $createLinkNode('https://example.com').append(
-                    $createTextNode('world'),
-                  ),
+              $createLinkNode('https://example.com').append(
+                $createTextNode('world'),
+              ),
             );
           }
           expect(

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -61,20 +61,15 @@ import {
 import {createPortal} from 'react-dom';
 
 import {getSelectedNode} from '../../utils/getSelectedNode';
+import {$getSelectionLinkNode} from '../../utils/getSelectionLinkNode';
 import {sanitizeUrl} from '../../utils/url';
 
 function $getSelectedLinkNode(selection: RangeSelection): LinkNode | null {
-  const node = getSelectedNode(selection);
-  // 1. Node itself is a link
-  if ($isLinkNode(node)) {
-    return node;
+  const linkNode = $getSelectionLinkNode(selection);
+  if (linkNode) {
+    return linkNode;
   }
-  // 2. Parent is a link
-  const linkParent = $findMatchingParent(node, $isLinkNode);
-  if ($isLinkNode(linkParent)) {
-    return linkParent;
-  }
-  // 3. Right-biased adjacent link (for single-char links)
+  // Right-biased adjacent link (for single-char links)
   if (selection.isCollapsed()) {
     const anchor = selection.anchor;
     if (anchor.type === 'text') {
@@ -443,7 +438,7 @@ function useFloatingLinkEditorToolbar(
         const focusLinkNode = $getSelectedLinkNode(selection);
         const focusNode = getSelectedNode(selection);
         const focusAutoLinkNode = $findMatchingParent(
-          focusNode,
+          focusLinkNode || focusNode,
           $isAutoLinkNode,
         );
         if (!(focusLinkNode || focusAutoLinkNode)) {
@@ -454,6 +449,9 @@ function useFloatingLinkEditorToolbar(
           .getNodes()
           .filter(node => !$isLineBreakNode(node))
           .find(node => {
+            if (focusLinkNode && node.isParentOf(focusLinkNode)) {
+              return false;
+            }
             const linkNode = $findMatchingParent(node, $isLinkNode);
             const autoLinkNode = $findMatchingParent(node, $isAutoLinkNode);
             return (

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -60,7 +60,7 @@ import {
 } from 'react';
 import {createPortal} from 'react-dom';
 
-import {getSelectedNode} from '../../utils/getSelectedNode';
+import {$getSelectedNode} from '../../utils/getSelectedNode';
 import {$getSelectionLinkNode} from '../../utils/getSelectionLinkNode';
 import {sanitizeUrl} from '../../utils/url';
 
@@ -318,7 +318,7 @@ function FloatingLinkEditor({
           );
           const selection = $getSelection();
           if ($isRangeSelection(selection)) {
-            const parent = getSelectedNode(selection).getParent();
+            const parent = $getSelectedNode(selection).getParent();
             if ($isAutoLinkNode(parent)) {
               const linkNode = $createLinkNode(parent.getURL(), {
                 rel: parent.__rel,
@@ -436,7 +436,7 @@ function useFloatingLinkEditorToolbar(
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
         const focusLinkNode = $getSelectedLinkNode(selection);
-        const focusNode = getSelectedNode(selection);
+        const focusNode = $getSelectedNode(selection);
         const focusAutoLinkNode = $findMatchingParent(
           focusLinkNode || focusNode,
           $isAutoLinkNode,
@@ -510,7 +510,7 @@ function useFloatingLinkEditorToolbar(
         payload => {
           const selection = $getSelection();
           if ($isRangeSelection(selection)) {
-            const node = getSelectedNode(selection);
+            const node = $getSelectedNode(selection);
             const linkNode = $findMatchingParent(node, $isLinkNode);
             if ($isLinkNode(linkNode) && (payload.metaKey || payload.ctrlKey)) {
               window.open(linkNode.getURL(), '_blank');

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -10,7 +10,7 @@ import './index.css';
 
 import {useMergeRefs} from '@floating-ui/react';
 import {$isCodeNode} from '@lexical/code';
-import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
+import {TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalRovingTabIndexRef} from '@lexical/react/useLexicalRovingTabIndexRef';
@@ -45,6 +45,7 @@ import {createPortal} from 'react-dom';
 
 import {getDOMRangeRect} from '../../utils/getDOMRangeRect';
 import {getSelectedNode} from '../../utils/getSelectedNode';
+import {$getSelectionLinkNode} from '../../utils/getSelectionLinkNode';
 import {setFloatingElemPosition} from '../../utils/setFloatingElemPosition';
 import {INSERT_INLINE_COMMAND} from '../CommentPlugin';
 
@@ -410,12 +411,7 @@ function useFloatingTextFormatToolbar(
       setIsCode(selection.hasFormat('code'));
 
       // Update links
-      const parent = node.getParent();
-      if ($isLinkNode(parent) || $isLinkNode(node)) {
-        setIsLink(true);
-      } else {
-        setIsLink(false);
-      }
+      setIsLink($getSelectionLinkNode(selection) !== null);
 
       if (
         !$isCodeNode(selection.anchor.getNode().getParent()) &&

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -44,7 +44,7 @@ import {
 import {createPortal} from 'react-dom';
 
 import {getDOMRangeRect} from '../../utils/getDOMRangeRect';
-import {getSelectedNode} from '../../utils/getSelectedNode';
+import {$getSelectedNode} from '../../utils/getSelectedNode';
 import {$getSelectionLinkNode} from '../../utils/getSelectionLinkNode';
 import {setFloatingElemPosition} from '../../utils/setFloatingElemPosition';
 import {INSERT_INLINE_COMMAND} from '../CommentPlugin';
@@ -396,7 +396,7 @@ function useFloatingTextFormatToolbar(
         return;
       }
 
-      const node = getSelectedNode(selection);
+      const node = $getSelectedNode(selection);
 
       // Update text format
       setIsBold(selection.hasFormat('bold'));

--- a/packages/lexical-playground/src/plugins/ShortcutsExtension/index.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsExtension/index.ts
@@ -38,7 +38,7 @@ import {
 } from 'lexical';
 
 import {DEFAULT_FONT_SIZE} from '../../context/ToolbarContext';
-import {getSelectedNode} from '../../utils/getSelectedNode';
+import {$getSelectedNode} from '../../utils/getSelectedNode';
 import {sanitizeUrl} from '../../utils/url';
 import {INSERT_INLINE_COMMAND} from '../CommentPlugin';
 import {
@@ -221,7 +221,7 @@ export const ShortcutsExtension = defineExtension({
         const selection = $getSelection();
         let isLink = false;
         if ($isRangeSelection(selection)) {
-          const node = getSelectedNode(selection);
+          const node = $getSelectedNode(selection);
           isLink = $isLinkNode(node) || $isLinkNode(node.getParent());
         }
         isLinkEditMode.value = !isLink;

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -79,7 +79,7 @@ import {$createStickyNode} from '../../nodes/StickyNode';
 import DropDown, {DropDownItem} from '../../ui/DropDown';
 import DropdownColorPicker from '../../ui/DropdownColorPicker';
 import {isKeyboardInput} from '../../utils/focusUtils';
-import {getSelectedNode} from '../../utils/getSelectedNode';
+import {$getSelectedNode} from '../../utils/getSelectedNode';
 import {$getSelectionLinkNode} from '../../utils/getSelectionLinkNode';
 import {sanitizeUrl} from '../../utils/url';
 import {EmbedConfigs} from '../AutoEmbedPlugin';
@@ -670,7 +670,7 @@ export default function ToolbarPlugin({
       updateToolbarState('isRTL', $isParentElementRTL(selection));
 
       // Update links
-      const node = getSelectedNode(selection);
+      const node = $getSelectedNode(selection);
       const parent = node.getParent();
       const isLink = $getSelectionLinkNode(selection) !== null;
       updateToolbarState('isLink', isLink);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -80,6 +80,7 @@ import DropDown, {DropDownItem} from '../../ui/DropDown';
 import DropdownColorPicker from '../../ui/DropdownColorPicker';
 import {isKeyboardInput} from '../../utils/focusUtils';
 import {getSelectedNode} from '../../utils/getSelectedNode';
+import {$getSelectionLinkNode} from '../../utils/getSelectionLinkNode';
 import {sanitizeUrl} from '../../utils/url';
 import {EmbedConfigs} from '../AutoEmbedPlugin';
 import {INSERT_COLLAPSIBLE_COMMAND} from '../CollapsibleExtension';
@@ -671,7 +672,7 @@ export default function ToolbarPlugin({
       // Update links
       const node = getSelectedNode(selection);
       const parent = node.getParent();
-      const isLink = $isLinkNode(parent) || $isLinkNode(node);
+      const isLink = $getSelectionLinkNode(selection) !== null;
       updateToolbarState('isLink', isLink);
 
       const tableNode = $findMatchingParent(node, $isTableNode);

--- a/packages/lexical-playground/src/utils/getSelectedNode.ts
+++ b/packages/lexical-playground/src/utils/getSelectedNode.ts
@@ -9,7 +9,12 @@ import type {ElementNode, RangeSelection, TextNode} from 'lexical';
 
 import {$isAtNodeEnd} from '@lexical/selection';
 
-export function getSelectedNode(
+/**
+ * Resolve the node a {@link RangeSelection} points at, biased towards the
+ * endpoint that is not at a node boundary. Reads the active editor state, so
+ * it must be called from a read or update context.
+ */
+export function $getSelectedNode(
   selection: RangeSelection,
 ): TextNode | ElementNode {
   const anchor = selection.anchor;

--- a/packages/lexical-playground/src/utils/getSelectionLinkNode.ts
+++ b/packages/lexical-playground/src/utils/getSelectionLinkNode.ts
@@ -7,44 +7,64 @@
  */
 import {$isLinkNode, type LinkNode} from '@lexical/link';
 import {
+  $caretRangeFromSelection,
   $findMatchingParent,
-  $isLineBreakNode,
+  type CaretRange,
   type RangeSelection,
 } from 'lexical';
 
 import {$getSelectedNode} from './getSelectedNode';
 
+function $findRangeLinkNode(range: CaretRange): LinkNode | null {
+  for (const {origin} of range) {
+    const link = $findMatchingParent(origin, $isLinkNode);
+    if (link !== null) {
+      return link;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the {@link LinkNode} a selection refers to, or `null` when it does
+ * not refer to exactly one.
+ *
+ * A text selection resolves from its endpoint, which keeps the right-biased
+ * lookup that lets an adjacent single-character link win. A non-collapsed
+ * selection made of element points — how some browsers represent select-all —
+ * additionally resolves a link that the range covers through an ancestor such
+ * as the containing paragraph or the root.
+ */
 export function $getSelectionLinkNode(
   selection: RangeSelection,
 ): LinkNode | null {
   // Preserve the existing endpoint-based behavior for text selections.
   // The link editor separately verifies that the whole range is in one link.
-  const node = $getSelectedNode(selection);
-  const parent = $findMatchingParent(node, $isLinkNode);
-  if ($isLinkNode(parent)) {
+  const parent = $findMatchingParent($getSelectedNode(selection), $isLinkNode);
+  if (parent !== null) {
     return parent;
   }
   if (selection.isCollapsed()) {
     return null;
   }
 
-  // Element points can select a whole link through its containing paragraph
-  // or root. Include those ancestors without treating unrelated content as
-  // part of the link.
-  const nodes = selection.getNodes();
-  for (const selected of nodes) {
-    const link = $findMatchingParent(selected, $isLinkNode);
-    if ($isLinkNode(link)) {
-      return nodes.every(
-        selectedNode =>
-          $isLineBreakNode(selectedNode) ||
-          selectedNode.is(link) ||
-          selectedNode.isParentOf(link) ||
-          link.isParentOf(selectedNode),
-      )
-        ? link
-        : null;
+  // Walk the range once to find the link it enters, then once more to confirm
+  // it covers nothing else: every node the walk visits has to be the link, one
+  // of its ancestors, or one of its descendants. Both walks are lazy and stop
+  // as soon as the answer is known.
+  const range = $caretRangeFromSelection(selection);
+  const link = $findRangeLinkNode(range);
+  if (link === null) {
+    return null;
+  }
+  for (const {origin} of range) {
+    if (
+      !link.is(origin) &&
+      !link.isParentOf(origin) &&
+      !origin.isParentOf(link)
+    ) {
+      return null;
     }
   }
-  return null;
+  return link;
 }

--- a/packages/lexical-playground/src/utils/getSelectionLinkNode.ts
+++ b/packages/lexical-playground/src/utils/getSelectionLinkNode.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {$isLinkNode, type LinkNode} from '@lexical/link';
+import {
+  $findMatchingParent,
+  $isLineBreakNode,
+  type RangeSelection,
+} from 'lexical';
+
+import {getSelectedNode} from './getSelectedNode';
+
+export function $getSelectionLinkNode(
+  selection: RangeSelection,
+): LinkNode | null {
+  // Preserve the existing endpoint-based behavior for text selections.
+  // The link editor separately verifies that the whole range is in one link.
+  const node = getSelectedNode(selection);
+  const parent = $findMatchingParent(node, $isLinkNode);
+  if ($isLinkNode(parent)) {
+    return parent;
+  }
+  if (selection.isCollapsed()) {
+    return null;
+  }
+
+  // Element points can select a whole link through its containing paragraph
+  // or root. Include those ancestors without treating unrelated content as
+  // part of the link.
+  const nodes = selection.getNodes();
+  for (const selected of nodes) {
+    const link = $findMatchingParent(selected, $isLinkNode);
+    if ($isLinkNode(link)) {
+      return nodes.every(
+        selectedNode =>
+          $isLineBreakNode(selectedNode) ||
+          selectedNode.is(link) ||
+          selectedNode.isParentOf(link) ||
+          link.isParentOf(selectedNode),
+      )
+        ? link
+        : null;
+    }
+  }
+  return null;
+}

--- a/packages/lexical-playground/src/utils/getSelectionLinkNode.ts
+++ b/packages/lexical-playground/src/utils/getSelectionLinkNode.ts
@@ -12,14 +12,14 @@ import {
   type RangeSelection,
 } from 'lexical';
 
-import {getSelectedNode} from './getSelectedNode';
+import {$getSelectedNode} from './getSelectedNode';
 
 export function $getSelectionLinkNode(
   selection: RangeSelection,
 ): LinkNode | null {
   // Preserve the existing endpoint-based behavior for text selections.
   // The link editor separately verifies that the whole range is in one link.
-  const node = getSelectedNode(selection);
+  const node = $getSelectedNode(selection);
   const parent = $findMatchingParent(node, $isLinkNode);
   if ($isLinkNode(parent)) {
     return parent;


### PR DESCRIPTION
## Description

The toolbar's link state and the floating link editor resolved the link from a single endpoint node (`getSelectedNode`), so they only recognised a link when an endpoint sat inside it. A selection can also be represented by **element points**, where `anchor` and `focus` are the containing paragraph or the root rather than the linked text — this is how some browsers represent select-all. Selecting nothing but a link that way left the "Insert link" button inactive, kept the link editor closed, and showed the text format toolbar instead.

This adds a shared `$getSelectionLinkNode` helper. It keeps the endpoint-based behavior for text selections and, for a non-collapsed selection, additionally resolves a link when every selected node belongs to one link — allowing the link's own ancestors and line breaks, so a paragraph or root boundary resolves while unrelated sibling content does not. `ToolbarPlugin`, `FloatingTextFormatToolbarPlugin` and `FloatingLinkEditorPlugin` now share it.

Unchanged by design: a collapsed paragraph point does not activate the link state, a selection spanning a link plus other content resolves to `null`, and the right-biased adjacent-link lookup for single-character links is kept.

Closes #9137

## Test plan

### Before

```
$ pnpm run test-unit packages/lexical-playground/__tests__/unit/FloatingTextFormatToolbar.test.tsx

 × hides the text toolbar when an entire linked paragraph is selected 109ms
 FAIL  |unit| .../FloatingTextFormatToolbar.test.tsx > hides the text toolbar when an entire linked paragraph is selected
AssertionError: expected <div …(4)>…(12)</div> to be null // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

```
$ pnpm run test-e2e-chromium -g "#9137"

  1) Links › keeps the link toolbar active for paragraph element points (#9137)
    Error: expect(locator).toHaveClass(expected) failed
    Expected pattern: /active/
    Received string:  "toolbar-item spaced "
  (same failure for the autolink/paragraph, link/root and autolink/root cases)

  4 failed
```

### After

```
$ pnpm run test-unit packages/lexical-playground/__tests__/unit/SelectionLinkNode.test.ts packages/lexical-playground/__tests__/unit/FloatingTextFormatToolbar.test.tsx

 Test Files  2 passed (2)
      Tests  10 passed (10)
```

```
$ pnpm run test-e2e-chromium -g "#9137"

  ✓ Links › keeps the autolink toolbar active for root element points (#9137) (2.9s)
  ✓ Links › keeps the link toolbar active for root element points (#9137) (3.0s)
  ✓ Links › keeps the link toolbar active for paragraph element points (#9137) (2.9s)
  ✓ Links › keeps the autolink toolbar active for paragraph element points (#9137) (3.1s)

  4 passed (4.3s)
```