### PR TITLE
[*] Bug Fix: Keep modern Flow variance keywords in the www Flow stubs

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "minimist": "^1.2.5",
     "npm-run-all": "^4.1.5",
     "playwright": "^1.62.1",
-    "prettier": "^3.8.1",
+    "prettier": "^3.8.5",
     "prettier-plugin-hermes-parser": "^0.36.1",
     "prettier-plugin-organize-attributes": "^1.0.0",
     "prettier-plugin-tailwindcss": "^0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   react-dom: 19.2.5
   '@types/node': 25.9.1
   postcss: 8.5.15
-  prettier: 3.8.1
+  prettier: 3.8.5
   yaml@^1: ^1.10.3
   uuid: '>=14.0.0'
   webpack-dev-server: '>=5.2.4'
@@ -75,7 +75,7 @@ importers:
         version: 1.62.1
       '@prettier/sync':
         specifier: ^0.6.1
-        version: 0.6.1(prettier@3.8.1)
+        version: 0.6.1(prettier@3.8.5)
       '@rollup/plugin-alias':
         specifier: ^6.0.0
         version: 6.0.0(rollup@4.63.1)
@@ -219,7 +219,7 @@ importers:
         version: 0.37.0
       hermes-transform:
         specifier: ^0.37.0
-        version: 0.37.0(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.8.1)
+        version: 0.37.0(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.8.5)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -239,17 +239,17 @@ importers:
         specifier: ^1.62.1
         version: 1.62.1
       prettier:
-        specifier: 3.8.1
-        version: 3.8.1
+        specifier: 3.8.5
+        version: 3.8.5
       prettier-plugin-hermes-parser:
         specifier: ^0.36.1
-        version: 0.36.1(prettier@3.8.1)
+        version: 0.36.1(prettier@3.8.5)
       prettier-plugin-organize-attributes:
         specifier: ^1.0.0
-        version: 1.0.0(prettier@3.8.1)
+        version: 1.0.0(prettier@3.8.5)
       prettier-plugin-tailwindcss:
         specifier: ^0.8.0
-        version: 0.8.0(prettier-plugin-organize-attributes@1.0.0(prettier@3.8.1))(prettier@3.8.1)
+        version: 0.8.0(prettier-plugin-organize-attributes@1.0.0(prettier@3.8.5))(prettier@3.8.5)
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -1331,8 +1331,8 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
       prettier:
-        specifier: 3.8.1
-        version: 3.8.1
+        specifier: 3.8.5
+        version: 3.8.5
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -1357,7 +1357,7 @@ importers:
         version: 8.0.1(@babel/core@8.0.1)
       '@prettier/sync':
         specifier: ^0.6.1
-        version: 0.6.1(prettier@3.8.1)
+        version: 0.6.1(prettier@3.8.5)
       '@rollup/plugin-babel':
         specifier: ^7.1.0
         version: 7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)
@@ -1708,7 +1708,7 @@ importers:
         version: 10.1.0
       prettier-plugin-tailwindcss:
         specifier: ^0.8.0
-        version: 0.8.0(prettier-plugin-organize-attributes@1.0.0(prettier@3.8.1))(prettier@3.8.1)
+        version: 0.8.0(prettier-plugin-organize-attributes@1.0.0(prettier@3.8.5))(prettier@3.8.5)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -4690,7 +4690,7 @@ packages:
   '@prettier/sync@0.6.1':
     resolution: {integrity: sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==}
     peerDependencies:
-      prettier: 3.8.1
+      prettier: 3.8.5
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -9365,7 +9365,7 @@ packages:
   hermes-transform@0.37.0:
     resolution: {integrity: sha512-wMf/X3dMz8+/7RJSoydAd5BV/ltYCw1lCX/A7wApEmYpWsxipwLZ5T1SMJl0uWrebZM41ua8Z4gut5dLe5dHlQ==}
     peerDependencies:
-      prettier: 3.8.1
+      prettier: 3.8.5
 
   history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
@@ -11778,13 +11778,13 @@ packages:
   prettier-plugin-hermes-parser@0.36.1:
     resolution: {integrity: sha512-i1wirokdDStTGNtYGlE9Y4Mf4W7VYo43Uz4j/Fhm63FsPdxVFgSeeaSPDYDbXMRDYpEKyNtB/k3FlcH4VKYlnQ==}
     peerDependencies:
