### PR TITLE
[lexical-code-core][lexical-code-prism][lexical-code-shiki] Refactor: move the duplicated updateCodeGutter into @lexical/code-core

### DIFF
--- a/packages/lexical-code-core/flow/LexicalCodeCore.js.flow
+++ b/packages/lexical-code-core/flow/LexicalCodeCore.js.flow
@@ -108,6 +108,15 @@ declare export class CodeNode extends ElementNode {
   getLanguage(): string | void;
 }
 
+/**
+ * CodeGutter
+ */
+
+declare export function $updateCodeGutter(
+  node: CodeNode,
+  editor: LexicalEditor,
+): void;
+
 declare export var CodeExtension: LexicalExtension<ExtensionConfigBase, "@lexical/code", unknown, unknown>;
 
 export type CodeIndentConfig = {

--- a/packages/lexical-code-core/src/CodeGutter.ts
+++ b/packages/lexical-code-core/src/CodeGutter.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {CodeNode} from './CodeNode';
+
+import {$isLineBreakNode, type LexicalEditor} from 'lexical';
+
+/**
+ * @internal
+ * Write the line numbers of a {@link CodeNode} to the `data-gutter`
+ * attribute of its DOM element as a newline separated list (`"1\n2\n3"`),
+ * so a theme can render them with `content: attr(data-gutter)`. There is
+ * one line per `LineBreakNode` child plus one. The attribute is only
+ * rewritten when the number of children has changed since the last call.
+ *
+ * Both `@lexical/code-prism` and `@lexical/code-shiki` call this from their
+ * CodeNode mutation listener.
+ *
+ * @param node The CodeNode whose gutter should be updated.
+ * @param editor The editor that rendered the node.
+ */
+export function $updateCodeGutter(node: CodeNode, editor: LexicalEditor): void {
+  const codeElement = editor.getElementByKey(node.getKey());
+  if (codeElement === null) {
+    return;
+  }
+  const children = node.getChildren();
+  const childrenLength = children.length;
+  // @ts-ignore: internal field
+  if (childrenLength === codeElement.__cachedChildrenLength) {
+    // Avoid updating the attribute if the children length hasn't changed.
+    return;
+  }
+  // @ts-ignore:: internal field
+  codeElement.__cachedChildrenLength = childrenLength;
+  let gutter = '1';
+  let count = 1;
+  for (let i = 0; i < childrenLength; i++) {
+    if ($isLineBreakNode(children[i])) {
+      gutter += '\n' + ++count;
+    }
+  }
+  codeElement.setAttribute('data-gutter', gutter);
+}

--- a/packages/lexical-code-core/src/__tests__/unit/CodeGutter.test.ts
+++ b/packages/lexical-code-core/src/__tests__/unit/CodeGutter.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createCodeHighlightNode,
+  $createCodeNode,
+  $isCodeNode,
+  $updateCodeGutter,
+  CodeNode,
+} from '@lexical/code-core';
+import {
+  $createLineBreakNode,
+  $getNodeByKey,
+  $getRoot,
+  type LexicalEditor,
+  type NodeKey,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {assert, describe, expect, it} from 'vitest';
+
+// The same CodeNode mutation listener that @lexical/code-prism and
+// @lexical/code-shiki register.
+function registerCodeGutter(editor: LexicalEditor): () => void {
+  return editor.registerMutationListener(
+    CodeNode,
+    mutations => {
+      editor.read('latest', () => {
+        for (const [key, type] of mutations) {
+          if (type !== 'destroyed') {
+            const node = $getNodeByKey(key);
+            if (node !== null) {
+              $updateCodeGutter(node as CodeNode, editor);
+            }
+          }
+        }
+      });
+    },
+    {skipInitialization: false},
+  );
+}
+
+function getGutter(editor: LexicalEditor, key: NodeKey): string | null {
+  const codeElement = editor.getElementByKey(key);
+  assert(codeElement !== null, 'expected the CodeNode to be rendered');
+  return codeElement.getAttribute('data-gutter');
+}
+
+describe('$updateCodeGutter', () => {
+  initializeUnitTest(testEnv => {
+    it('numbers a single line', async () => {
+      const {editor} = testEnv;
+      registerCodeGutter(editor);
+
+      let key!: NodeKey;
+      await editor.update(() => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append($createCodeHighlightNode('const a = 1;'));
+        $getRoot().append(codeNode);
+        key = codeNode.getKey();
+      });
+
+      expect(getGutter(editor, key)).toBe('1');
+    });
+
+    it('numbers several lines', async () => {
+      const {editor} = testEnv;
+      registerCodeGutter(editor);
+
+      let key!: NodeKey;
+      await editor.update(() => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append(
+          $createCodeHighlightNode('a'),
+          $createLineBreakNode(),
+          $createCodeHighlightNode('b'),
+          $createLineBreakNode(),
+          $createCodeHighlightNode('c'),
+        );
+        $getRoot().append(codeNode);
+        key = codeNode.getKey();
+      });
+
+      expect(getGutter(editor, key)).toBe('1\n2\n3');
+    });
+
+    it('numbers an empty trailing line', async () => {
+      const {editor} = testEnv;
+      registerCodeGutter(editor);
+
+      let key!: NodeKey;
+      await editor.update(() => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append($createCodeHighlightNode('a'), $createLineBreakNode());
+        $getRoot().append(codeNode);
+        key = codeNode.getKey();
+      });
+
+      expect(getGutter(editor, key)).toBe('1\n2');
+    });
+
+    it('follows an edit that changes the line count', async () => {
+      const {editor} = testEnv;
+      registerCodeGutter(editor);
+
+      let key!: NodeKey;
+      await editor.update(() => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append(
+          $createCodeHighlightNode('a'),
+          $createLineBreakNode(),
+          $createCodeHighlightNode('b'),
+        );
+        $getRoot().append(codeNode);
+        key = codeNode.getKey();
+      });
+      expect(getGutter(editor, key)).toBe('1\n2');
+
+      await editor.update(() => {
+        const codeNode = $getNodeByKey(key);
+        assert($isCodeNode(codeNode), 'expected a CodeNode');
+        codeNode.append($createLineBreakNode(), $createCodeHighlightNode('c'));
+      });
+      expect(getGutter(editor, key)).toBe('1\n2\n3');
+
+      await editor.update(() => {
+        const codeNode = $getNodeByKey(key);
+        assert($isCodeNode(codeNode), 'expected a CodeNode');
+        codeNode.splice(1, codeNode.getChildrenSize() - 1, []);
+      });
+      expect(getGutter(editor, key)).toBe('1');
+    });
+
+    it('only rewrites the attribute when the number of children changes', async () => {
+      const {editor} = testEnv;
+      registerCodeGutter(editor);
+
+      let key!: NodeKey;
+      await editor.update(() => {
+        const codeNode = $createCodeNode('javascript');
+        codeNode.append(
+          $createCodeHighlightNode('a'),
+          $createLineBreakNode(),
+          $createCodeHighlightNode('b'),
+        );
+        $getRoot().append(codeNode);
+        key = codeNode.getKey();
+      });
+      expect(getGutter(editor, key)).toBe('1\n2');
+
+      const codeElement = editor.getElementByKey(key);
+      assert(codeElement !== null, 'expected the CodeNode to be rendered');
+      codeElement.setAttribute('data-gutter', 'unchanged');
+      editor.read(() => {
+        const codeNode = $getNodeByKey(key);
+        assert($isCodeNode(codeNode), 'expected a CodeNode');
+        $updateCodeGutter(codeNode, editor);
+      });
+      expect(getGutter(editor, key)).toBe('unchanged');
+
+      await editor.update(() => {
+        const codeNode = $getNodeByKey(key);
+        assert($isCodeNode(codeNode), 'expected a CodeNode');
+        codeNode.append($createLineBreakNode());
+      });
+      expect(getGutter(editor, key)).toBe('1\n2\n3');
+    });
+  });
+});

