### PR TITLE
[lexical] Bug Fix: TextNode setMode, setTextContent and isSimpleText read the latest state

### DIFF
--- a/packages/lexical/src/__tests__/unit/TextNodeStaleState.test.ts
+++ b/packages/lexical/src/__tests__/unit/TextNodeStaleState.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {TextNode} from 'lexical';
+
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {describe, expect, test} from 'vitest';
+
+import {initializeUnitTest} from '../utils';
+
+describe('TextNode stale state readers', () => {
+  initializeUnitTest(testEnv => {
+    test('setTextContent can restore the original text through a stale reference', async () => {
+      const {editor} = testEnv;
+      let text!: TextNode;
+
+      await editor.update(() => {
+        text = $createTextNode('a');
+        $getRoot().append($createParagraphNode().append(text));
+      });
+
+      await editor.update(() => {
+        // setTextContent() goes through getWritable(), which in a later update
+        // clones the node. `text` still points at the previous version, so an
+        // early return that compares against stale state skips a real change.
+        text.setTextContent('b');
+        text.setTextContent('a');
+
+        expect(text.getTextContent()).toBe('a');
+      });
+    });
+
+    test('setMode can restore the original mode through a stale reference', async () => {
+      const {editor} = testEnv;
+      let text!: TextNode;
+
+      await editor.update(() => {
+        text = $createTextNode('a');
+        $getRoot().append($createParagraphNode().append(text));
+      });
+
+      await editor.update(() => {
+        text.setMode('token');
+        text.setMode('normal');
+
+        expect(text.getMode()).toBe('normal');
+      });
+    });
+
+    test('isSimpleText reflects the latest mode', async () => {
+      const {editor} = testEnv;
+      let text!: TextNode;
+
+      await editor.update(() => {
+        text = $createTextNode('a');
+        $getRoot().append($createParagraphNode().append(text));
+      });
+
+      await editor.update(() => {
+        text.setMode('token');
+
+        expect(text.isToken()).toBe(true);
+        expect(text.isSimpleText()).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -529,7 +529,8 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
    * @returns true if the node is simple text, false otherwise.
    */
   isSimpleText(): boolean {
-    return this.__type === 'text' && this.__mode === 0;
+    const self = this.getLatest();
+    return self.__type === 'text' && self.__mode === 0;
   }
 
   /**
@@ -829,7 +830,7 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
    */
   setMode(type: TextModeType): this {
     const mode = TEXT_MODE_TO_TYPE[type];
-    if (this.__mode === mode) {
+    if (this.getLatest().__mode === mode) {
       return this;
     }
     const self = this.getWritable();
@@ -845,7 +846,7 @@ export class TextNode extends LexicalNode implements InlineFormattableNode {
    * @returns this TextNode.
    */
   setTextContent(text: string): this {
-    if (this.__text === text) {
+    if (this.getLatest().__text === text) {
       return this;
     }
     const self = this.getWritable();


### PR DESCRIPTION
## Description

setMode() and setTextContent() skip the write when the requested value equals `this.__mode` / `this.__text`, and isSimpleText() reads `this.__mode`. None of them go through getLatest(). In a later update, the first setter call clones the node through getWritable(), so a reference held from the previous update is stale from then on. Calling `text.setTextContent('b')` then `text.setTextContent('a')` on a node whose text was 'a' compares against the stale 'a' and returns early, so the node keeps 'b'. setMode('token') followed by setMode('normal') leaves the node in token mode the same way, and isSimpleText() keeps answering true after setMode('token') while isToken() already says true.

This reads the latest version in those three places, the same way getMode(), isToken() and isSegmented() already do, and the way #9080 fixed the LinkNode readers.

## Test plan

### Before

pnpm vitest run --project unit packages/lexical/src/__tests__/unit/TextNodeStaleState.test.ts

     × setTextContent can restore the original text through a stale reference
     × setMode can restore the original mode through a stale reference
     × isSimpleText reflects the latest mode
AssertionError: expected 'b' to be 'a' // Object.is equality
AssertionError: expected 'token' to be 'normal' // Object.is equality
AssertionError: expected true to be false // Object.is equality
      Tests  3 failed (3)

### After

 ✓ |unit| packages/lexical/src/__tests__/unit/TextNodeStaleState.test.ts (3 tests)
      Tests  3 passed (3)

Unit suites for lexical, lexical-selection, lexical-link, lexical-markdown, lexical-text, lexical-rich-text and lexical-clipboard: 119 files, 2815 tests passed. eslint, prettier and tsc are clean. E2E browser tests were not run; the change is not browser-specific.

AI tools used
