### PR TITLE
[lexical] Bug Fix: Avoid redundant selection change command

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -318,7 +318,9 @@ function onSelectionChange(
     focusOffset,
   } = getDOMSelectionPoints(domSelection, editor._rootElement);
   const inputState = editor._inputState;
-  if (inputState.isSelectionChangeFromDOMUpdate) {
+  const isSelectionChangeFromDOMUpdate =
+    inputState.isSelectionChangeFromDOMUpdate;
+  if (isSelectionChangeFromDOMUpdate) {
     inputState.isSelectionChangeFromDOMUpdate = false;
     const appliedPoints = inputState.selectionChangeFromDOMUpdatePoints;
     inputState.selectionChangeFromDOMUpdatePoints = null;
@@ -488,7 +490,18 @@ function onSelectionChange(
       }
     }
 
-    dispatchCommand(editor, SELECTION_CHANGE_COMMAND);
+    const previousSelection = $getPreviousSelection();
+    const hasSelectionChanged =
+      isSelectionChangeFromDOMUpdate ||
+      (selection !== null
+        ? selection.dirty ||
+          !$isRangeSelection(selection) ||
+          !selection.is(previousSelection)
+        : previousSelection !== null);
+
+    if (hasSelectionChanged) {
+      dispatchCommand(editor, SELECTION_CHANGE_COMMAND);
+    }
   });
 }
 