-      prettier: 3.8.1
+      prettier: 3.8.5
 
   prettier-plugin-organize-attributes@1.0.0:
     resolution: {integrity: sha512-+NmameaLxbCcylEXsKPmawtzla5EE6ECqvGkpfQz4KM847fXDifB1gFnPQEpoADAq6IXg+cMI8Z0ISJEXa6fhg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      prettier: 3.8.1
+      prettier: 3.8.5
 
   prettier-plugin-tailwindcss@0.8.0:
     resolution: {integrity: sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==}
@@ -11797,7 +11797,7 @@ packages:
       '@shopify/prettier-plugin-liquid': '*'
       '@trivago/prettier-plugin-sort-imports': '*'
       '@zackad/prettier-plugin-twig': '*'
-      prettier: 3.8.1
+      prettier: 3.8.5
       prettier-plugin-astro: '*'
       prettier-plugin-css-order: '*'
       prettier-plugin-jsdoc: '*'
@@ -11841,8 +11841,8 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.5:
+    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -18394,10 +18394,10 @@ snapshots:
 
   '@preact/signals-core@1.14.1': {}
 
-  '@prettier/sync@0.6.1(prettier@3.8.1)':
+  '@prettier/sync@0.6.1(prettier@3.8.5)':
     dependencies:
       make-synchronized: 0.8.0
-      prettier: 3.8.1
+      prettier: 3.8.5
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -23316,7 +23316,7 @@ snapshots:
       md5: 2.3.0
       mkdirp: 1.0.4
       node-stream-zip: 1.15.0
-      prettier: 3.8.1
+      prettier: 3.8.5
       rimraf: 3.0.2
       semver: 7.7.4
       simple-git: 3.36.0(supports-color@10.2.2)
@@ -23333,7 +23333,7 @@ snapshots:
       '@babel/highlight': 7.25.9
       commander: 6.2.1
       lodash: 4.18.1
-      prettier: 3.8.1
+      prettier: 3.8.5
       shelljs: 0.8.5
       typescript: 4.4.4
       typescript-compiler: 1.4.1-2
@@ -23796,7 +23796,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.37.0
 
-  hermes-transform@0.37.0(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.8.1):
+  hermes-transform@0.37.0(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.8.5):
     dependencies:
       '@babel/code-frame': 7.29.7
       esquery: 1.7.0
@@ -23804,7 +23804,7 @@ snapshots:
       hermes-eslint: 0.37.0(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))
       hermes-estree: 0.37.0
       hermes-parser: 0.37.0
-      prettier: 3.8.1
+      prettier: 3.8.5
       string-width: 4.2.3
     transitivePeerDependencies:
       - eslint
@@ -26535,21 +26535,21 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-hermes-parser@0.36.1(prettier@3.8.1):
+  prettier-plugin-hermes-parser@0.36.1(prettier@3.8.5):
     dependencies:
-      prettier: 3.8.1
+      prettier: 3.8.5
 
-  prettier-plugin-organize-attributes@1.0.0(prettier@3.8.1):
+  prettier-plugin-organize-attributes@1.0.0(prettier@3.8.5):
     dependencies:
-      prettier: 3.8.1
+      prettier: 3.8.5
 
-  prettier-plugin-tailwindcss@0.8.0(prettier-plugin-organize-attributes@1.0.0(prettier@3.8.1))(prettier@3.8.1):
+  prettier-plugin-tailwindcss@0.8.0(prettier-plugin-organize-attributes@1.0.0(prettier@3.8.5))(prettier@3.8.5):
     dependencies:
-      prettier: 3.8.1
+      prettier: 3.8.5
     optionalDependencies:
-      prettier-plugin-organize-attributes: 1.0.0(prettier@3.8.1)
+      prettier-plugin-organize-attributes: 1.0.0(prettier@3.8.5)
 
-  prettier@3.8.1: {}
+  prettier@3.8.5: {}
 
   pretty-error@4.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ overrides:
   react-dom: '19.2.5'
   '@types/node': '25.9.1'
   postcss: '8.5.15'
-  prettier: '3.8.1'
+  prettier: '3.8.5'
   'yaml@^1': '^1.10.3'
   uuid: '>=14.0.0'
   webpack-dev-server: '>=5.2.4'