--- a/packages/lexical-code-core/src/index.ts
+++ b/packages/lexical-code-core/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 export {CodeExtension, CodeImportExtension} from './CodeExtension';
+export {$updateCodeGutter} from './CodeGutter';
 export {
   $createCodeHighlightNode,
   $isCodeHighlightNode,

--- a/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code-prism/src/CodeHighlighterPrism.ts
@@ -10,6 +10,7 @@ import {
   $isCodeHighlightNode,
   $isCodeNode,
   $plainifyCodeContent,
+  $updateCodeGutter,
   CodeExtension,
   CodeHighlightNode,
   CodeIndentExtension,
@@ -98,30 +99,6 @@ function $textNodeTransform(
     // code highlight nodes converted back to normal text
     node.replace($createTextNode(node.__text));
   }
-}
-
-function updateCodeGutter(node: CodeNode, editor: LexicalEditor): void {
-  const codeElement = editor.getElementByKey(node.getKey());
-  if (codeElement === null) {
-    return;
-  }
-  const children = node.getChildren();
-  const childrenLength = children.length;
-  // @ts-ignore: internal field
-  if (childrenLength === codeElement.__cachedChildrenLength) {
-    // Avoid updating the attribute if the children length hasn't changed.
-    return;
-  }
-  // @ts-ignore:: internal field
-  codeElement.__cachedChildrenLength = childrenLength;
-  let gutter = '1';
-  let count = 1;
-  for (let i = 0; i < childrenLength; i++) {
-    if ($isLineBreakNode(children[i])) {
-      gutter += '\n' + ++count;
-    }
-  }
-  codeElement.setAttribute('data-gutter', gutter);
 }
 
 function $codeNodeTransform(
@@ -389,7 +366,7 @@ export function registerHighlightingOnly(
               if (type !== 'destroyed') {
                 const node = $getNodeByKey(key);
                 if (node !== null) {
-                  updateCodeGutter(node as CodeNode, editor);
+                  $updateCodeGutter(node as CodeNode, editor);
                 }
               }
             }

--- a/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
+++ b/packages/lexical-code-shiki/src/CodeHighlighterShiki.ts
@@ -10,6 +10,7 @@ import {
   $isCodeHighlightNode,
   $isCodeNode,
   $plainifyCodeContent,
+  $updateCodeGutter,
   CodeExtension,
   CodeHighlightNode,
   CodeIndentExtension,
@@ -94,30 +95,6 @@ function $textNodeTransform(
     // code highlight nodes converted back to normal text
     node.replace($createTextNode(node.__text));
   }
-}
-
-function updateCodeGutter(node: CodeNode, editor: LexicalEditor): void {
-  const codeElement = editor.getElementByKey(node.getKey());
-  if (codeElement === null) {
-    return;
-  }
-  const children = node.getChildren();
-  const childrenLength = children.length;
-  // @ts-ignore: internal field
-  if (childrenLength === codeElement.__cachedChildrenLength) {
-    // Avoid updating the attribute if the children length hasn't changed.
-    return;
-  }
-  // @ts-ignore:: internal field
-  codeElement.__cachedChildrenLength = childrenLength;
-  let gutter = '1';
-  let count = 1;
-  for (let i = 0; i < childrenLength; i++) {
-    if ($isLineBreakNode(children[i])) {
-      gutter += '\n' + ++count;
-    }
-  }
-  codeElement.setAttribute('data-gutter', gutter);
 }
 
 interface TransformState {
@@ -406,7 +383,7 @@ export function registerHighlightingOnly(
               if (type !== 'destroyed') {
                 const node = $getNodeByKey(key);
                 if (node !== null) {
-                  updateCodeGutter(node as CodeNode, editor);
+                  $updateCodeGutter(node as CodeNode, editor);
                 }
               }
             }


### PR DESCRIPTION
## Description

`@lexical/code-prism` and `@lexical/code-shiki` each had their own private copy of `updateCodeGutter`, and the two copies were identical line for line. @etrepum asked on #8468 for this gutter code to be consolidated into `@lexical/code-core`, and it's the first step of the plan I posted on #8459.

This moves it into `@lexical/code-core` as `$updateCodeGutter` in a new `CodeGutter.ts`, exports it from the package index and declares it in the Flow file. Both highlighters now import it from there and their copies are gone. The function body is unchanged byte for byte, so the `data-gutter` string and the `__cachedChildrenLength` check are exactly what they were.

I gave it the `$` prefix because it reads the node's children, so it has to run inside a read or an update. That's already where both callers use it: the CodeNode mutation listener, inside `editor.read('latest', ...)`. It's marked `@internal` like `registerCodeIndentation`, since only the two highlighters call it.

I also added unit tests in `@lexical/code-core` that pin the exact `data-gutter` value for a single line, several lines, an empty trailing line and an edit that changes the line count, plus the cache that skips the write when the child count doesn't change. They run in a real editor with a copy of the mutation listener both highlighters register.

Part of #8459

## Test plan

### Before

On `origin/main` (84eabc38). The `packages/lexical-code` filter picks up `lexical-code`, `lexical-code-core`, `lexical-code-prism` and `lexical-code-shiki`. The `lexical-code` tests already pin `data-gutter` through prism's `registerCodeHighlighting`.

```
$ pnpm exec vitest --project unit --no-watch --maxWorkers=2 packages/lexical-code
 Test Files  15 passed (15)
      Tests  291 passed | 1 skipped (292)
```

### After

```
$ pnpm exec vitest --project unit --no-watch --maxWorkers=2 --reporter=verbose packages/lexical-code
 ✓ |unit| packages/lexical-code-core/src/__tests__/unit/CodeGutter.test.ts > $updateCodeGutter > numbers a single line 108ms
 ✓ |unit| packages/lexical-code-core/src/__tests__/unit/CodeGutter.test.ts > $updateCodeGutter > numbers several lines 6ms
 ✓ |unit| packages/lexical-code-core/src/__tests__/unit/CodeGutter.test.ts > $updateCodeGutter > numbers an empty trailing line 6ms
 ✓ |unit| packages/lexical-code-core/src/__tests__/unit/CodeGutter.test.ts > $updateCodeGutter > follows an edit that changes the line count 7ms
 ✓ |unit| packages/lexical-code-core/src/__tests__/unit/CodeGutter.test.ts > $updateCodeGutter > only rewrites the attribute when the number of children changes 4ms
 Test Files  16 passed (16)
      Tests  296 passed | 1 skipped (297)

$ pnpm run flow
Found 0 errors
```

`tsc` over the four code packages passes, and eslint and prettier are clean on the changed files. I ran this on Node 25 locally, so Node 22 and 24 are left to CI. I didn't run the browser or e2e suites locally either. The playground e2e specs pin `data-gutter` in a lot of places, and since the output is unchanged they should stay green.