--- a/packages/lexical/src/__tests__/browser/Issue8885SafariLinkSelectionChange.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8885SafariLinkSelectionChange.test.ts
@@ -20,15 +20,11 @@ import {
   $createTextNode,
   $getRoot,
   COMMAND_PRIORITY_CRITICAL,
+  isDOMTextNode,
   type NodeKey,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
-import {describe, expect, onTestFinished, test, vi} from 'vitest';
-
-const ext = defineExtension({
-  dependencies: [RichTextExtension],
-  name: '[8885-selection-change-browser]',
-});
+import {assert, describe, expect, onTestFinished, test, vi} from 'vitest';
 
 /**
  * Give the browser a beat to deliver any native selectionchange task from focus
@@ -45,7 +41,12 @@ function mountEditor() {
   contentEditable.contentEditable = 'true';
   container.appendChild(contentEditable);
 
-  const editor = buildEditorFromExtensions(ext);
+  const editor = buildEditorFromExtensions(
+    defineExtension({
+      dependencies: [RichTextExtension],
+      name: '[8885-selection-change-browser]',
+    }),
+  );
   editor.setRootElement(contentEditable);
 
   onTestFinished(() => {
@@ -75,13 +76,10 @@ describe('Issue #8885: SELECTION_CHANGE_COMMAND on redundant selectionchange', (
     contentEditable.focus();
     await settle();
 
-    let selectionChangeCount = 0;
+    const onSelectionChange = vi.fn(() => false);
     const unregister = editor.registerCommand(
       SELECTION_CHANGE_COMMAND,
-      () => {
-        selectionChangeCount += 1;
-        return false;
-      },
+      onSelectionChange,
       COMMAND_PRIORITY_CRITICAL,
     );
     onTestFinished(() => {
@@ -91,25 +89,36 @@ describe('Issue #8885: SELECTION_CHANGE_COMMAND on redundant selectionchange', (
     // 1. A redundant selectionchange event where the selection did not change.
     // On unmodified base, onSelectionChange blindly dispatches SELECTION_CHANGE_COMMAND.
     document.dispatchEvent(new Event('selectionchange'));
-    expect(selectionChangeCount).toBe(0);
+    expect(onSelectionChange).not.toHaveBeenCalled();
 
     // 2. Legitimate caret movement within the node must still dispatch.
     const textDOM = editor.getElementByKey(textKey);
-    expect(textDOM).not.toBeNull();
-    const domTextNode = textDOM!.firstChild as Text;
-    document.getSelection()!.setBaseAndExtent(domTextNode, 2, domTextNode, 2);
-    await vi.waitFor(() => expect(selectionChangeCount).toBe(1));
+    const domTextNode = textDOM?.firstChild;
+    assert(isDOMTextNode(domTextNode));
+    let domSelection = document.getSelection();
+    assert(domSelection !== null);
+    domSelection.setBaseAndExtent(domTextNode, 2, domTextNode, 2);
+    await vi.waitFor(() => expect(onSelectionChange).toHaveBeenCalledTimes(1));
 
     // Another redundant selectionchange at the new position must not dispatch.
     document.dispatchEvent(new Event('selectionchange'));
-    expect(selectionChangeCount).toBe(1);
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
 
     // 3. Legitimate range expansion must still dispatch.
-    document.getSelection()!.setBaseAndExtent(domTextNode, 2, domTextNode, 8);
-    await vi.waitFor(() => expect(selectionChangeCount).toBe(2));
+    domSelection = document.getSelection();
+    assert(domSelection !== null);
+    domSelection.setBaseAndExtent(domTextNode, 2, domTextNode, 8);
+    await vi.waitFor(() => expect(onSelectionChange).toHaveBeenCalledTimes(2));
 
     // Redundant selectionchange with range selection must not dispatch.
     document.dispatchEvent(new Event('selectionchange'));
-    expect(selectionChangeCount).toBe(2);
+    expect(onSelectionChange).toHaveBeenCalledTimes(2);
+
+    // Changing the range on text outside the editor does not trigger SELECTION_CHANGE_COMMAND
+    const outsideText = document.createTextNode('Foo');
+    document.body.appendChild(outsideText);
+    domSelection.setBaseAndExtent(outsideText, 1, outsideText, 1);
+    await settle();
+    expect(onSelectionChange).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/lexical/src/__tests__/browser/Issue8885SafariLinkSelectionChange.test.ts
+++ b/packages/lexical/src/__tests__/browser/Issue8885SafariLinkSelectionChange.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Regression test for #8885 — Safari/WebKit fires redundant `selectionchange`
+ * events on interactions outside the editor (such as clicking the floating link
+ * menu). Lexical must only dispatch SELECTION_CHANGE_COMMAND when the selection
+ * has actually changed.
+ */
+
+import {buildEditorFromExtensions, defineExtension} from '@lexical/extension';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  COMMAND_PRIORITY_CRITICAL,
+  type NodeKey,
+  SELECTION_CHANGE_COMMAND,
+} from 'lexical';
+import {describe, expect, onTestFinished, test, vi} from 'vitest';
+
+const ext = defineExtension({
+  dependencies: [RichTextExtension],
+  name: '[8885-selection-change-browser]',
+});
+
+/**
+ * Give the browser a beat to deliver any native selectionchange task from focus
+ * before registering the listener.
+ */
+function settle(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 50));
+}
+
+function mountEditor() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const contentEditable = document.createElement('div');
+  contentEditable.contentEditable = 'true';
+  container.appendChild(contentEditable);
+
+  const editor = buildEditorFromExtensions(ext);
+  editor.setRootElement(contentEditable);
+
+  onTestFinished(() => {
+    editor.setRootElement(null);
+    document.body.removeChild(container);
+    editor.dispose();
+  });
+
+  return {contentEditable, editor};
+}
+
+describe('Issue #8885: SELECTION_CHANGE_COMMAND on redundant selectionchange', () => {
+  test('suppresses redundant selectionchange without suppressing legitimate selection changes', async () => {
+    const {contentEditable, editor} = mountEditor();
+
+    let textKey: NodeKey = '';
+    editor.update(
+      () => {
+        const text = $createTextNode('Hello world');
+        textKey = text.getKey();
+        $getRoot().clear().append($createParagraphNode().append(text));
+        text.select(5, 5);
+      },
+      {discrete: true},
+    );
+
+    contentEditable.focus();
+    await settle();
+
+    let selectionChangeCount = 0;
+    const unregister = editor.registerCommand(
+      SELECTION_CHANGE_COMMAND,
+      () => {
+        selectionChangeCount += 1;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+    onTestFinished(() => {
+      unregister();
+    });
+
+    // 1. A redundant selectionchange event where the selection did not change.
+    // On unmodified base, onSelectionChange blindly dispatches SELECTION_CHANGE_COMMAND.
+    document.dispatchEvent(new Event('selectionchange'));
+    expect(selectionChangeCount).toBe(0);
+
+    // 2. Legitimate caret movement within the node must still dispatch.
+    const textDOM = editor.getElementByKey(textKey);
+    expect(textDOM).not.toBeNull();
+    const domTextNode = textDOM!.firstChild as Text;
+    document.getSelection()!.setBaseAndExtent(domTextNode, 2, domTextNode, 2);
+    await vi.waitFor(() => expect(selectionChangeCount).toBe(1));
+
+    // Another redundant selectionchange at the new position must not dispatch.
+    document.dispatchEvent(new Event('selectionchange'));
+    expect(selectionChangeCount).toBe(1);
+
+    // 3. Legitimate range expansion must still dispatch.
+    document.getSelection()!.setBaseAndExtent(domTextNode, 2, domTextNode, 8);
+    await vi.waitFor(() => expect(selectionChangeCount).toBe(2));
+
+    // Redundant selectionchange with range selection must not dispatch.
+    document.dispatchEvent(new Event('selectionchange'));
+    expect(selectionChangeCount).toBe(2);
+  });
+});


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

This PR is based on the patch from https://github.com/facebook/lexical/pull/9138

Explicit conditions have been added for the `SELECTION_CHANGE_COMMAND` dispatcher to prevent false triggers, such as when a user interacts with the interface outside the editor (for example, by clicking a link in a floating toolbar).

Closes #8885

## Test plan

### Before

Safari generates a `selectionchange` event when you click on buttons that contain text, and the lexical dispatcher dispatches `SELECTION_CHANGE_COMMAND`

https://github.com/user-attachments/assets/2b7611f3-ce95-458b-bf6c-fe0845cadb5e


### After

Changing the selection on text outside the editor no longer triggers SELECTION_CHANGE_COMMAND. A browser test has been added

https://github.com/user-attachments/assets/00698bea-4543-41bd-9004-3961c62559cc