--- a/scripts/www/__tests__/unit/transformFlowFileContents.test.ts
+++ b/scripts/www/__tests__/unit/transformFlowFileContents.test.ts
@@ -83,6 +83,22 @@ const EXTRA_BLOCK_COMMENT =
  */
 `.trim() + '\n';
 
+// Modern Flow variance syntax must survive the transform verbatim. The www
+// copies are checked by Flow, which rejects the legacy `+`/`-` sigils with
+// "The `-` variance sigil is deprecated. Use `writeonly` instead."
+const VARIANCE =
+  `
+export interface InlineFormattableNode {
+  readonly __isInlineFormattable: true;
+}
+declare export class DOMSlot<out T extends HTMLElement> {
+  readonly element: T;
+  readonly before: Node | null;
+}
+export type ContextRecord = {readonly [string | symbol]: unknown};
+declare export function $setState<in T>(value: T): void;
+`.trim() + '\n';
+
 describe('transformFlowFileContents', () => {
   [
     {
@@ -104,6 +120,11 @@ describe('transformFlowFileContents', () => {
       input: [HEADER_BEFORE].join('\n'),
       output: [HEADER_AFTER].join('\n'),
       title: 'header',
+    },
+    {
+      input: [HEADER_BEFORE, VARIANCE].join('\n'),
+      output: [HEADER_AFTER, VARIANCE].join('\n'),
+      title: 'variance keywords',
     },
   ].forEach(({input, output, title}) => {
     it(`transforms ${title}`, async () => {


### PR DESCRIPTION
## Description

`scripts/www/transformFlowFileContents.mjs` reprints every `packages/*/flow/*.js.flow`
stub through `hermes-transform`, which prints via prettier. Since #9143 bumped
hermes-transform to 0.37.0 while the `prettier` override in `pnpm-workspace.yaml`
held prettier at 3.8.1, that pairing prints the modern variance keywords as the
deprecated sigil, and inverts them: `readonly` and `out` both come out as `-`,
which Flow reads as contravariant.

The www copies are `@flow strict` and land in a Flow-checked tree, so every
affected property fails the `unsupported-syntax` lint:

```
Error -------------------------------- html/shared/lexical/Lexical.js.flow:1528:3
The `-` variance sigil is deprecated. Use `writeonly` instead. [unsupported-syntax]

  1528|   -type: 'node-caret-range';
          ^
```

80 properties across `Lexical`, `LexicalHtml`, `LexicalUtils` and
`LexicalExtension` are affected — every `readonly`/`out`/`in` annotation the
stubs declare.

prettier 3.8.5 prints the keywords correctly, so this raises the override (and
the matching devDependency floor) from 3.8.1 to 3.8.5, and adds a
`transformFlowFileContents` case asserting that variance syntax round-trips
unchanged.

Note that `prettier-plugin-hermes-parser` is no longer a peer dependency of
hermes-transform as of 0.37.0 and does not affect this either way — 0.36.1 and
0.37.0 of the plugin, and no plugin at all, all print the same.

## Test plan

Reprinting the four real stubs through the repo's own transform, counting lines
that come out with a `-` sigil:

### Before

```
$ node check.mjs
packages/lexical/flow/Lexical.js.flow: 62 bad lines
    -__isInlineFormattable: true;
    declare export class DOMSlot<-T extends HTMLElement> {
    -element: T;
packages/lexical-html/flow/LexicalHtml.js.flow: 12 bad lines
    -cfg: ContextConfig<Ctx, V>,
    -updater: (prev: V) => V,
    -nodes: '*' | ReadonlyArray<NodeMatch<T>>,
packages/lexical-utils/flow/LexicalUtils.js.flow: 4 bad lines
    -stateConfig: StateConfig<K, V>,
    -$get: <T extends LexicalNode>(node: T) => V,
    -$set: <T extends LexicalNode>(
packages/lexical-extension/flow/LexicalExtension.js.flow: 2 bad lines
    -value: T;
    -data: {[string]: unknown},
prettier resolved: 3.8.1
```

```
$ npx vitest run scripts/www/__tests__/unit/transformFlowFileContents.test.ts

 FAIL  |scripts-unit| scripts/www/__tests__/unit/transformFlowFileContents.test.ts > transformFlowFileContents > transforms variance keywords
AssertionError: expected '/**\n * Copyright (c) Meta Platforms,…' to be '/**\n * Copyright (c) Meta Platforms,…' // Object.is equality

- Expected
+ Received

   export interface InlineFormattableNode {
-    readonly __isInlineFormattable: true;
+    -__isInlineFormattable: true;
   }
-  declare export class DOMSlot<out T extends HTMLElement> {
+  declare export class DOMSlot<-T extends HTMLElement> {
-    readonly element: T;
+    -element: T;
-    readonly before: Node | null;
+    -before: Node | null;
   }
-  export type ContextRecord = {readonly [string | symbol]: unknown};
+  export type ContextRecord = {-[string | symbol]: unknown};
-  declare export function $setState<in T>(value: T): void;
+  declare export function $setState<-T>(value: T): void;

 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

### After

```
$ node check.mjs
packages/lexical/flow/Lexical.js.flow: 0 bad lines
packages/lexical-html/flow/LexicalHtml.js.flow: 0 bad lines
packages/lexical-utils/flow/LexicalUtils.js.flow: 0 bad lines
packages/lexical-extension/flow/LexicalExtension.js.flow: 0 bad lines
prettier resolved: 3.8.5
```

```
$ npx vitest run scripts/www/__tests__/unit/transformFlowFileContents.test.ts

 ✓ |scripts-unit| scripts/www/__tests__/unit/transformFlowFileContents.test.ts (5 tests) 142ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

`npx prettier --list-different` reports no change on the files this PR touches.
