### PR TITLE
[lexical] Bug Fix: Preserve all blocks when pasting disjoint pre tags

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1246,7 +1246,14 @@ export class RangeSelection implements BaseSelection {
     // CASE 1: insert inside a code block
     if ($isElementNode(firstBlock) && '__language' in firstBlock) {
       if ('__language' in nodes[0]) {
-        this.insertText(nodes[0].getTextContent());
+        // A DOM import can produce several top-level nodes for one paste
+        // (for example, disjoint <pre> elements separated by a <br>). Keep
+        // every imported block instead of silently discarding everything
+        // after the first CodeNode (#9151).
+        // Normalize the imported run so a standalone separator between block
+        // nodes is represented by the block boundary, not an extra newline.
+        const blocks = $wrapInlineNodes(nodes).getChildren();
+        this.insertText(blocks.map(node => node.getTextContent()).join('\n'));
       } else {
         const [, index] = $removeTextAndSplitBlock(this);
         firstBlock.splice(index, 0, nodes);

--- a/packages/lexical/src/__tests__/unit/Issue9151Repro.test.ts
+++ b/packages/lexical/src/__tests__/unit/Issue9151Repro.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$insertDataTransferForRichText} from '@lexical/clipboard';
+import {$createCodeNode, $isCodeNode} from '@lexical/code';
+import {
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+} from 'lexical';
+import {initializeUnitTest, invariant} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
+
+const DISJOINT_PRE_HTML =
+  '<pre>Some text here</pre> </br><pre>Some more text there</pre>';
+const PASTED_TEXT = 'Some text here\n\nSome more text there';
+
+describe('Regression #9151', () => {
+  initializeUnitTest(testEnv => {
+    test('preserves every pre block pasted into an empty code block', async () => {
+      const {editor} = testEnv;
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/html', DISJOINT_PRE_HTML);
+
+      await editor.update(
+        () => {
+          const code = $createCodeNode();
+          $getRoot().append(code);
+          code.select();
+
+          const selection = $getSelection();
+          invariant($isRangeSelection(selection), 'Expected a range selection');
+          $insertDataTransferForRichText(dataTransfer, selection, editor);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const root = $getRoot();
+        expect(root.getChildrenSize()).toBe(1);
+        const code = root.getFirstChild();
+        invariant($isCodeNode(code), 'Expected the existing CodeNode');
+        expect(code.getTextContent()).toBe(PASTED_TEXT);
+      });
+    });
+
+    test('keeps surrounding code and places the caret after all pasted blocks', async () => {
+      const {editor} = testEnv;
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/html', DISJOINT_PRE_HTML);
+
+      await editor.update(
+        () => {
+          const text = $createTextNode('beforeafter');
+          $getRoot().append($createCodeNode().append(text));
+          text.select('before'.length, 'before'.length);
+
+          const selection = $getSelection();
+          invariant($isRangeSelection(selection), 'Expected a range selection');
+          $insertDataTransferForRichText(dataTransfer, selection, editor);
+        },
+        {discrete: true},
+      );
+
+      editor.read(() => {
+        const code = $getRoot().getFirstChild();
+        invariant($isCodeNode(code), 'Expected the existing CodeNode');
+        expect(code.getTextContent()).toBe(`before${PASTED_TEXT}after`);
+
+        const selection = $getSelection();
+        invariant($isRangeSelection(selection), 'Expected a range selection');
+        expect(selection.isCollapsed()).toBe(true);
+        expect(selection.anchor.getNode().getTextContent()).toBe(
+          `before${PASTED_TEXT}after`,
+        );
+        expect(selection.anchor.offset).toBe(
+          'before'.length + PASTED_TEXT.length,
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Pasting HTML containing disjoint `<pre>` elements into an existing code block
only inserted the first imported CodeNode. This loses subsequent pasted
content.

This change normalizes the imported block run and inserts the text of every
imported block into the existing code block. Standalone separators are
normalized through the existing block-wrapping path so the pasted spacing is
preserved.

Closes #9151

## Test plan

### Before

`pnpm exec vitest run --project unit packages/lexical/src/__tests__/unit/Issue9151Repro.test.ts`
failed both regression cases: only `Some text here` was retained, and the
surrounding-code case became `beforeSome text hereafter`.

### After

`pnpm exec vitest run --project unit packages/lexical/src/__tests__/unit/Issue9151Repro.test.ts`
`Test Files 1 passed (1); Tests 2 passed (2)`

Related focused suites:
`Test Files 4 passed (4); Tests 121 passed (121)`

`pnpm run tsc` and `pnpm run build` both exited 0.
